### PR TITLE
fix(agent_builder): fix agent builder error when using file_location.

### DIFF
--- a/autogen/agentchat/contrib/agent_builder.py
+++ b/autogen/agentchat/contrib/agent_builder.py
@@ -203,7 +203,7 @@ Match roles in the role set to each expert in expert set.
             builder_filter_dict.update({"model": builder_model})
         if len(builder_model_tags) != 0:
             builder_filter_dict.update({"tags": builder_model_tags})
-        builder_config_list = autogen.config_list_from_json(config_file_or_env, filter_dict=builder_filter_dict)
+        builder_config_list = autogen.config_list_from_json(config_file_or_env, file_location=config_file_location, filter_dict=builder_filter_dict)
         if len(builder_config_list) == 0:
             raise RuntimeError(
                 f"Fail to initialize build manager: {builder_model}{builder_model_tags} does not exist in {config_file_or_env}. "


### PR DESCRIPTION
```python
 builder = agent_builder.AgentBuilder(
        builder_model=single_llm_model,
        agent_model=single_llm_model,
        config_file_location="./settings",
        config_file_or_env="config_list.json",
 )
```

When I use config_file_location, AgentBuilder reports an error due to an unassigned parameter in autogen.config_list_from_json on line 206.

Here's the error message, it looks like you just need to add file_location to solve the problem.

![image](https://github.com/user-attachments/assets/c43019e7-daf8-4bb7-a1e6-735e168058a4)
