### PR TITLE
limit coding to python and shell in autobuild

### DIFF
--- a/autogen/agentchat/contrib/agent_builder.py
+++ b/autogen/agentchat/contrib/agent_builder.py
@@ -117,6 +117,7 @@ Suggest no more than {max_agents} experts with their name according to the follo
 # Task requirement
 - Expert's name should follow the format: [skill]_Expert.
 - Only reply the names of the experts, separated by ",".
+- If coding skills are required, they should be limited to Python and Shell.
 For example: Python_Expert, Math_Expert, ... """
 
     AGENT_SYS_MSG_PROMPT = """# Your goal


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://ag2ai.github.io/ag2/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. --> 
The current autobuild only restricts coding to Python and Shell within the CODING_AND_TASK_SKILL_INSTRUCTION section. However, this does not completely prevent the LLM from generating agents in other programming languages, such as Java_Expert or C_Expert.

Adding restrictions in the AGENT_NAME_PROMPT can address this issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
