### PR TITLE
Updated bedrock.py to handle case of deploying it over Lambda function with attached role

### DIFF
--- a/autogen/oai/bedrock.py
+++ b/autogen/oai/bedrock.py
@@ -96,7 +96,19 @@ class BedrockClient:
         if "response_format" in kwargs and kwargs["response_format"] is not None:
             warnings.warn("response_format is not supported for Bedrock, it will be ignored.", UserWarning)
 
-        self.bedrock_runtime = session.client(service_name="bedrock-runtime", config=bedrock_config)
+        #if haven't got any access_key or secret_key in environment variable or via arugments then
+        if self._aws_access_key is None or self._aws_access_key == "" or self._aws_secret_key is None or self._aws_secret_key == "":
+            
+            # attempts to get client from attached role of mananged service (lambda, ec2, ecs, etc.)
+            self.bedrock_runtime = boto3.client(service_name="bedrock-runtime", config=bedrock_config)
+        else:
+            session = boto3.Session(
+                aws_access_key_id=self._aws_access_key,
+                aws_secret_access_key=self._aws_secret_key,
+                aws_session_token=self._aws_session_token,
+                profile_name=self._aws_profile_name,
+            )
+            self.bedrock_runtime = session.client(service_name="bedrock-runtime", config=bedrock_config)
 
     def message_retrieval(self, response):
         """Retrieve the messages from the response."""

--- a/autogen/oai/bedrock.py
+++ b/autogen/oai/bedrock.py
@@ -96,10 +96,15 @@ class BedrockClient:
         if "response_format" in kwargs and kwargs["response_format"] is not None:
             warnings.warn("response_format is not supported for Bedrock, it will be ignored.", UserWarning)
 
-        #if haven't got any access_key or secret_key in environment variable or via arugments then
-        if self._aws_access_key is None or self._aws_access_key == "" or self._aws_secret_key is None or self._aws_secret_key == "":
-            
-            # attempts to get client from attached role of mananged service (lambda, ec2, ecs, etc.)
+        # if haven't got any access_key or secret_key in environment variable or via arguments then
+        if (
+            self._aws_access_key is None
+            or self._aws_access_key == ""
+            or self._aws_secret_key is None
+            or self._aws_secret_key == ""
+        ):
+
+            # attempts to get client from attached role of managed service (lambda, ec2, ecs, etc.)
             self.bedrock_runtime = boto3.client(service_name="bedrock-runtime", config=bedrock_config)
         else:
             session = boto3.Session(

--- a/website/docs/topics/non-openai-models/cloud-bedrock.ipynb
+++ b/website/docs/topics/non-openai-models/cloud-bedrock.ipynb
@@ -10,26 +10,26 @@
    "source": [
     "# Amazon Bedrock\n",
     "\n",
-    "AutoGen allows you to use Amazon's generative AI Bedrock service to run inference with a number of open-weight models and as well as their own models.\n",
+    "AG2 allows you to use Amazon's generative AI Bedrock service to run inference with a number of open-weight models and as well as their own models.\n",
     "\n",
     "Amazon Bedrock supports models from providers such as Meta, Anthropic, Cohere, and Mistral.\n",
     "\n",
-    "In this notebook, we demonstrate how to use Anthropic's Sonnet model for AgentChat in AutoGen.\n",
+    "In this notebook, we demonstrate how to use Anthropic's Sonnet model for AgentChat in AG2.\n",
     "\n",
     "## Model features / support\n",
     "\n",
-    "Amazon Bedrock supports a wide range of models, not only for text generation but also for image classification and generation. Not all features are supported by AutoGen or by the Converse API used. Please see [Amazon's documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#conversation-inference-supported-models-features) on the features supported by the Converse API.\n",
+    "Amazon Bedrock supports a wide range of models, not only for text generation but also for image classification and generation. Not all features are supported by AG2 or by the Converse API used. Please see [Amazon's documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#conversation-inference-supported-models-features) on the features supported by the Converse API.\n",
     "\n",
-    "At this point in time AutoGen supports text generation and image classification (passing images to the LLM).\n",
+    "At this point in time AG2 supports text generation and image classification (passing images to the LLM).\n",
     "\n",
     "It does not, yet, support image generation ([contribute](https://microsoft.github.io/autogen/docs/contributor-guide/contributing/)).\n",
     "\n",
     "## Requirements\n",
-    "To use Amazon Bedrock with AutoGen, first you need to install the `pyautogen[bedrock]` package.\n",
+    "To use Amazon Bedrock with AG2, first you need to install the `ag2[bedrock]` package.\n",
     "\n",
     "## Pricing\n",
     "\n",
-    "When we combine the number of models supported and costs being on a per-region basis, it's not feasible to maintain the costs for each model+region combination within the AutoGen implementation. Therefore, it's recommended that you add the following to your config with cost per 1,000 input and output tokens, respectively:\n",
+    "When we combine the number of models supported and costs being on a per-region basis, it's not feasible to maintain the costs for each model+region combination within the AG2 implementation. Therefore, it's recommended that you add the following to your config with cost per 1,000 input and output tokens, respectively:\n",
     "```\n",
     "{\n",
     "    ...\n",
@@ -123,6 +123,15 @@
     "    }\n",
     "]\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using within an AWS Lambda function\n",
+    "\n",
+    "If you are using your AG2 code within an AWS Lambda function, you can utilise the attached role to access the Bedrock service and do not need to provide access, token, or profile values."
    ]
   },
   {


### PR DESCRIPTION
#84 [Bug]: Code doesn't work on AWS Lambda function when deployed with attached Role to access bedrock service.

## Description
Code was not working on AWS Lambda function when deployed with attached Role to access bedrock service.

## Why are these changes needed?
When passed credentials locally or via AWS profile, it works fine. However, it doesn't pick automatically session when deployed on AWS with managed services (eg: AWS Lambda function, Amazon ECS task, etc.) or Amazon EC2 with attached role. Although it is recommended and more secure way than creating access credentials.

I have made changes to build bedrock-runtime client directly using boto3 which uses attached Role to managed AWS service.

This is more secure way to running code over AWS. Tested it with AWS Lambda function and ECS container task.

### Key Changes:
- Implemented direct bedrock-runtime client creation via boto3
- Added support for IAM Role-based authentication
- Verified functionality on AWS Lambda and ECS container tasks

## Related issue number
Fixes #84

## Checks
- [x] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally. [NA - as no mention in docs]
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. [It requires managed AWS servers to test it]
- [ ] I've made sure all auto checks have passed.

## Testing Details
- Successfully tested on AWS Lambda function
- Verified on ECS container task
- Confirmed proper IAM Role recognition and authentication