### PR TITLE
Restrict license checks to staged/committed files only

### DIFF
--- a/scripts/pre-commit-license-check.py
+++ b/scripts/pre-commit-license-check.py
@@ -8,95 +8,112 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import List
 
 REQUIRED_ELEMENTS = [r"Copyright.*Owners of https://github\.com/ag2ai", r"SPDX-License-Identifier: Apache-2\.0"]
 
 
-def get_changed_files():
-    """Get list of Python files changed in this PR/push."""
+def get_github_pr_files() -> List[Path]:
+    """Get list of Python files changed in a GitHub PR."""
     try:
-        # If running in GitHub Actions PR
         if os.getenv("GITHUB_EVENT_PATH"):
             with open(os.getenv("GITHUB_EVENT_PATH")) as f:
                 event = json.load(f)
 
-            # For pull requests
+            # For pull requests, get changed files from the event payload
             if os.getenv("GITHUB_EVENT_NAME") == "pull_request":
-                # Use the files listed in the PR event
                 changed_files = []
-                for file in event["pull_request"]["changed_files"]:
+                for file in event.get("pull_request", {}).get("changed_files", []):
                     filename = file.get("filename", "")
                     if filename.endswith(".py"):
                         changed_files.append(Path(filename))
                 return changed_files
-            # For pushes
+
+            # For push events, use git diff
             else:
                 result = subprocess.run(
                     ["git", "diff", "--name-only", "HEAD^", "HEAD"], capture_output=True, text=True, check=True
                 )
-        # If running locally, check staged files
-        else:
-            result = subprocess.run(
-                ["git", "diff", "--cached", "--name-only", "--diff-filter=AMR"],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-
-        # Filter for Python files and convert to Path objects
-        return [Path(file) for file in result.stdout.splitlines() if file.endswith(".py")]
-    except subprocess.CalledProcessError as e:
-        print(f"Error getting changed files: {e}")
-        sys.exit(1)
+                return [Path(file) for file in result.stdout.splitlines() if file.endswith(".py")]
     except Exception as e:
-        print(f"Error processing files: {e}")
-        sys.exit(1)
+        print(f"Error getting PR files: {e}")
+    return []
+
+
+def get_staged_files() -> List[Path]:
+    """Get list of staged Python files using git command."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=AMR"], capture_output=True, text=True, check=True
+        )
+        files = result.stdout.splitlines()
+        return [Path(file) for file in files if file.endswith(".py")]
+    except subprocess.CalledProcessError as e:
+        print(f"Error getting staged files: {e}")
+        return []
 
 
 def should_check_file(file_path: Path) -> bool:
-    # Skip __init__.py files
-    return file_path.name != "__init__.py"
+    """Skip __init__.py files and check if file exists."""
+    return file_path.name != "__init__.py" and file_path.exists()
 
 
-def check_file_header(file_path):
-    with open(file_path, "r", encoding="utf-8") as f:
-        # Read first few lines of the file
-        content = f.read(500)
+def check_file_header(file_path: Path) -> List[str]:
+    """Check if file has required license headers."""
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read(500)
+            missing_elements = []
+            for pattern in REQUIRED_ELEMENTS:
+                if not re.search(pattern, content[:500], re.IGNORECASE):
+                    missing_elements.append(pattern)
+            return missing_elements
+    except Exception as e:
+        print(f"Error processing file {file_path}: {e}")
+        return []
 
-        # Check if all required elements are present near the start of the file
-        missing_elements = []
-        for pattern in REQUIRED_ELEMENTS:
-            if not re.search(pattern, content[:500], re.IGNORECASE):
-                missing_elements.append(pattern)
 
-        return missing_elements
+def get_files_to_check() -> List[Path]:
+    """Determine which files to check based on environment."""
+    try:
+        if "--all-files" in sys.argv:
+            return list(Path(".").rglob("*.py"))
+
+        if os.getenv("GITHUB_ACTIONS") == "true":
+            return get_github_pr_files()
+
+        return get_staged_files()
+    except Exception as e:
+        print(f"Error getting files to check: {e}")
+        return []
 
 
-def main():
-    failed = False
-    changed_files = get_changed_files()
+def main() -> None:
+    """Main function to check license headers."""
+    try:
+        failed = False
+        files_to_check = get_files_to_check()
 
-    if not changed_files:
-        print("No Python files were changed.")
-        return
+        if not files_to_check:
+            print("No Python files to check")
+            return
 
-    for py_file in changed_files:
-        if not should_check_file(py_file):
-            continue
+        for py_file in files_to_check:
+            if not should_check_file(py_file):
+                continue
 
-        if not py_file.exists():
-            print(f"Warning: File {py_file} no longer exists (may have been deleted)")
-            continue
+            missing_elements = check_file_header(py_file)
+            if missing_elements:
+                failed = True
+                print(f"\nIncomplete or missing license header in: {py_file}")
+                print(
+                    "\nSee https://ag2ai.github.io/ag2/docs/contributor-guide/contributing/#license-headers for guidance."
+                )
 
-        missing_elements = check_file_header(py_file)
-        if missing_elements:
-            failed = True
-            print(f"\nIncomplete or missing license header in: {py_file}")
-            print(
-                "\nSee https://ag2ai.github.io/ag2/docs/contributor-guide/contributing/#license-headers for guidance."
-            )
-
-    sys.exit(1 if failed else 0)
+        sys.exit(1 if failed else 0)
+    except Exception as e:
+        print(f"Error in main: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/pre-commit-license-check.py
+++ b/scripts/pre-commit-license-check.py
@@ -2,11 +2,55 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python3
+import json
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
 REQUIRED_ELEMENTS = [r"Copyright.*Owners of https://github\.com/ag2ai", r"SPDX-License-Identifier: Apache-2\.0"]
+
+
+def get_changed_files():
+    """Get list of Python files changed in this PR/push."""
+    try:
+        # If running in GitHub Actions PR
+        if os.getenv("GITHUB_EVENT_PATH"):
+            with open(os.getenv("GITHUB_EVENT_PATH")) as f:
+                event = json.load(f)
+
+            # For pull requests
+            if os.getenv("GITHUB_EVENT_NAME") == "pull_request":
+                # Use the files listed in the PR event
+                changed_files = []
+                for file in event["pull_request"]["changed_files"]:
+                    filename = file.get("filename", "")
+                    if filename.endswith(".py"):
+                        changed_files.append(Path(filename))
+                return changed_files
+            # For pushes
+            else:
+                result = subprocess.run(
+                    ["git", "diff", "--name-only", "HEAD^", "HEAD"], capture_output=True, text=True, check=True
+                )
+        # If running locally, check staged files
+        else:
+            result = subprocess.run(
+                ["git", "diff", "--cached", "--name-only", "--diff-filter=AMR"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+        # Filter for Python files and convert to Path objects
+        return [Path(file) for file in result.stdout.splitlines() if file.endswith(".py")]
+    except subprocess.CalledProcessError as e:
+        print(f"Error getting changed files: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error processing files: {e}")
+        sys.exit(1)
 
 
 def should_check_file(file_path: Path) -> bool:
@@ -30,8 +74,18 @@ def check_file_header(file_path):
 
 def main():
     failed = False
-    for py_file in Path(".").rglob("*.py"):
+    changed_files = get_changed_files()
+
+    if not changed_files:
+        print("No Python files were changed.")
+        return
+
+    for py_file in changed_files:
         if not should_check_file(py_file):
+            continue
+
+        if not py_file.exists():
+            print(f"Warning: File {py_file} no longer exists (may have been deleted)")
             continue
 
         missing_elements = check_file_header(py_file)
@@ -41,16 +95,6 @@ def main():
             print(
                 "\nSee https://ag2ai.github.io/ag2/docs/contributor-guide/contributing/#license-headers for guidance."
             )
-
-            """
-            # For more detailed output:
-            print("Missing required elements:")
-            for element in missing_elements:
-                print(f"  - {element}")
-            print("\nHeader should contain:")
-            print("  1. Copyright notice with 'Owners of https://github.com/ag2ai'")
-            print("  2. SPDX-License-Identifier: Apache-2.0")
-            """
 
     sys.exit(1 if failed else 0)
 


### PR DESCRIPTION
## Why are these changes needed?

In my previous implementation of the license check, #90, when running the check locally with `pre-commit run` it would check all python files, irrespective of whether they were staged or not.

This update fixes that.

Also, when this runs as a GitHub action it will check against the base branch.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
