### PR TITLE
Update test to avoid Azure content filter

### DIFF
--- a/test/agentchat/test_async.py
+++ b/test/agentchat/test_async.py
@@ -23,7 +23,7 @@ def get_market_news(ind, ind_upper):
     data = {
         "feed": [
             {
-                "title": "Palantir CEO Says Our Generation's Atomic Bomb Could Be AI Weapon - And Arrive Sooner Than You Think - Palantir Technologies  ( NYSE:PLTR ) ",
+                "title": "Palantir CEO Says Our Generation's Main Challenge Could Be AI Against Humanity - And Arrive Sooner Than You Think - Palantir Technologies  ( NYSE:PLTR ) ",
                 "summary": "Christopher Nolan's blockbuster movie \"Oppenheimer\" has reignited the public discourse surrounding the United States' use of an atomic bomb on Japan at the end of World War II.",
                 "overall_sentiment_score": 0.009687,
             },

--- a/test/agentchat/test_async.py
+++ b/test/agentchat/test_async.py
@@ -24,7 +24,7 @@ def get_market_news(ind, ind_upper):
         "feed": [
             {
                 "title": "Palantir CEO Says Our Generation's Main Challenge Could Be AI Against Humanity - And Arrive Sooner Than You Think - Palantir Technologies  ( NYSE:PLTR ) ",
-                "summary": "Christopher Nolan's blockbuster movie \"Oppenheimer\" has reignited the public discourse surrounding the United States' use of an atomic bomb on Japan at the end of World War II.",
+                "summary": "Christopher Nolan's blockbuster movie \"Oppenheimer\" has reignited the public discourse surrounding the United States' use of a weapon on Japan at the end of World War II.",
                 "overall_sentiment_score": 0.009687,
             },
             {

--- a/test/agentchat/test_async.py
+++ b/test/agentchat/test_async.py
@@ -63,7 +63,7 @@ def get_market_news(ind, ind_upper):
 @pytest.mark.skipif(skip_openai, reason=reason)
 @pytest.mark.asyncio
 async def test_async_groupchat():
-    config_list = autogen.config_list_from_json(OAI_CONFIG_LIST, KEY_LOC, filter_dict={"tags": ["gpt-3.5-turbo"]})
+    config_list = autogen.config_list_from_json(OAI_CONFIG_LIST, KEY_LOC, filter_dict={"tags": ["gpt-4o-mini"]})
 
     # create an AssistantAgent instance named "assistant"
     assistant = autogen.AssistantAgent(
@@ -97,7 +97,7 @@ async def test_async_groupchat():
 @pytest.mark.skipif(skip_openai, reason=reason)
 @pytest.mark.asyncio
 async def test_stream():
-    config_list = autogen.config_list_from_json(OAI_CONFIG_LIST, KEY_LOC, filter_dict={"tags": ["gpt-3.5-turbo"]})
+    config_list = autogen.config_list_from_json(OAI_CONFIG_LIST, KEY_LOC, filter_dict={"tags": ["gpt-4o-mini"]})
     data = asyncio.Future()
 
     async def add_stock_price_data():


### PR DESCRIPTION
## Why are these changes needed?

The text in the sample data feed in [test_async.py](https://github.com/ag2ai/ag2/blob/4889c5858b9ba06e2fc0e44a09e192d616c26261/test/agentchat/test_async.py#L26) is triggering the Azure OpenAI content filter. This updates the text to avoid that as it's not the purpose of this test.

`
            {
                "title": "Palantir CEO Says Our Generation's Atomic Bomb Could Be AI Weapon - And Arrive Sooner Than You Think - Palantir Technologies  ( NYSE:PLTR ) ",
                "summary": "Christopher Nolan's blockbuster movie \"Oppenheimer\" has reignited the public discourse surrounding the United States' use of an atomic bomb on Japan at the end of World War II.",
                "overall_sentiment_score": 0.009687,
            },
`
to
`
            {
                "title": "Palantir CEO Says Our Generation's Main Challenge Could Be AI Against Humanity - And Arrive Sooner Than You Think - Palantir Technologies  ( NYSE:PLTR ) ",
                "summary": "Christopher Nolan's blockbuster movie \"Oppenheimer\" has reignited the public discourse surrounding the United States' use of a weapon on Japan at the end of World War II.",
                "overall_sentiment_score": 0.009687,
            },
`

Also updated the model used from `gpt-3.5-turbo` to `gpt-4o-mini`.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
