### PR TITLE
Patch/logging

### DIFF
--- a/autogen/logger/logger_utils.py
+++ b/autogen/logger/logger_utils.py
@@ -4,15 +4,16 @@
 #
 # Portions derived from  https://github.com/microsoft/autogen are under the MIT License.
 # SPDX-License-Identifier: MIT
-import datetime
 import inspect
+from datetime import datetime, timezone
+from pathlib import Path, PurePath
 from typing import Any, Dict, List, Tuple, Union
 
 __all__ = ("get_current_ts", "to_dict")
 
 
 def get_current_ts() -> str:
-    return datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
 
 
 def to_dict(
@@ -22,6 +23,8 @@ def to_dict(
 ) -> Any:
     if isinstance(obj, (int, float, str, bool)):
         return obj
+    elif isinstance(obj, (Path, PurePath)):
+        return str(obj)
     elif callable(obj):
         return inspect.getsource(obj).strip()
     elif isinstance(obj, dict):

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -7,6 +7,7 @@
 import json
 import sqlite3
 import uuid
+from pathlib import Path
 from typing import Any, Callable
 from unittest.mock import Mock, patch
 
@@ -232,12 +233,16 @@ def test_log_oai_client(db_connection):
 
 def test_to_dict():
     from autogen import Agent
+    from autogen.coding import LocalCommandLineCodeExecutor
+
+    agent_executor = LocalCommandLineCodeExecutor(work_dir=Path("."))
 
     agent1 = autogen.ConversableAgent(
         "alice",
         human_input_mode="NEVER",
         llm_config=False,
         default_auto_reply="This is alice speaking.",
+        code_execution_config={"executor": agent_executor},
     )
 
     agent2 = autogen.ConversableAgent(
@@ -256,6 +261,7 @@ def test_to_dict():
             self.d = None
             self.test_function = lambda x, y: x + y
             self.extra_key = "remove this key"
+            self.path = Path("/to/something")
 
     class Bar(object):
         def init(self):
@@ -277,6 +283,7 @@ def test_to_dict():
             "c": {"some_key": [7, 8, 9]},
             "d": None,
             "test_function": "self.test_function = lambda x, y: x + y",
+            "path": "/to/something",
         }
     ]
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -5,6 +5,7 @@
 # Portions derived from  https://github.com/microsoft/autogen are under the MIT License.
 # SPDX-License-Identifier: MIT
 import json
+import os
 import sqlite3
 import uuid
 from pathlib import Path
@@ -276,6 +277,7 @@ def test_to_dict():
     bar = Bar()
     bar.build()
 
+    expected_path = "\\to\\something" if os.name == "nt" else "/to/something"
     expected_foo_val_field = [
         {
             "a": 1.234,
@@ -283,7 +285,7 @@ def test_to_dict():
             "c": {"some_key": [7, 8, 9]},
             "d": None,
             "test_function": "self.test_function = lambda x, y: x + y",
-            "path": "/to/something",
+            "path": expected_path,
         }
     ]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://ag2ai.github.io/ag2/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Handle `datetime.utcnow()` deprecation warning
- Handle serializing pathlib.Path instances:
    Serializing / logging agents with (e.g.):
     ```
     ...
     code_execution_config={"executor":  LocalCommandLineCodeExecutor(work_dir=Path("."))
     ...
     ```
     Raises a type error (with WindowsPath/PosixPath not being serializable).
     Maybe related: https://github.com/microsoft/autogen/issues/2286#issue-2226973981
     

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally.
- [x] I've ~added~ updated tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
