### PR TITLE
Update github/microsoft/autogen links

### DIFF
--- a/website/docs/topics/llm_configuration.ipynb
+++ b/website/docs/topics/llm_configuration.ipynb
@@ -120,7 +120,7 @@
     "\n",
     "````{=mdx}\n",
     ":::tip\n",
-    "By default this will create a model client which assumes an OpenAI API (or compatible) endpoint. To use custom model clients, see [here](https://github.com/microsoft/autogen/blob/main/notebook/agentchat_custom_model.ipynb).\n",
+    "By default this will create a model client which assumes an OpenAI API (or compatible) endpoint. To use custom model clients, see [here](https://github.com/ag2ai/ag2/blob/main/notebook/agentchat_custom_model.ipynb).\n",
     ":::\n",
     "````\n",
     "\n",
@@ -472,7 +472,7 @@
     "- [`config_list_from_models`](/docs/reference/oai/openai_utils#config_list_from_models): Creates configurations based on a provided list of models, useful when targeting specific models without manually specifying each configuration.\n",
     "- [`config_list_from_dotenv`](/docs/reference/oai/openai_utils#config_list_from_dotenv): Constructs a configuration list from a `.env` file, offering a consolidated way to manage multiple API configurations and keys from a single file.\n",
     "\n",
-    "See [this notebook](https://github.com/microsoft/autogen/blob/main/notebook/config_loader_utility_functions.ipynb) for examples of using the above functions."
+    "See [this notebook](https://github.com/ag2ai/ag2/blob/main/notebook/config_loader_utility_functions.ipynb) for examples of using the above functions."
    ]
   }
  ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://ag2ai.github.io/ag2/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Two links in the [LLM Configuration documentation](https://ag2ai.github.io/ag2/docs/topics/llm_configuration) are broken because they are pointing to the Microsoft repo. I updated these links to point to `ag2ai` instead.
 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
