### PR TITLE
Update github/microsoft/autogen link in chess documentation.

### DIFF
--- a/notebook/agentchat_nested_chats_chess.ipynb
+++ b/notebook/agentchat_nested_chats_chess.ipynb
@@ -298,7 +298,7 @@
     "\n",
     "The following diagram illustrates the nested chat between the player agent and the board agent.\n",
     "\n",
-    "![Conversational Chess](https://media.githubusercontent.com/media/microsoft/autogen/main/notebook/nested-chats-chess.png)\n",
+    "![Conversational Chess](https://media.githubusercontent.com/media/ag2ai/ag2/main/notebook/nested-chats-chess.png)\n",
     "\n",
     "See [nested chats tutorial chapter](/docs/tutorial/conversation-patterns#nested-chats)\n",
     "for more information."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://ag2ai.github.io/ag2/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
An image in the [Nested Chat Chess documentation](https://ag2ai.github.io/ag2/docs/notebooks/agentchat_nested_chats_chess/) is broken because it is linked to `/microsoft/autogen`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
