### PR TITLE
fix base_url not work in groq

### DIFF
--- a/autogen/oai/groq.py
+++ b/autogen/oai/groq.py
@@ -68,6 +68,7 @@ class GroqClient:
 
         if "response_format" in kwargs and kwargs["response_format"] is not None:
             warnings.warn("response_format is not supported for Groq API, it will be ignored.", UserWarning)
+        self.base_url = kwargs.get("base_url", None)
 
     def message_retrieval(self, response) -> List:
         """
@@ -149,7 +150,7 @@ class GroqClient:
         groq_params["messages"] = groq_messages
 
         # We use chat model by default, and set max_retries to 5 (in line with typical retries loop)
-        client = Groq(api_key=self.api_key, max_retries=5)
+        client = Groq(api_key=self.api_key, max_retries=5, base_url=self.base_url)
 
         # Token counts will be returned
         prompt_tokens = 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://ag2ai.github.io/ag2/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The base_url functionality in Groq was not working correctly in AutoGen version 0.4.1. This PR addresses the issue by fixing the logic for handling the base_url parameter, ensuring it functions as expected.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
