### PR TITLE
Fix Group Chat usage summary (tokens + cost)

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1024,6 +1024,20 @@ class ConversableAgent(LLMAgent):
 
             raise RuntimeError(msg)
 
+    def _get_related_agents_for_usage(self) -> List[Agent]:
+        """Gets all agents related to this agent so they can be used in the usage summary.
+
+        In ConversableAgent, this is only itself, but this can be overridden in other Agent classes to add additional agents, such as for
+        the agents in a group chat when self is the GroupChatManager."""
+
+        return [self]
+
+    @staticmethod
+    def _get_agents_for_usage_summary(sender: "ConversableAgent", recipient: "ConversableAgent") -> List[Agent]:
+        """Gets all agents for a chat session in order to calculate the usage summary."""
+
+        return list(set(sender._get_related_agents_for_usage() + recipient._get_related_agents_for_usage()))
+
     def initiate_chat(
         self,
         recipient: "ConversableAgent",
@@ -1162,7 +1176,7 @@ class ConversableAgent(LLMAgent):
         chat_result = ChatResult(
             chat_history=self.chat_messages[recipient],
             summary=summary,
-            cost=gather_usage_summary([self, recipient]),
+            cost=gather_usage_summary(ConversableAgent._get_agents_for_usage_summary(self, recipient)),
             human_input=self._human_input,
         )
         return chat_result
@@ -1228,7 +1242,7 @@ class ConversableAgent(LLMAgent):
         chat_result = ChatResult(
             chat_history=self.chat_messages[recipient],
             summary=summary,
-            cost=gather_usage_summary([self, recipient]),
+            cost=gather_usage_summary(ConversableAgent._get_agents_for_usage_summary(self, recipient)),
             human_input=self._human_input,
         )
         return chat_result

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1666,3 +1666,12 @@ class GroupChatManager(ConversableAgent):
         reply_content = " ".join(words[:clear_word_index] + words[clear_word_index + skip_words_number :])
 
         return reply_content
+
+    def _get_related_agents_for_usage(self) -> List[Agent]:
+        """Gets all agents in the groupchat in order to calculate the usage summary.
+
+        This overrides the ConversableAgent method to include groupchat agents.
+
+        TODO: Persist and include the speaker selection agent from the auto speaker selection mode."""
+
+        return [self] + self._groupchat.agents


### PR DESCRIPTION
UPDATE: We are exploring the native integration of telemetry to provide a more holistic capture of the key events and costs of your AG2 workflow. So, this PR may be supeseded by that integration. Exploration continues...

## Why are these changes needed?

An issue raised by @bassilkhilo, #103, identified a bug with the ChatResult of a group chat not including the costs.

After investigating, I've found that when calculating the costs in `initiate_chat`/`a_initiate_chat` it is not looking at the costs of the agents in the group chat (only the initiating agent and the group chat manager).

This addresses that.

The status of this PR is that it is pulling through the costs of the agents in the group chat, however it is not including the costs of the speaker selection agent when in auto speaker selection mode. This needs to be addressed as well.

As it is, this will work for a swarm, which doesn't use that.

TODO: Review nested chats to ensure those costs are coming through as well.

## Related issue number

Closes #103 

## Checks

- [ ] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
