### PR TITLE
Setup.py > underscores to hyphens fix

### DIFF
--- a/.github/workflows/contrib-graph-rag-tests.yml
+++ b/.github/workflows/contrib-graph-rag-tests.yml
@@ -45,7 +45,7 @@ jobs:
           pip install pytest
       - name: Install FalkorDB SDK when on linux
         run: |
-          pip install -e .[graph_rag_falkor_db]
+          pip install -e .[graph-rag-falkor-db]
       - name: Set AUTOGEN_USE_DOCKER based on OS
         shell: bash
         run: |

--- a/notebook/agentchat_graph_rag_falkordb.ipynb
+++ b/notebook/agentchat_graph_rag_falkordb.ipynb
@@ -13,7 +13,7 @@
     "FalkorDB's GraphRAG-SDK is a dependency for this notebook, which can be installed with ag2 via pip:\n",
     "\n",
     "```bash\n",
-    "pip install ag2[graph_rag_falkor_db]\n",
+    "pip install ag2[graph-rag-falkor-db]\n",
     "```\n",
     "\n",
     "or if you have already installed ag2/autogen/pyautogen\n",

--- a/notebook/agentchat_swarm_graphrag_trip_planner.ipynb
+++ b/notebook/agentchat_swarm_graphrag_trip_planner.ipynb
@@ -25,7 +25,7 @@
     "FalkorDB's GraphRAG-SDK is a dependency for this notebook, which can be installed with ag2 via pip:\n",
     "\n",
     "```bash\n",
-    "pip install ag2[graph_rag_falkor_db]\n",
+    "pip install ag2[graph-rag-falkor-db]\n",
     "```\n",
     "\n",
     "For more information, please refer to the [installation guide](/docs/installation/).\n",

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,9 @@ elif current_os == "Linux":
 # pysqlite3-binary used so it doesn't need to compile pysqlite3
 autobuild = ["chromadb", "sentence-transformers", "huggingface-hub", "pysqlite3-binary"]
 
+# NOTE: underscores in pip install, e.g. pip install ag2[graph_rag_falkor_db], will automatically
+# convert to hyphens. So, do not include underscores in the name of extras.
+
 extra_require = {
     "test": [
         "ipykernel",

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ extra_require = {
     "retrievechat-pgvector": retrieve_chat_pgvector,
     "retrievechat-mongodb": [*retrieve_chat, "pymongo>=4.0.0"],
     "retrievechat-qdrant": [*retrieve_chat, "qdrant_client", "fastembed>=0.3.1"],
-    "graph_rag_falkor_db": graph_rag_falkor_db,
+    "graph-rag-falkor-db": graph_rag_falkor_db,
     "autobuild": autobuild,
     "captainagent": autobuild + ["pandas"],
     "teachable": ["chromadb"],


### PR DESCRIPTION
## Why are these changes needed?

`pip install` does not allow underscores in the package extras, so the `graph_rag_falkor_db` extra is being interpreted as `graph-rag-falkor-db` and can't be found in the setup.py.

This fixes that by changing it to hyphens so they can install either:
`pip install ag2[graph_rag_falkor_db]` or `pip install ag2[graph-rag-falkor-db]`

## Related issue number

Discord issue

## Checks

- [ ] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
