### PR TITLE
Updated resolutions for Dall-e-3 for Contrib tests

### DIFF
--- a/test/agentchat/contrib/capabilities/test_image_generation_capability.py
+++ b/test/agentchat/contrib/capabilities/test_image_generation_capability.py
@@ -34,11 +34,11 @@ from conftest import MOCK_OPEN_AI_API_KEY, skip_openai  # noqa: E402
 
 filter_dict = {"model": ["gpt-4o-mini"]}
 
-RESOLUTIONS = ["256x256", "512x512", "1024x1024"]
+RESOLUTIONS = ["1024x1024", "1792x1024", "1024x1792"]
 QUALITIES = ["standard", "hd"]
 PROMPTS = [
-    "Generate an image of a robot holding a 'I Love Autogen' sign",
-    "Generate an image of a dog holding a 'I Love Autogen' sign",
+    "Generate an image of a robot holding a 'I Love AG2' sign",
+    "Generate an image of a dog holding a 'I Love AG2' sign",
 ]
 
 
@@ -228,5 +228,5 @@ def test_image_generation_capability_cache(monkeypatch):
 
 if __name__ == "__main__":
     test_dalle_image_generator(
-        dalle_config={"config_list": openai_utils.config_list_from_models(model_list=["dall-e-2"], exclude="aoai")}
+        dalle_config={"config_list": openai_utils.config_list_from_models(model_list=["dall-e-3"], exclude="aoai")}
     )


### PR DESCRIPTION
## Why are these changes needed?

Recently updated contrib tests had dall-e-2 supported resolutions while changing to dall-e-3, which supports different resolutions. This fixes that.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
