### PR TITLE
fix: ReasoningAgent blog links

### DIFF
--- a/website/blog/2024-12-02-ReasoningAgent2/index.mdx
+++ b/website/blog/2024-12-02-ReasoningAgent2/index.mdx
@@ -70,12 +70,14 @@ tags: [LLM, GPT, research]
    </CardGroup>
 </div>
 
-![Tree of Thoughts](img/reasoningagent_1.png)
+<iframe width="560" height="315" src="https://www.youtube.com/embed/sS8Q5yMuEhs?si=MfWmzflK94S94FEx" title="ReasoningAgent" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **TL;DR:**
 * We introduce **ReasoningAgent**, an AG2 agent that implements tree-of-thought reasoning with beam search to solve complex problems.
 * ReasoningAgent explores multiple reasoning paths in parallel and uses a grader agent to evaluate and select the most promising paths.
 * The exploration trajectory and thought tree can be saved locally for further analysis. These logs can even be saved as SFT dataset and preference dataset for DPO and PPO training.
+
+![Tree of Thoughts](img/reasoningagent_1.png)
 
 ## Introduction
 

--- a/website/blog/2024-12-20-Reasoning-Update/index.mdx
+++ b/website/blog/2024-12-20-Reasoning-Update/index.mdx
@@ -58,7 +58,7 @@ tags: [LLM, GPT, research, tutorial]
    </CardGroup>
 </div>
 
-![Tree of Thoughts](img/mcts_example.png)
+<iframe width="560" height="315" src="https://www.youtube.com/embed/W7hfRA7XXjI?si=ImwXfHIYGosmaRFi" title="Reasoning Agent with MCTS" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **Key Updates in this Release:**
 
@@ -73,6 +73,8 @@ tags: [LLM, GPT, research, tutorial]
 3. Enhanced Features
    * New `forest_size` parameter enables maintaining multiple independent reasoning trees
    * Support for ground truth answers in prompts to generate training data for LLM fine-tuning
+
+![Tree of Thoughts](img/mcts_example.png)
 
 ## Introduction
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://ag2ai.github.io/ag2/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

added the youtube links to the ReasoningAgent blogs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://ag2ai.github.io/ag2/. See https://ag2ai.github.io/ag2/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
