### PR TITLE
Adding AnthropicVertexAI API support in the Anthropic LLM lib under oai

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -578,6 +578,13 @@ class OpenAIWrapper:
             if key in config:
                 openai_config[key] = config[key]
 
+    def _configure_openai_config_for_vertextai(self, config: dict[str, Any], openai_config: dict[str, Any]) -> None:
+        """Update openai_config with Google credentials from config."""
+        required_keys = ["gcp_project_id", "gcp_region", "gcp_auth_token"]
+        for key in required_keys:
+            if key in config:
+                openai_config[key] = config[key]
+
     def _register_default_client(self, config: dict[str, Any], openai_config: dict[str, Any]) -> None:
         """Create a client with the given config to override openai_config,
         after removing extra kwargs.
@@ -615,8 +622,10 @@ class OpenAIWrapper:
                 client = GeminiClient(response_format=response_format, **openai_config)
                 self._clients.append(client)
             elif api_type is not None and api_type.startswith("anthropic"):
-                if "api_key" not in config:
+                if "api_key" not in config and "aws_region" in config:
                     self._configure_openai_config_for_bedrock(config, openai_config)
+                elif "api_key" not in config and "gcp_region" in config:
+                    self._configure_openai_config_for_vertextai(config, openai_config)
                 if anthropic_import_exception:
                     raise ImportError("Please install `anthropic` to use Anthropic API.")
                 client = AnthropicClient(response_format=response_format, **openai_config)

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ extra_require = {
     "jupyter-executor": jupyter_executor,
     "types": types,
     "long-context": ["llmlingua<0.3"],
-    "anthropic": ["anthropic>=0.23.1"],
+    "anthropic": ["anthropic[vertex]>=0.23.1"],
     "cerebras": ["cerebras_cloud_sdk>=1.0.0"],
     "mistral": ["mistralai>=1.0.1"],
     "groq": ["groq>=0.9.0"],

--- a/test/oai/test_anthropic.py
+++ b/test/oai/test_anthropic.py
@@ -60,7 +60,7 @@ def test_initialization_missing_api_key():
     os.environ.pop("AWS_SECRET_KEY", None)
     os.environ.pop("AWS_SESSION_TOKEN", None)
     os.environ.pop("AWS_REGION", None)
-    with pytest.raises(ValueError, match="API key or AWS credentials are required to use the Anthropic API."):
+    with pytest.raises(ValueError, match="credentials are required to use the Anthropic API."):
         AnthropicClient()
 
     AnthropicClient(api_key="dummy_api_key")
@@ -75,6 +75,13 @@ def anthropic_client_with_aws_credentials():
         aws_region="us-west-2",
     )
 
+@pytest.fixture()
+def anthropic_client_with_vertexai_credentials():
+    return AnthropicClient(
+        gcp_project_id="dummy_project_id",
+        gcp_region="us-west-2",
+        gcp_auth_token="dummy_auth_token",
+    )
 
 @pytest.mark.skipif(skip, reason=reason)
 def test_intialization(anthropic_client):
@@ -95,6 +102,19 @@ def test_intialization_with_aws_credentials(anthropic_client_with_aws_credential
     assert (
         anthropic_client_with_aws_credentials.aws_region == "us-west-2"
     ), "`aws_region` should be correctly set in the config"
+
+
+@pytest.mark.skipif(skip, reason=reason)
+def test_initialization_with_vertexai_credentials(anthropic_client_with_vertexai_credentials):
+    assert (
+        anthropic_client_with_vertexai_credentials.gcp_project_id == "dummy_project_id"
+    ), "`gcp_project_id` should be correctly set in the config"
+    assert (
+        anthropic_client_with_vertexai_credentials.gcp_region == "us-west-2"
+    ), "`gcp_region` should be correctly set in the config"
+    assert (
+        anthropic_client_with_vertexai_credentials.gcp_auth_token == "dummy_auth_token"
+    ), "`gcp_auth_token` should be correctly set in the config"
 
 
 # Test cost calculation

--- a/test/oai/test_anthropic.py
+++ b/test/oai/test_anthropic.py
@@ -75,6 +75,7 @@ def anthropic_client_with_aws_credentials():
         aws_region="us-west-2",
     )
 
+
 @pytest.fixture()
 def anthropic_client_with_vertexai_credentials():
     return AnthropicClient(
@@ -82,6 +83,7 @@ def anthropic_client_with_vertexai_credentials():
         gcp_region="us-west-2",
         gcp_auth_token="dummy_auth_token",
     )
+
 
 @pytest.mark.skipif(skip, reason=reason)
 def test_intialization(anthropic_client):

--- a/website/docs/topics/non-openai-models/cloud-anthropic.ipynb
+++ b/website/docs/topics/non-openai-models/cloud-anthropic.ipynb
@@ -171,9 +171,10 @@
    "source": [
     "### Alternative Anthropic VertexAI Client (Google Default Authentication)\n",
     "\n",
-    "If the gcp_auth_token is not provided in the configuration, the client will use Google’s default authentication mechanism. This requires the appropriate credentials to be configured in your environment, such as:\n",
-    "\t•\tService account key: You can set the GOOGLE_APPLICATION_CREDENTIALS environment variable to point to your service account key file.\n",
-    "\t•\tCloud Shell or GCP Compute Engine: When running in a GCP-managed environment, default authentication is automatically applied.\n",
+    "If the `gcp_auth_token` is not provided in the configuration, the client will use Google’s default authentication mechanism. This requires the appropriate credentials to be configured in your environment, such as:\n",
+    "\n",
+    "- Service account key: You can set the GOOGLE_APPLICATION_CREDENTIALS environment variable to point to your service account key file.\n",
+    "- Cloud Shell or GCP Compute Engine: When running in a GCP-managed environment, default authentication is automatically applied.",
     "\n",
     "Example of setting up the environment variable:\n",
     "\n",

--- a/website/docs/topics/non-openai-models/cloud-anthropic.ipynb
+++ b/website/docs/topics/non-openai-models/cloud-anthropic.ipynb
@@ -173,11 +173,11 @@
     "\n",
     "If the `gcp_auth_token` is not provided in the configuration, the client will use Google’s default authentication mechanism. This requires the appropriate credentials to be configured in your environment, such as:\n",
     "\n",
-    "- Service account key: You can set the GOOGLE_APPLICATION_CREDENTIALS environment variable to point to your service account key file.\n",
+    "- Service account key: You can set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to your service account key file.\n",
     "- Cloud Shell or GCP Compute Engine: When running in a GCP-managed environment, default authentication is automatically applied.",
     "\n",
-    "Example of setting up the environment variable:\n",
     "\n",
+    "Example of setting up the environment variable:\n",
     "export GOOGLE_APPLICATION_CREDENTIALS=\"/path/to/your/service-account-key.json\"\n",
     "\n",
     "This allows seamless integration without explicitly specifying the authentication token in your code."

--- a/website/docs/topics/non-openai-models/cloud-anthropic.ipynb
+++ b/website/docs/topics/non-openai-models/cloud-anthropic.ipynb
@@ -130,6 +130,62 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Alternative Anthropic VertexAI Client (GCP)\n",
+    "\n",
+    "To use the Anthropic VertexAI client in AutoGen, you need to configure it for use with Google Cloud Platform (GCP). Ensure you have the necessary project credentials and install the required package.\n",
+    "\n",
+    "Configuration\n",
+    "\n",
+    "The following configuration example demonstrates how to set up Anthropic VertexAI:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "config_list_vertexai = [\n",
+    "    {\n",
+    "        \"model\": \"claude-3-5-sonnet-20240620-v1:0\",\n",
+    "        \"gcp_project_id\": \"your_project_id\",\n",
+    "        \"gcp_region\": \"us-west-2\",  # Replace with your GCP region\n",
+    "        \"gcp_auth_token\": None,  # Optional: If not passed, Google Default Authentication will be used\n",
+    "        \"api_type\": \"anthropic\",\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "assistant = autogen.AssistantAgent(\n",
+    "    \"assistant\",\n",
+    "    llm_config={\n",
+    "        \"config_list\": config_list_vertexai,\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Alternative Anthropic VertexAI Client (Google Default Authentication)\n",
+    "\n",
+    "If the gcp_auth_token is not provided in the configuration, the client will use Google’s default authentication mechanism. This requires the appropriate credentials to be configured in your environment, such as:\n",
+    "\t•\tService account key: You can set the GOOGLE_APPLICATION_CREDENTIALS environment variable to point to your service account key file.\n",
+    "\t•\tCloud Shell or GCP Compute Engine: When running in a GCP-managed environment, default authentication is automatically applied.\n",
+    "\n",
+    "Example of setting up the environment variable:\n",
+    "\n",
+    "export GOOGLE_APPLICATION_CREDENTIALS=\"/path/to/your/service-account-key.json\"\n",
+    "\n",
+    "This allows seamless integration without explicitly specifying the authentication token in your code."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Two-agent Coding Example"
    ]
   },

--- a/website/docs/topics/non-openai-models/cloud-anthropic.ipynb
+++ b/website/docs/topics/non-openai-models/cloud-anthropic.ipynb
@@ -178,6 +178,7 @@
     "\n",
     "\n",
     "Example of setting up the environment variable:\n",
+    "\n",
     "export GOOGLE_APPLICATION_CREDENTIALS=\"/path/to/your/service-account-key.json\"\n",
     "\n",
     "This allows seamless integration without explicitly specifying the authentication token in your code."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The changes include adding support AnthropicVertex inside oai/anthropic.py and oai/client.py, so that Anthropic models running in GCP can be used in Ag2 for building Agents.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #308 
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [  ] I've made sure all auto checks have passed.
