### PR TITLE
[Docs] Add missing front matter metadata in notebook

### DIFF
--- a/notebook/agentchat_MathChat.ipynb
+++ b/notebook/agentchat_MathChat.ipynb
@@ -993,6 +993,12 @@
   }
  ],
  "metadata": {
+  "front_matter": {
+    "description": "Using MathChat to Solve Math Problems",
+    "tags": [
+        "math"
+    ]
+  },
   "kernelspec": {
    "display_name": "flaml_dev",
    "language": "python",

--- a/notebook/agentchat_graph_rag_falkordb.ipynb
+++ b/notebook/agentchat_graph_rag_falkordb.ipynb
@@ -341,6 +341,13 @@
   }
  ],
  "metadata": {
+  "front_matter": {
+    "description": "Using FalkorGraphRagCapability with agents for GraphRAG Question & Answering",
+    "tags": [
+        "RAG",
+        "FalkorDB"
+    ]
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebook/agentchat_realtime_websocket.ipynb
+++ b/notebook/agentchat_realtime_websocket.ipynb
@@ -295,6 +295,13 @@
   }
  ],
  "metadata": {
+  "front_matter": {
+   "description": "RealtimeAgent using websockets",
+   "tags": [
+    "realtime",
+    "websockets"
+   ]
+  },
   "kernelspec": {
    "display_name": ".venv-3.9",
    "language": "python",

--- a/notebook/config_loader_utility_functions.ipynb
+++ b/notebook/config_loader_utility_functions.ipynb
@@ -361,6 +361,13 @@
   }
  ],
  "metadata": {
+  "front_matter": {
+    "description": "Config loader utility functions",
+    "tags": [
+        "utility",
+        "config"
+    ]
+  },
   "kernelspec": {
    "display_name": "masterclass",
    "language": "python",

--- a/website/mint.json
+++ b/website/mint.json
@@ -628,7 +628,10 @@
             "notebooks/agentchat_realtime_websocket",
             "notebooks/agentchat_reasoning_agent",
             "notebooks/agentchat_captainagent_crosstool",
-            "notebooks/agentchat_realtime_websocket"
+            "notebooks/agentchat_realtime_websocket",
+            "notebooks/agentchat_graph_rag_falkordb",
+            "notebooks/agentchat_MathChat",
+            "notebooks/config_loader_utility_functions"
           ]
         },
         "notebooks/Gallery"

--- a/website/mint.json
+++ b/website/mint.json
@@ -305,9 +305,13 @@
               "pages": [
                 "docs/reference/agentchat/realtime_agent/client",
                 "docs/reference/agentchat/realtime_agent/function_observer",
+                "docs/reference/agentchat/realtime_agent/oai_realtime_client",
                 "docs/reference/agentchat/realtime_agent/realtime_agent",
+                "docs/reference/agentchat/realtime_agent/realtime_client",
                 "docs/reference/agentchat/realtime_agent/realtime_observer",
+                "docs/reference/agentchat/realtime_agent/twilio_audio_adapter",
                 "docs/reference/agentchat/realtime_agent/twilio_observer",
+                "docs/reference/agentchat/realtime_agent/websocket_audio_adapter",
                 "docs/reference/agentchat/realtime_agent/websocket_observer"
               ]
             },
@@ -623,7 +627,8 @@
             "notebooks/agentchat_realtime_swarm",
             "notebooks/agentchat_realtime_websocket",
             "notebooks/agentchat_reasoning_agent",
-            "notebooks/agentchat_captainagent_crosstool"
+            "notebooks/agentchat_captainagent_crosstool",
+            "notebooks/agentchat_realtime_websocket"
           ]
         },
         "notebooks/Gallery"

--- a/website/snippets/data/NotebooksMetadata.mdx
+++ b/website/snippets/data/NotebooksMetadata.mdx
@@ -1023,8 +1023,6 @@ export const notebooksMetadata = [
         "description": "Swarm Ochestration",
         "image": null,
         "tags": [
-            "realtime",
-            "twilio",
             "orchestration",
             "group chat",
             "swarm"
@@ -1248,5 +1246,16 @@ export const notebooksMetadata = [
             "crewai"
         ],
         "source": "/notebook/agentchat_captainagent_crosstool.ipynb"
+    },
+    {
+        "title": "RealtimeAgent with local websocket connection",
+        "link": "/notebooks/agentchat_realtime_websocket",
+        "description": "RealtimeAgent using websockets",
+        "image": null,
+        "tags": [
+            "realtime",
+            "websockets"
+        ],
+        "source": "/notebook/agentchat_realtime_websocket.ipynb"
     }
 ];

--- a/website/snippets/data/NotebooksMetadata.mdx
+++ b/website/snippets/data/NotebooksMetadata.mdx
@@ -1257,5 +1257,37 @@ export const notebooksMetadata = [
             "websockets"
         ],
         "source": "/notebook/agentchat_realtime_websocket.ipynb"
+    },
+    {
+        "title": "Using FalkorGraphRagCapability with agents for GraphRAG Question & Answering",
+        "link": "/notebooks/agentchat_graph_rag_falkordb",
+        "description": "Using FalkorGraphRagCapability with agents for GraphRAG Question & Answering",
+        "image": null,
+        "tags": [
+            "RAG",
+            "FalkorDB"
+        ],
+        "source": "/notebook/agentchat_graph_rag_falkordb.ipynb"
+    },
+    {
+        "title": "Auto Generated Agent Chat: Using MathChat to Solve Math Problems",
+        "link": "/notebooks/agentchat_MathChat",
+        "description": "Using MathChat to Solve Math Problems",
+        "image": null,
+        "tags": [
+            "math"
+        ],
+        "source": "/notebook/agentchat_MathChat.ipynb"
+    },
+    {
+        "title": "Config loader utility functions",
+        "link": "/notebooks/config_loader_utility_functions",
+        "description": "Config loader utility functions",
+        "image": null,
+        "tags": [
+            "utility",
+            "config"
+        ],
+        "source": "/notebook/config_loader_utility_functions.ipynb"
     }
 ];


### PR DESCRIPTION
## Why are these changes needed?

The `notebook/agentchat_realtime_websocket.ipynb` notebook is missing the front_matter metadata and because of which it is not being rendered in the documentation. This PR fixes adds the required front_matter metadata to the notebook and fixes the issue.


## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
