### PR TITLE
Swarm: Restore lost SWARM_MANAGER return

### DIFF
--- a/autogen/agentchat/contrib/swarm_agent.py
+++ b/autogen/agentchat/contrib/swarm_agent.py
@@ -352,6 +352,8 @@ def _determine_next_agent(
             return None if user_agent is None else user_agent
         elif after_work_condition == AfterWorkOption.STAY:
             return last_speaker
+        elif after_work_condition == AfterWorkOption.SWARM_MANAGER:
+            return "auto"
     else:
         raise ValueError("Invalid After Work condition or return value from callable")
 


### PR DESCRIPTION
## Why are these changes needed?

In PR #217, the return "auto" line was lost when merging with main in the last commit. This restores it.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
