### PR TITLE
Fix deps problem with CrewAI on Win32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,8 @@ twilio = [
 interop-crewai = [
     "crewai[tools]>=0.86,<1; python_version>='3.10' and python_version<'3.13'",
     "weaviate-client==4.10.2; python_version>='3.10' and python_version<'3.13'",
+    # crewai uses litellm, litellm introduced uvloop as deps with version 1.57.5 which does not support win32
+    "litellm<1.57.5; sys_platform=='win32'",
 ]
 interop-langchain = ["langchain-community>=0.3.12,<1"]
 interop-pydantic-ai = ["pydantic-ai==0.0.13"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

CrewAI has litellm as deps and litellm introduced uvloop as deps with version 1.57.5 which does not support win32. This PR keep the version of litellm smaller than 1.57.5.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #430 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
