### PR TITLE
content parameter of TextMessage class can also be list

### DIFF
--- a/autogen/messages/agent_messages.py
+++ b/autogen/messages/agent_messages.py
@@ -189,7 +189,7 @@ class ToolCallMessage(BasePrintReceivedMessage):
 
 @wrap_message
 class TextMessage(BasePrintReceivedMessage):
-    content: Optional[Union[str, int, float, bool]] = None  # type: ignore [assignment]
+    content: Optional[Union[str, int, float, bool, list[dict[str, str]]]] = None  # type: ignore [assignment]
 
     def print(self, f: Optional[Callable[..., Any]] = None) -> None:
         f = f or print

--- a/test/messages/test_agent_messages.py
+++ b/test/messages/test_agent_messages.py
@@ -305,9 +305,34 @@ class TestToolCallMessage:
 
 
 class TestTextMessage:
-    def test_print_context_message(self, uuid: UUID, sender: ConversableAgent, recipient: ConversableAgent) -> None:
-        message = {"content": "hello {name}", "context": {"name": "there"}}
-
+    @pytest.mark.parametrize(
+        "message, expected_content",
+        [
+            (
+                {"content": "hello {name}", "context": {"name": "there"}},
+                "hello {name}",
+            ),
+            (
+                {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Please extract table from the following image and convert it to Markdown.",
+                        }
+                    ]
+                },
+                "Please extract table from the following image and convert it to Markdown.",
+            ),
+        ],
+    )
+    def test_print_messages(
+        self,
+        uuid: UUID,
+        sender: ConversableAgent,
+        recipient: ConversableAgent,
+        message: dict[str, Any],
+        expected_content: str,
+    ) -> None:
         actual = create_received_message_model(uuid=uuid, message=message, sender=sender, recipient=recipient)
 
         assert isinstance(actual, TextMessage)
@@ -315,7 +340,7 @@ class TestTextMessage:
             "type": "text",
             "content": {
                 "uuid": uuid,
-                "content": "hello {name}",
+                "content": message["content"],
                 "sender_name": "sender",
                 "recipient_name": "recipient",
             },
@@ -325,11 +350,9 @@ class TestTextMessage:
         mock = MagicMock()
         actual.print(f=mock)
 
-        # print(mock.call_args_list)
-
         expected_call_args_list = [
             call("\x1b[33msender\x1b[0m (to recipient):\n", flush=True),
-            call("hello {name}", flush=True),
+            call(expected_content, flush=True),
             call(
                 "\n",
                 "--------------------------------------------------------------------------------",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fixes Pydantic error breaking MultimodalConversableAgent

When using the `MultimodalConversableAgent`, the `create_received_message_model` function occasionally attempts to construct a `TextMessage` by setting its `content` to a structure like `[{'type': 'text', 'text': '...'}]`.

As a result, to accommodate this structure in `TextMessage.content`, the type annotation should be updated to include `list[dict[str, str]]`.

## Related issue number
Closes #383 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
