### PR TITLE
Fix devcontainer failing because of pyyaml version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,7 @@ test = [
 
 docs = [
     "pydoc-markdown",
-    "pyyaml",
+    "pyyaml==6.0.2",
     "termcolor",
     "nbclient",
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If we don't explicitly specify `pyyaml` version, it resolves to an older version which has some issues with installing- https://github.com/yaml/pyyaml/issues/724. The fix is to simply pin the version of `pyyaml` like `pyyaml==6.0.2`. 

To prevent similar issues from happening in the future, we should use pinned versions for dev dependencies - https://github.com/ag2ai/ag2/issues/453

## Related issue number

Closes #460 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
