### PR TITLE
Add Validation for name in ConversableAgent to Prevent Whitespace

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -103,7 +103,6 @@ class ConversableAgent(LLMAgent):
         chat_messages: Optional[dict[Agent, list[dict]]] = None,
         silent: Optional[bool] = None,
         context_variables: Optional[dict[str, Any]] = None,
-        validate_name: bool = True,
     ):
         """Args:
         name (str): name of the agent.
@@ -164,9 +163,7 @@ class ConversableAgent(LLMAgent):
             code_execution_config.copy() if hasattr(code_execution_config, "copy") else code_execution_config
         )
 
-        # Validation for name using regex to detect any whitespace
-        if validate_name and re.search(r"\s", name):
-            raise ValueError(f"The name of the agent cannot contain any whitespace. The name provided is: '{name}'")
+        self._validate_name(name)
         self._name = name
         # a dictionary of conversations, default value is list
         if chat_messages is None:
@@ -286,6 +283,11 @@ class ConversableAgent(LLMAgent):
             "process_message_before_send": [],
             "update_agent_state": [],
         }
+
+    def _validate_name(self, name: str) -> None:
+        # Validation for name using regex to detect any whitespace
+        if re.search(r"\s", name):
+            raise ValueError(f"The name of the agent cannot contain any whitespace. The name provided is: '{name}'")
 
     def _validate_llm_config(self, llm_config):
         assert llm_config in (None, False) or isinstance(llm_config, dict), (

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -103,6 +103,7 @@ class ConversableAgent(LLMAgent):
         chat_messages: Optional[dict[Agent, list[dict]]] = None,
         silent: Optional[bool] = None,
         context_variables: Optional[dict[str, Any]] = None,
+        validate_name: bool = True,
     ):
         """Args:
         name (str): name of the agent.
@@ -164,7 +165,7 @@ class ConversableAgent(LLMAgent):
         )
 
         # Validation for name using regex to detect any whitespace
-        if re.search(r"\s", name):
+        if validate_name and re.search(r"\s", name):
             raise ValueError(f"The name of the agent cannot contain any whitespace. The name provided is: '{name}'")
         self._name = name
         # a dictionary of conversations, default value is list

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -163,6 +163,9 @@ class ConversableAgent(LLMAgent):
             code_execution_config.copy() if hasattr(code_execution_config, "copy") else code_execution_config
         )
 
+        # Validation for name using regex to detect any whitespace
+        if re.search(r"\s", name):
+            raise ValueError(f"The name of the agent cannot contain any whitespace. The name provided is: '{name}'")
         self._name = name
         # a dictionary of conversations, default value is list
         if chat_messages is None:

--- a/autogen/agentchat/realtime_agent/realtime_agent.py
+++ b/autogen/agentchat/realtime_agent/realtime_agent.py
@@ -76,7 +76,6 @@ class RealtimeAgent(ConversableAgent):
             chat_messages=None,
             silent=None,
             context_variables=None,
-            validate_name=False,
         )
         self._logger = logger
         self._function_observer = FunctionObserver(logger=logger)
@@ -109,6 +108,10 @@ class RealtimeAgent(ConversableAgent):
         self._start_swarm_chat = False
         self._initial_agent: Optional[SwarmAgent] = None
         self._agents: Optional[list[SwarmAgent]] = None
+
+    def _validate_name(self, name: str) -> None:
+        # RealtimeAgent does not need to validate the name
+        pass
 
     @property
     def logger(self) -> Logger:

--- a/autogen/agentchat/realtime_agent/realtime_agent.py
+++ b/autogen/agentchat/realtime_agent/realtime_agent.py
@@ -76,6 +76,7 @@ class RealtimeAgent(ConversableAgent):
             chat_messages=None,
             silent=None,
             context_variables=None,
+            validate_name=False,
         )
         self._logger = logger
         self._function_observer = FunctionObserver(logger=logger)

--- a/test/agentchat/contrib/capabilities/test_vision_capability.py
+++ b/test/agentchat/contrib/capabilities/test_vision_capability.py
@@ -40,7 +40,7 @@ def vision_capability(lmm_config):
 
 @pytest.fixture
 def conversable_agent():
-    return ConversableAgent(name="conversable agent", llm_config=False)
+    return ConversableAgent(name="conversable_agent", llm_config=False)
 
 
 @pytest.mark.skipif(

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -39,6 +39,15 @@ def conversable_agent():
     )
 
 
+@pytest.mark.parametrize("name", ["agent name", "agent_name ", " agent\nname", " agent\tname"])
+def test_conversable_agent_name_with_white_space_raises_error(name: str) -> None:
+    with pytest.raises(
+        ValueError,
+        match=f"The name of the agent cannot contain any whitespace. The name provided is: '{name}'",
+    ):
+        ConversableAgent(name=name)
+
+
 def test_sync_trigger():
     agent = ConversableAgent("a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
     agent1 = ConversableAgent("a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")

--- a/test/messages/test_agent_messages.py
+++ b/test/messages/test_agent_messages.py
@@ -732,7 +732,7 @@ class TestGroupChatResumeMessage:
 class TestGroupChatRunChatMessage:
     def test_print(self, uuid: UUID) -> None:
         speaker = ConversableAgent(
-            "assistant uno", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
+            "assistant_uno", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
         )
         silent = False
 
@@ -743,7 +743,7 @@ class TestGroupChatRunChatMessage:
             "type": "group_chat_run_chat",
             "content": {
                 "uuid": uuid,
-                "speaker_name": "assistant uno",
+                "speaker_name": "assistant_uno",
                 "verbose": True,
             },
         }
@@ -754,7 +754,7 @@ class TestGroupChatRunChatMessage:
 
         # print(mock.call_args_list)
 
-        expected_call_args_list = [call("\x1b[32m\nNext speaker: assistant uno\n\x1b[0m", flush=True)]
+        expected_call_args_list = [call("\x1b[32m\nNext speaker: assistant_uno\n\x1b[0m", flush=True)]
 
         assert mock.call_args_list == expected_call_args_list
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR adds regex-based validation to the ConversableAgent class to ensure the name attribute does not contain any whitespace. A ValueError with a clear message is raised if validation fails.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #451 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
