### PR TITLE
fix: typos in documentation files

### DIFF
--- a/website/_blogs/2023-12-01-AutoGenStudio/index.mdx
+++ b/website/_blogs/2023-12-01-AutoGenStudio/index.mdx
@@ -226,7 +226,7 @@ Yes. AutoGen standardizes on the openai model api format, and you can use any ap
 For other OSS models, we recommend using a server such as vllm to instantiate an openai compliant endpoint.
 
 **Q: The Server Starts But I Can't Access the UI**
-A: If you are running the server on a remote machine (or a local machine that fails to resolve localhost correstly), you may need to specify the host address. By default, the host address is set to `localhost`. You can specify the host address using the `--host <host>` argument. For example, to start the server on port 8081 and local address such that it is accessible from other machines on the network, you can run the following command:
+A: If you are running the server on a remote machine (or a local machine that fails to resolve localhost correctly), you may need to specify the host address. By default, the host address is set to `localhost`. You can specify the host address using the `--host <host>` argument. For example, to start the server on port 8081 and local address such that it is accessible from other machines on the network, you can run the following command:
 
 ```bash
 autogenstudio ui --port 8081 --host 0.0.0.0

--- a/website/docs/autogen-studio/getting-started.mdx
+++ b/website/docs/autogen-studio/getting-started.mdx
@@ -32,7 +32,7 @@ title: Getting Started
 
 ![ARA](./img/ara_stockprices.png)
 
-AutoGen Studio is an low-code interface built to help you rapidly prototype AI agents, enhance them with skills, compose them into workflows and interact with them to accomplish tasks. It is built on top of the [AutoGen](https://docs.ag2.ai) framework, which is a toolkit for building AI agents.
+AutoGen Studio is a low-code interface built to help you rapidly prototype AI agents, enhance them with skills, compose them into workflows and interact with them to accomplish tasks. It is built on top of the [AutoGen](https://docs.ag2.ai) framework, which is a toolkit for building AI agents.
 
 Code for AutoGen Studio is on GitHub at [build-with-ag2](https://github.com/ag2ai/build-with-ag2/tree/main/samples/apps/autogen-studio)
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `correstly` to `correctly`
Corrected `AutoGen Studio is an low-code` to `AutoGen Studio is a low-code`

Please review the changes and let me know if any additional changes are needed.