### PR TITLE
Fix typos and formatting in documentation

### DIFF
--- a/website/docs/autogen-studio/usage.mdx
+++ b/website/docs/autogen-studio/usage.mdx
@@ -10,7 +10,7 @@ AutoGen Studio implements several entities that are ultimately composed into a w
 
 ### Skills
 
-A skill is a python function that implements the solution to a task. In general, a good skill has a descriptive name (e.g. generate*images), extensive docstrings and good defaults (e.g., writing out files to disk for persistence and reuse). Skills can be \_associated with* or _attached to_ agent specifications.
+A skill is a python function that implements the solution to a task. In general, a good skill has a descriptive name (e.g. generate_images), extensive docstrings and good defaults (e.g., writing out files to disk for persistence and reuse). Skills can be \_associated with* or _attached to_ agent specifications.
 
 ![AutoGen Studio Skill Interface](./img/skill.png)
 
@@ -61,7 +61,7 @@ The agent workflow responds by _writing and executing code_ to create a python p
 
 > Note: You can also view the debug console that generates useful information to see how the agents are interacting in the background. */}
 
-{/* - Build: Users begin by constructing their workflows. They may incorporate previously developed skills/models into agents within the workflow. User's can immediately test their workflows in the the same view or in a saved session in the playground.
+{/* - Build: Users begin by constructing their workflows. They may incorporate previously developed skills/models into agents within the workflow. User's can immediately test their workflows in the same view or in a saved session in the playground.
 
 - Playground: Users can start a new session, select an agent workflow, and engage in a "chat" with this agent workflow. It is important to note the significant differences between a traditional chat with a Large Language Model (LLM) and a chat with a group of agents. In the former, the response is typically a single formatted reply, while in the latter, it consists of a history of conversations among the agents.
 

--- a/website/docs/tutorial/code-executors.ipynb
+++ b/website/docs/tutorial/code-executors.ipynb
@@ -72,7 +72,7 @@
     "code block that prints a random number.\n",
     "First we create an agent with the code executor\n",
     "that uses a temporary directory to store the code files.\n",
-    "We specify `human_input_mode=\"ALWAYS\"` to manually validate the safety of the the code being \n",
+    "We specify `human_input_mode=\"ALWAYS\"` to manually validate the safety of the code being \n",
     "executed."
    ]
   },
@@ -441,7 +441,7 @@
    "metadata": {},
    "source": [
     "Now we can try a more complex example that involves querying the web.\n",
-    "Let's say we want to get the the stock price gains year-to-date for\n",
+    "Let's say we want to get the stock price gains year-to-date for\n",
     "Tesla and Meta (formerly Facebook). We can also use the two agents\n",
     "with several iterations of conversation.\n"
    ]


### PR DESCRIPTION


Changes in website/docs/autogen-studio/usage.mdx:
- Fix function name format: generate*images -> generate_images


Changes in website/docs/tutorial/code-executors.ipynb:
- Remove duplicate "the": "validate the safety of the the code" -> "validate the safety of the code"
- Remove duplicate "the": "get the the stock price gains" -> "get the stock price gains"

These changes improve documentation readability by fixing formatting inconsistencies and removing redundant words.
