### PR TITLE
Fix typos and grammar

### DIFF
--- a/dotnet/src/AutoGen.Core/Extension/GroupChatExtension.cs
+++ b/dotnet/src/AutoGen.Core/Extension/GroupChatExtension.cs
@@ -92,7 +92,7 @@ public static class GroupChatExtension
                 .FindLastIndex(x => x.IsGroupChatClearMessage());
 
         // if multiple clr messages, e.g [msg, clr, msg, clr, msg, clr, msg]
-        // only keep the the messages after the second last clr message.
+        // only keep the messages after the second last clr message.
         if (messages.Count(m => m.IsGroupChatClearMessage()) > 1)
         {
             lastCLRMessageIndex = messages.ToList()

--- a/website/docs/ecosystem/azure_cosmos_db.mdx
+++ b/website/docs/ecosystem/azure_cosmos_db.mdx
@@ -8,7 +8,7 @@ sidebarTitle: Azure Cosmos DB
 
 Azure Cosmos DB is a fully managed [NoSQL](https://learn.microsoft.com/en-us/azure/cosmos-db/distributed-nosql), [relational](https://learn.microsoft.com/en-us/azure/cosmos-db/distributed-relational), and [vector database](https://learn.microsoft.com/azure/cosmos-db/vector-database). It offers single-digit millisecond response times, automatic and instant scalability, along with guaranteed speed at any scale. Your business continuity is assured with up to 99.999% availability backed by SLA.
 
-Your can simplify your application development by using this single database service for all your AI agent memory system needs, from [geo-replicated distributed cache](https://medium.com/@marcodesanctis2/using-azure-cosmos-db-as-your-persistent-geo-replicated-distributed-cache-b381ad80f8a0) to tracing/logging to [vector database](https://learn.microsoft.com/en-us/azure/cosmos-db/vector-database).
+You can simplify your application development by using this single database service for all your AI agent memory system needs, from [geo-replicated distributed cache](https://medium.com/@marcodesanctis2/using-azure-cosmos-db-as-your-persistent-geo-replicated-distributed-cache-b381ad80f8a0) to tracing/logging to [vector database](https://learn.microsoft.com/en-us/azure/cosmos-db/vector-database).
 
 Learn more about how Azure Cosmos DB enhances the performance of your [AI agent](https://learn.microsoft.com/en-us/azure/cosmos-db/ai-agents).
 


### PR DESCRIPTION

Changes:
1. dotnet/src/AutoGen.Core/Extension/GroupChatExtension.cs
- // only keep the the messages
+ // only keep the messages
Reason: Removed duplicate word "the"

2. website/docs/ecosystem/azure_cosmos_db.mdx  
- Your can simplify
+ You can simplify
Reason: Fixed grammar error

These minor changes improve documentation clarity and code readability.