### PR TITLE
 Fix incorrect link path in documentation

### DIFF
--- a/dotnet/website/articles/Roundrobin-chat.md
+++ b/dotnet/website/articles/Roundrobin-chat.md
@@ -10,7 +10,7 @@ flowchart LR
 ```
 
 > [!NOTE]
-> Complete code can be found in [Example11_Sequential_GroupChat_Example](https://github.com/ag2ai/ag2/blob/dotnet/dotnet/sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs);
+> Complete code can be found in [Example11_Sequential_GroupChat_Example](https://github.com/ag2ai/ag2/blob/main/dotnet/sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs);
 
 Step 1: Add required using statements
 


### PR DESCRIPTION


Changes:
1. dotnet/website/articles/Roundrobin-chat.md
- https://github.com/ag2ai/ag2/blob/dotnet/dotnet/sample/...
+ https://github.com/ag2ai/ag2/blob/main/dotnet/sample/...
Reason: Updated link path from 'dotnet' to 'main' branch to ensure correct example code reference

The change fixes a broken link in the documentation by pointing to the correct branch ('main' instead of 'dotnet'), ensuring users can access the example code properly.