### PR TITLE
Fix typos in variable names and documentation labels

### DIFF
--- a/dotnet/test/AutoGen.Anthropic.Tests/AnthropicClientAgentTest.cs
+++ b/dotnet/test/AutoGen.Anthropic.Tests/AnthropicClientAgentTest.cs
@@ -176,7 +176,7 @@ public class AnthropicClientAgentTest
             )
             .RegisterMessageConnector();
 
-        var weatherFunctionArgumets = """
+        var weatherFunctionArguments = """
                                       {
                                           "city": "Philadelphia",
                                           "date": "6/14/2024"
@@ -184,8 +184,8 @@ public class AnthropicClientAgentTest
                                       """;
 
         var function = new AnthropicTestFunctionCalls();
-        var functionCallResult = await function.GetWeatherReportWrapper(weatherFunctionArgumets);
-        var toolCall = new ToolCall(function.WeatherReportFunctionContract.Name!, weatherFunctionArgumets)
+        var functionCallResult = await function.GetWeatherReportWrapper(weatherFunctionArguments);
+        var toolCall = new ToolCall(function.WeatherReportFunctionContract.Name!, weatherFunctionArguments)
         {
             ToolCallId = "get_weather",
             Result = functionCallResult,

--- a/dotnet/website/articles/getting-start.md
+++ b/dotnet/website/articles/getting-start.md
@@ -23,4 +23,4 @@ Getting started with AutoGen.Net by following the [tutorial](../tutorial/Chat-wi
 You can find more examples under the [sample project](https://github.com/ag2ai/ag2/tree/dotnet/dotnet/sample/AutoGen.BasicSamples).
 
 ### Report a bug or request a feature
-You can report a bug or request a feature by creating a new issue in the [github issue](https://github.com/ag2ai/ag2/issues) and specifying the label "donet" 
+You can report a bug or request a feature by creating a new issue in the [github issue](https://github.com/ag2ai/ag2/issues) and specifying the label "dotnet" 


### PR DESCRIPTION

Changes:
1. dotnet/test/AutoGen.Anthropic.Tests/AnthropicClientAgentTest.cs:
- Old: weatherFunctionArgumets -> New: weatherFunctionArguments
Reason: Fixed spelling error in variable name for better code consistency

2. dotnet/website/articles/getting-start.md:
- Old: "donet" -> New: "dotnet" 
Reason: Corrected label name to match official .NET platform naming

Files modified:
- dotnet/test/AutoGen.Anthropic.Tests/AnthropicClientAgentTest.cs
- dotnet/website/articles/getting-start.md