### PR TITLE
Fix Grammar and Variable Name Typos

### DIFF
--- a/dotnet/test/AutoGen.Mistral.Tests/MistralClientAgentTests.cs
+++ b/dotnet/test/AutoGen.Mistral.Tests/MistralClientAgentTests.cs
@@ -87,13 +87,13 @@ public partial class MistralClientAgentTests
             randomSeed: 0)
             .RegisterMessageConnector();
 
-        var weatherFunctionArgumets = """
+        var weatherFunctionArguments = """
             {
                 "city": "Seattle"
             }
             """;
-        var functionCallResult = await this.GetWeatherWrapper(weatherFunctionArgumets);
-        var toolCall = new ToolCall(this.GetWeatherFunctionContract.Name!, weatherFunctionArgumets)
+        var functionCallResult = await this.GetWeatherWrapper(weatherFunctionArguments);
+        var toolCall = new ToolCall(this.GetWeatherFunctionContract.Name!, weatherFunctionArguments)
         {
             ToolCallId = "012345678", // Mistral AI requires the tool call id to be a length of 9
             Result = functionCallResult,
@@ -101,7 +101,7 @@ public partial class MistralClientAgentTests
         IMessage[] chatHistory = [
             new TextMessage(Role.User, "what's the weather in Seattle?"),
             new ToolCallMessage([toolCall], from: agent.Name),
-            new ToolCallResultMessage([toolCall], weatherFunctionArgumets),
+            new ToolCallResultMessage([toolCall], weatherFunctionArguments),
         ];
 
         var reply = await agent.SendAsync(chatHistory: chatHistory);

--- a/dotnet/test/AutoGen.Ollama.Tests/OllamaAgentTests.cs
+++ b/dotnet/test/AutoGen.Ollama.Tests/OllamaAgentTests.cs
@@ -96,7 +96,7 @@ public class OllamaAgentTests
     }
 
     [ApiKeyFact("OLLAMA_HOST")]
-    public async Task ItReturnValidMessageUsingLLavaAsync()
+    public async Task ItReturnsValidMessageUsingLLavaAsync()
     {
         var host = Environment.GetEnvironmentVariable("OLLAMA_HOST")
                    ?? throw new InvalidOperationException("OLLAMA_HOST is not set.");
@@ -160,7 +160,7 @@ public class OllamaAgentTests
     }
 
     [ApiKeyFact("OLLAMA_HOST")]
-    public async Task ItReturnValidStreamingMessageUsingLLavaAsync()
+    public async Task ItReturnsValidStreamingMessageUsingLLavaAsync()
     {
         var host = Environment.GetEnvironmentVariable("OLLAMA_HOST")
                    ?? throw new InvalidOperationException("OLLAMA_HOST is not set.");


### PR DESCRIPTION


Changes in dotnet/test/AutoGen.Ollama.Tests/OllamaAgentTests.cs:

1. Method names:
- ItReturnValidMessageUsingLLavaAsync -> ItReturnsValidMessageUsingLLavaAsync
- ItReturnValidStreamingMessageUsingLLavaAsync -> ItReturnsValidStreamingMessageUsingLLavaAsync

2. Variable name:
- weatherFunctionArgumets -> weatherFunctionArguments

Reason: Fixed grammar for third-person singular verb form with "It" subject and corrected spelling of "Arguments". No functional changes, only improved readability and naming consistency.