### PR TITLE
fix: support openai o1 model with custom model name.

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -303,8 +303,8 @@ class OpenAIClient:
             completions = self._oai_client.chat.completions if "messages" in params else self._oai_client.completions  # type: ignore [attr-defined]
             create_or_parse = completions.create
 
-        # needs to be updated when the o3 is released to generalize
-        is_o1 = "model" in params and params["model"].startswith("o1")
+        # HACK: needs to be updated when the o3 is released to generalize
+        is_o1 = "model" in params and "o1-" in params["model"]
 
         # If streaming is enabled and has messages, then iterate over the chunks of the response.
         if params.get("stream", False) and "messages" in params and not is_o1:
@@ -461,8 +461,8 @@ class OpenAIClient:
         if "max_tokens" in params:
             params["max_completion_tokens"] = params.pop("max_tokens")
 
-        # TODO - When o1-mini and o1-preview point to newer models (e.g. 2024-12-...), remove them from this list but leave the 2024-09-12 dated versions
-        system_not_allowed = model_name in ("o1-mini", "o1-preview", "o1-mini-2024-09-12", "o1-preview-2024-09-12")
+        # HACK: When o1-mini and o1-preview point to newer models (e.g. 2024-12-...), remove them from this list but leave the 2024-09-12 dated versions
+        system_not_allowed = "o1-" in model_name
 
         if "messages" in params and system_not_allowed:
             # o1-mini (2024-09-12) and o1-preview (2024-09-12) don't support role='system' messages, only 'user' and 'assistant'


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For my company, MediaTek, we use custom name called `aide-o1-preview` and `aide-o1-mini` for `o1` and `o1-mini` via `Azure Service`.
I know using `"o1-" in model_name` to detect o1 model can be bad, but as far as I know, only OpenAI o1 model contains `o1-` and it perfectly solve my problem.

I am open to discuss more about how to fix it better.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

#347 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
