### PR TITLE
making TextMessage take a list[dict[str, str | dict[str, Any]]] as value because MultimodalConversableAgent was breaking while processing images.

### DIFF
--- a/autogen/messages/agent_messages.py
+++ b/autogen/messages/agent_messages.py
@@ -189,7 +189,7 @@ class ToolCallMessage(BasePrintReceivedMessage):
 
 @wrap_message
 class TextMessage(BasePrintReceivedMessage):
-    content: Optional[Union[str, int, float, bool, list[dict[str, str]]]] = None  # type: ignore [assignment]
+    content: Optional[Union[str, int, float, bool, list[dict[str, str | dict[str, Any]]]]] = None  # type: ignore [assignment]
 
     def print(self, f: Optional[Callable[..., Any]] = None) -> None:
         f = f or print

--- a/autogen/messages/agent_messages.py
+++ b/autogen/messages/agent_messages.py
@@ -4,7 +4,7 @@
 
 from abc import ABC
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -189,7 +189,7 @@ class ToolCallMessage(BasePrintReceivedMessage):
 
 @wrap_message
 class TextMessage(BasePrintReceivedMessage):
-    content: Optional[Union[str, int, float, bool, List[Dict[str, Union[str, Dict[str, Any]]]]]] = None  # type: ignore [assignment]
+    content: Optional[Union[str, int, float, bool, list[dict[str, Union[str, dict[str, Any]]]]]] = None  # type: ignore [assignment]
 
     def print(self, f: Optional[Callable[..., Any]] = None) -> None:
         f = f or print

--- a/autogen/messages/agent_messages.py
+++ b/autogen/messages/agent_messages.py
@@ -4,7 +4,7 @@
 
 from abc import ABC
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -189,7 +189,7 @@ class ToolCallMessage(BasePrintReceivedMessage):
 
 @wrap_message
 class TextMessage(BasePrintReceivedMessage):
-    content: Optional[Union[str, int, float, bool, list[dict[str, str | dict[str, Any]]]]] = None  # type: ignore [assignment]
+    content: Optional[Union[str, int, float, bool, List[Dict[str, Union[str, Dict[str, Any]]]]]] = None  # type: ignore [assignment]
 
     def print(self, f: Optional[Callable[..., Any]] = None) -> None:
         f = f or print

--- a/test/messages/test_agent_messages.py
+++ b/test/messages/test_agent_messages.py
@@ -330,9 +330,7 @@ class TestTextMessage:
                         }
                     ]
                 },
-                {
-                    "url": "https://media.githubusercontent.com/media/ag2ai/ag2/refs/heads/main/website/static/img/autogen_agentchat.png"
-                },
+                "<image>",
             ),
         ],
     )

--- a/test/messages/test_agent_messages.py
+++ b/test/messages/test_agent_messages.py
@@ -319,6 +319,21 @@ class TestTextMessage:
                 },
                 "Please extract table from the following image and convert it to Markdown.",
             ),
+            (
+                {
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "https://media.githubusercontent.com/media/ag2ai/ag2/refs/heads/main/website/static/img/autogen_agentchat.png"
+                            },
+                        }
+                    ]
+                },
+                {
+                    "url": "https://media.githubusercontent.com/media/ag2ai/ag2/refs/heads/main/website/static/img/autogen_agentchat.png"
+                },
+            ),
         ],
     )
     def test_print_messages(


### PR DESCRIPTION
making TextMessage take a list[dict[str, str | dict[str, Any]]] as value because MultimodalConversableAgent was breaking while processing images.

<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

making TextMessage take a list[dict[str, str | dict[str, Any]]] as value because MultimodalConversableAgent was breaking while processing images. Now with TextMessage taking dict with object value this should not breaking existing functionality of MultimodalConversableAgent

## Related issue number
#558 

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
