### PR TITLE
docs: Fix incomplete Gunicorn command Update faqs.mdx

### DIFF
--- a/website/docs/autogen-studio/faqs.mdx
+++ b/website/docs/autogen-studio/faqs.mdx
@@ -26,10 +26,21 @@ For other OSS models, we recommend using a server such as vllm, LMStudio, Ollama
 
 ## Q: The server starts but I can't access the UI
 
-A: If you are running the server on a remote machine (or a local machine that fails to resolve localhost correctly), you may need to specify the host address. By default, the host address is set to `localhost`. You can specify the host address using the `--host <host>` argument. For example, to start the server on port 8081 and local address such that it is accessible from other machines on the network, you can run the following command:
+A: If you are running the server on a remote machine (or a local machine that fails to resolve localhost correctly), you may need to specify the host address. By default, the host address is set to `localhost`. You can specify the host address using the `--host <host>` argument. For example:
+
+- **For Docker or cloud environments (external access required):**
 
 ```bash
-autogenstudio ui --port 8081 --host 0.0.0.0
+gunicorn -w $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) --timeout 12600 -k uvicorn.workers.UvicornWorker autogenstudio.web.app:app --bind "0.0.0.0:8081"
+```
+
+- **For local development (restrict to localhost):**
+
+```bash
+gunicorn -w $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) --timeout 12600 -k uvicorn.workers.UvicornWorker autogenstudio.web.app:app --bind "127.0.0.1:8081"
+```
+
+To start the server on port 8081 and make it accessible from other machines on the network, use the command for Docker/cloud environments.
 ```
 
 ## Q: Can I export my agent workflows for use in a python app?
@@ -82,8 +93,16 @@ COPY --chown=user . $HOME/app
 CMD gunicorn -w $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) --timeout 12600 -k uvicorn.workers.UvicornWorker autogenstudio.web.app:app --bind "0.0.0.0:8081"
 ```
 
-Using Gunicorn as the application server for improved performance is recommended. To run AutoGen Studio with Gunicorn, you can use the following command:
+To run AutoGen Studio with Gunicorn, use one of the following commands based on your environment:
+
+- **For Docker or cloud environments (external access required):**
 
 ```bash
 gunicorn -w $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) --timeout 12600 -k uvicorn.workers.UvicornWorker autogenstudio.web.app:app --bind "0.0.0.0:8081"
+```
+
+- **For local development (restrict to localhost):**
+
+```bash
+gunicorn -w $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) --timeout 12600 -k uvicorn.workers.UvicornWorker autogenstudio.web.app:app --bind "127.0.0.1:8081"
 ```

--- a/website/docs/autogen-studio/faqs.mdx
+++ b/website/docs/autogen-studio/faqs.mdx
@@ -85,5 +85,5 @@ CMD gunicorn -w $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) --timeout 12600 -k uvi
 Using Gunicorn as the application server for improved performance is recommended. To run AutoGen Studio with Gunicorn, you can use the following command:
 
 ```bash
-gunicorn -w $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) --timeout 12600 -k uvicorn.workers.UvicornWorker autogenstudio.web.app:app --bind
+gunicorn -w $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) --timeout 12600 -k uvicorn.workers.UvicornWorker autogenstudio.web.app:app --bind "0.0.0.0:8081"
 ```


### PR DESCRIPTION
## Why are these changes needed?
 
I noticed a  issue in the last code block where the Gunicorn command for launching AutoGen Studio was incomplete. The command was missing the port specification, which is necessary for the server to run properly.

I’ve updated it to include the correct binding to `0.0.0.0:8081`. This should resolve the issue and allow the server to start as expected.  

Here’s the corrected command:  
```bash  
gunicorn -w $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) --timeout 12600 -k uvicorn.workers.UvicornWorker autogenstudio.web.app:app --bind "0.0.0.0:8081"  
```

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
