### PR TITLE
Add retries and xfail on Gemini test failed on ResourceExhausted exception

### DIFF
--- a/test/agentchat/realtime_agent/clients/test_gemini_realtime_client.py
+++ b/test/agentchat/realtime_agent/clients/test_gemini_realtime_client.py
@@ -11,7 +11,7 @@ from anyio import move_on_after
 from autogen.agentchat.realtime_agent.clients import GeminiRealtimeClient, RealtimeClientProtocol
 from autogen.agentchat.realtime_agent.realtime_events import AudioDelta, SessionCreated
 
-from ....conftest import Credentials
+from ....conftest import Credentials, suppress_gemini_resource_exhausted
 
 
 class TestGeminiRealtimeClient:
@@ -31,6 +31,7 @@ class TestGeminiRealtimeClient:
         assert isinstance(client, RealtimeClientProtocol)
 
     @pytest.mark.gemini
+    @suppress_gemini_resource_exhausted
     @pytest.mark.asyncio
     async def test_not_connected(self, client: GeminiRealtimeClient) -> None:
         with pytest.raises(RuntimeError, match=r"Client is not connected, call connect\(\) first."):
@@ -41,6 +42,7 @@ class TestGeminiRealtimeClient:
         assert not scope.cancelled_caught
 
     @pytest.mark.gemini
+    @suppress_gemini_resource_exhausted
     @pytest.mark.asyncio
     async def test_start_read_events(self, client: GeminiRealtimeClient) -> None:
         mock = MagicMock()
@@ -63,6 +65,7 @@ class TestGeminiRealtimeClient:
         assert isinstance(calls_args[0][0], SessionCreated)
 
     @pytest.mark.gemini
+    @suppress_gemini_resource_exhausted
     @pytest.mark.asyncio
     async def test_send_text(self, client: GeminiRealtimeClient) -> None:
         mock = MagicMock()

--- a/test/agentchat/realtime_agent/clients/test_gemini_realtime_client.py
+++ b/test/agentchat/realtime_agent/clients/test_gemini_realtime_client.py
@@ -32,12 +32,12 @@ class TestGeminiRealtimeClient:
 
     @pytest.mark.gemini
     @suppress_gemini_resource_exhausted
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_not_connected(self, client: GeminiRealtimeClient) -> None:
         with pytest.raises(RuntimeError, match=r"Client is not connected, call connect\(\) first."):
             with move_on_after(1) as scope:
                 async for _ in client.read_events():
-                    pass
+                    assert False
 
         assert not scope.cancelled_caught
 

--- a/test/agentchat/test_agent_logging.py
+++ b/test/agentchat/test_agent_logging.py
@@ -16,7 +16,7 @@ from _pytest.mark import ParameterSet
 import autogen
 import autogen.runtime_logging
 
-from ..conftest import Credentials, credentials_all_llms
+from ..conftest import Credentials, credentials_all_llms, suppress_gemini_resource_exhausted
 
 TEACHER_MESSAGE = """
     You are roleplaying a math teacher, and your job is to help your students with linear algebra.
@@ -267,6 +267,7 @@ def _test_groupchat_logging(credentials: Credentials, credentials2: Credentials,
 
 
 @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
+@suppress_gemini_resource_exhausted
 def test_groupchat_logging(
     credentials_from_test_param: Credentials,
     db_connection: Generator[Optional[sqlite3.Connection], Any, None],

--- a/test/agentchat/test_agent_logging.py
+++ b/test/agentchat/test_agent_logging.py
@@ -175,6 +175,7 @@ def _test_two_agents_logging(
 
 
 @pytest.mark.parametrize("credentials_fixture", credentials_all_llms)
+@suppress_gemini_resource_exhausted
 def test_two_agents_logging(
     credentials_fixture: ParameterSet,
     request: pytest.FixtureRequest,

--- a/test/agentchat/test_assistant_agent.py
+++ b/test/agentchat/test_assistant_agent.py
@@ -12,7 +12,7 @@ import pytest
 
 from autogen.agentchat import AssistantAgent, UserProxyAgent
 
-from ..conftest import Credentials, credentials_all_llms
+from ..conftest import Credentials, credentials_all_llms, suppress_gemini_resource_exhausted
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -56,6 +56,7 @@ def _test_ai_user_proxy_agent(credentials: Credentials) -> None:
 
 
 @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
+@suppress_gemini_resource_exhausted
 def test_ai_user_proxy_agent(
     credentials_from_test_param: Credentials,
 ) -> None:

--- a/test/agentchat/test_async.py
+++ b/test/agentchat/test_async.py
@@ -12,7 +12,7 @@ import pytest
 
 import autogen
 
-from ..conftest import Credentials, credentials_all_llms
+from ..conftest import Credentials, credentials_all_llms, suppress_gemini_resource_exhausted
 
 
 def get_market_news(ind, ind_upper):
@@ -89,6 +89,7 @@ async def _test_async_groupchat(credentials: Credentials):
 
 
 @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
+@suppress_gemini_resource_exhausted
 @pytest.mark.asyncio
 async def test_async_groupchat(
     credentials_from_test_param: Credentials,
@@ -163,6 +164,7 @@ async def _test_stream(credentials: Credentials):
 
 
 @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
+@suppress_gemini_resource_exhausted
 @pytest.mark.asyncio
 async def test_stream(
     credentials_from_test_param: Credentials,

--- a/test/agentchat/test_async_get_human_input.py
+++ b/test/agentchat/test_async_get_human_input.py
@@ -12,7 +12,7 @@ import pytest
 
 import autogen
 
-from ..conftest import Credentials, credentials_all_llms
+from ..conftest import Credentials, credentials_all_llms, suppress_gemini_resource_exhausted
 
 
 async def _test_async_get_human_input(credentials: Credentials) -> None:
@@ -41,6 +41,7 @@ async def _test_async_get_human_input(credentials: Credentials) -> None:
 
 
 @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
+@suppress_gemini_resource_exhausted
 @pytest.mark.asyncio
 async def test_async_get_human_input(
     credentials_from_test_param: Credentials,
@@ -77,6 +78,7 @@ async def _test_async_max_turn(credentials: Credentials):
 
 
 @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
+@suppress_gemini_resource_exhausted
 @pytest.mark.asyncio
 async def test_async_max_turn(
     credentials_from_test_param: Credentials,

--- a/test/agentchat/test_async_get_human_input.py
+++ b/test/agentchat/test_async_get_human_input.py
@@ -67,7 +67,7 @@ async def _test_async_max_turn(credentials: Credentials):
     user_proxy.a_get_human_input = AsyncMock(return_value="Not funny. Try again.")
 
     res = await user_proxy.a_initiate_chat(
-        assistant, clear_history=True, max_turns=3, message="Hello, make a joke about AI."
+        assistant, clear_history=True, max_turns=3, message="Hello, make a non-offensive joke about AI."
     )
     print("Result summary:", res.summary)
     print("Human input:", res.human_input)

--- a/test/agentchat/test_cache_agent.py
+++ b/test/agentchat/test_cache_agent.py
@@ -15,7 +15,7 @@ from autogen.agentchat import AssistantAgent, UserProxyAgent
 from autogen.cache import Cache
 from autogen.import_utils import skip_on_missing_imports
 
-from ..conftest import Credentials
+from ..conftest import Credentials, suppress_gemini_resource_exhausted
 
 
 @pytest.mark.openai
@@ -80,6 +80,7 @@ def test_redis_cache(credentials_gpt_4o_mini: Credentials):
 
 @pytest.mark.skip(reason="Currently not working")
 @pytest.mark.gemini
+@suppress_gemini_resource_exhausted
 @pytest.mark.redis
 @skip_on_missing_imports(["openai", "redis"], "redis")
 def test_redis_cache_gemini(credentials_gemini_pro: Credentials):

--- a/test/agentchat/test_chats.py
+++ b/test/agentchat/test_chats.py
@@ -16,7 +16,7 @@ import autogen
 from autogen import AssistantAgent, GroupChat, GroupChatManager, UserProxyAgent, initiate_chats
 from autogen.agentchat.chat import _post_process_carryover_item
 
-from ..conftest import Credentials, credentials_all_llms
+from ..conftest import Credentials, credentials_all_llms, suppress_gemini_resource_exhausted
 
 
 @pytest.fixture
@@ -543,6 +543,7 @@ def _test_chats_w_func(credentials: Credentials, tasks_work_dir: str):
 
 
 @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
+@suppress_gemini_resource_exhausted
 def test_chats_w_func(
     credentials_from_test_param: Credentials,
     tasks_work_dir: str,

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -23,7 +23,7 @@ from autogen.agentchat import ConversableAgent, UserProxyAgent
 from autogen.agentchat.conversable_agent import register_function
 from autogen.exception_utils import InvalidCarryOverType, SenderRequired
 
-from ..conftest import Credentials, credentials_all_llms
+from ..conftest import Credentials, credentials_all_llms, suppress_gemini_resource_exhausted
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -1056,6 +1056,7 @@ async def _test_function_registration_e2e_async(credentials: Credentials) -> Non
 
 
 @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
+@suppress_gemini_resource_exhausted
 @pytest.mark.asyncio
 async def test_function_registration_e2e_async(
     credentials_from_test_param: Credentials,
@@ -1494,6 +1495,7 @@ def test_handle_carryover():
 
 
 @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
+@suppress_gemini_resource_exhausted
 def test_conversable_agent_with_whitespaces_in_name_end2end(
     credentials_from_test_param: Credentials,
     request: pytest.FixtureRequest,
@@ -1584,6 +1586,7 @@ def test_context_variables():
 
 @pytest.mark.skip(reason="This test is failing. We need to investigate the issue.")
 @pytest.mark.gemini
+@suppress_gemini_resource_exhausted
 def test_gemini_with_tools_parameters_set_to_is_annotated_with_none_as_default_value(
     credentials_gemini_pro: Credentials,
 ) -> None:

--- a/test/agentchat/test_dependancy_injection.py
+++ b/test/agentchat/test_dependancy_injection.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from autogen.agentchat import ConversableAgent, UserProxyAgent
 from autogen.tools import BaseContext, ChatContext, Depends
 
-from ..conftest import Credentials, credentials_all_llms
+from ..conftest import Credentials, credentials_all_llms, suppress_gemini_resource_exhausted
 
 
 class MyContext(BaseContext, BaseModel):
@@ -254,6 +254,7 @@ class TestDependencyInjection:
         )
 
     @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
+    @suppress_gemini_resource_exhausted
     @pytest.mark.parametrize("is_async", [False, True])
     @pytest.mark.asyncio
     async def test_end2end(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -369,7 +369,7 @@ credentials_all_llms = [
 T = TypeVar("T", bound=Callable[..., Any])
 
 
-def suppress(exception: type[BaseException], retries: Optional[int] = None, timeout: int = 60) -> Callable[[T], T]:
+def suppress(exception: type[BaseException], *, retries: Optional[int] = None, timeout: int = 60) -> Callable[[T], T]:
     """Suppresses the specified exception and retries the function a specified number of times.
 
     Args:
@@ -413,6 +413,6 @@ def suppress_gemini_resource_exhausted(func: T) -> T:
     with optional_import_block():
         from google.api_core.exceptions import ResourceExhausted
 
-        return suppress(ResourceExhausted)(func)
+        return suppress(ResourceExhausted, retries=2)(func)
 
     return func

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,16 +4,19 @@
 #
 # Portions derived from  https://github.com/microsoft/autogen are under the MIT License.
 # SPDX-License-Identifier: MIT
+import functools
 import os
 import re
+import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional, TypeVar
 
 import pytest
 from _pytest.outcomes import Skipped
 from pytest import CallInfo, Item
 
 import autogen
+from autogen.import_utils import optional_import_block
 
 KEY_LOC = str((Path(__file__).parents[1] / "notebook").resolve())
 OAI_CONFIG_LIST = "OAI_CONFIG_LIST"
@@ -362,3 +365,54 @@ credentials_all_llms = [
         marks=pytest.mark.anthropic,
     ),
 ]
+
+T = TypeVar("T", bound=Callable[..., Any])
+
+
+def suppress(exception: type[BaseException], retries: Optional[int] = None, timeout: int = 60) -> Callable[[T], T]:
+    """Suppresses the specified exception and retries the function a specified number of times.
+
+    Args:
+        exception (type[BaseException]): The exception to suppress.
+        retries (Optional[int]): The number of times to retry the function. If None, the function will tried once and just return in case of exception raised. Defaults to None.
+        timeout (int): The time to wait between retries in seconds. Defaults to 60.
+
+    """
+
+    def decorator(
+        func: T, exception: type[BaseException] = exception, retries: Optional[int] = retries, timeout: int = timeout
+    ) -> T:
+        @functools.wraps(func)
+        def wrapper(
+            *args: Any,
+            exception: type[BaseException] = exception,
+            retries: Optional[int] = retries,
+            timeout: int = timeout,
+            **kwargs: Any,
+        ) -> Any:
+            if retries is None:
+                try:
+                    return func(*args, **kwargs)
+                except exception:
+                    pytest.xfail(f"Suppressed '{exception}' raised")
+            else:
+                for i in range(retries):
+                    try:
+                        return func(*args, **kwargs)
+                    except exception:
+                        if i >= retries - 1:
+                            pytest.xfail(f"Suppressed '{exception}' raised {i + 1} times")
+                        time.sleep(timeout)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def suppress_gemini_resource_exhausted(func: T) -> T:
+    with optional_import_block():
+        from google.api_core.exceptions import ResourceExhausted
+
+        return suppress(ResourceExhausted)(func)
+
+    return func

--- a/test/test_conftest.py
+++ b/test/test_conftest.py
@@ -8,10 +8,11 @@
 
 import pytest
 
-from .conftest import Credentials, credentials_all_llms
+from .conftest import Credentials, credentials_all_llms, suppress_gemini_resource_exhausted
 
 
 @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
+@suppress_gemini_resource_exhausted
 def test_credentials_from_test_param_fixture(
     credentials_from_test_param: Credentials,
     request: pytest.FixtureRequest,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We often get a ReseourceExhausted exception in CI due to quota: 

https://github.com/ag2ai/ag2/actions/runs/12968968958/job/36172514039

This PR retries those tests after a 1 minute timeout. If they fail, after three retries it marks them as `xfail` (expected to fail).

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #655

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
