### PR TITLE
Sanitize pytest output by patching the _pytest._io.TerminalWritter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,6 +286,7 @@ markers = [
     "interop",
     "browser_use",
     "crawl4ai",
+    "run_in_separate_process",
 ]
 
 [tool.black]

--- a/test/test_conftest.py
+++ b/test/test_conftest.py
@@ -6,9 +6,11 @@
 # SPDX-License-Identifier: MIT
 
 
+import subprocess
+
 import pytest
 
-from .conftest import Credentials, credentials_all_llms, suppress_gemini_resource_exhausted
+from .conftest import Credentials, Secrets, credentials_all_llms, suppress_gemini_resource_exhausted
 
 
 @pytest.mark.parametrize("credentials_from_test_param", credentials_all_llms, indirect=True)
@@ -33,3 +35,37 @@ def test_credentials_from_test_param_fixture(
         assert first_config["api_type"] == "anthropic"
     else:
         assert False, f"Unknown LLM fixture: {current_llm}"
+
+
+class TestSecrets:
+    def test_sanitize_secrets(self):
+        Secrets.add_secret("mysecret")
+        data = "This contains mysecret and ysecre and somemysecreand should be sanitized."
+        sanitized = Secrets.sanitize_secrets(data)
+        assert sanitized == "This contains ***** and ***** and some*****and should be sanitized."
+
+    @pytest.mark.run_in_separate_process
+    def test_raise_exception_with_secret(self):
+        Secrets.add_secret("mysecret")
+        raise Exception("This is a test exception. mysecret exposed!!!")
+
+    def test_sensitive_output_is_sanitized(self):
+        # Run pytest for the sensitive tests and capture the output
+        result = subprocess.run(
+            [
+                "pytest",
+                "-m",
+                "run_in_separate_process",
+                "-s",
+                "test/test_conftest.py::TestSecrets::test_raise_exception_with_secret",
+            ],  # Run tests with the 'run_in_separate_process' marker
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        # Combine stdout and stderr to search for secrets
+        output = result.stdout + result.stderr
+
+        assert "mysecret" not in output, "Secret exposed in test output!"
+        assert "*****" in output, "Sanitization is not working as expected!"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR will add secret sanitization to pytest output so that if, for any case, a secret is printed in pytest report it will be replaced with '*****'

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #588
## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
