### PR TITLE
[Docs] Correct blog link in Browsing Capabilities blog

### DIFF
--- a/website/_blogs/2025-01-31-Websurfing-Tools/index.mdx
+++ b/website/_blogs/2025-01-31-Websurfing-Tools/index.mdx
@@ -32,7 +32,7 @@ tags: [tools, tool calling, web surfing, browser use, crawl4ai]
 
 ## Introduction
 
-Previously, in our [Cross-Framework LLM Tool Integration](/docs/blog/2024-12-20-Tools-interoperability/) guide, we combined tools from frameworks like **LangChain**, **CrewAI**, and **PydanticAI** to enhance AG2.
+Previously, in our [Cross-Framework LLM Tool Integration](/docs/blog/2024-12-20-Tools-interoperability) guide, we combined tools from frameworks like **LangChain**, **CrewAI**, and **PydanticAI** to enhance AG2.
 
 Now, we’re taking AG2 even further by integrating [`Browser Use`](https://github.com/browser-use/browser-use) and [`Crawl4AI`](https://github.com/unclecode/crawl4ai), enabling agents to navigate websites, extract dynamic content, and interact with web pages. This unlocks new possibilities for automated data collection, web automation, and more.
 ![Browser Use Example](/docs/use-cases/reference-agents/assets/websurferagent_animated.gif)

--- a/website/_blogs/2025-01-31-Websurfing-Tools/index.mdx
+++ b/website/_blogs/2025-01-31-Websurfing-Tools/index.mdx
@@ -32,7 +32,7 @@ tags: [tools, tool calling, web surfing, browser use, crawl4ai]
 
 ## Introduction
 
-Previously, in our [Cross-Framework LLM Tool Integration](/blog/2024-12-20-Tools-interoperability) guide, we combined tools from frameworks like **LangChain**, **CrewAI**, and **PydanticAI** to enhance AG2.
+Previously, in our [Cross-Framework LLM Tool Integration](/docs/blog/2024-12-20-Tools-interoperability/) guide, we combined tools from frameworks like **LangChain**, **CrewAI**, and **PydanticAI** to enhance AG2.
 
 Now, we’re taking AG2 even further by integrating [`Browser Use`](https://github.com/browser-use/browser-use) and [`Crawl4AI`](https://github.com/unclecode/crawl4ai), enabling agents to navigate websites, extract dynamic content, and interact with web pages. This unlocks new possibilities for automated data collection, web automation, and more.
 ![Browser Use Example](/docs/use-cases/reference-agents/assets/websurferagent_animated.gif)


### PR DESCRIPTION
## Why are these changes needed?

The link to a previous blog in the Browsing Capabilities blog needs an update based on new documentation.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
