### PR TITLE
docs: Fix grammar in image addition instructions

### DIFF
--- a/website/docs/use-cases/community-gallery/community-gallery.mdx
+++ b/website/docs/use-cases/community-gallery/community-gallery.mdx
@@ -20,7 +20,7 @@ Thank you for your interest in contributing! To add your demo to the gallery, pl
 
   - Updated `website/snippets/data/GalleryItems.mdx` file with your application entry.
 
-  - The application image added to the `static/img/gallery` directory if the image is local. If the image is hosted online, just update the `image` property with the URL of the image.
+  - The application image should be added to the `static/img/gallery` directory if the image is local. If the image is hosted online, just update the `image` property with the URL of the image.
 
   - Below is an example of an entry in the `website/snippets/data/GalleryItems.mdx` file:
 


### PR DESCRIPTION
## Why are these changes needed?

I noticed a grammatical error in the instructions for adding application images. The sentence was missing the word "should" to make it grammatically correct.

I've updated it to:  

- The application image **should be** added to the `static/img/gallery` directory if the image is local. If the image is hosted online, just update the `image` property with the URL of the image.  

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
