### PR TITLE
Expose question_message param in register swarm

### DIFF
--- a/autogen/agentchat/realtime/experimental/realtime_swarm.py
+++ b/autogen/agentchat/realtime/experimental/realtime_swarm.py
@@ -337,6 +337,7 @@ class SwarmableRealtimeAgent(SwarmableAgent):
         realtime_agent: "RealtimeAgent",
         initial_agent: ConversableAgent,
         agents: list[ConversableAgent],
+        question_message: Optional[str] = None,
     ) -> None:
         self._initial_agent = initial_agent
         self._agents = agents
@@ -344,6 +345,7 @@ class SwarmableRealtimeAgent(SwarmableAgent):
 
         self._answer_event: anyio.Event = anyio.Event()
         self._answer: str = ""
+        self.question_message = question_message or QUESTION_MESSAGE
 
         super().__init__(
             name=realtime_agent._name,
@@ -410,7 +412,7 @@ class SwarmableRealtimeAgent(SwarmableAgent):
         async def get_input() -> None:
             async with create_task_group() as tg:
                 tg.soonify(self.ask_question)(
-                    QUESTION_MESSAGE.format(messages[-1]["content"]),
+                    self.question_message.format(messages[-1]["content"]),
                     question_timeout=QUESTION_TIMEOUT_SECONDS,
                 )
 
@@ -457,6 +459,7 @@ def register_swarm(
     initial_agent: ConversableAgent,
     agents: list[ConversableAgent],
     system_message: Optional[str] = None,
+    question_message: Optional[str] = None,
 ) -> None:
     """Create a SwarmableRealtimeAgent.
 
@@ -465,7 +468,10 @@ def register_swarm(
         initial_agent (ConversableAgent): The initial agent.
         agents (list[ConversableAgent]): The agents in the swarm.
         system_message (Optional[str]): The system message to set for the agent. If None, the default system message is used.
+        question_message (Optional[str]): The question message to set for the agent. If None, the default QUESTION_MESSAGE is used.
     """
-    swarmable_agent = SwarmableRealtimeAgent(realtime_agent=realtime_agent, initial_agent=initial_agent, agents=agents)
+    swarmable_agent = SwarmableRealtimeAgent(
+        realtime_agent=realtime_agent, initial_agent=initial_agent, agents=agents, question_message=question_message
+    )
 
     swarmable_agent.configure_realtime_agent(system_message=system_message)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

To make the `question_message` that is sent to the `RealtimeAgent` configurable, we need to expose it as a param in `register_swarm` function, as we did for the `system_message`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #819 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
