### PR TITLE
[Bug fix]: Fix tool registration from a Tool

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -3100,9 +3100,6 @@ class ConversableAgent(LLMAgent):
         else:
             raise ValueError(f"Unsupported API style: {api_style}")
 
-        # Register in the agent's function map
-        self.register_function({tool.name: tool.func})
-
     def register_for_execution(
         self,
         name: Optional[str] = None,

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -408,7 +408,7 @@ class ConversableAgent(LLMAgent):
         """
         if name:
             func._name = name
-        else:
+        elif not hasattr(func, "_name"):
             func._name = func.__name__
 
         if description:

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -3100,6 +3100,9 @@ class ConversableAgent(LLMAgent):
         else:
             raise ValueError(f"Unsupported API style: {api_style}")
 
+        # Register in the agent's function map
+        self.register_function({tool.name: tool.func})
+
     def register_for_execution(
         self,
         name: Optional[str] = None,


### PR DESCRIPTION
## Why are these changes needed?

There's a bug with tools and swarm function registration: `Tool` does not support `__name__` but it has `_name`, so updated ConversableAgent._add_single_function to cater for this.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
