### PR TITLE
[Docs] Fix the export_module decorator to update the __module__ attribute of a symbol only when building the docs

### DIFF
--- a/autogen/doc_utils.py
+++ b/autogen/doc_utils.py
@@ -4,6 +4,7 @@
 
 __all__ = ["export_module"]
 
+import os
 from typing import Callable, TypeVar
 
 T = TypeVar("T")
@@ -11,6 +12,9 @@ T = TypeVar("T")
 
 def export_module(module: str) -> Callable[[T], T]:
     def decorator(cls: T) -> T:
+        if os.getenv("ADD_PDOC_PLACEHOLDER_TO_MODULE") is None:
+            return cls
+
         original_module = getattr(cls, "__module__", None)
         setattr(cls, "__module__", f"{original_module}__PDOC_PLACEHOLDER__{module}")
         return cls

--- a/website/generate_api_references.py
+++ b/website/generate_api_references.py
@@ -4,7 +4,27 @@
 
 from __future__ import annotations
 
-from autogen._website.generate_api_references import main
+import os
+from contextlib import contextmanager
+from typing import Generator
+
+
+@contextmanager
+def _add_pdoc_placeholder_env() -> Generator[None, None, None]:
+    """Add the environment variable ADD_PDOC_PLACEHOLDER_TO_MODULE to the current environment.
+
+    The export_module decorator in doc_utils.py uses this environment variable, if set, the decorator modifies the __module__ attribute of the decorated symbol.
+    If the environment variable is not set, the decorator does not modify the __module__ attribute.
+    """
+    os.environ["ADD_PDOC_PLACEHOLDER_TO_MODULE"] = "1"
+    try:
+        yield
+    finally:
+        os.environ.pop("ADD_PDOC_PLACEHOLDER_TO_MODULE")
+
 
 if __name__ == "__main__":
-    main()
+    with _add_pdoc_placeholder_env():
+        from autogen._website.generate_api_references import main
+
+        main()


### PR DESCRIPTION
## Related issue number

Closes #836 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
