### PR TITLE
Remove default code execution config from `run` executor agent

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -3272,6 +3272,8 @@ class ConversableAgent(LLMAgent):
     ) -> Generator["ConversableAgent", None, None]:
         """Creates a user proxy / tool executor agent.
 
+        Note: Code execution is not enabled by default. Pass the code execution config into executor_kwargs, if needed.
+
         Args:
             executor_kwargs: agent's arguments.
             tools: tools to register for execution with the agent.
@@ -3286,10 +3288,6 @@ class ConversableAgent(LLMAgent):
         executor = ConversableAgent(
             name=agent_name,
             human_input_mode=agent_human_input_mode,
-            code_execution_config={
-                "work_dir": "coding",
-                "use_docker": True,
-            },
             **executor_kwargs,
         )
 
@@ -3318,7 +3316,7 @@ class ConversableAgent(LLMAgent):
     ) -> ChatResult:
         """Run a chat with the agent using the given message.
 
-        A second agent will be created to represent the user, this agent will by known by the name 'user'.
+        A second agent will be created to represent the user, this agent will by known by the name 'user'. This agent does not have code execution enabled by default.
 
         The user can terminate the conversation when prompted or, if agent's reply contains 'TERMINATE', it will terminate.
 

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -3316,7 +3316,7 @@ class ConversableAgent(LLMAgent):
     ) -> ChatResult:
         """Run a chat with the agent using the given message.
 
-        A second agent will be created to represent the user, this agent will by known by the name 'user'. This agent does not have code execution enabled by default.
+        A second agent will be created to represent the user, this agent will by known by the name 'user'. This agent does not have code execution enabled by default, if needed pass the code execution config in with the executor_kwargs parameter.
 
         The user can terminate the conversation when prompted or, if agent's reply contains 'TERMINATE', it will terminate.
 


### PR DESCRIPTION
## Why are these changes needed?

Removes the hard coding of the code execution config on the internal agent created for ConversableAgent`s `run` method.

If code execution is required, the code execution config can be passed in through the `executor_kwargs` parameter on `run`.

By defaulting it, this was causing issues with new users trying the quick start examples.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
