### PR TITLE
Fix stuck build check

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -8,11 +8,6 @@ on:
     - cron: "0 0 * * *" # daily at midnight UTC
   pull_request:
     branches: ["main"]
-    paths:
-      - 'autogen/**'
-      - 'test/**'
-      - '.github/workflows/**'
-      - 'pyproject.toml'
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/test-with-optional-deps.yml
+++ b/.github/workflows/test-with-optional-deps.yml
@@ -8,11 +8,6 @@ on:
     - cron: "0 0 * * *" # daily at midnight UTC
   pull_request:
     branches: ["main"]
-    paths:
-      - 'autogen/**'
-      - 'test/**'
-      - '.github/workflows/**'
-      - 'pyproject.toml'
   merge_group:
     types: [checks_requested]
 
@@ -22,7 +17,40 @@ concurrency:
 permissions: {}
 
 jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      hasChanges: ${{ steps.filter.outputs.autogen == 'true' || steps.filter.outputs.test == 'true' || steps.filter.outputs.workflows == 'true' || steps.filter.outputs.setup == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            autogen:
+              - "autogen/**"
+            test:
+              - "test/**"
+            workflows:
+              - ".github/workflows/**"
+            setup:
+              - "pyproject.toml"
+      - name: autogen has changes
+        run: echo "autogen has changes"
+        if: steps.filter.outputs.autogen == 'true'
+      - name: test has changes
+        run: echo "test has changes"
+        if: steps.filter.outputs.test == 'true'
+      - name: workflows has changes
+        run: echo "workflows has changes"
+        if: steps.filter.outputs.workflows == 'true'
+      - name: setup has changes
+        run: echo "setup has changes"
+        if: steps.filter.outputs.setup == 'true'
+
   test:
+    needs: paths-filter
+    if: needs.paths-filter.outputs.hasChanges == 'true'
     runs-on: ${{ matrix.os }}
     env:
       AUTOGEN_USE_DOCKER: ${{ matrix.os != 'ubuntu-latest'  && 'False' }}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

`build-check` is not passing and getting stuck because I used `paths` filter directly in `pull_request` trigger. This will not trigger `test` which is needed by `build-check` and `build-check` gets stuck.

The fix is to remove it and let `paths-filter` job handle it.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #865 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
