### PR TITLE
fix(docs): Correct typos and minor wording issues in documentation

### DIFF
--- a/website/docs/contributor-guide/file-bug-report.mdx
+++ b/website/docs/contributor-guide/file-bug-report.mdx
@@ -1,5 +1,5 @@
 ---
-title: File A Bug Report
+title: File a Bug Report
 ---
 
 When you submit an issue to [GitHub](https://github.com/ag2ai/ag2/issues), please do your best to

--- a/website/docs/contributor-guide/setup-development-environment.mdx
+++ b/website/docs/contributor-guide/setup-development-environment.mdx
@@ -71,7 +71,7 @@ If you are contributing to the AG2 project, you will need an LLM key depending o
 
 ## Setting up the Development Environment
 
-To contribute to the AG2 project, AG2 provides three different method to setup the development environment:
+To contribute to the AG2 project, AG2 provides three different methods to set up the development environment:
 
 <Tabs>
   <Tab title="Dev Containers">

--- a/website/docs/ecosystem/agentops.mdx
+++ b/website/docs/ecosystem/agentops.mdx
@@ -81,7 +81,7 @@ After initializing AgentOps, AG2 will now start automatically tracking your agen
 
 ## Extra links
 
-- [🐦 Twitter](https://twitter.com/agentopsai/)
+- [🐦 X](https://x.com/agentopsai/)
 - [📢 Discord](https://discord.gg/JHPt4C7r)
 - [🖇️ AgentOps Dashboard](https://app.agentops.ai/ref?=autogen)
 - [📙 Documentation](https://docs.agentops.ai/introduction)

--- a/website/docs/faq/FAQ.mdx
+++ b/website/docs/faq/FAQ.mdx
@@ -41,7 +41,7 @@ When you call `initiate_chat` the conversation restarts by default. You can use 
 
 ## `max_consecutive_auto_reply` vs `max_turn` vs `max_round`
 
-- [`max_consecutive_auto_reply`](/docs/api-reference/autogen/ConversableAgent#max-consecutive-auto-reply-2) the maximum number of consecutive auto replie (a reply from an agent without human input is considered an auto reply). It plays a role when `human_input_mode` is not "ALWAYS".
+- [`max_consecutive_auto_reply`](/docs/api-reference/autogen/ConversableAgent#max-consecutive-auto-reply-2) the maximum number of consecutive auto replies (a reply from an agent without human input is considered an auto reply). It plays a role when `human_input_mode` is not "ALWAYS".
 - [`max_turns` in `ConversableAgent.initiate_chat`](/docs/api-reference/autogen/ConversableAgent#initiate-chat) limits the number of conversation turns between two conversable agents (without differentiating auto-reply and reply/input from human)
 - [`max_round` in GroupChat](https://docs.ag2.ai/docs/api-reference/autogen/GroupChat#groupchat) specifies the maximum number of rounds in a group chat session.
 

--- a/website/docs/home/quick-start.mdx
+++ b/website/docs/home/quick-start.mdx
@@ -83,7 +83,7 @@ emma = ConversableAgent(
     llm_config=llm_config,
     system_message=(
       "Your name is Emma and you are a comedian "
-      "in two-person comedy show. Say the word FINISH "
+      "in a two-person comedy show. Say the word FINISH "
       "ONLY AFTER you've heard 2 of Jack's jokes."
     ),
 )


### PR DESCRIPTION
- Fixed incorrect article usage in `quick-start.mdx` ("in two-person comedy show" → "in a two-person comedy show").
- Corrected singular/plural inconsistency in `setup-development-environment.mdx` ("method" → "methods").
- Fixed incorrect verb form in `setup-development-environment.mdx` ("setup" → "set up").
- Updated outdated Twitter link in `agentops.mdx` to X.com.
- Corrected singular/plural mismatch in `FAQ.mdx` ("auto replie" → "auto replies").

