### PR TITLE
Add a way to manually trigger workflow when needed

### DIFF
--- a/.github/workflows/contrib-graph-rag-tests.yml
+++ b/.github/workflows/contrib-graph-rag-tests.yml
@@ -6,6 +6,7 @@ name: ContribGraphRagTests
 on:
   schedule:
     - cron: "0 0 * * *" # daily at midnight UTC
+  workflow_dispatch: # allows manual triggering of the workflow
   pull_request_target:
     branches: ["main"]
     paths:

--- a/.github/workflows/contrib-llm-test.yml
+++ b/.github/workflows/contrib-llm-test.yml
@@ -6,6 +6,7 @@ name: Contrib tests with LLMs
 on:
   schedule:
     - cron: "0 0 * * *" # daily at midnight UTC
+  workflow_dispatch: # allows manual triggering of the workflow
   pull_request_target:
     branches: ["main"]
     paths:

--- a/.github/workflows/contrib-test.yml
+++ b/.github/workflows/contrib-test.yml
@@ -6,6 +6,7 @@ name: Contrib tests without LLMs
 on:
   schedule:
     - cron: "0 0 * * *" # daily at midnight UTC
+  workflow_dispatch: # allows manual triggering of the workflow
   pull_request:
     branches: ["main"]
     paths:

--- a/.github/workflows/core-llm-test.yml
+++ b/.github/workflows/core-llm-test.yml
@@ -6,6 +6,7 @@ name: Core tests with LLMs
 on:
   schedule:
     - cron: "0 0 * * *" # daily at midnight UTC
+  workflow_dispatch: # allows manual triggering of the workflow
   pull_request_target:
     branches: ["main"]
     paths:

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -6,6 +6,7 @@ name: Core tests without LLMs
 on:
   schedule:
     - cron: "0 0 * * *" # daily at midnight UTC
+  workflow_dispatch: # allows manual triggering of the workflow
   pull_request:
     branches: ["main"]
   merge_group:

--- a/.github/workflows/test-with-optional-deps.yml
+++ b/.github/workflows/test-with-optional-deps.yml
@@ -6,6 +6,7 @@ name: Tests with optional dependencies
 on:
   schedule:
     - cron: "0 0 * * *" # daily at midnight UTC
+  workflow_dispatch: # allows manual triggering of the workflow
   pull_request:
     branches: ["main"]
   merge_group:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently we run tests in main branch once everyday based on schedule. But this runs tests for the changes from previous day. If somehow the last commit has a failing test, then coverage gets affected. Even if the test is fixed, there is no way to retrigger the tests with latest changes on main. 

This PR tries to fix it by adding a manual way to trigger workflows with latest changes. This is also a step for eventually fixing the https://github.com/ag2ai/ag2/issues/890. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
