### PR TITLE
Fix document utils tests

### DIFF
--- a/autogen/agentchat/contrib/rag/document_utils.py
+++ b/autogen/agentchat/contrib/rag/document_utils.py
@@ -83,7 +83,7 @@ def download_url(url: Any, output_dir: Optional[Union[str, Path]] = None) -> Pat
         filename += ".html"
     output_dir = Path(output_dir) if output_dir else Path()
     filepath = output_dir / filename
-    with filepath.open("w", encoding="utf-8") as f:
+    with open(file=filepath, mode="w", encoding="utf-8") as f:
         f.write(rendered_html)
 
     return filepath
@@ -105,12 +105,13 @@ def list_files(directory: Union[Path, str]) -> list[Path]:
 @export_module("autogen.agentchat.contrib.rag")
 def handle_input(input_path: Union[Path, str], output_dir: Optional[Union[Path, str]] = None) -> list[Path]:
     """Process the input string and return the appropriate file paths"""
-    input_path = Path(input_path)
 
-    if is_url(str(input_path)):
+    if isinstance(input_path, str) and is_url(input_path):
         _logger.info("Detected URL. Downloading content...")
         return [download_url(url=input_path, output_dir=output_dir)]
-    elif input_path.is_dir():
+    else:
+        input_path = Path(input_path)
+    if input_path.is_dir():
         _logger.info("Detected directory. Listing files...")
         return list_files(directory=input_path)
     elif input_path.is_file():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The unit tests are failing. Right now some are still failing from dev docker container because of Selenium exception.
This PR fix the tests that they are tested successfully from local as following,

```
pytest test/agentchat/contrib/rag/test_document_utils.py
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.11.5, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/yzhai/workspace/ag2ai/ag2
configfile: pyproject.toml
plugins: cov-6.0.0, anyio-3.5.0, devtools-0.12.2
collected 23 items                                                                                                                                           
...
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

---------- coverage: platform darwin, python 3.11.5-final-0 ----------
Coverage XML written to file coverage.xml

=============================================================== 23 passed, 2 warnings in 7.47s ===============================================================
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
