### PR TITLE
Add custom field serializer for agent in SwarmResult

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2351,7 +2351,7 @@
         "filename": "test/agentchat/contrib/test_swarm.py",
         "hashed_secret": "957af7971d66cb7bfda1fff979038caeffd61025",
         "is_verified": false,
-        "line_number": 263,
+        "line_number": 289,
         "is_secret": false
       }
     ],
@@ -3116,5 +3116,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-12T10:49:54Z"
+  "generated_at": "2025-02-13T03:43:01Z"
 }

--- a/autogen/agentchat/contrib/swarm_agent.py
+++ b/autogen/agentchat/contrib/swarm_agent.py
@@ -10,7 +10,7 @@ from inspect import signature
 from types import MethodType
 from typing import Any, Callable, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 
 from ...doc_utils import export_module
 from ...oai import OpenAIWrapper
@@ -754,6 +754,12 @@ class SwarmResult(BaseModel):
     values: str = ""
     agent: Optional[Union[ConversableAgent, str]] = None
     context_variables: dict[str, Any] = {}
+
+    @field_serializer("agent", when_used="json")
+    def serialize_agent(self, agent: Union[ConversableAgent, str]) -> str:
+        if isinstance(agent, ConversableAgent):
+            return agent.name
+        return agent
 
     class Config:  # Add this inner class
         arbitrary_types_allowed = True

--- a/test/agentchat/contrib/test_swarm.py
+++ b/test/agentchat/contrib/test_swarm.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+import json
 from typing import Any, Optional, Union
 from unittest.mock import MagicMock, patch
 
@@ -57,6 +58,31 @@ def test_swarm_result():
     agent = ConversableAgent("test")
     result = SwarmResult(values="test", agent=agent)
     assert result.agent == agent
+
+
+def test_swarm_result_serialization():
+    agent = ConversableAgent(name="test_agent", human_input_mode="NEVER")
+    result = SwarmResult(
+        values="test",
+        agent=agent,
+        context_variables={"key": "value"},
+    )
+
+    serialized = json.loads(result.model_dump_json())
+    assert serialized["agent"] == "test_agent"
+    assert serialized["values"] == "test"
+    assert serialized["context_variables"] == {"key": "value"}
+
+    result = SwarmResult(
+        values="test",
+        agent="test_agent",
+        context_variables={"key": "value"},
+    )
+
+    serialized = json.loads(result.model_dump_json())
+    assert serialized["agent"] == "test_agent"
+    assert serialized["values"] == "test"
+    assert serialized["context_variables"] == {"key": "value"}
 
 
 def test_after_work_initialization():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This will add a custom fialed serializer for the agent field in the SwarmReslut which will enable the SwarmResult to serialize the ConversableAgent class using agent.name property

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #943

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
