### PR TITLE
Correct hook processing order on ConversableAgent.a_generate_reply

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -2489,13 +2489,13 @@ class ConversableAgent(LLMAgent):
         # Call the hookable method that gives registered hooks a chance to update agent state, used for their context variables.
         self.update_agent_state_before_reply(messages)
 
-        # Call the hookable method that gives registered hooks a chance to process all messages.
-        # Message modifications do not affect the incoming messages or self._oai_messages.
-        messages = self.process_all_messages_before_reply(messages)
-
         # Call the hookable method that gives registered hooks a chance to process the last message.
         # Message modifications do not affect the incoming messages or self._oai_messages.
         messages = self.process_last_received_message(messages)
+
+        # Call the hookable method that gives registered hooks a chance to process all messages.
+        # Message modifications do not affect the incoming messages or self._oai_messages.
+        messages = self.process_all_messages_before_reply(messages)
 
         for reply_func_tuple in self._reply_func_list:
             reply_func = reply_func_tuple["reply_func"]


### PR DESCRIPTION
## Why are these changes needed?

The hook processing order on `generate_reply` and `a_generate_reply` is different.

Correcting `a_generate_reply` to be:
- update_agent_state
- process_last_received_message
- process_all_messages_before_reply

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
