### PR TITLE
Swarm and Google Gemini client test fixes

### DIFF
--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -40,6 +40,7 @@ Resources:
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import copy
 import json
@@ -192,6 +193,17 @@ class GeminiClient:
         }
 
     def create(self, params: dict) -> ChatCompletion:
+        # When running in async context via run_in_executor from ConversableAgent.a_generate_oai_reply,
+        # this method runs in a new thread that doesn't have an event loop by default. The Google Genai
+        # client requires an event loop even for synchronous operations, so we need to ensure one exists.
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No event loop exists in this thread (which happens when called from an executor)
+            # Create a new event loop for this thread to satisfy Genai client requirements
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            
         if self.use_vertexai:
             self._initialize_vertexai(**params)
         else:

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -203,7 +203,7 @@ class GeminiClient:
             # Create a new event loop for this thread to satisfy Genai client requirements
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-            
+
         if self.use_vertexai:
             self._initialize_vertexai(**params)
         else:

--- a/test/agentchat/contrib/test_swarm.py
+++ b/test/agentchat/contrib/test_swarm.py
@@ -323,6 +323,7 @@ def test_on_condition_handoff():
         messages=TEST_MESSAGES,
         agents=[agent1, agent2],
         max_rounds=5,
+        exclude_transit_message=False,
     )
     assert context_vars is None
     assert last_speaker
@@ -455,6 +456,7 @@ def test_function_transfer():
         agents=[agent1, agent2],
         context_variables=test_context_variables,
         max_rounds=4,
+        exclude_transit_message=False,
     )
     assert context_vars
     assert last_speaker
@@ -675,6 +677,7 @@ def test_string_agent_params_for_transfer():
         messages="Begin by calling the hello_world() function.",
         after_work=AfterWork(AfterWorkOption.TERMINATE),
         max_rounds=5,
+        exclude_transit_message=False,
     )
 
     # Assertions to verify the behavior
@@ -840,6 +843,7 @@ def test_on_condition_unique_function_names():
         messages=TEST_MESSAGES,
         agents=[agent1, agent2],
         max_rounds=5,
+        exclude_transit_message=False,
     )
     assert chat_result
     assert context_vars is None


### PR DESCRIPTION
## Why are these changes needed?

Fixes issues with tests failing:
- Swarm tests failed because the removal of transfer messages is on by default now, updated tests to not remove the transfer messages.
- Gemini failed because it wasn't handling asynchronous use of the client which the genai.Client class did not like as we use `run_in_executor`. Tested with direct API and with vertex AI and appears okay now.

## Related issue number

Closes #1121
Closes #1122 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
