### PR TITLE
Enable tool removal by name

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -2980,11 +2980,9 @@ class ConversableAgent(LLMAgent):
                 for tool in current_tools:
                     tool_name = tool["function"]["name"]
 
-                    if isinstance(tool_sig, str):                    
-                        is_different = tool_name != tool_sig # Match by name
-                    else:
-                        is_different = tool != tool_sig # Match my schema
-                    
+                    # Match by tool name, or by tool signature
+                    is_different = tool_name != tool_sig if isinstance(tool_sig, str) else tool != tool_sig
+
                     if is_different:
                         filtered_tools.append(tool)
 

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -2973,7 +2973,22 @@ class ConversableAgent(LLMAgent):
                 logger.error(error_msg)
                 raise AssertionError(error_msg)
             else:
-                self.llm_config["tools"] = [tool for tool in self.llm_config["tools"] if tool != tool_sig]
+                current_tools = self.llm_config["tools"]
+                filtered_tools = []
+
+                # Loop through and rebuild tools list without the tool to remove
+                for tool in current_tools:
+                    tool_name = tool["function"]["name"]
+
+                    if isinstance(tool_sig, str):                    
+                        is_different = tool_name != tool_sig # Match by name
+                    else:
+                        is_different = tool != tool_sig # Match my schema
+                    
+                    if is_different:
+                        filtered_tools.append(tool)
+
+                self.llm_config["tools"] = filtered_tools
         else:
             if not isinstance(tool_sig, dict):
                 raise ValueError(

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -1741,6 +1741,29 @@ def test_remove_tool_for_llm(mock_credentials: Credentials):
     print(tool_schemas)
     assert mock_tool.name not in tool_schemas
 
+def test_remove_tool_by_name_for_llm(mock_credentials: Credentials):
+    """Test removing a tool."""
+    agent = ConversableAgent(name="agent", llm_config=mock_credentials.llm_config)
+
+    def sample_tool_func(my_prop: str) -> str:
+        return my_prop * 2
+
+    mock_tool = Tool(name="test_tool", description="A test tool", func_or_tool=sample_tool_func)
+
+    agent.register_for_llm()(mock_tool)
+
+    # Remove the tool by name
+    agent.update_tool_signature(tool_sig="test_tool", is_remove=True)
+
+    # Verify tool was removed from internal list
+    assert "tools" not in mock_credentials.llm_config
+
+    # Verify tool was unregistered from LLM
+    tool_schemas = [tool["function"]["name"] for tool in agent.llm_config.get("tools", [])]
+    print(mock_tool.name)
+    print(tool_schemas)
+    assert mock_tool.name not in tool_schemas
+
 
 def test_remove_tool_for_llm_not_found(mock_credentials: Credentials):
     """Test removing a non-existent tool raises ValueError."""

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -1741,6 +1741,7 @@ def test_remove_tool_for_llm(mock_credentials: Credentials):
     print(tool_schemas)
     assert mock_tool.name not in tool_schemas
 
+
 def test_remove_tool_by_name_for_llm(mock_credentials: Credentials):
     """Test removing a tool."""
     agent = ConversableAgent(name="agent", llm_config=mock_credentials.llm_config)


### PR DESCRIPTION
## Why are these changes needed?

In ConversableAgent the update_tool_signature function allows a string or dictionary to be passed in but if set for removal it only evaluates it against the dictionary value.

This was causing the swarm to fail because tools would not be removed for the conditional hand offs.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
