### PR TITLE
Solves issue with SwarmResult.agent AfterWorkOption -> str

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -823,7 +823,7 @@
         "filename": "test/agentchat/contrib/test_swarm.py",
         "hashed_secret": "957af7971d66cb7bfda1fff979038caeffd61025",
         "is_verified": false,
-        "line_number": 295,
+        "line_number": 299,
         "is_secret": false
       }
     ],

--- a/autogen/agentchat/contrib/swarm_agent.py
+++ b/autogen/agentchat/contrib/swarm_agent.py
@@ -505,10 +505,12 @@ def _determine_next_agent(
 
     after_work_next_agent_selection_msg = None
 
-    # Resolve after_work condition (agent-level overrides global)
-    after_work_condition = (
-        last_swarm_speaker._swarm_after_work if last_swarm_speaker._swarm_after_work is not None else swarm_after_work
-    )
+    if after_work_condition is None:
+        # Resolve after_work condition if one hasn't been passed in (agent-level overrides global)
+        after_work_condition = (
+            last_swarm_speaker._swarm_after_work if last_swarm_speaker._swarm_after_work is not None else swarm_after_work
+        )
+
     if isinstance(after_work_condition, AfterWork):
         after_work_next_agent_selection_msg = after_work_condition.next_agent_selection_msg
         after_work_condition = after_work_condition.agent

--- a/autogen/agentchat/contrib/swarm_agent.py
+++ b/autogen/agentchat/contrib/swarm_agent.py
@@ -840,7 +840,7 @@ class SwarmResult(BaseModel):
     """
 
     values: str = ""
-    agent: Optional[Union[ConversableAgent, str]] = None
+    agent: Optional[Union[ConversableAgent, AfterWorkOption, str]] = None
     context_variables: dict[str, Any] = {}
 
     @field_serializer("agent", when_used="json")

--- a/autogen/agentchat/contrib/swarm_agent.py
+++ b/autogen/agentchat/contrib/swarm_agent.py
@@ -835,7 +835,7 @@ class SwarmResult(BaseModel):
 
     Args:
         values (str): The result values as a string.
-        agent (ConversableAgent, str): The agent instance or agent name as a string, if applicable.
+        agent (ConversableAgent, AfterWorkOption, str): The agent instance, AfterWorkOption, or agent name as a string, if applicable.
         context_variables (dict): A dictionary of context variables.
     """
 

--- a/autogen/agentchat/contrib/swarm_agent.py
+++ b/autogen/agentchat/contrib/swarm_agent.py
@@ -508,7 +508,9 @@ def _determine_next_agent(
     if after_work_condition is None:
         # Resolve after_work condition if one hasn't been passed in (agent-level overrides global)
         after_work_condition = (
-            last_swarm_speaker._swarm_after_work if last_swarm_speaker._swarm_after_work is not None else swarm_after_work
+            last_swarm_speaker._swarm_after_work
+            if last_swarm_speaker._swarm_after_work is not None
+            else swarm_after_work
         )
 
     if isinstance(after_work_condition, AfterWork):

--- a/test/agentchat/contrib/test_swarm.py
+++ b/test/agentchat/contrib/test_swarm.py
@@ -1290,6 +1290,7 @@ def test_compress_message_func():
         f"Wrong message processing: {modified}"
     )
 
+
 def test_swarmresult_afterworkoption_tool_swarmresult():
     """Tests processing of the return of an AfterWorkOption in a SwarmResult. This is put in the tool executors _next_agent attribute."""
 
@@ -1297,7 +1298,7 @@ def test_swarmresult_afterworkoption_tool_swarmresult():
         last_speaker_agent: ConversableAgent,
         tool_execution_swarm_result: Union[ConversableAgent, AfterWorkOption, str],
         next_agent_afterworkoption: AfterWorkOption,
-        swarm_afterworkoption: AfterWorkOption
+        swarm_afterworkoption: AfterWorkOption,
     ) -> Optional[Agent]:
         another_agent = ConversableAgent(name="another_agent")
         tool_executor, _ = _prepare_swarm_agents(last_speaker_agent, [last_speaker_agent, another_agent])
@@ -1326,28 +1327,41 @@ def test_swarmresult_afterworkoption_tool_swarmresult():
         )
 
     dummy_agent = ConversableAgent("dummy_1")
-    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, AfterWorkOption.TERMINATE, AfterWorkOption.STAY, AfterWorkOption.STAY)
+    next_speaker = call_determine_next_agent_from_tool_execution(
+        dummy_agent, AfterWorkOption.TERMINATE, AfterWorkOption.STAY, AfterWorkOption.STAY
+    )
     assert next_speaker is None, "Expected None as the next speaker for AfterWorkOption.TERMINATE"
 
     dummy_agent = ConversableAgent("dummy_1")
-    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, AfterWorkOption.STAY, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE)
+    next_speaker = call_determine_next_agent_from_tool_execution(
+        dummy_agent, AfterWorkOption.STAY, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE
+    )
     assert next_speaker.name == "dummy_1", "Expected the last speaker as the next speaker for AfterWorkOption.TERMINATE"
 
     dummy_agent = ConversableAgent("dummy_1")
-    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, AfterWorkOption.REVERT_TO_USER, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE)
+    next_speaker = call_determine_next_agent_from_tool_execution(
+        dummy_agent, AfterWorkOption.REVERT_TO_USER, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE
+    )
     assert next_speaker.name == "User", "Expected the user agent as the next speaker for AfterWorkOption.REVERT_TO_USER"
 
     dummy_agent = ConversableAgent("dummy_1")
-    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, AfterWorkOption.SWARM_MANAGER, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE)
+    next_speaker = call_determine_next_agent_from_tool_execution(
+        dummy_agent, AfterWorkOption.SWARM_MANAGER, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE
+    )
     assert next_speaker == "auto", "Expected the auto speaker selection mode for AfterWorkOption.SWARM_MANAGER"
 
     dummy_agent = ConversableAgent("dummy_1")
-    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, "dummy_1", AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE)
+    next_speaker = call_determine_next_agent_from_tool_execution(
+        dummy_agent, "dummy_1", AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE
+    )
     assert next_speaker == dummy_agent, "Expected the auto speaker selection mode for AfterWorkOption.SWARM_MANAGER"
 
     dummy_agent = ConversableAgent("dummy_1")
-    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, dummy_agent, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE)
+    next_speaker = call_determine_next_agent_from_tool_execution(
+        dummy_agent, dummy_agent, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE
+    )
     assert next_speaker == dummy_agent, "Expected the auto speaker selection mode for AfterWorkOption.SWARM_MANAGER"
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/agentchat/contrib/test_swarm.py
+++ b/test/agentchat/contrib/test_swarm.py
@@ -65,6 +65,10 @@ def test_swarm_result():
     result = SwarmResult(values="test", agent=agent)
     assert result.agent == agent
 
+    # Test AfterWorkOption
+    result = SwarmResult(agent=AfterWorkOption.TERMINATE)
+    assert isinstance(result.agent, AfterWorkOption)
+
 
 def test_swarm_result_serialization():
     agent = ConversableAgent(name="test_agent", human_input_mode="NEVER")

--- a/test/agentchat/contrib/test_swarm.py
+++ b/test/agentchat/contrib/test_swarm.py
@@ -1290,6 +1290,64 @@ def test_compress_message_func():
         f"Wrong message processing: {modified}"
     )
 
+def test_swarmresult_afterworkoption_tool_swarmresult():
+    """Tests processing of the return of an AfterWorkOption in a SwarmResult. This is put in the tool executors _next_agent attribute."""
+
+    def call_determine_next_agent_from_tool_execution(
+        last_speaker_agent: ConversableAgent,
+        tool_execution_swarm_result: Union[ConversableAgent, AfterWorkOption, str],
+        next_agent_afterworkoption: AfterWorkOption,
+        swarm_afterworkoption: AfterWorkOption
+    ) -> Optional[Agent]:
+        another_agent = ConversableAgent(name="another_agent")
+        tool_executor, _ = _prepare_swarm_agents(last_speaker_agent, [last_speaker_agent, another_agent])
+        tool_executor._swarm_next_agent = tool_execution_swarm_result
+        user = UserProxyAgent("User")
+        groupchat = GroupChat(
+            agents=[last_speaker_agent],
+            messages=[
+                {"tool_calls": "", "role": "tool", "content": "Test message"},
+                {"role": "tool", "content": "Test message 2", "name": "dummy_1"},
+                {"role": "assistant", "content": "Test message 3", "name": "dummy_1"},
+            ],
+        )
+
+        last_speaker_agent._swarm_after_work = next_agent_afterworkoption
+
+        return _determine_next_agent(
+            last_speaker=last_speaker_agent,
+            groupchat=groupchat,
+            initial_agent=last_speaker_agent,
+            use_initial_agent=False,
+            tool_execution=tool_executor,
+            swarm_agent_names=["dummy_1"],
+            user_agent=user,
+            swarm_after_work=swarm_afterworkoption,
+        )
+
+    dummy_agent = ConversableAgent("dummy_1")
+    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, AfterWorkOption.TERMINATE, AfterWorkOption.STAY, AfterWorkOption.STAY)
+    assert next_speaker is None, "Expected None as the next speaker for AfterWorkOption.TERMINATE"
+
+    dummy_agent = ConversableAgent("dummy_1")
+    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, AfterWorkOption.STAY, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE)
+    assert next_speaker.name == "dummy_1", "Expected the last speaker as the next speaker for AfterWorkOption.TERMINATE"
+
+    dummy_agent = ConversableAgent("dummy_1")
+    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, AfterWorkOption.REVERT_TO_USER, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE)
+    assert next_speaker.name == "User", "Expected the user agent as the next speaker for AfterWorkOption.REVERT_TO_USER"
+
+    dummy_agent = ConversableAgent("dummy_1")
+    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, AfterWorkOption.SWARM_MANAGER, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE)
+    assert next_speaker == "auto", "Expected the auto speaker selection mode for AfterWorkOption.SWARM_MANAGER"
+
+    dummy_agent = ConversableAgent("dummy_1")
+    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, "dummy_1", AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE)
+    assert next_speaker == dummy_agent, "Expected the auto speaker selection mode for AfterWorkOption.SWARM_MANAGER"
+
+    dummy_agent = ConversableAgent("dummy_1")
+    next_speaker = call_determine_next_agent_from_tool_execution(dummy_agent, dummy_agent, AfterWorkOption.TERMINATE, AfterWorkOption.TERMINATE)
+    assert next_speaker == dummy_agent, "Expected the auto speaker selection mode for AfterWorkOption.SWARM_MANAGER"
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
The previous constructor of SwarmResult converts AfterWorkOptions to a string. This causes exceptions when a function sets an AfterWorkOption as the next agent.

<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current constructor of SwarmResults converts AfterworkOption to `str`. This causes exceptions when trying to select the next agent, because the str is compared against the list of all agents, but the agent doesn't exist.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
