### PR TITLE
GPT Assistant tests - cater for openai dependency

### DIFF
--- a/test/agentchat/contrib/test_gpt_assistant.py
+++ b/test/agentchat/contrib/test_gpt_assistant.py
@@ -10,18 +10,21 @@ import os
 import uuid
 from unittest.mock import MagicMock
 
-import openai
 import pytest
 
 from autogen import OpenAIWrapper, UserProxyAgent
 from autogen.agentchat.contrib.gpt_assistant_agent import GPTAssistantAgent
 from autogen.oai.openai_utils import detect_gpt_assistant_api_version, retrieve_assistants_by_name
+from autogen.import_utils import optional_import_block, skip_on_missing_imports
 
 from ...conftest import Credentials
 
+with optional_import_block() as result:
+    import openai  # noqa: F401
 
 @pytest.mark.openai
 @pytest.mark.parametrize("provider", ["openai", "azure"])
+@skip_on_missing_imports(["openai"], "openai")
 def test_gpt_assistant_chat_openai(
     provider: str, credentials_gpt_4o_mini: Credentials, credentials_azure: Credentials
 ) -> None:
@@ -54,7 +57,7 @@ def _test_gpt_assistant_chat(credentials: Credentials) -> None:
         ask_ossinsight_mock(question)
         return "The repository microsoft/autogen has 123,456 stars on GitHub."
 
-    name = f"For test_gpt_assistant_chat {uuid.uuid4()}"
+    name = f"For_test_gpt_assistant_chat_{uuid.uuid4()}"
     analyst = GPTAssistantAgent(
         name=name,
         llm_config=credentials.llm_config,
@@ -99,6 +102,7 @@ def _test_gpt_assistant_chat(credentials: Credentials) -> None:
 
 @pytest.mark.openai
 @pytest.mark.parametrize("provider", ["openai", "azure"])
+@skip_on_missing_imports(["openai"], "openai")
 def test_get_assistant_instructions(
     provider: str, credentials_gpt_4o_mini: Credentials, credentials_azure: Credentials
 ) -> None:
@@ -114,7 +118,7 @@ def _test_get_assistant_instructions(credentials: Credentials) -> None:
     """Test function to create a new GPTAssistantAgent, set its instructions, retrieve the instructions,
     and assert that the retrieved instructions match the set instructions.
     """
-    name = f"For test_get_assistant_instructions {uuid.uuid4()}"
+    name = f"For_test_get_assistant_instructions_{uuid.uuid4()}"
     assistant = GPTAssistantAgent(
         name,
         instructions="This is a test",
@@ -131,6 +135,7 @@ def _test_get_assistant_instructions(credentials: Credentials) -> None:
 
 @pytest.mark.openai
 @pytest.mark.parametrize("provider", ["openai", "azure"])
+@skip_on_missing_imports(["openai"], "openai")
 def test_gpt_assistant_instructions_overwrite(
     provider: str, credentials_gpt_4o_mini: Credentials, credentials_azure: Credentials
 ) -> None:
@@ -152,7 +157,7 @@ def _test_gpt_assistant_instructions_overwrite(credentials: Credentials) -> None
     3. Create a new GPTAssistantAgent with the same ID but different instructions and `overwrite_instructions=True`.
     4. Check that the instructions of the assistant have been overwritten with the new ones.
     """
-    name = f"For test_gpt_assistant_instructions_overwrite {uuid.uuid4()}"
+    name = f"For_test_gpt_assistant_instructions_overwrite_{uuid.uuid4()}"
     instructions1 = "This is a test #1"
     instructions2 = "This is a test #2"
 
@@ -186,11 +191,12 @@ def _test_gpt_assistant_instructions_overwrite(credentials: Credentials) -> None
 
 
 @pytest.mark.openai
+@skip_on_missing_imports(["openai"], "openai")
 def test_gpt_assistant_existing_no_instructions(credentials_gpt_4o_mini: Credentials) -> None:
     """Test function to check if the GPTAssistantAgent can retrieve instructions for an existing assistant
     even if the assistant was created with no instructions initially.
     """
-    name = f"For test_gpt_assistant_existing_no_instructions {uuid.uuid4()}"
+    name = f"For_test_gpt_assistant_existing_no_instructions_{uuid.uuid4()}"
     instructions = "This is a test #1"
 
     assistant = GPTAssistantAgent(
@@ -222,6 +228,7 @@ def test_gpt_assistant_existing_no_instructions(credentials_gpt_4o_mini: Credent
 
 
 @pytest.mark.openai
+@skip_on_missing_imports(["openai"], "openai")
 def test_get_assistant_files(credentials_gpt_4o_mini: Credentials) -> None:
     """Test function to create a new GPTAssistantAgent, set its instructions, retrieve the instructions,
     and assert that the retrieved instructions match the set instructions.
@@ -229,7 +236,7 @@ def test_get_assistant_files(credentials_gpt_4o_mini: Credentials) -> None:
     current_file_path = os.path.abspath(__file__)
     openai_client = OpenAIWrapper(config_list=credentials_gpt_4o_mini.config_list)._clients[0]._oai_client
     file = openai_client.files.create(file=open(current_file_path, "rb"), purpose="assistants")  # noqa: SIM115
-    name = f"For test_get_assistant_files {uuid.uuid4()}"
+    name = f"For_test_get_assistant_files_{uuid.uuid4()}"
     gpt_assistant_api_version = detect_gpt_assistant_api_version()
 
     # keep it to test older version of assistant config
@@ -263,9 +270,10 @@ def test_get_assistant_files(credentials_gpt_4o_mini: Credentials) -> None:
 
 
 @pytest.mark.openai
+@skip_on_missing_imports(["openai"], "openai")
 def test_assistant_retrieval(credentials_gpt_4o_mini: Credentials) -> None:
     """Test function to check if the GPTAssistantAgent can retrieve the same assistant"""
-    name = f"For test_assistant_retrieval {uuid.uuid4()}"
+    name = f"For_test_assistant_retrieval_{uuid.uuid4()}"
 
     function_1_schema = {
         "name": "call_function_1",
@@ -298,7 +306,7 @@ def test_assistant_retrieval(credentials_gpt_4o_mini: Credentials) -> None:
             "file_ids": [file_1.id, file_2.id],
         }
 
-        name = f"For test_assistant_retrieval {uuid.uuid4()}"
+        name = f"For_test_assistant_retrieval_{uuid.uuid4()}"
 
         assistant_first = GPTAssistantAgent(
             name,
@@ -334,9 +342,10 @@ def test_assistant_retrieval(credentials_gpt_4o_mini: Credentials) -> None:
 
 
 @pytest.mark.openai
+@skip_on_missing_imports(["openai"], "openai")
 def test_assistant_mismatch_retrieval(credentials_gpt_4o_mini: Credentials) -> None:
     """Test function to check if the GPTAssistantAgent can filter out the mismatch assistant"""
-    name = f"For test_assistant_retrieval {uuid.uuid4()}"
+    name = f"For_test_assistant_retrieval_{uuid.uuid4()}"
 
     function_1_schema = {
         "name": "call_function_1",
@@ -372,7 +381,7 @@ def test_assistant_mismatch_retrieval(credentials_gpt_4o_mini: Credentials) -> N
             "config_list": credentials_gpt_4o_mini.config_list,
         }
 
-        name = f"For test_assistant_retrieval {uuid.uuid4()}"
+        name = f"For_test_assistant_retrieval_{uuid.uuid4()}"
 
         assistant_first, assistant_instructions_mistaching = None, None
         try:
@@ -430,6 +439,7 @@ def test_assistant_mismatch_retrieval(credentials_gpt_4o_mini: Credentials) -> N
 
 
 @pytest.mark.openai
+@skip_on_missing_imports(["openai"], "openai")
 def test_gpt_assistant_tools_overwrite(credentials_gpt_4o_mini: Credentials) -> None:
     """Test that the tools of a GPTAssistantAgent can be overwritten or not depending on the value of the
     `overwrite_tools` parameter when creating a new assistant with the same ID.
@@ -508,7 +518,7 @@ def test_gpt_assistant_tools_overwrite(credentials_gpt_4o_mini: Credentials) -> 
         },
     ]
 
-    name = f"For test_gpt_assistant_tools_overwrite {uuid.uuid4()}"
+    name = f"For_test_gpt_assistant_tools_overwrite_{uuid.uuid4()}"
 
     # Create an assistant with original tools
     assistant_org = GPTAssistantAgent(
@@ -547,6 +557,7 @@ def test_gpt_assistant_tools_overwrite(credentials_gpt_4o_mini: Credentials) -> 
 
 
 @pytest.mark.openai
+@skip_on_missing_imports(["openai"], "openai")
 def test_gpt_reflection_with_llm(credentials_gpt_4o_mini: Credentials) -> None:
     gpt_assistant = GPTAssistantAgent(
         name="assistant", llm_config={"config_list": credentials_gpt_4o_mini.config_list, "assistant_id": None}
@@ -575,6 +586,7 @@ def test_gpt_reflection_with_llm(credentials_gpt_4o_mini: Credentials) -> None:
 
 
 @pytest.mark.openai
+@skip_on_missing_imports(["openai"], "openai")
 def test_assistant_tool_and_function_role_messages(credentials_gpt_4o_mini: Credentials) -> None:
     """Tests that internally generated roles ('tool', 'function') are correctly mapped to
     OpenAI Assistant API-compatible role ('assistant') before sending to the OpenAI API
@@ -582,7 +594,7 @@ def test_assistant_tool_and_function_role_messages(credentials_gpt_4o_mini: Cred
 
     See PR: Fix role mapping in GPTAssistantAgent for OpenAI API compatibility #46
     """
-    name = f"For test_gpt_assistant_special_roles {uuid.uuid4()}"
+    name = f"For_test_gpt_assistant_special_roles_{uuid.uuid4()}"
     assistant = GPTAssistantAgent(
         name,
         llm_config={


### PR DESCRIPTION
## Why are these changes needed?

With 0.7.6 removing openai package, the GPT Assistant tests were failing as they assume openai is installed.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
