### PR TITLE
OpenAI exception handling and httpx dependency

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -1146,6 +1146,8 @@ class OpenAIWrapper:
                         logger.debug(f"config {i} failed", exc_info=True)
                         if i == last:
                             raise
+                    else:
+                        raise
                 else:
                     raise
             except (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "packaging",
     "asyncer==0.0.8",
     "fast-depends>=2.4.12,<3",
+    "httpx>=0.28.1,<1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Why are these changes needed?

Further updates now that openai is an optional dependency (based on tests failing):
OpenAI exception handling and httpx dependency

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
