### PR TITLE
Documentation warning for openai dependency

### DIFF
--- a/website/docs/home/quick-start.mdx
+++ b/website/docs/home/quick-start.mdx
@@ -4,6 +4,15 @@ title: "Quick Start"
 
 AG2 (formerly AutoGen) is an open-source programming framework for building AI agents and facilitating their cooperation to solve tasks. AG2 supports tool use, autonomous and human-in-the-loop workflows, and multi-agent conversation patterns.
 
+<Warning>
+**From version 0.8**: The OpenAI package, `openai`, is not installed by default.
+
+Install AG2 with your preferred model provider(s), for example:
+- `pip install ag2[openai]`
+- `pip install ag2[gemini]`
+- `pip install ag2[anthropic,cohere,mistral]`
+</Warning>
+
 ### Let's go
 
 ```sh

--- a/website/docs/user-guide/basic-concepts/installing-ag2.mdx
+++ b/website/docs/user-guide/basic-concepts/installing-ag2.mdx
@@ -5,6 +5,16 @@ title: Installing AG2
 We recommended using a virtual environment for your project to keep your packages contained. See [venv](https://docs.python.org/3/library/venv.html).
 </Tip>
 
+<Warning>
+**From version 0.8**: The OpenAI package, `openai`, is not installed by default.
+
+Install AG2 with your preferred model provider(s), for example:
+- `pip install ag2[openai]`
+- `pip install ag2[gemini]`
+- `pip install ag2[anthropic,cohere,mistral]`
+</Warning>
+
+
 Install AG2 on your machine:
 
 ```bash

--- a/website/docs/user-guide/basic-concepts/llm-configuration/llm-configuration.mdx
+++ b/website/docs/user-guide/basic-concepts/llm-configuration/llm-configuration.mdx
@@ -6,6 +6,15 @@ Your AG2 agents are likely to need an LLM and you can configure one, or more, fo
 
 AG2's agents can use LLMs through OpenAI, Anthropic, Google, Amazon, Mistral AI, Cerebras, Together AI, and Groq. Locally hosted models can also be used through Ollama, LiteLLM, and LM Studio.
 
+<Warning>
+**From version 0.8**: The OpenAI package, `openai`, is not installed by default.
+
+Install AG2 with your preferred model provider(s), for example:
+- `pip install ag2[openai]`
+- `pip install ag2[gemini]`
+- `pip install ag2[anthropic,cohere,mistral]`
+</Warning>
+
 First, we define our configuration with the API type, model, and, if necessary, the key.
 
 ```python

--- a/website/docs/user-guide/models/openai.mdx
+++ b/website/docs/user-guide/models/openai.mdx
@@ -7,9 +7,9 @@ sidebarTitle: OpenAI
 
 ## Installation
 
-If you are using a version before 0.8 the OpenAI package will already be installed and ready to use.
-
-If you are installing a newer version of AG2, you need to install the AG2 package with the OpenAI extra.
+<Warning>
+**From version 0.8**: The OpenAI package, `openai`, is not installed by default, install it with the `openai` extra as shown below.
+</Warning>
 
 ``` bash
 pip install ag2[openai]


### PR DESCRIPTION
## Why are these changes needed?

Adds warnings on four pages noting that the `openai` package is no longer installed by default.
- Quick Start
- Basic Concepts > Installing AG2
- Basic Concepts > LLM Configuration > LLMs
- Model Providers > OpenAI

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
