### PR TITLE
[Swarm] OnCondition supports "not" available

### DIFF
--- a/website/docs/user-guide/advanced-concepts/swarm/use-case.mdx
+++ b/website/docs/user-guide/advanced-concepts/swarm/use-case.mdx
@@ -318,6 +318,12 @@ Together with the ability to put context into an agent's system message ([`Updat
 
 Here we can see the use of context variable keys in the `available` parameter as well as the `has_order_in_context` function as an alternative to context variables. You will notice that the function does the same as using a context variable key string in this case.
 
+<Tip>
+When using context variable keys in the `available` parameter of OnCondition, by default it must evaluate to `True` for the condition to become available.
+
+If you want to do the opposite, make it available if the context variable equates to `False`, you can put an exclamation before the context variable key value, e.g. `available="!is_logged_in"`.
+</Tip>
+
 ```python
 # HANDOFFS
 register_hand_off(


### PR DESCRIPTION
## Why are these changes needed?

At the moment the OnCondition's available parameter can take a string to represent a context variable key and it will evaluate that key's value as True to determine if the OnCondition is available for checking.

However, sometimes we want an OnCondition to be available if the context variable value equates to False. For example we may have a context variable key called "is_logged_in" but we want to transfer to an agent if they are not logged in.

This PR allows a developer to put an exclamation ahead of the context variable name and it will evaluate it as available if it is `False`.

E.g.
`OnCondition(target=authentication_agent, condition="Authenticate the user", available="!is_logged_in")`

This will be available if the context variable value for the key "is_logged_in" is equivalent to False.

## Related issue number

Closes #1220 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
