### PR TITLE
ContextExpression support for len for collections

### DIFF
--- a/test/agentchat/test_utils.py
+++ b/test/agentchat/test_utils.py
@@ -354,3 +354,56 @@ class TestContextExpressionNewSyntax:
         # Test complex precedence
         assert ContextExpression("!${a} | ${b} & ${c}").evaluate(context) is False  # (!a) | (b & c)
         assert ContextExpression("!(${a} | ${b}) & ${c}").evaluate(context) is False  # (!(a | b)) & c
+
+    def test_length_operations(self) -> None:
+        """Test length operations with lists and other collections."""
+        context = {
+            "empty_list": [],
+            "non_empty_list": [1, 2, 3],
+            "single_item": ["test"],
+            "empty_string": "",
+            "non_empty_string": "hello",
+            "empty_dict": {},
+            "non_empty_dict": {"key": "value"},
+        }
+
+        # Test length with empty list
+        assert ContextExpression("len(${empty_list}) == 0").evaluate(context) is True
+        assert ContextExpression("len(${empty_list}) != 0").evaluate(context) is False
+        assert ContextExpression("len(${empty_list}) > 0").evaluate(context) is False
+        assert ContextExpression("len(${empty_list}) < 1").evaluate(context) is True
+
+        # Test length with non-empty list
+        assert ContextExpression("len(${non_empty_list}) == 3").evaluate(context) is True
+        assert ContextExpression("len(${non_empty_list}) != 0").evaluate(context) is True
+        assert ContextExpression("len(${non_empty_list}) > 0").evaluate(context) is True
+        assert ContextExpression("len(${non_empty_list}) >= 3").evaluate(context) is True
+        assert ContextExpression("len(${non_empty_list}) < 5").evaluate(context) is True
+
+        # Test length with single item list
+        assert ContextExpression("len(${single_item}) == 1").evaluate(context) is True
+
+        # Test length with strings
+        assert ContextExpression("len(${empty_string}) == 0").evaluate(context) is True
+        assert ContextExpression("len(${non_empty_string}) == 5").evaluate(context) is True
+        assert ContextExpression("len(${non_empty_string}) > len(${empty_string})").evaluate(context) is True
+
+        # Test length with dictionaries
+        assert ContextExpression("len(${empty_dict}) == 0").evaluate(context) is True
+        assert ContextExpression("len(${non_empty_dict}) == 1").evaluate(context) is True
+
+        # Test length with non-existent variables
+        assert ContextExpression("len(${non_existent}) == 0").evaluate(context) is True
+
+        # Test length with symbolic operators
+        assert ContextExpression("len(${non_empty_list}) > 0 & len(${empty_list}) == 0").evaluate(context) is True
+        assert ContextExpression("len(${empty_list}) == 0 | len(${non_empty_list}) == 0").evaluate(context) is True
+        assert ContextExpression("!(len(${empty_list}) > 0)").evaluate(context) is True
+
+        # Test complex expressions with length
+        assert ContextExpression(
+            "len(${non_empty_list}) > 0 & (len(${empty_list}) == 0 | len(${single_item}) == 1)"
+        ).evaluate(context) is True
+        assert ContextExpression(
+            "len(${empty_dict}) == 0 & len(${non_empty_dict}) == 1 & len(${non_empty_string}) == 5"
+        ).evaluate(context) is True

--- a/test/agentchat/test_utils.py
+++ b/test/agentchat/test_utils.py
@@ -401,9 +401,15 @@ class TestContextExpressionNewSyntax:
         assert ContextExpression("!(len(${empty_list}) > 0)").evaluate(context) is True
 
         # Test complex expressions with length
-        assert ContextExpression(
-            "len(${non_empty_list}) > 0 & (len(${empty_list}) == 0 | len(${single_item}) == 1)"
-        ).evaluate(context) is True
-        assert ContextExpression(
-            "len(${empty_dict}) == 0 & len(${non_empty_dict}) == 1 & len(${non_empty_string}) == 5"
-        ).evaluate(context) is True
+        assert (
+            ContextExpression(
+                "len(${non_empty_list}) > 0 & (len(${empty_list}) == 0 | len(${single_item}) == 1)"
+            ).evaluate(context)
+            is True
+        )
+        assert (
+            ContextExpression(
+                "len(${empty_dict}) == 0 & len(${non_empty_dict}) == 1 & len(${non_empty_string}) == 5"
+            ).evaluate(context)
+            is True
+        )

--- a/website/docs/user-guide/advanced-concepts/swarm/deep-dive.mdx
+++ b/website/docs/user-guide/advanced-concepts/swarm/deep-dive.mdx
@@ -89,10 +89,12 @@ The syntax for creating an using [`OnContextCondition`](/docs/api-reference/auto
   - Logical: `not, !, and, &, or, |`
   - Comparison: `>, <, >=, <=, ==, !=`
 - Parentheses can be used for grouping
+- Supports `len(${var_name})`: Gets the length of a list, string, or other collection
 - Examples:
     - `not ${logged_in} and ${is_admin} or ${guest_checkout}`
     - `!${logged_in} & ${is_admin} | ${guest_checkout}`
     - `${attempts} > 3 | ${is_admin} == True`
+    - `len(${search_results}) > 5`
 
 ```python
 register_hand_off(
@@ -100,7 +102,7 @@ register_hand_off(
     hand_to=[
         OnContextCondition(
             target=agent_2,
-            condition=ContextExpression("(${account_level} > 2 and ${budget_remaining} > 0) or ${account_tier} == 'Gold'"),
+            condition=ContextExpression("(${account_level} > 2 and ${budget_remaining} > 0) or ${account_tier} == 'Gold' or len(${order_count}) > 10"),
             available="logged_in"),
         OnCondition(target=agent_3, condition="condition_2"), # LLM-based, evaluated after OnContextCondition's
     ]


### PR DESCRIPTION
## Why are these changes needed?

A useful mechanism in ContextExpression to check if lists have items or not, e.g.:
```
OnContextCondition(
    target=my_agent,
    condition=ContextExpression("len(${orders}) > 0")
)
```
## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
