### PR TITLE
fix: fix script execution check for direct run

### DIFF
--- a/scripts/docs_build.sh
+++ b/scripts/docs_build.sh
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
 set -e
 set -x
 
@@ -24,6 +23,6 @@ docs_build() {
     docs_generate "$force"
 }
 
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]] && [[ "${BASH_SOURCE[0]}" == "$(realpath "$0")" ]]; then
     docs_build "$1"
 fi


### PR DESCRIPTION
## Description 

I’ve added a check to ensure the script is executed directly and not sourced. The check now uses `realpath` to verify that the script's path is absolute, improving accuracy. This replaces the old `if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then`, making the execution condition more reliable and precise.

## Why are these changes needed?

These changes improve the script’s reliability by ensuring it’s only executed directly and not sourced. The previous method for checking script execution was less precise, and this update provides a more accurate solution by using `realpath`.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.