### PR TITLE
chore: fix default value for `max_round` in `group_chat_config` section

### DIFF
--- a/website/user-guide/captainagent/configurations.mdx
+++ b/website/user-guide/captainagent/configurations.mdx
@@ -85,7 +85,7 @@ Configures the retriever model used for fetching relevant tools from the library
 This section is used to configure the group chat settings. `group_chat_config` also takes in arguments for initializing `autogen.GroupChat`. Refer to all the configurables [here](/docs/reference/agentchat/groupchat).
 
 ### `max_round`
-Specifies the maximum number of rounds in a group chat session. Defaults to `10`.
+Specifies the maximum number of rounds in a group chat session. Defaults to `15`.
 
 ### `kwargs`
 `group_chat_config` also takes in arguments for initializing `autogen.GroupChat`. Refer to all the configurables [here](/docs/reference/agentchat/groupchat).


### PR DESCRIPTION
##  Description
I noticed a issue in the documentation for the `group_chat_config` section. The default value for the `max_round` parameter was incorrectly listed as `10`, but it should actually be `15` according to the example configuration provided earlier.

Here’s the corrected version:

```
### `max_round`
Specifies the maximum number of rounds in a group chat session. Defaults to `15`.
```

This update should clarify the correct default value.

---

## Why are these changes needed?  
The default value for `max_round` in the `group_chat_config` section was listed incorrectly as `10`. The correct default value, according to the example configuration, is `15`. This change ensures the documentation is accurate and consistent.

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.