### PR TITLE
Add guidance on using GOOGLE_GEMINI_API_KEY

### DIFF
--- a/website/docs/user-guide/models/google-gemini.mdx
+++ b/website/docs/user-guide/models/google-gemini.mdx
@@ -68,6 +68,12 @@ Sample OAI_CONFIG_LIST
 ]
 ```
 
+<Tip>
+You can put your Google Gemini API key in an environment variable named `GOOGLE_GEMINI_API_KEY` instead of using the `api_key` in your LLM configuration.
+
+For guidance on using environment variables, see our [LLMs documentation](/docs/user-guide/basic-concepts/llm-configuration/llm-configuration#environment-variables).
+</Tip>
+
 ## Gemini coding example
 
 ```python


### PR DESCRIPTION
## Why are these changes needed?

Gemini docs were missing the guidance to use GOOGLE_GEMINI_API_KEY instead of `api_key`.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
