### PR TITLE
Updated support for OpenAI package 1.66.2

### DIFF
--- a/autogen/oai/oai_models/chat_completion_message.py
+++ b/autogen/oai/oai_models/chat_completion_message.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Taken over from https://github.com/openai/openai-python/blob/3e69750d47df4f0759d4a28ddc68e4b38756d9ca/src/openai/types/chat/chat_completion_message.py
+# Taken over from https://github.com/openai/openai-python/blob/16a10604fbd0d82c1382b84b417a1d6a2d33a7f1/src/openai/types/chat/chat_completion_message.py
 
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
@@ -14,7 +14,29 @@ from ._models import BaseModel
 from .chat_completion_audio import ChatCompletionAudio
 from .chat_completion_message_tool_call import ChatCompletionMessageToolCall
 
-__all__ = ["ChatCompletionMessage", "FunctionCall"]
+__all__ = ["Annotation", "AnnotationURLCitation", "ChatCompletionMessage", "FunctionCall"]
+
+
+class AnnotationURLCitation(BaseModel):
+    end_index: int
+    """The index of the last character of the URL citation in the message."""
+
+    start_index: int
+    """The index of the first character of the URL citation in the message."""
+
+    title: str
+    """The title of the web resource."""
+
+    url: str
+    """The URL of the web resource."""
+
+
+class Annotation(BaseModel):
+    type: Literal["url_citation"]
+    """The type of the URL citation. Always `url_citation`."""
+
+    url_citation: AnnotationURLCitation
+    """A URL citation when using web search."""
 
 
 class FunctionCall(BaseModel):
@@ -39,6 +61,12 @@ class ChatCompletionMessage(BaseModel):
 
     role: Literal["assistant"]
     """The role of the author of this message."""
+
+    annotations: Optional[List[Annotation]] = None
+    """
+    Annotations for the message, when applicable, as when using the
+    [web search tool](https://platform.openai.com/docs/guides/tools-web-search?api-mode=chat).
+    """
 
     audio: Optional[ChatCompletionAudio] = None
     """

--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -749,17 +749,17 @@ def detect_gpt_assistant_api_version() -> str:
 def create_gpt_vector_store(client: "OpenAI", name: str, fild_ids: list[str]) -> Any:
     """Create a openai vector store for gpt assistant"""
     try:
-        vector_store = client.beta.vector_stores.create(name=name)
+        vector_store = client.vector_stores.create(name=name)
     except Exception as e:
         raise AttributeError(f"Failed to create vector store, please install the latest OpenAI python package: {e}")
 
     # poll the status of the file batch for completion.
-    batch = client.beta.vector_stores.file_batches.create_and_poll(vector_store_id=vector_store.id, file_ids=fild_ids)
+    batch = client.vector_stores.file_batches.create_and_poll(vector_store_id=vector_store.id, file_ids=fild_ids)
 
     if batch.status == "in_progress":
         time.sleep(1)
         logging.debug(f"file batch status: {batch.file_counts}")
-        batch = client.beta.vector_stores.file_batches.poll(vector_store_id=vector_store.id, batch_id=batch.id)
+        batch = client.vector_stores.file_batches.poll(vector_store_id=vector_store.id, batch_id=batch.id)
 
     if batch.status == "completed":
         return vector_store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ flaml = [
 # public distributions
 
 openai = [
-    "openai>=1.58",
+    "openai>=1.66.2",
 ]
 
 openai-realtime = [

--- a/test/agentchat/contrib/test_gpt_assistant.py
+++ b/test/agentchat/contrib/test_gpt_assistant.py
@@ -260,7 +260,7 @@ def test_get_assistant_files(credentials_gpt_4o_mini: Credentials) -> None:
             vectorstore_ids = oas_assistant.tool_resources.file_search.vector_store_ids
             retrieved_file_ids = []
             for vectorstore_id in vectorstore_ids:
-                files = assistant.openai_client.beta.vector_stores.files.list(vector_store_id=vectorstore_id)
+                files = assistant.openai_client.vector_stores.files.list(vector_store_id=vectorstore_id)
                 retrieved_file_ids.extend([fild.id for fild in files])
         expected_file_id = file.id
     finally:


### PR DESCRIPTION
## Why are these changes needed?

Fix use of vector_stores from the OpenAI package, no longer in beta.

Update OpenAI dependency to minimum of 1.66.2

## Related issue number

Closes #1319 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
