### PR TITLE
Add package version to import utils

### DIFF
--- a/autogen/agentchat/contrib/capabilities/generate_images.py
+++ b/autogen/agentchat/contrib/capabilities/generate_images.py
@@ -65,7 +65,7 @@ class ImageGenerator(Protocol):
 
 
 @require_optional_import("PIL", "unknown")
-@require_optional_import("openai", "openai")
+@require_optional_import("openai>=1.66.2", "openai")
 class DalleImageGenerator:
     """Generates images using OpenAI's DALL-E models.
 

--- a/autogen/agentchat/realtime/experimental/clients/oai/base_client.py
+++ b/autogen/agentchat/realtime/experimental/clients/oai/base_client.py
@@ -27,7 +27,7 @@ global_logger = getLogger(__name__)
 
 
 @register_realtime_client()
-@require_optional_import("openai", "openai-realtime", except_for=["get_factory", "__init__"])
+@require_optional_import("openai>=1.66.2", "openai-realtime", except_for=["get_factory", "__init__"])
 @export_module("autogen.agentchat.realtime.experimental.clients")
 class OpenAIRealtimeClient(RealtimeClientBase):
     """(Experimental) Client for OpenAI Realtime API."""

--- a/autogen/coding/jupyter/import_utils.py
+++ b/autogen/coding/jupyter/import_utils.py
@@ -51,7 +51,7 @@ def require_jupyter_kernel_gateway_installed() -> Callable[[T], T]:
     else:
 
         def decorator(o: T) -> T:
-            return patch_object(o, missing_modules=[], dep_target="jupyter-executor")
+            return patch_object(o, missing_modules={}, dep_target="jupyter-executor")
 
     return decorator
 

--- a/autogen/import_utils.py
+++ b/autogen/import_utils.py
@@ -140,7 +140,8 @@ def get_missing_imports(modules: Union[str, Iterable[str]]) -> list[str]:
     if isinstance(modules, str):
         modules = [modules]
 
-    return [m for m in modules if m not in sys.modules]
+    module_infos = [ModuleInfo.from_str(module) for module in modules]
+    return [m.name for m in module_infos if not m.is_in_sys_modules()]
 
 
 T = TypeVar("T")

--- a/autogen/import_utils.py
+++ b/autogen/import_utils.py
@@ -41,19 +41,24 @@ class ModuleInfo:
         if self.name not in sys.modules:
             return f"'{self.name}' is not installed."
 
-        installed_version = sys.modules[self.name].__version__
+        installed_version = (
+            sys.modules[self.name].__version__ if hasattr(sys.modules[self.name], "__version__") else None
+        )
+        if installed_version is None and (self.min_version or self.max_version):
+            return f"'{self.name}' is installed, but the version is not available."
+
         if self.min_version:
             msg = f"'{self.name}' is installed, but the installed version {installed_version} is too low (required '{self}')."
             if not self.min_inclusive and installed_version == self.min_version:
                 return msg
-            if self.min_inclusive and installed_version < self.min_version:
+            if self.min_inclusive and installed_version < self.min_version:  # type: ignore[operator]
                 return msg
 
         if self.max_version:
             msg = f"'{self.name}' is installed, but the installed version {installed_version} is too high (required '{self}')."
-            if not self.max_inclusive and sys.modules[self.name].__version__ == self.max_version:
+            if not self.max_inclusive and installed_version == self.max_version:
                 return msg
-            if self.max_inclusive and sys.modules[self.name].__version__ > self.max_version:
+            if self.max_inclusive and installed_version > self.max_version:  # type: ignore[operator]
                 return msg
 
         return None

--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -290,7 +290,7 @@ class PlaceHolderClient:
         self.config = config
 
 
-@require_optional_import("openai", "openai")
+@require_optional_import("openai>=1.66.2", "openai")
 class OpenAIClient:
     """Follows the Client protocol and wraps the OpenAI client."""
 
@@ -675,7 +675,6 @@ class OpenAIClient:
         }
 
 
-# @require_optional_import("openai", "openai")
 @export_module("autogen")
 class OpenAIWrapper:
     """A wrapper class for openai client."""
@@ -832,7 +831,7 @@ class OpenAIWrapper:
         else:
             if api_type is not None and api_type.startswith("azure"):
 
-                @require_optional_import("openai", "openai")
+                @require_optional_import("openai>=1.66.2", "openai")
                 def create_azure_openai_client() -> "AzureOpenAI":
                     self._configure_azure_openai(config, openai_config)
                     client = AzureOpenAI(**openai_config)
@@ -892,7 +891,7 @@ class OpenAIWrapper:
                 self._clients.append(client)
             else:
 
-                @require_optional_import("openai", "openai")
+                @require_optional_import("openai>=1.66.2", "openai")
                 def create_openai_client() -> "OpenAI":
                     client = OpenAI(**openai_config)
                     self._clients.append(OpenAIClient(client, response_format))

--- a/test/test_import_utils.py
+++ b/test/test_import_utils.py
@@ -6,7 +6,59 @@ from typing import Any, Optional, Type, Union
 
 import pytest
 
-from autogen.import_utils import optional_import_block, require_optional_import
+from autogen.import_utils import PackageInfo, optional_import_block, require_optional_import, split_package_info
+
+
+class TestPackageInfo:
+    @pytest.mark.parametrize(
+        "package_info, expected",
+        [
+            (
+                "jupyter-client>=8.6.0,<9.0.0",
+                PackageInfo(
+                    name="jupyter-client",
+                    min_version="8.6.0",
+                    max_version="9.0.0",
+                    min_inclusive=True,
+                    max_inclusive=False,
+                ),
+            ),
+            (
+                "jupyter-client>=8.6.0",
+                PackageInfo(
+                    name="jupyter-client",
+                    min_version="8.6.0",
+                    max_version=None,
+                    min_inclusive=True,
+                    max_inclusive=False,
+                ),
+            ),
+            (
+                "jupyter-client<9.0.0",
+                PackageInfo(
+                    name="jupyter-client",
+                    min_version=None,
+                    max_version="9.0.0",
+                    min_inclusive=False,
+                    max_inclusive=False,
+                ),
+            ),
+            (
+                "jupyter-client",
+                PackageInfo(
+                    name="jupyter-client", min_version=None, max_version=None, min_inclusive=False, max_inclusive=False
+                ),
+            ),
+        ],
+    )
+    def test_split_package_info(self, package_info: str, expected: PackageInfo) -> None:
+        result = split_package_info(package_info)
+        assert result == expected
+
+    def test_split_package_info_with_invalid_format(self) -> None:
+        package_info = "jupyter-client>="
+        with pytest.raises(ValueError, match="Invalid package information: jupyter-client>="):
+            split_package_info(package_info)
 
 
 class TestOptionalImportBlock:

--- a/test/test_import_utils.py
+++ b/test/test_import_utils.py
@@ -22,6 +22,15 @@ def mock_module() -> Iterator[ModuleType]:
     del sys.modules[module_name]
 
 
+@pytest.fixture
+def mock_module_without_version() -> Iterator[ModuleType]:
+    module_name = "mock_module"
+    module = ModuleType(module_name)
+    sys.modules[module_name] = module
+    yield module
+    del sys.modules[module_name]
+
+
 class MockModule:
     def __init__(self, name: str, version: str):
         self.__name__ = name
@@ -146,6 +155,21 @@ class TestmoduleInfo:
         ],
     )
     def test_is_in_sys_modules(self, mock_module: ModuleType, module_info: ModuleInfo, expected: Optional[str]) -> None:
+        assert module_info.is_in_sys_modules() == expected
+
+    @pytest.mark.parametrize(
+        "module_info, expected",
+        [
+            (ModuleInfo(name="mock_module"), None),
+            (
+                ModuleInfo(name="mock_module", min_version="1.0.0", min_inclusive=True),
+                "'mock_module' is installed, but the version is not available.",
+            ),
+        ],
+    )
+    def test_is_in_sys_modules_without_version(
+        self, mock_module_without_version: ModuleType, module_info: ModuleInfo, expected: Optional[str]
+    ) -> None:
         assert module_info.is_in_sys_modules() == expected
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Also, can we check the openai version in the import_openai attempt? There's an old openai version available which passes that import attempt but should be considered as a failure of import instead [ref](https://discord.com/channels/1153072414184452236/1248044812956074075/1349149229733515357).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #1330

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
