### PR TITLE
Correct code execution document text

### DIFF
--- a/website/docs/user-guide/advanced-concepts/code-execution.mdx
+++ b/website/docs/user-guide/advanced-concepts/code-execution.mdx
@@ -68,7 +68,7 @@ Now we have the agent generate a reply given a message with a Python code block.
 ```python
 message_with_code_block = """This is a message with code block.
 The code block is below:
-'''python
+``""" + """`python
 import numpy as np
 import matplotlib.pyplot as plt
 x = np.random.randint(0, 100, 100)
@@ -76,7 +76,7 @@ y = np.random.randint(0, 100, 100)
 plt.scatter(x, y)
 plt.savefig('scatter.png')
 print('Scatter plot saved to scatter.png')
-'''
+``""" + """`
 This is the end of the message.
 """
 


### PR DESCRIPTION
## Why are these changes needed?

As per [Discord issue](https://discord.com/channels/1153072414184452236/1349181422832980008/1349181422832980008), the code execution sample uses '''python instead of ```python. This means that running it as is won't work.

The documentation doesn't build successfully if I change it, so have changed the string:

```
message_with_code_block = """This is a message with code block.
The code block is below:
``""" + """`python
import numpy as np
import matplotlib.pyplot as plt
x = np.random.randint(0, 100, 100)
y = np.random.randint(0, 100, 100)
plt.scatter(x, y)
plt.savefig('scatter.png')
print('Scatter plot saved to scatter.png')
``""" + """`
This is the end of the message.
"""
```

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
