### PR TITLE
Termination messages

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1484,7 +1484,7 @@ class ConversableAgent(LLMAgent):
                 self.send(msg2send, recipient, request_reply=True, silent=silent)
 
             else:  # No breaks in the for loop, so we have reached max turns
-                iostream.send(TerminationMessage(termination_reason=f"Maximum turns ({max_turns}) reached."))
+                iostream.send(TerminationMessage(termination_reason=f"Maximum turns ({max_turns}) reached"))
         else:
             self._prepare_chat(recipient, clear_history)
             if isinstance(message, Callable):
@@ -2177,7 +2177,7 @@ class ConversableAgent(LLMAgent):
         if messages is None:
             messages = self._oai_messages[sender] if sender else []
 
-        termination_reason = ""
+        termination_reason = None
 
         # if there are no messages, continue the conversation
         if not messages:
@@ -2194,15 +2194,15 @@ class ConversableAgent(LLMAgent):
             no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
             # if the human input is empty, and the message is a termination message, then we will terminate the conversation
             if not reply and self._is_termination_msg(message):
-                termination_reason = f"Termination message condition on agent '{self.name}' met."
+                termination_reason = f"Termination message condition on agent '{self.name}' met"
             elif reply == "exit":
-                termination_reason = "User requested to end the conversation."
+                termination_reason = "User requested to end the conversation"
 
             reply = reply if reply or not self._is_termination_msg(message) else "exit"
         else:
             if self._consecutive_auto_reply_counter[sender] >= self._max_consecutive_auto_reply_dict[sender]:
                 if self.human_input_mode == "NEVER":
-                    termination_reason = "Maximum number of consecutive auto-replies reached."
+                    termination_reason = "Maximum number of consecutive auto-replies reached"
                     reply = "exit"
                 else:
                     # self.human_input_mode == "TERMINATE":
@@ -2216,15 +2216,15 @@ class ConversableAgent(LLMAgent):
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation
                     if reply != "exit" and terminate:
                         termination_reason = (
-                            f"Termination message condition on agent '{self.name}' met and no human input provided."
+                            f"Termination message condition on agent '{self.name}' met and no human input provided"
                         )
                     elif reply == "exit":
-                        termination_reason = "User requested to end the conversation."
+                        termination_reason = "User requested to end the conversation"
 
                     reply = reply if reply or not terminate else "exit"
             elif self._is_termination_msg(message):
                 if self.human_input_mode == "NEVER":
-                    termination_reason = f"Termination message condition on agent '{self.name}' met."
+                    termination_reason = f"Termination message condition on agent '{self.name}' met"
                     reply = "exit"
                 else:
                     # self.human_input_mode == "TERMINATE":
@@ -2236,7 +2236,7 @@ class ConversableAgent(LLMAgent):
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation
                     if not reply or reply == "exit":
                         termination_reason = (
-                            f"Termination message condition on agent '{self.name}' met and no human input provided."
+                            f"Termination message condition on agent '{self.name}' met and no human input provided"
                         )
 
                     reply = reply or "exit"
@@ -2320,6 +2320,9 @@ class ConversableAgent(LLMAgent):
             config = self
         if messages is None:
             messages = self._oai_messages[sender] if sender else []
+
+        termination_reason = None
+
         message = messages[-1] if messages else {}
         reply = ""
         no_human_input_msg = ""
@@ -2331,15 +2334,15 @@ class ConversableAgent(LLMAgent):
             no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
             # if the human input is empty, and the message is a termination message, then we will terminate the conversation
             if not reply and self._is_termination_msg(message):
-                termination_reason = f"Termination message condition on agent '{self.name}' met."
+                termination_reason = f"Termination message condition on agent '{self.name}' met"
             elif reply == "exit":
-                termination_reason = "User requested to end the conversation."
+                termination_reason = "User requested to end the conversation"
 
             reply = reply if reply or not self._is_termination_msg(message) else "exit"
         else:
             if self._consecutive_auto_reply_counter[sender] >= self._max_consecutive_auto_reply_dict[sender]:
                 if self.human_input_mode == "NEVER":
-                    termination_reason = "Maximum number of consecutive auto-replies reached."
+                    termination_reason = "Maximum number of consecutive auto-replies reached"
                     reply = "exit"
                 else:
                     # self.human_input_mode == "TERMINATE":
@@ -2353,15 +2356,15 @@ class ConversableAgent(LLMAgent):
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation
                     if reply != "exit" and terminate:
                         termination_reason = (
-                            f"Termination message condition on agent '{self.name}' met and no human input provided."
+                            f"Termination message condition on agent '{self.name}' met and no human input provided"
                         )
                     elif reply == "exit":
-                        termination_reason = "User requested to end the conversation."
+                        termination_reason = "User requested to end the conversation"
 
                     reply = reply if reply or not terminate else "exit"
             elif self._is_termination_msg(message):
                 if self.human_input_mode == "NEVER":
-                    termination_reason = f"Termination message condition on agent '{self.name}' met."
+                    termination_reason = f"Termination message condition on agent '{self.name}' met"
                     reply = "exit"
                 else:
                     # self.human_input_mode == "TERMINATE":
@@ -2373,7 +2376,7 @@ class ConversableAgent(LLMAgent):
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation
                     if not reply or reply == "exit":
                         termination_reason = (
-                            f"Termination message condition on agent '{self.name}' met and no human input provided."
+                            f"Termination message condition on agent '{self.name}' met and no human input provided"
                         )
 
                     reply = reply or "exit"

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1484,11 +1484,7 @@ class ConversableAgent(LLMAgent):
                 self.send(msg2send, recipient, request_reply=True, silent=silent)
 
             else:  # No breaks in the for loop, so we have reached max turns
-                iostream.send(
-                    TerminationMessage(
-                        termination_reason=f"Maximum turns ({max_turns}) reached.", sender=self, recipient=recipient
-                    )
-                )
+                iostream.send(TerminationMessage(termination_reason=f"Maximum turns ({max_turns}) reached."))
         else:
             self._prepare_chat(recipient, clear_history)
             if isinstance(message, Callable):
@@ -2259,7 +2255,7 @@ class ConversableAgent(LLMAgent):
             self._consecutive_auto_reply_counter[sender] = 0
 
             if termination_reason:
-                iostream.send(TerminationMessage(termination_reason=termination_reason, sender=sender, recipient=self))
+                iostream.send(TerminationMessage(termination_reason=termination_reason))
 
             return True, None
 
@@ -2396,7 +2392,7 @@ class ConversableAgent(LLMAgent):
             self._consecutive_auto_reply_counter[sender] = 0
 
             if termination_reason:
-                iostream.send(TerminationMessage(termination_reason=termination_reason, sender=sender, recipient=self))
+                iostream.send(TerminationMessage(termination_reason=termination_reason))
 
             return True, None
 

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -52,7 +52,8 @@ from ..messages.agent_messages import (
     ExecuteFunctionMessage,
     ExecutedFunctionMessage,
     GenerateCodeExecutionReplyMessage,
-    TerminationAndHumanReplyMessage,
+    TerminationAndHumanReplyNoInputMessage,
+    TerminationMessage,
     UsingAutoReplyMessage,
     create_received_message_model,
 )
@@ -1459,6 +1460,8 @@ class ConversableAgent(LLMAgent):
         Returns:
             ChatResult: an ChatResult object.
         """
+        iostream = IOStream.get_default()
+
         _chat_info = locals().copy()
         _chat_info["sender"] = self
         consolidate_chat_info(_chat_info, uniform_sender=self)
@@ -1468,8 +1471,8 @@ class ConversableAgent(LLMAgent):
             agent.client_cache = cache
         if isinstance(max_turns, int):
             self._prepare_chat(recipient, clear_history, reply_at_receive=False)
-            for _ in range(max_turns):
-                if _ == 0:
+            for i in range(max_turns):
+                if i == 0:
                     if isinstance(message, Callable):
                         msg2send = message(_chat_info["sender"], _chat_info["recipient"], kwargs)
                     else:
@@ -1479,6 +1482,13 @@ class ConversableAgent(LLMAgent):
                 if msg2send is None:
                     break
                 self.send(msg2send, recipient, request_reply=True, silent=silent)
+
+            else:  # No breaks in the for loop, so we have reached max turns
+                iostream.send(
+                    TerminationMessage(
+                        termination_reason=f"Maximum turns ({max_turns}) reached.", sender=self, recipient=recipient
+                    )
+                )
         else:
             self._prepare_chat(recipient, clear_history)
             if isinstance(message, Callable):
@@ -2171,6 +2181,8 @@ class ConversableAgent(LLMAgent):
         if messages is None:
             messages = self._oai_messages[sender] if sender else []
 
+        termination_reason = ""
+
         # if there are no messages, continue the conversation
         if not messages:
             return False, None
@@ -2185,10 +2197,16 @@ class ConversableAgent(LLMAgent):
             )
             no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
             # if the human input is empty, and the message is a termination message, then we will terminate the conversation
+            if not reply and self._is_termination_msg(message):
+                termination_reason = f"Termination message condition on agent '{self.name}' met."
+            elif reply == "exit":
+                termination_reason = "User requested to end the conversation."
+
             reply = reply if reply or not self._is_termination_msg(message) else "exit"
         else:
             if self._consecutive_auto_reply_counter[sender] >= self._max_consecutive_auto_reply_dict[sender]:
                 if self.human_input_mode == "NEVER":
+                    termination_reason = "Maximum number of consecutive auto-replies reached."
                     reply = "exit"
                 else:
                     # self.human_input_mode == "TERMINATE":
@@ -2200,9 +2218,17 @@ class ConversableAgent(LLMAgent):
                     )
                     no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation
+                    if reply != "exit" and terminate:
+                        termination_reason = (
+                            f"Termination message condition on agent '{self.name}' met and no human input provided."
+                        )
+                    elif reply == "exit":
+                        termination_reason = "User requested to end the conversation."
+
                     reply = reply if reply or not terminate else "exit"
             elif self._is_termination_msg(message):
                 if self.human_input_mode == "NEVER":
+                    termination_reason = f"Termination message condition on agent '{self.name}' met."
                     reply = "exit"
                 else:
                     # self.human_input_mode == "TERMINATE":
@@ -2210,19 +2236,31 @@ class ConversableAgent(LLMAgent):
                         f"Please give feedback to {sender_name}. Press enter or type 'exit' to stop the conversation: "
                     )
                     no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
+
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation
+                    if not reply or reply == "exit":
+                        termination_reason = (
+                            f"Termination message condition on agent '{self.name}' met and no human input provided."
+                        )
+
                     reply = reply or "exit"
 
         # print the no_human_input_msg
         if no_human_input_msg:
             iostream.send(
-                TerminationAndHumanReplyMessage(no_human_input_msg=no_human_input_msg, sender=sender, recipient=self)
+                TerminationAndHumanReplyNoInputMessage(
+                    no_human_input_msg=no_human_input_msg, sender=sender, recipient=self
+                )
             )
 
         # stop the conversation
         if reply == "exit":
             # reset the consecutive_auto_reply_counter
             self._consecutive_auto_reply_counter[sender] = 0
+
+            if termination_reason:
+                iostream.send(TerminationMessage(termination_reason=termination_reason, sender=sender, recipient=self))
+
             return True, None
 
         # send the human reply
@@ -2296,10 +2334,16 @@ class ConversableAgent(LLMAgent):
             )
             no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
             # if the human input is empty, and the message is a termination message, then we will terminate the conversation
+            if not reply and self._is_termination_msg(message):
+                termination_reason = f"Termination message condition on agent '{self.name}' met."
+            elif reply == "exit":
+                termination_reason = "User requested to end the conversation."
+
             reply = reply if reply or not self._is_termination_msg(message) else "exit"
         else:
             if self._consecutive_auto_reply_counter[sender] >= self._max_consecutive_auto_reply_dict[sender]:
                 if self.human_input_mode == "NEVER":
+                    termination_reason = "Maximum number of consecutive auto-replies reached."
                     reply = "exit"
                 else:
                     # self.human_input_mode == "TERMINATE":
@@ -2311,9 +2355,17 @@ class ConversableAgent(LLMAgent):
                     )
                     no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation
+                    if reply != "exit" and terminate:
+                        termination_reason = (
+                            f"Termination message condition on agent '{self.name}' met and no human input provided."
+                        )
+                    elif reply == "exit":
+                        termination_reason = "User requested to end the conversation."
+
                     reply = reply if reply or not terminate else "exit"
             elif self._is_termination_msg(message):
                 if self.human_input_mode == "NEVER":
+                    termination_reason = f"Termination message condition on agent '{self.name}' met."
                     reply = "exit"
                 else:
                     # self.human_input_mode == "TERMINATE":
@@ -2321,19 +2373,31 @@ class ConversableAgent(LLMAgent):
                         f"Please give feedback to {sender_name}. Press enter or type 'exit' to stop the conversation: "
                     )
                     no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
+
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation
+                    if not reply or reply == "exit":
+                        termination_reason = (
+                            f"Termination message condition on agent '{self.name}' met and no human input provided."
+                        )
+
                     reply = reply or "exit"
 
         # print the no_human_input_msg
         if no_human_input_msg:
             iostream.send(
-                TerminationAndHumanReplyMessage(no_human_input_msg=no_human_input_msg, sender=sender, recipient=self)
+                TerminationAndHumanReplyNoInputMessage(
+                    no_human_input_msg=no_human_input_msg, sender=sender, recipient=self
+                )
             )
 
         # stop the conversation
         if reply == "exit":
             # reset the consecutive_auto_reply_counter
             self._consecutive_auto_reply_counter[sender] = 0
+
+            if termination_reason:
+                iostream.send(TerminationMessage(termination_reason=termination_reason, sender=sender, recipient=self))
+
             return True, None
 
         # send the human reply

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -28,6 +28,7 @@ from ..messages.agent_messages import (
     SpeakerAttemptFailedMultipleAgentsMessage,
     SpeakerAttemptFailedNoAgentsMessage,
     SpeakerAttemptSuccessfulMessage,
+    TerminationMessage,
 )
 from ..oai.client import ModelClient
 from ..runtime_logging import log_new_agent, logging_enabled
@@ -1148,6 +1149,8 @@ class GroupChatManager(ConversableAgent):
         config: Optional[GroupChat] = None,
     ) -> tuple[bool, Optional[str]]:
         """Run a group chat."""
+        iostream = IOStream.get_default()
+
         if messages is None:
             messages = self._oai_messages[sender]
         message = messages[-1]
@@ -1155,6 +1158,7 @@ class GroupChatManager(ConversableAgent):
         groupchat = config
         send_introductions = getattr(groupchat, "send_introductions", False)
         silent = getattr(self, "_silent", False)
+        termination_reason = None
 
         if send_introductions:
             # Broadcast the intro
@@ -1175,8 +1179,13 @@ class GroupChatManager(ConversableAgent):
             for agent in groupchat.agents:
                 if agent != speaker:
                     self.send(message, agent, request_reply=False, silent=True)
-            if self._is_termination_msg(message) or i == groupchat.max_round - 1:
-                # The conversation is over or it's the last round
+            if self._is_termination_msg(message):
+                # The conversation is over
+                termination_reason = f"Termination message condition on the GroupChatManager '{self.name}' met."
+                break
+            elif i == groupchat.max_round - 1:
+                # It's the last round
+                termination_reason = f"Maximum rounds ({groupchat.max_round}) reached."
                 break
             try:
                 # select the next speaker
@@ -1197,10 +1206,12 @@ class GroupChatManager(ConversableAgent):
                     raise
             except NoEligibleSpeakerError:
                 # No eligible speaker, terminate the conversation
+                termination_reason = "No eligible speaker found."
                 break
 
             if reply is None:
                 # no reply is generated, exit the chat
+                termination_reason = "No reply generated."
                 break
 
             # check for "clear history" phrase in reply and activate clear history function if found
@@ -1219,6 +1230,10 @@ class GroupChatManager(ConversableAgent):
             for a in groupchat.agents:
                 a.client_cache = a.previous_cache
                 a.previous_cache = None
+
+        if termination_reason:
+            iostream.send(TerminationMessage(termination_reason=termination_reason, sender=sender, recipient=self))
+
         return True, None
 
     async def a_run_chat(
@@ -1228,6 +1243,8 @@ class GroupChatManager(ConversableAgent):
         config: Optional[GroupChat] = None,
     ):
         """Run a group chat asynchronously."""
+        iostream = IOStream.get_default()
+
         if messages is None:
             messages = self._oai_messages[sender]
         message = messages[-1]
@@ -1235,6 +1252,7 @@ class GroupChatManager(ConversableAgent):
         groupchat = config
         send_introductions = getattr(groupchat, "send_introductions", False)
         silent = getattr(self, "_silent", False)
+        termination_reason = None
 
         if send_introductions:
             # Broadcast the intro
@@ -1253,6 +1271,7 @@ class GroupChatManager(ConversableAgent):
 
             if self._is_termination_msg(message):
                 # The conversation is over
+                termination_reason = f"Termination message condition on the GroupChatManager '{self.name}' met."
                 break
 
             # broadcast the message to all agents except the speaker
@@ -1261,6 +1280,7 @@ class GroupChatManager(ConversableAgent):
                     await self.a_send(message, agent, request_reply=False, silent=True)
             if i == groupchat.max_round - 1:
                 # the last round
+                termination_reason = f"Maximum rounds ({groupchat.max_round}) reached."
                 break
             try:
                 # select the next speaker
@@ -1278,10 +1298,14 @@ class GroupChatManager(ConversableAgent):
                     raise
             except NoEligibleSpeakerError:
                 # No eligible speaker, terminate the conversation
+                termination_reason = "No eligible speaker found."
                 break
 
             if reply is None:
+                # no reply is generated, exit the chat
+                termination_reason = "No reply generated."
                 break
+
             # The speaker sends the message without requesting a reply
             await speaker.a_send(reply, self, request_reply=False, silent=silent)
             message = self.last_message(speaker)
@@ -1289,6 +1313,10 @@ class GroupChatManager(ConversableAgent):
             for a in groupchat.agents:
                 a.client_cache = a.previous_cache
                 a.previous_cache = None
+
+        if termination_reason:
+            iostream.send(TerminationMessage(termination_reason=termination_reason, sender=sender, recipient=self))
+
         return True, None
 
     def resume(

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1232,7 +1232,7 @@ class GroupChatManager(ConversableAgent):
                 a.previous_cache = None
 
         if termination_reason:
-            iostream.send(TerminationMessage(termination_reason=termination_reason, sender=sender, recipient=self))
+            iostream.send(TerminationMessage(termination_reason=termination_reason))
 
         return True, None
 
@@ -1315,7 +1315,7 @@ class GroupChatManager(ConversableAgent):
                 a.previous_cache = None
 
         if termination_reason:
-            iostream.send(TerminationMessage(termination_reason=termination_reason, sender=sender, recipient=self))
+            iostream.send(TerminationMessage(termination_reason=termination_reason))
 
         return True, None
 

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1181,11 +1181,11 @@ class GroupChatManager(ConversableAgent):
                     self.send(message, agent, request_reply=False, silent=True)
             if self._is_termination_msg(message):
                 # The conversation is over
-                termination_reason = f"Termination message condition on the GroupChatManager '{self.name}' met."
+                termination_reason = f"Termination message condition on the GroupChatManager '{self.name}' met"
                 break
             elif i == groupchat.max_round - 1:
                 # It's the last round
-                termination_reason = f"Maximum rounds ({groupchat.max_round}) reached."
+                termination_reason = f"Maximum rounds ({groupchat.max_round}) reached"
                 break
             try:
                 # select the next speaker
@@ -1206,12 +1206,12 @@ class GroupChatManager(ConversableAgent):
                     raise
             except NoEligibleSpeakerError:
                 # No eligible speaker, terminate the conversation
-                termination_reason = "No eligible speaker found."
+                termination_reason = "No eligible speaker found"
                 break
 
             if reply is None:
                 # no reply is generated, exit the chat
-                termination_reason = "No reply generated."
+                termination_reason = "No reply generated"
                 break
 
             # check for "clear history" phrase in reply and activate clear history function if found
@@ -1271,7 +1271,7 @@ class GroupChatManager(ConversableAgent):
 
             if self._is_termination_msg(message):
                 # The conversation is over
-                termination_reason = f"Termination message condition on the GroupChatManager '{self.name}' met."
+                termination_reason = f"Termination message condition on the GroupChatManager '{self.name}' met"
                 break
 
             # broadcast the message to all agents except the speaker
@@ -1280,7 +1280,7 @@ class GroupChatManager(ConversableAgent):
                     await self.a_send(message, agent, request_reply=False, silent=True)
             if i == groupchat.max_round - 1:
                 # the last round
-                termination_reason = f"Maximum rounds ({groupchat.max_round}) reached."
+                termination_reason = f"Maximum rounds ({groupchat.max_round}) reached"
                 break
             try:
                 # select the next speaker
@@ -1298,12 +1298,12 @@ class GroupChatManager(ConversableAgent):
                     raise
             except NoEligibleSpeakerError:
                 # No eligible speaker, terminate the conversation
-                termination_reason = "No eligible speaker found."
+                termination_reason = "No eligible speaker found"
                 break
 
             if reply is None:
                 # no reply is generated, exit the chat
-                termination_reason = "No reply generated."
+                termination_reason = "No reply generated"
                 break
 
             # The speaker sends the message without requesting a reply

--- a/autogen/messages/agent_messages.py
+++ b/autogen/messages/agent_messages.py
@@ -42,7 +42,8 @@ __all__ = [
     "SpeakerAttemptFailedMultipleAgentsMessage",
     "SpeakerAttemptFailedNoAgentsMessage",
     "SpeakerAttemptSuccessfulMessage",
-    "TerminationAndHumanReplyMessage",
+    "TerminationAndHumanReplyNoInputMessage",
+    "TerminationMessage",
     "TextMessage",
     "ToolCallMessage",
     "ToolResponseMessage",
@@ -545,7 +546,9 @@ class GroupChatRunChatMessage(BaseMessage):
 
 
 @wrap_message
-class TerminationAndHumanReplyMessage(BaseMessage):
+class TerminationAndHumanReplyNoInputMessage(BaseMessage):
+    """When the human-in-the-loop is prompted but provides no input."""
+
     no_human_input_msg: str
     sender_name: str
     recipient_name: str
@@ -596,6 +599,31 @@ class UsingAutoReplyMessage(BaseMessage):
         f = f or print
 
         f(colored("\n>>>>>>>> USING AUTO REPLY...", "red"), flush=True)
+
+
+@wrap_message
+class TerminationMessage(BaseMessage):
+    """When a workflow termination condition is met"""
+
+    termination_reason: str
+
+    def __init__(
+        self,
+        *,
+        uuid: Optional[UUID] = None,
+        termination_reason: str,
+        sender: Optional["Agent"] = None,
+        recipient: "Agent",
+    ):
+        super().__init__(
+            uuid=uuid,
+            termination_reason=termination_reason,
+        )
+
+    def print(self, f: Optional[Callable[..., Any]] = None) -> None:
+        f = f or print
+
+        f(colored(f"\n>>>>>>>> TERMINATING: {self.termination_reason}", "red"), flush=True)
 
 
 @wrap_message

--- a/autogen/messages/agent_messages.py
+++ b/autogen/messages/agent_messages.py
@@ -612,8 +612,6 @@ class TerminationMessage(BaseMessage):
         *,
         uuid: Optional[UUID] = None,
         termination_reason: str,
-        sender: Optional["Agent"] = None,
-        recipient: "Agent",
     ):
         super().__init__(
             uuid=uuid,

--- a/test/messages/test_agent_messages.py
+++ b/test/messages/test_agent_messages.py
@@ -34,7 +34,7 @@ from autogen.messages.agent_messages import (
     SpeakerAttemptFailedMultipleAgentsMessage,
     SpeakerAttemptFailedNoAgentsMessage,
     SpeakerAttemptSuccessfulMessage,
-    TerminationAndHumanReplyMessage,
+    TerminationAndHumanReplyNoInputMessage,
     TextMessage,
     ToolCallMessage,
     ToolResponseMessage,
@@ -801,13 +801,13 @@ class TestTerminationAndHumanReplyMessage:
     def test_print(self, uuid: UUID, sender: ConversableAgent, recipient: ConversableAgent) -> None:
         no_human_input_msg = "NO HUMAN INPUT RECEIVED."
 
-        actual = TerminationAndHumanReplyMessage(
+        actual = TerminationAndHumanReplyNoInputMessage(
             uuid=uuid,
             no_human_input_msg=no_human_input_msg,
             sender=sender,
             recipient=recipient,
         )
-        assert isinstance(actual, TerminationAndHumanReplyMessage)
+        assert isinstance(actual, TerminationAndHumanReplyNoInputMessage)
 
         expected_model_dump = {
             "type": "termination_and_human_reply",

--- a/test/messages/test_agent_messages.py
+++ b/test/messages/test_agent_messages.py
@@ -35,6 +35,7 @@ from autogen.messages.agent_messages import (
     SpeakerAttemptFailedNoAgentsMessage,
     SpeakerAttemptSuccessfulMessage,
     TerminationAndHumanReplyNoInputMessage,
+    TerminationMessage,
     TextMessage,
     ToolCallMessage,
     ToolResponseMessage,
@@ -810,7 +811,7 @@ class TestTerminationAndHumanReplyMessage:
         assert isinstance(actual, TerminationAndHumanReplyNoInputMessage)
 
         expected_model_dump = {
-            "type": "termination_and_human_reply",
+            "type": "termination_and_human_reply_no_input",
             "content": {
                 "uuid": uuid,
                 "no_human_input_msg": no_human_input_msg,
@@ -824,6 +825,34 @@ class TestTerminationAndHumanReplyMessage:
         actual.print(f=mock)
         # print(mock.call_args_list)
         expected_call_args_list = [call("\x1b[31m\n>>>>>>>> NO HUMAN INPUT RECEIVED.\x1b[0m", flush=True)]
+        assert mock.call_args_list == expected_call_args_list
+
+
+class TestTerminationMessage:
+    def test_print(self, uuid: UUID) -> None:
+        termination_reason = "User requested to end the conversation."
+
+        actual = TerminationMessage(
+            uuid=uuid,
+            termination_reason=termination_reason,
+        )
+        assert isinstance(actual, TerminationMessage)
+
+        expected_model_dump = {
+            "type": "termination",
+            "content": {
+                "uuid": uuid,
+                "termination_reason": termination_reason,
+            },
+        }
+        assert actual.model_dump() == expected_model_dump
+
+        mock = MagicMock()
+        actual.print(f=mock)
+        # print(mock.call_args_list)
+        expected_call_args_list = [
+            call("\x1b[31m\n>>>>>>>> TERMINATING: " + termination_reason + "\x1b[0m", flush=True)
+        ]
         assert mock.call_args_list == expected_call_args_list
 
 


### PR DESCRIPTION
## Why are these changes needed?

It's not always clear why a workflow ends, so introducing termination messages assists in providing clear reasons why a conversation is terminating.

**Note:** There is no way to turn these specific messages on or off so they will be pushed to the iostream like other messages. They are, however, a new type of message, `TerminationMessage`.

Examples of termination messages, these appear upon termination:

Blank reply:
```
human (to gcm):
And more blank!
--------------------------------------------------------------------------------
Next speaker: blank_agent
>>>>>>>> TERMINATING: No reply generated.
```

Maximum turns reached:
```
my_agent (to user):
If you have any more questions or need assistance, feel free to ask! G'DAY!
--------------------------------------------------------------------------------
>>>>>>>> TERMINATING: Maximum turns (2) reached.
```

Maximum rounds reached:
```
my_agent (to gcm):
The sky appears blue due to a phenomenon called Rayleigh scattering. When sunlight enters the Earth's atmosphere, it interacts with gas molecules and small particles. Blue light has a shorter wavelength compared to other colors in the spectrum, so it is scattered in all directions more effectively. This scattering causes the sky to look predominantly blue during the day. G'DAY!
--------------------------------------------------------------------------------
>>>>>>>> TERMINATING: Maximum rounds (2) reached.
```

User enters 'exit':
```
Replying as human. Provide feedback to gcm. Press enter to skip and use auto-reply,
or type 'exit' to end the conversation: exit    
>>>>>>>> TERMINATING: User requested to end the conversation.
```

Termination message condition and user had option to continue but chose to exit
```
Emma (to Jack):
Emma: Haha! Exactly! And let’s not forget the drama—“You call this a garnish? Where’s the seaweed confit?!” I guess when it comes to cooking, some fish just can’t take the heat… or the salt! FINISH
--------------------------------------------------------------------------------
Please give feedback to Emma. Press enter or type 'exit' to stop the conversation: exit
>>>>>>>> TERMINATING: Termination message condition on agent 'Jack' met and no human input provided.
```

Termination message condition
```
Emma (to Jack):
Emma: Haha! Exactly! And let’s not forget the drama—“You call this a garnish? Where’s the seaweed confit?!” I guess when it comes to cooking, some fish just can’t take the heat… or the salt! FINISH
--------------------------------------------------------------------------------
>>>>>>>> TERMINATING: Termination message condition on agent 'Jack' met.
```

GroupChatManager termination message condition:
```
human (to gcm):
TERMINATE
--------------------------------------------------------------------------------
>>>>>>>> TERMINATING: Termination message condition on the GroupChatManager 'gcm' met.
```

## Related issue number

Closes #1332 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
