### PR TITLE
Add UUID to terminating messages

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1206,7 +1206,7 @@ class GroupChatManager(ConversableAgent):
                     raise
             except NoEligibleSpeakerError:
                 # No eligible speaker, terminate the conversation
-                termination_reason = "No eligible speaker found"
+                termination_reason = "No next speaker selected"
                 break
 
             if reply is None:
@@ -1298,7 +1298,7 @@ class GroupChatManager(ConversableAgent):
                     raise
             except NoEligibleSpeakerError:
                 # No eligible speaker, terminate the conversation
-                termination_reason = "No eligible speaker found"
+                termination_reason = "No next speaker selected"
                 break
 
             if reply is None:

--- a/autogen/messages/agent_messages.py
+++ b/autogen/messages/agent_messages.py
@@ -621,7 +621,7 @@ class TerminationMessage(BaseMessage):
     def print(self, f: Optional[Callable[..., Any]] = None) -> None:
         f = f or print
 
-        f(colored(f"\n>>>>>>>> TERMINATING RUN {str(self.uuid)}: {self.termination_reason}", "red"), flush=True)
+        f(colored(f"\n>>>>>>>> TERMINATING RUN ({str(self.uuid)}): {self.termination_reason}", "red"), flush=True)
 
 
 @wrap_message

--- a/autogen/messages/agent_messages.py
+++ b/autogen/messages/agent_messages.py
@@ -621,7 +621,7 @@ class TerminationMessage(BaseMessage):
     def print(self, f: Optional[Callable[..., Any]] = None) -> None:
         f = f or print
 
-        f(colored(f"\n>>>>>>>> TERMINATING: {self.termination_reason}", "red"), flush=True)
+        f(colored(f"\n>>>>>>>> TERMINATING RUN {str(self.uuid)}: {self.termination_reason}", "red"), flush=True)
 
 
 @wrap_message

--- a/test/messages/test_agent_messages.py
+++ b/test/messages/test_agent_messages.py
@@ -851,7 +851,9 @@ class TestTerminationMessage:
         actual.print(f=mock)
         # print(mock.call_args_list)
         expected_call_args_list = [
-            call("\x1b[31m\n>>>>>>>> TERMINATING RUN (" + str(uuid) + "): " + termination_reason + "\x1b[0m", flush=True)
+            call(
+                "\x1b[31m\n>>>>>>>> TERMINATING RUN (" + str(uuid) + "): " + termination_reason + "\x1b[0m", flush=True
+            )
         ]
         assert mock.call_args_list == expected_call_args_list
 

--- a/test/messages/test_agent_messages.py
+++ b/test/messages/test_agent_messages.py
@@ -851,7 +851,7 @@ class TestTerminationMessage:
         actual.print(f=mock)
         # print(mock.call_args_list)
         expected_call_args_list = [
-            call("\x1b[31m\n>>>>>>>> TERMINATING: " + termination_reason + "\x1b[0m", flush=True)
+            call("\x1b[31m\n>>>>>>>> TERMINATING RUN (" + str(uuid) + "): " + termination_reason + "\x1b[0m", flush=True)
         ]
         assert mock.call_args_list == expected_call_args_list
 


### PR DESCRIPTION
## Why are these changes needed?

As we sometimes run chats within chats, the terminating messages may look like the main chat is terminating. To assist, we are adding the ID to help distinguish if you see multiple termination messages.

It would also be good to have a message when starting a chat that has the ID so that it can be associated with the termination. Not in this PR.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
