### PR TITLE
Updated pydantic version to 2.10.6 (<2.10.2 failing)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "python-dotenv",
     "tiktoken",
     # Disallowing 2.6.0 can be removed when this is fixed https://github.com/pydantic/pydantic/issues/8705
-    "pydantic>=2.6.1,<3",
+    "pydantic>=2.10.6,<3",
     "docker",
     "packaging",
     "asyncer==0.0.8",


### PR DESCRIPTION
## Why are these changes needed?

@lazToum noted that Pydantic versions < 2.10.2 are failing (from `autogen/tools/function_utils.py`):
```
from pydantic._internal._typing_extra import try_eval_type  # type: ignore[attr-defined]
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: cannot import name 'try_eval_type' from 'pydantic._internal._typing_extra' (.../site-packages/pydantic/_internal/_typing_extra.py). Did you mean: '_eval_type'?
```

This updates to the current version, which doesn't throw this exception.

## Related issue number

Closes #1316

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
