### PR TITLE
Fix pydantic import issue for version <2.10.2

### DIFF
--- a/autogen/tools/function_utils.py
+++ b/autogen/tools/function_utils.py
@@ -8,7 +8,7 @@ import functools
 import inspect
 import json
 from logging import getLogger
-from typing import Annotated, Any, Callable, ForwardRef, Mapping, Optional, TypeVar, Union
+from typing import Annotated, Any, Callable, ForwardRef, Optional, TypeVar, Union
 
 from packaging.version import parse
 from pydantic import BaseModel, Field, TypeAdapter
@@ -22,14 +22,7 @@ from .dependency_injection import Field as AG2Field
 if parse(pydantic_version) < parse("2.10.2"):
     from pydantic._internal._typing_extra import eval_type_lenient
 else:
-    from pydantic._internal._typing_extra import eval_type
-
-    def eval_type_lenient(
-        value: Any,
-        globalns: Optional[dict[str, Any]] = None,
-        localns: Optional[Mapping[str, Any]] = None,
-    ) -> Any:
-        return eval_type(value, globalns, localns, lenient=True)  # type: ignore[call-arg]
+    from pydantic._internal._typing_extra import try_eval_type as eval_type_lenient
 
 
 __all__ = ["get_function_schema", "load_basemodels_if_needed", "serialize_to_str"]

--- a/autogen/tools/function_utils.py
+++ b/autogen/tools/function_utils.py
@@ -20,9 +20,9 @@ from ..doc_utils import export_module
 from .dependency_injection import Field as AG2Field
 
 if parse(pydantic_version) < parse("2.10.2"):
-    from pydantic._internal._typing_extra import eval_type_lenient
+    from pydantic._internal._typing_extra import eval_type_lenient as try_eval_type
 else:
-    from pydantic._internal._typing_extra import try_eval_type as eval_type_lenient
+    from pydantic._internal._typing_extra import try_eval_type
 
 
 __all__ = ["get_function_schema", "load_basemodels_if_needed", "serialize_to_str"]
@@ -46,7 +46,7 @@ def get_typed_annotation(annotation: Any, globalns: dict[str, Any]) -> Any:
         annotation = annotation.description
     if isinstance(annotation, str):
         annotation = ForwardRef(annotation)
-        annotation, _ = eval_type_lenient(annotation, globalns, globalns)
+        annotation, _ = try_eval_type(annotation, globalns, globalns)
     return annotation
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When using Pydantic version < v2.10.2, we get this error:
```
    from pydantic._internal._typing_extra import try_eval_type  # type: ignore[attr-defined]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: cannot import name 'try_eval_type' from 'pydantic._internal._typing_extra' (.../site-packages/pydantic/_internal/_typing_extra.py). Did you mean: '_eval_type'?
```

The reason is internal change in a way forward references are being evaluated.

This PR uses different functions for evaluating forwarded references, depending on the version of Pydantic installed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #1316 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
