### PR TITLE
Type fixes for LlamaIndexQueryEngine

### DIFF
--- a/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
+++ b/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
@@ -176,14 +176,14 @@ class LlamaIndexQueryEngine:
             logger.info(f"Loading docs from directory: {input_dir}")
             if not os.path.exists(input_dir):
                 raise ValueError(f"Input directory not found: {input_dir}")
-            loaded_documents.extend(self.file_reader_class(input_dir=input_dir).load_data())  # type: ignore[call-arg]
+            loaded_documents.extend(self.file_reader_class(input_dir=input_dir).load_data())  # type: ignore[operator, call-arg]
 
         if input_docs:
             for doc in input_docs:
                 logger.info(f"Loading input doc: {doc}")
                 if not os.path.exists(doc):
                     raise ValueError(f"Document file not found: {doc}")
-            loaded_documents.extend(self.file_reader_class(input_files=input_docs).load_data())  # type: ignore[call-arg]
+            loaded_documents.extend(self.file_reader_class(input_files=input_docs).load_data())  # type: ignore[operator, call-arg]
 
         if not input_dir and not input_docs:
             raise ValueError("No input directory or docs provided!")

--- a/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
+++ b/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
@@ -44,7 +44,7 @@ class LlamaIndexQueryEngine:
         self,
         vector_store: "BasePydanticVectorStore",
         llm: Optional["LLM"] = None,
-        file_reader_class: Optional["SimpleDirectoryReader"] = None,
+        file_reader_class: Optional[type["SimpleDirectoryReader"]] = None,
     ) -> None:
         """
         Initializes the LlamaIndexQueryEngine with the given vector store.
@@ -175,14 +175,14 @@ class LlamaIndexQueryEngine:
             logger.info(f"Loading docs from directory: {input_dir}")
             if not os.path.exists(input_dir):
                 raise ValueError(f"Input directory not found: {input_dir}")
-            loaded_documents.extend(self.file_reader_class(input_dir=input_dir).load_data())
+            loaded_documents.extend(self.file_reader_class(input_dir=input_dir).load_data())  # type: ignore[operator]
 
         if input_docs:
             for doc in input_docs:
                 logger.info(f"Loading input doc: {doc}")
                 if not os.path.exists(doc):
                     raise ValueError(f"Document file not found: {doc}")
-            loaded_documents.extend(self.file_reader_class(input_files=input_docs).load_data())
+            loaded_documents.extend(self.file_reader_class(input_files=input_docs).load_data())  # type: ignore[operator, arg-type]
 
         if not input_dir and not input_docs:
             raise ValueError("No input directory or docs provided!")

--- a/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
+++ b/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
@@ -176,14 +176,14 @@ class LlamaIndexQueryEngine:
             logger.info(f"Loading docs from directory: {input_dir}")
             if not os.path.exists(input_dir):
                 raise ValueError(f"Input directory not found: {input_dir}")
-            loaded_documents.extend(self.file_reader_class(input_dir=input_dir).load_data())
+            loaded_documents.extend(self.file_reader_class(input_dir=input_dir).load_data())  # type: ignore[call-arg]
 
         if input_docs:
             for doc in input_docs:
                 logger.info(f"Loading input doc: {doc}")
                 if not os.path.exists(doc):
                     raise ValueError(f"Document file not found: {doc}")
-            loaded_documents.extend(self.file_reader_class(input_files=input_docs).load_data())  # type: ignore[arg-type]
+            loaded_documents.extend(self.file_reader_class(input_files=input_docs).load_data())  # type: ignore[call-arg]
 
         if not input_dir and not input_docs:
             raise ValueError("No input directory or docs provided!")

--- a/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
+++ b/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
@@ -45,14 +45,14 @@ class LlamaIndexQueryEngine:
         self,
         vector_store: "BasePydanticVectorStore",
         llm: Optional["LLM"] = None,
-        file_reader_class: Optional[type["BaseReader"]] = None,
+        file_reader_class: Optional["SimpleDirectoryReader"] = None,
     ) -> None:
         """
         Initializes the LlamaIndexQueryEngine with the given vector store.
         Args:
             vector_store: The vector store to use for indexing and querying documents.
             llm: LLM model used by LlamaIndex for query processing. You can find more supported LLMs at [LLM](https://docs.llamaindex.ai/en/stable/module_guides/models/llms/).
-            file_reader_class: The file reader class to use for loading documents. Defaults to SimpleDirectoryReader.
+            file_reader_class: The file reader class to use for loading documents. Only SimpleDirectoryReader is currently supported.
         """
         self.llm: LLM = llm or OpenAI(model="gpt-4o", temperature=0.0)  # type: ignore[no-any-unimported]
         self.vector_store = vector_store
@@ -176,14 +176,14 @@ class LlamaIndexQueryEngine:
             logger.info(f"Loading docs from directory: {input_dir}")
             if not os.path.exists(input_dir):
                 raise ValueError(f"Input directory not found: {input_dir}")
-            loaded_documents.extend(self.file_reader_class(input_dir=input_dir).load_data())  # type: ignore[operator,call-arg]
+            loaded_documents.extend(self.file_reader_class(input_dir=input_dir).load_data())
 
         if input_docs:
             for doc in input_docs:
                 logger.info(f"Loading input doc: {doc}")
                 if not os.path.exists(doc):
                     raise ValueError(f"Document file not found: {doc}")
-            loaded_documents.extend(self.file_reader_class(input_files=input_docs).load_data())  # type: ignore[operator,call-arg]
+            loaded_documents.extend(self.file_reader_class(input_files=input_docs).load_data())
 
         if not input_dir and not input_docs:
             raise ValueError("No input directory or docs provided!")

--- a/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
+++ b/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
@@ -176,14 +176,14 @@ class LlamaIndexQueryEngine:
             logger.info(f"Loading docs from directory: {input_dir}")
             if not os.path.exists(input_dir):
                 raise ValueError(f"Input directory not found: {input_dir}")
-            loaded_documents.extend(self.file_reader_class(input_dir=input_dir).load_data())  # type: ignore[operator, call-arg]
+            loaded_documents.extend(self.file_reader_class(input_dir=input_dir).load_data())  # type: ignore[operator,call-arg]
 
         if input_docs:
             for doc in input_docs:
                 logger.info(f"Loading input doc: {doc}")
                 if not os.path.exists(doc):
                     raise ValueError(f"Document file not found: {doc}")
-            loaded_documents.extend(self.file_reader_class(input_files=input_docs).load_data())  # type: ignore[operator, call-arg]
+            loaded_documents.extend(self.file_reader_class(input_files=input_docs).load_data())  # type: ignore[operator,call-arg]
 
         if not input_dir and not input_docs:
             raise ValueError("No input directory or docs provided!")

--- a/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
+++ b/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
@@ -13,7 +13,6 @@ from ....import_utils import optional_import_block, require_optional_import
 with optional_import_block():
     from llama_index.core import SimpleDirectoryReader, StorageContext, VectorStoreIndex
     from llama_index.core.llms import LLM
-    from llama_index.core.readers.base import BaseReader
     from llama_index.core.schema import Document as LlamaDocument
     from llama_index.core.vector_stores.types import BasePydanticVectorStore
     from llama_index.llms.openai import OpenAI

--- a/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
+++ b/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
@@ -45,7 +45,7 @@ class LlamaIndexQueryEngine:
         self,
         vector_store: "BasePydanticVectorStore",
         llm: Optional["LLM"] = None,
-        file_reader_class: Optional["BaseReader"] = None,
+        file_reader_class: Optional[type["BaseReader"]] = None,
     ) -> None:
         """
         Initializes the LlamaIndexQueryEngine with the given vector store.

--- a/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
+++ b/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
@@ -171,7 +171,7 @@ class LlamaIndexQueryEngine:
             ValueError: If any provided file path does not exist.
             ValueError: If neither input_dir nor input_docs is provided.
         """
-        loaded_documents = []
+        loaded_documents: list["LlamaDocument"] = []  # type: ignore[no-any-unimported]
         if input_dir:
             logger.info(f"Loading docs from directory: {input_dir}")
             if not os.path.exists(input_dir):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,8 @@ google-search = [
 
 neo4j = [
     "docx2txt==0.8",
-    "llama-index==0.12.22",
+    "llama-index>=0.12,<1",
     "llama-index-graph-stores-neo4j==0.4.6",
-    "llama-index-core==0.12.22",
     "llama-index-readers-web==0.3.7",
 ]
 


### PR DESCRIPTION
## Why are these changes needed?

Type checks are failing for LlamaIndexQueryEngine:
```
autogen/agentchat/contrib/rag/llamaindex_query_engine.py:174: error: Need type annotation for "loaded_documents" (hint: "loaded_documents: list[<type>] = ...")  [var-annotated]
autogen/agentchat/contrib/rag/llamaindex_query_engine.py:179: error: "BaseReader" not callable  [operator]
autogen/agentchat/contrib/rag/llamaindex_query_engine.py:186: error: "BaseReader" not callable  [operator]
autogen/agentchat/contrib/rag/llamaindex_query_engine.py:186: note: Error code "operator" not covered by "type: ignore" comment
```

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
