### PR TITLE
docs: Fix incorrect model name

### DIFF
--- a/website/docs/home/quick-start.mdx
+++ b/website/docs/home/quick-start.mdx
@@ -42,7 +42,7 @@ from autogen import ConversableAgent, LLMConfig
 
 # 2. Define our LLM configuration for OpenAI's GPT-4o mini
 #    uses the OPENAI_API_KEY environment variable
-llm_config = LLMConfig(api_type="openai", model="gpt-4o-mini")
+llm_config = LLMConfig(api_type="openai", model="gpt-4o")
 
 # 3. Create our LLM agent
 with llm_config:
@@ -68,7 +68,7 @@ from autogen import ConversableAgent, LLMConfig
 
 # 2. Define our LLM configuration for OpenAI's GPT-4o mini,
 #    uses the OPENAI_API_KEY environment variable
-llm_config = LLMConfig(api_type="openai", model="gpt-4o-mini")
+llm_config = LLMConfig(api_type="openai", model="gpt-4o")
 
 # 3. Create our agents who will tell each other jokes,
 #    with Jack ending the chat when Emma says FINISH
@@ -113,7 +113,7 @@ from autogen import ConversableAgent, GroupChat, GroupChatManager, LLMConfig
 
 # Define our LLM configuration for OpenAI's GPT-4o mini
 # uses the OPENAI_API_KEY environment variable
-llm_config = LLMConfig(api_type="openai", model="gpt-4o-mini")
+llm_config = LLMConfig(api_type="openai", model="gpt-4o")
 
 with llm_config:
     # Planner agent setup


### PR DESCRIPTION
## Why are these changes needed?

The model name `gpt-4o-mini` was incorrectly referenced in the documentation. The correct model name is `gpt-4o`. This change ensures that users follow accurate instructions when configuring their models.

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.