### PR TITLE
YouTube tool notebook metadata and documentation page linking

### DIFF
--- a/notebook/tools_youtube_search.ipynb
+++ b/notebook/tools_youtube_search.ipynb
@@ -139,15 +139,15 @@
   }
  ],
  "metadata": {
-    "front_matter": {
-        "description": "YouTube Search Integration with AG2",
-        "tags": [
-            "tools",
-            "youtube",
-            "video",
-            "search"
-        ]
-        },     
+  "front_matter": {
+   "description": "YouTube Search Integration with AG2",
+   "tags": [
+    "tools",
+    "youtube",
+    "video",
+    "search"
+   ]
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebook/tools_youtube_search.ipynb
+++ b/notebook/tools_youtube_search.ipynb
@@ -139,6 +139,15 @@
   }
  ],
  "metadata": {
+    "front_matter": {
+        "description": "YouTube Search Integration with AG2",
+        "tags": [
+            "tools",
+            "youtube",
+            "video",
+            "search"
+        ]
+        },     
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -263,7 +263,8 @@
               "group": "Google APIs",
               "pages":
               [
-                "docs/user-guide/reference-tools/google-api/google-search"
+                "docs/user-guide/reference-tools/google-api/google-search",
+                "docs/user-guide/reference-tools/google-api/youtube-search"
               ]
             },
             "docs/user-guide/reference-tools/perplexity-search",


### PR DESCRIPTION
## Why are these changes needed?

Add YouTube tool notebook metadata and Documentation page link

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
