### PR TITLE
Fixes the URL to Basic concepts in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The project is currently maintained by a [dynamic group of volunteers](MAINTAINE
 
 ## Getting started
 
-For a step-by-step walk through of AG2 concepts and code, see [Basic Concepts](https://docs.ag2.ai/docs/user-guide/basic-concepts) in our documentation.
+For a step-by-step walk through of AG2 concepts and code, see [Basic Concepts](https://docs.ag2.ai/0.8.5/docs/user-guide/basic-concepts/) in our documentation.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The project is currently maintained by a [dynamic group of volunteers](MAINTAINE
 
 ## Getting started
 
-For a step-by-step walk through of AG2 concepts and code, see [Basic Concepts](https://docs.ag2.ai/0.8.5/docs/user-guide/basic-concepts/) in our documentation.
+For a step-by-step walk through of AG2 concepts and code, see [Basic Concepts](https://docs.ag2.ai/latest/docs/user-guide/basic-concepts/installing-ag2/) in our documentation.
 
 ### Installation
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The link to basic concepts is broken. This PR fixes it by pointing to the basic concepts section in 0.8.5 docs.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #1547

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
