### PR TITLE
Clean up ConversableAgent doc: improved clarity, added example links

### DIFF
--- a/website/docs/user-guide/basic-concepts/conversable-agent.mdx
+++ b/website/docs/user-guide/basic-concepts/conversable-agent.mdx
@@ -2,9 +2,9 @@
 title: ConversableAgent
 ---
 
-ConversableAgent is at the heart of all AG2 agents while also being a fully functioning agent.
+The [`ConversableAgent`](/docs/api-reference/autogen/ConversableAgent) is at the heart of all AG2 agents and functions as a fully operational agent on its own.
 
-Let's *converse* with ConversableAgent in just 5 simple steps.
+Let's *converse* with `ConversableAgent` in just five simple steps.
 
 import Example from "/snippets/python-examples/conversableagentchat.mdx";
 
@@ -35,3 +35,12 @@ Let's break it down:
     --------------------------------------------------------------------------------
     Replying as user. Provide feedback to helpful_agent. Press enter to skip and use auto-reply, or type 'exit' to end the conversation:
     ```
+<Tip>
+
+Looking for real-world usage of `ConversableAgent`?
+Check out these notebook examples:
+
+- [Sequential Chats](https://docs.ag2.ai/latest/docs/use-cases/notebooks/notebooks/agentchats_sequential_chats/?h=conversable)
+- [Image Generation Capability](https://docs.ag2.ai/latest/docs/use-cases/notebooks/notebooks/agentchat_image_generation_capability/?h=conversable)
+
+</Tip>


### PR DESCRIPTION
## Why are these changes needed?

Improved the ConversableAgent documentation to enhance readability and accessibility:
- Refined explanations for clarity
- Hyperlinked the first reference to [ConversableAgent] to the API docs
- Added a <Tip> block with links to real-world examples
- Passed pre-commit checks successfully

## Related issue number

Closes #1507

## Checks

- [x] I've included the needed doc changes
- [ ] I've added tests (not relevant here — doc-only change)
- [x] I've made sure all auto checks have passed
