### PR TITLE
chore: fix validation logic for empty descriptions

### DIFF
--- a/autogen/agentchat/contrib/llamaindex_conversable_agent.py
+++ b/autogen/agentchat/contrib/llamaindex_conversable_agent.py
@@ -47,7 +47,7 @@ class LLamaIndexConversableAgent(ConversableAgent):
         if llama_index_agent is None:
             raise ValueError("llama_index_agent must be provided")
 
-        if description is None or description.isspace():
+        if not description or description.strip() == "":
             raise ValueError("description must be provided")
 
         super().__init__(


### PR DESCRIPTION
## Why are these changes needed?

The original check using `description.isspace()` fails to catch empty strings (`""`), allowing invalid inputs to pass through. This fix ensures that both `None`, empty strings, and strings with only whitespace are properly handled by using `not description or description.strip() == ""`.

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.  
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.  
- [x] I've made sure all auto checks have passed.