### PR TITLE
chore: fixed dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,8 @@ print(chat_result.chat_history[-1]["content"])
 
 AG2 supports more advanced concepts to help you build your AI agent workflows. You can find more information in the documentation.
 
-- [Structured Output](https://docs.ag2.ai/latest/docs/user-guide/basic-concepts/llm-configuration/llm-configuration/structured-outputs)
-- [Ending a conversation](https://docs.ag2.ai/docs/user-guide/basic-concepts/ending-a-chat)
+- [Structured Output](https://docs.ag2.ai/latest/docs/user-guide/basic-concepts/llm-configuration/structured-outputs)
+- [Ending a conversation](https://docs.ag2.ai/latest/docs/user-guide/basic-concepts/orchestration/ending-a-chat/)
 - [Retrieval Augmented Generation (RAG)](https://docs.ag2.ai/docs/user-guide/advanced-concepts/rag)
 - [Code Execution](https://docs.ag2.ai/docs/user-guide/advanced-concepts/code-execution)
 - [Tools with Secrets](https://docs.ag2.ai/docs/user-guide/basic-concepts/tools/tools-with-secrets)

--- a/announcements.md
+++ b/announcements.md
@@ -16,7 +16,7 @@ We adopt the Apache 2.0 license from v0.3. This enhances our commitment to open-
 
 🎉 Apr 17, 2024: Andrew Ng cited AutoGen in [The Batch newsletter](https://www.deeplearning.ai/the-batch/issue-245/) and [What's next for AI agentic workflows](https://youtu.be/sal78ACtGTc?si=JduUzN_1kDnMq0vF) at Sequoia Capital's AI Ascent (Mar 26).
 
-🎉 Mar 3, 2024: What's new in AutoGen? 📰[Blog](https://docs.ag2.ai/blog/2024-03-03-AutoGen-Update); 📺[Youtube](https://www.youtube.com/watch?v=j_mtwQiaLGU).
+🎉 Mar 3, 2024: What's new in AutoGen? 📰[Blog](https://docs.ag2.ai/latest/docs/blog/2024/03/03/AutoGen-Update/); 📺[Youtube](https://www.youtube.com/watch?v=j_mtwQiaLGU).
 
 🎉 Mar 1, 2024: the first AutoGen multi-agent experiment on the challenging [GAIA](https://huggingface.co/spaces/gaia-benchmark/leaderboard) benchmark achieved the No. 1 accuracy in all the three levels.
 
@@ -26,7 +26,7 @@ We adopt the Apache 2.0 license from v0.3. This enhances our commitment to open-
 
 🔥 Nov 24: pyautogen [v0.2](https://github.com/ag2ai/ag2/releases/tag/v0.2.0) is released with many updates and new features compared to v0.1.1. It switches to using openai-python v1. Please read the [migration guide](https://docs.ag2.ai/docs/installation/Installation).
 
-🔥 Nov 11: OpenAI's Assistants are available in AutoGen and interoperatable with other AutoGen agents! Checkout our [blogpost](https://docs.ag2.ai/blog/2023-11-13-OAI-assistants) for details and examples.
+🔥 Nov 11: OpenAI's Assistants are available in AutoGen and interoperatable with other AutoGen agents! Checkout our [blogpost](https://docs.ag2.ai/latest/docs/blog/2023/11/13/OAI-assistants/) for details and examples.
 
 🎉 Nov 8, 2023: AutoGen is selected into [Open100: Top 100 Open Source achievements](https://www.benchcouncil.org/evaluation/opencs/annual.html) 35 days after spinoff from [FLAML](https://github.com/microsoft/FLAML).
 


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Several documentation links in `README.md` and `announcements.md` were outdated and returning 404 errors. I updated them to point to the correct current locations in our documentation.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
