### PR TITLE
fix: register_handoff is not working as expected in a_run_swarm 

### DIFF
--- a/autogen/agentchat/contrib/graph_rag/falkor_graph_query_engine.py
+++ b/autogen/agentchat/contrib/graph_rag/falkor_graph_query_engine.py
@@ -36,7 +36,7 @@ class FalkorGraphQueryEngine:
         """Initialize a FalkorDB knowledge graph.
         Please also refer to https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/kg.py
 
-        TODO: Fix LLM API cost calculation for FalkorDB useages.
+        TODO: Fix LLM API cost calculation for FalkorDB usages.
 
         Args:
             name (str): Knowledge graph name.

--- a/autogen/agentchat/contrib/swarm_agent.py
+++ b/autogen/agentchat/contrib/swarm_agent.py
@@ -1139,6 +1139,10 @@ async def a_initiate_swarm_chat(
     # Point all ConversableAgent's context variables to this function's context_variables
     _setup_context_variables(tool_execution, agents, manager, context_variables)
 
+    # Link all agents with the GroupChatManager to allow access to the group chat
+    # and other agents, particularly the tool executor for setting _swarm_next_agent
+    _link_agents_to_swarm_manager(groupchat.agents, manager)  # Commented out as the function is not defined
+
     if len(processed_messages) > 1:
         last_agent, last_message = await manager.a_resume(messages=processed_messages)
         clear_history = False
@@ -1312,11 +1316,13 @@ def register_hand_off(
             elif isinstance(transit.target, dict):
                 # Transition to a nested chat
                 # We will store them here and establish them in the initiate_swarm_chat
-                agent._swarm_nested_chat_handoffs.append({  # type: ignore[attr-defined]
-                    "nested_chats": transit.target,
-                    "condition": transit.condition,
-                    "available": transit.available,
-                })
+                agent._swarm_nested_chat_handoffs.append(
+                    {  # type: ignore[attr-defined]
+                        "nested_chats": transit.target,
+                        "condition": transit.condition,
+                        "available": transit.available,
+                    }
+                )
 
         elif isinstance(transit, OnContextCondition):
             agent._swarm_oncontextconditions.append(transit)  # type: ignore[attr-defined]


### PR DESCRIPTION
## Why are these changes needed?

I am doing one poc with a_run_swarm. I am just replicating the context router example using a_run_swarm. it didn't get transitioned properly. I got an error saying,

`AttributeError: 'ConversableAgent' object has no attribute '_swarm_manager'`

Closes #1603 

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

I haven't done anything in checks. But, I am thinking it's a minor fix, so.
