### PR TITLE
[Docs] Home Page bug fix on desktop breakpoint

### DIFF
--- a/website/mkdocs/docs/stylesheets/extra.css
+++ b/website/mkdocs/docs/stylesheets/extra.css
@@ -94,6 +94,13 @@ a.internal-link::after {
     content: "\00A0↪";
 }
 
+ /* Hide both sidebars but keep navigation tabs */
+@media (min-width: 1220px) {
+  .md-sidebar, .md-sidebar--primary, .md-sidebar--secondary {
+    display: none !important;
+  }
+}
+
 .md-header, .md-tabs {
     background-color: #000;
 }

--- a/website/mkdocs/docs/stylesheets/extra.css
+++ b/website/mkdocs/docs/stylesheets/extra.css
@@ -94,13 +94,6 @@ a.internal-link::after {
     content: "\00A0↪";
 }
 
- /* Hide both sidebars but keep navigation tabs */
-@media (min-width: 1220px) {
-  .md-sidebar, .md-sidebar--primary, .md-sidebar--secondary {
-    display: none !important;
-  }
-}
-
 .md-header, .md-tabs {
     background-color: #000;
 }

--- a/website/mkdocs/overrides/home.html
+++ b/website/mkdocs/overrides/home.html
@@ -97,6 +97,13 @@
     padding-top: 0 !important;
   }
 
+   /* On desktop, hide both sidebars but keep navigation tabs */
+  @media (min-width: 1220px) {
+    .md-sidebar, .md-sidebar--primary, .md-sidebar--secondary {
+      display: none !important;
+    }
+  }
+
   /* Simple styles */
   .home-container {
     background: linear-gradient(335deg, #5fdbfd 0%, rgba(95, 219, 253, 1) 22.562992680180177%, rgba(128, 238, 211, 1) 50.895129504504496%, rgba(244, 235, 167, 1) 75.47353603603604%, rgba(244, 235, 167, 1) 100%);


### PR DESCRIPTION
## Why are these changes needed?
#1605 fixed accessing the menu on the Docs home page on mobile, but added these gaps to the desktop breakpoint.

### Before
<img width="1486" alt="image" src="https://github.com/user-attachments/assets/0ee75368-0c8d-4251-9950-a6c465ba9d01" />

### After
<img width="1367" alt="image" src="https://github.com/user-attachments/assets/d280c501-d3b8-43ea-87c0-39c291757c30" />


The sidebar divs aren't needed on the docs home page on desktop (so they should be hidden) but are necessary for viewing the menu on mobile. So I updated the CSS to hide these only on the Desktop breakpoint.

## Related issue number
None. Just a quick bug fix.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
