### PR TITLE
[Docs] Wording tweak on home page

### DIFF
--- a/website/mkdocs/overrides/home.html
+++ b/website/mkdocs/overrides/home.html
@@ -490,7 +490,7 @@
     <img src="images/cloud.png" alt="Cloud" class="cloud right small"/>
   </div>
   <div class="keyfeatures">
-    <h2 class="jersey">The End-to-End Platform for Multi-Agent Automation </h2>
+    <h2 class="jersey">The Open-Source Operating System for Agentic AI</h2>
     <div class="cardgroup">
       <div class="card yellow-bg">
         <div class="card-content">


### PR DESCRIPTION
## Why are these changes needed?
As per feedback from @qingyun-wu, I'm updating a heading on the docs home page from "The End-to-End Platform for Multi-Agent Automation" to "The Open-Source Operating System for Agentic AI". The word 'automation' is a bit restricted.

## Related issue number
None. Just a quick wording update

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
