### PR TITLE
Fix: stop printing request params to stdout for `o1` /` o1‑mini`; switch to `logger.debug`

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -654,7 +654,7 @@ class OpenAIClient:
         """Cater for the reasoning model (o1, o3..) parameters
         please refer: https://platform.openai.com/docs/guides/reasoning#limitations
         """
-        print(f"{params=}")
+        logger.debug(f"{params=}")
 
         # Unsupported parameters
         unsupported_params = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`print(f"{params=}")` unconditionally sends internal request parameters to **stdout** for the `o1` / `o1‑mini` code path.  
This risks leaking sensitive prompt data, and is inconsistent with other models.
Switching to `logger.debug(...)` (or removing the call) keeps stdout clean while still allowing developers to view the same details via standard logging configuration.

## Related issue number

Closes #1624 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
