### PR TITLE
docs: fix extra parentheses in docstring

### DIFF
--- a/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
+++ b/autogen/agentchat/contrib/rag/llamaindex_query_engine.py
@@ -154,7 +154,7 @@ class LlamaIndexQueryEngine:
         """
         Load documents from a directory and/or a sequence of file paths.
 
-        Default to uses LlamaIndex's SimpleDirectoryReader that supports multiple file[formats]((https://docs.llamaindex.ai/en/stable/module_guides/loading/simpledirectoryreader/#supported-file-types)).
+        Default to uses LlamaIndex's SimpleDirectoryReader that supports multiple file[formats](https://docs.llamaindex.ai/en/stable/module_guides/loading/simpledirectoryreader/#supported-file-types).
 
         Args:
             input_dir (Optional[Union[Path, str]]): The directory containing documents to be loaded.


### PR DESCRIPTION
Removes the redundant `((...))` brackets in the docstring to maintain correct formatting