### PR TITLE
[Docs] Tidy up whitespace and layout across all pages

### DIFF
--- a/website/docs/user-guide/advanced-concepts/swarm/concept-code.mdx
+++ b/website/docs/user-guide/advanced-concepts/swarm/concept-code.mdx
@@ -3,7 +3,11 @@ title: Swarm Concept Code
 sidebarTitle: Concepts code
 ---
 
+### Core Swarm Concepts
+
 Here are two simple and complete Swarm examples to demonstrate the basic concepts of a swarm.
+
+### Function-Based Agent Transfers
 
 This first example demonstrates (see matching numbers in the code):
 1. How to update and return context variables in functions
@@ -105,6 +109,8 @@ chat_result, context_variables, last_agent = initiate_swarm_chat(
     after_work=AfterWork(AfterWorkOption.TERMINATE),  # this is the default value
 )
 ```
+
+### User Interaction in Swarms
 
 This second example shows how to incorporate your own user agent into a swarm, allowing you to be a part of the swarm.
 

--- a/website/docs/user-guide/advanced-concepts/swarm/nested-chat.mdx
+++ b/website/docs/user-guide/advanced-concepts/swarm/nested-chat.mdx
@@ -3,6 +3,8 @@ title: Registering Handoffs to a nested chat
 sidebarTitle: Nested chats
 ---
 
+### Understanding Nested Chats in Swarms
+
 In addition to transferring to an agent, you can also trigger a nested chat by using a handoff with [`OnCondition`](/docs/api-reference/autogen/OnCondition). This is a useful way to perform sub-tasks without that work becoming part of the broader swarm's messages and agents.
 
 Configuring the nested chat is similar to [establishing a nested chat for an agent](/docs/user-guide/advanced-concepts/conversation-patterns-deep-dive#nested-chats).
@@ -23,6 +25,8 @@ nested_chats = [
  },
 ]
 ```
+
+### Configuring Carryover Context
 
 New to nested chats within swarms is the ability to **carryover some context from the swarm chat into the nested chat**. This is done by adding a carryover configuration. If you're not using carryover, then no messages from the swarm chat will be brought into the nested chat.
 
@@ -64,6 +68,8 @@ nested_chats = [
  },
 ]
 ```
+
+### Implementing Nested Chats as Handoffs
 
 Finally, we add the nested chat as a handoff in the same way as we do to an agent:
 

--- a/website/docs/user-guide/advanced-concepts/swarm/use-case.mdx
+++ b/website/docs/user-guide/advanced-concepts/swarm/use-case.mdx
@@ -7,6 +7,8 @@ sidebarTitle: Use Case Example
 If you haven't had a chance to read about or use AG2's Swarm orchestration, see the [Basic Concepts](/docs/user-guide/basic-concepts/orchestration/swarm) section on Swarm.
 </Tip>
 
+### Building a Customer Service Workflow
+
 You can build complex, yet flexible, workflows using AG2's Swarm orchestration.
 
 In this walk-through of a customer service workflow, we will utilize three of the advanced features available in a Swarm orchestration:
@@ -26,6 +28,8 @@ Key aspects of this swarm are:
 1. System messages are customized, incorporating the context of the workflow
 2. A nested chat handles the order retrieval and summarization
 3. Handoffs are conditional, only being available when they are relevant
+
+### Creating the Swarm Architecture
 
 #### Setting up
 
@@ -49,6 +53,8 @@ from autogen import (
 # Put your key in the OPENAI_API_KEY environment variable
 llm_config = LLMConfig(api_type="openai", model="gpt-4o-mini")
 ```
+
+### Implementing Advanced Swarm Features
 
 #### Context
 With all agents in a Swarm sharing a common context as well as being able to use that context in system messages and hand-off conditions, context variables are a key component to AG2's Swarm.

--- a/website/docs/user-guide/basic-concepts/conversable-agent.mdx
+++ b/website/docs/user-guide/basic-concepts/conversable-agent.mdx
@@ -4,13 +4,15 @@ title: ConversableAgent
 
 The [`ConversableAgent`](/docs/api-reference/autogen/ConversableAgent) is at the heart of all AG2 agents and functions as a fully operational agent on its own.
 
+### Getting Started with ConversableAgent
+
 Let's *converse* with `ConversableAgent` in just five simple steps.
 
 import Example from "/snippets/python-examples/conversableagentchat.mdx";
 
 <Example/>
 
-Let's break it down:
+### Let's break it down
 
 1. Import `ConversableAgent`, you'll find the most popular classes available directly from `autogen`.
 

--- a/website/docs/user-guide/basic-concepts/llm-configuration/structured-outputs.mdx
+++ b/website/docs/user-guide/basic-concepts/llm-configuration/structured-outputs.mdx
@@ -4,7 +4,11 @@ title: Structured outputs
 
 Working with freeform text from LLMs isn't optimal when you know how you want the reply formatted.
 
+### What Are Structured Outputs?
+
 Using structured outputs, you define a class, based on Pydantic's `BaseModel`, for the reply format you want and attach it to the LLM configuration. Replies from agent using that configuration will be in a matching JSON format.
+
+### Example: Structured Output for a Lesson Plan
 
 In earlier examples, we created a classroom lesson plan and provided guidance in the agent's system message to put the content in tags, like `<title>` and `<learning_objectives>`. Using structured outputs we can ensure that our lesson plans are formatted.
 
@@ -33,6 +37,9 @@ import Example from "/snippets/python-examples/structured_output.mdx";
   "script": "Introduction (10 minutes):\nBegin the class by asking students what they already know about the solar system. Write their responses on the board. \n\nIntroduce the topic by explaining that today they will be learning about the solar system, which includes the Sun, planets, moons, and other celestial objects.\n\nDirect Instruction (20 minutes):\nUse a visual aid (such as a poster or video) to show the solar system's structure. \n\nDiscuss the eight planets: Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, and Neptune. \n\nFor each planet, mention:\n- Its position from the Sun.\n- Key characteristics (e.g., size, color, temperature).\n- Any notable features (e.g., rings, atmosphere). \n\nInteractive Activity (15 minutes):\nSplit the class into small groups. Give each group a set of planet cards that include pictures and information. Have them work together to put the planets in order from the Sun. Each group will present their order and one interesting fact about each planet they discussed."
 }
 ```
+
+### Formatting the Output
+
 <Tip>
 Add a `format` function to the LessonPlan class in the example to convert the returned value into a string. [Example here](/docs/use-cases/notebooks/notebooks/agentchat_structured_outputs).
 </Tip>

--- a/website/docs/user-guide/basic-concepts/orchestration/nested-chat.mdx
+++ b/website/docs/user-guide/basic-concepts/orchestration/nested-chat.mdx
@@ -4,6 +4,8 @@ Title: Nested chat
 
 A powerful method to encapsulate a single workflow into an agent is through AG2's nested chats.
 
+### How Nested Chats Work
+
 Nested chats is powered by the nested chats handler, which is a pluggable component of [`ConversableAgent`](/docs/api-reference/autogen/ConversableAgent). The figure below illustrates how the nested chats handler triggers a sequence of nested chats when a message is received.
 
 ![nested_chat](../assets/nested-chats.png)
@@ -16,6 +18,8 @@ In each of the nested chats, the sender agent is always the same agent that trig
 
 In the end, the nested chat handler uses the results of the nested chats to produce a response to the original message (by default a summary of the last chat).
 
+### Example: Encapsulating Complex Workflows
+
 Here is an example of a nested chat where a single agent, `lead_teacher_agent` encapsulates a workflow involving five other agents. This inner workflow includes two-agent chats and a group chat.
 
 The end result is that when this agent is called to reply in a chat it will, internally, run through a workflow using the nested chats and a fully considered lesson plan will be returned as its reply.
@@ -23,6 +27,8 @@ The end result is that when this agent is called to reply in a chat it will, int
 import Example from "/snippets/python-examples/nestedchat.mdx";
 
 <Example/>
+
+### Benefits and Further Resources
 
 Nested chat is a useful conversation pattern that allows you to package complex workflows into a single agent.
 

--- a/website/docs/user-guide/basic-concepts/orchestration/sequential-chat.mdx
+++ b/website/docs/user-guide/basic-concepts/orchestration/sequential-chat.mdx
@@ -4,6 +4,8 @@ Title: Sequential chat
 
 As a sequence of chats between two agents chained together by a mechanism called *carryover*, the sequential chat pattern is useful for complex tasks that can be broken down into interdependent sub-tasks.
 
+### Understanding the Sequential Chat Pattern
+
 The figure below illustrates how this pattern works.
 
 ![initiate_chats](../assets/sequential-two-agent-chat.png)
@@ -13,6 +15,8 @@ In this pattern, a pair of agents start a two-agent chat, then the summary of th
 Carryover accumulates as the conversation moves forward, so each subsequent chat starts with all the carryovers from previous chats.
 
 The figure above shows distinct recipient agents for all the chats, however, the recipient agents in the sequence are allowed to repeat.
+
+### Building a Sequential Workflow
 
 To illustrate this pattern, let's create a sequential workflow to create our lesson plan for the fourth grade class.
 
@@ -25,6 +29,8 @@ A teacher agent will engage three agents sequentially:
 import Example from "/snippets/python-examples/sequentialchat.mdx";
 
 <Example/>
+
+### Customizing Chat Behavior
 
 The sequential chat is triggered by the teacher agent's [`initiate_chats`](/docs/api-reference/autogen/ConversableAgent#initiate-chats) method, which takes a list of dictionaries where each dictionary represents a chat between the teacher and the `recipient` agent.
 

--- a/website/docs/user-guide/basic-concepts/orchestration/swarm.mdx
+++ b/website/docs/user-guide/basic-concepts/orchestration/swarm.mdx
@@ -2,9 +2,13 @@
 title: Swarm
 ---
 
+### Introduction to Swarms
+
 Swarms are a versatile pattern that provide flows between agents that are determined at the swarm or agent-level. The control of the flow is managed through various mechanisms, including hand-offs, post-tool transitions, post-work transitions, or an internal group chat manager, all of which determine the next agent (or end the swarm).
 
 The simplest swarm comprises of a group of agents and utilizes the swarm's internal manager (a [`GroupChatManager`](/docs/api-reference/autogen/GroupChatManager)) to decide, based on the conversation messages and the agent's descriptions, who should be the next agent.
+
+### Basic Swarm Implementation
 
 Here's an example.
 

--- a/website/docs/user-guide/basic-concepts/tools/basics.mdx
+++ b/website/docs/user-guide/basic-concepts/tools/basics.mdx
@@ -3,6 +3,8 @@ title: Tools
 sidebarTitle: Overview
 ---
 
+### Understanding Tool Usage in AG2
+
 Agents significantly enhance their capabilities by leveraging tools, which provide access to external data, APIs, and additional functionality.
 
 In **AG2**, tool usage happens in two stages:
@@ -13,6 +15,8 @@ In **AG2**, tool usage happens in two stages:
 Typically, you'll create two agents. One to determine the appropriate tool and another to carry out the execution.
 
 <Note>In a conversation, the executor agent must always follow the agent that suggests a tool.</Note>
+
+### Example: Implementing a Date Tool
 
 import Example from "/snippets/python-examples/toolregister.mdx";
 
@@ -63,6 +67,8 @@ import Example from "/snippets/python-examples/toolregister.mdx";
 
     --------------------------------------------------------------------------------
     ```
+
+### Alternative Registration Methods
 
 Alternatively, you can use decorators [`register_for_execution`](/docs/api-reference/autogen/ConversableAgent#register-for-execution) and [`register_for_llm`](/docs/api-reference/autogen/ConversableAgent#register-for-llm) to register a tool. So, instead of using [`register_function`](/docs/api-reference/autogen/register_function), you can register them with the function definition.
 ```python

--- a/website/docs/user-guide/basic-concepts/tools/tools-with-secrets.mdx
+++ b/website/docs/user-guide/basic-concepts/tools/tools-with-secrets.mdx
@@ -2,6 +2,8 @@
 title: Tools with Secrets
 ---
 
+### Introduction to Dependency Injection
+
 Secrets such as password, tokens, or personal information needs to be protected from capture. AG2 provides dependency injection as a way to secure this sensitive information while still allowing agents to perform their tasks effectively, even when working with large language models (LLMs).
 
 Benefits of dependency injection:
@@ -25,6 +27,8 @@ from autogen.tools.dependency_injection import BaseContext, Depends
 
 llm_config = LLMConfig(api_type="openai", model="gpt-4o-mini", api_key=os.environ["OPENAI_API_KEY"])
 ```
+
+### Setting Up Third-Party Systems
 
 We have 2 external systems and have 2 related login credentials. We don't want or need the LLM to be aware of these credentials.
 
@@ -81,6 +85,8 @@ user_proxy = UserProxyAgent(
     llm_config=False,
 )
 ```
+
+### Implementing Secure Tools
 
 #### Creating credentials and tools with dependency injection
 For each 3rd party system we create the credentials and a tool.

--- a/website/docs/user-guide/reference-agents/websurferagent.mdx
+++ b/website/docs/user-guide/reference-agents/websurferagent.mdx
@@ -3,6 +3,8 @@ title: WebSurferAgent
 sidebarTitle: WebSurferAgent
 ---
 
+### Introduction to WebSurferAgent
+
 If you need an agent that can browse, extract, or interact with the web, [`WebSurferAgent`](/docs/api-reference/autogen/agents/experimental/WebSurferAgent) is a good choice. The agent actions the request(s) given to it by determining what to do on the web and browsing and crawling it, returning the details of what it finds.
 
 The [`WebSurferAgent`](/docs/api-reference/autogen/agents/experimental/WebSurferAgent) has two in-built web tools to choose from:
@@ -17,6 +19,8 @@ If you want to add browsing capabilities to your existing agents, see [this note
 <Warning>
 [`Browser Use`](https://github.com/browser-use/browser-use) requires **Python 3.11 or higher**.
 </Warning>
+
+### Installation and Setup
 
 To get started with [`WebSurferAgent`](/docs/api-reference/autogen/agents/experimental/WebSurferAgent), install AG2 with the `browser-use` and/or `crawl4ai` extras.
 ```bash
@@ -59,6 +63,7 @@ We had great experience with `OpenAI`, `Anthropic`, and `Gemini`. However, `Deep
 We had great experience with `OpenAI`, `Anthropic`, `Gemini` and `Ollama`. However, as of this writing, `DeepSeek` is encountering some issues.
 </Tip>
 
+### Using WebSurferAgent
 
 <Tabs>
   <Tab title="browser_use">


### PR DESCRIPTION
## Why are these changes needed?
Several documentation pages don't have adequete H3 headings in them. H3 headings create the table of contents on the right side of the documentation, and is helpful for navigating the page. It also helps break up the page well, making it easier to read and parse.

## Related issue number
Closes #1568 

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
