### PR TITLE
[Docs] Small fix to header on Tools page

### DIFF
--- a/website/docs/user-guide/basic-concepts/tools/basics.mdx
+++ b/website/docs/user-guide/basic-concepts/tools/basics.mdx
@@ -1,5 +1,5 @@
 ---
-title: Tools
+title: Overview
 sidebarTitle: Overview
 ---
 

--- a/website/docs/user-guide/basic-concepts/tools/index.mdx
+++ b/website/docs/user-guide/basic-concepts/tools/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+sidebarTitle: Tools
 ---
 
 Agents in AG2 leverage tools to extend their functionality, allowing them to interact with external systems, fetch real-time data, and execute complex tasks beyond the scope of a language model's internal knowledge. This enables a structured approach where agents decide which tool to use and then execute it accordingly.


### PR DESCRIPTION
## Why are these changes needed?
I noticed that the 'Tools' page showed 'Index' in the header, which was not ideal. This work fixes that.
<img width="3252" alt="image" src="https://github.com/user-attachments/assets/118fe2a1-e035-480f-9052-160ebb6f8068" />

Note: The tools page is organized a bit differently as most sections don't have a top level page, but instead, just load the first page of the section when you click on them. That being said, I think that should be part of a larger reorg of documentation. This was just a small PR to fix the title.


## Related issue number
None

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
