### PR TITLE
Anthropic Extended Thinking support

### DIFF
--- a/autogen/oai/anthropic.py
+++ b/autogen/oai/anthropic.py
@@ -120,6 +120,7 @@ class AnthropicLLMConfigEntry(LLMConfigEntry):
     max_tokens: int = Field(default=4096, ge=1)
     price: Optional[list[float]] = Field(default=None, min_length=2, max_length=2)
     tool_choice: Optional[dict] = None
+    thinking: Optional[dict] = None
 
     gcp_project_id: Optional[str] = None
     gcp_region: Optional[str] = None

--- a/autogen/oai/anthropic.py
+++ b/autogen/oai/anthropic.py
@@ -112,6 +112,7 @@ ANTHROPIC_PRICING_1k = {
 @register_llm_config
 class AnthropicLLMConfigEntry(LLMConfigEntry):
     api_type: Literal["anthropic"] = "anthropic"
+    timeout: Optional[int] = Field(default=None, ge=1)
     temperature: float = Field(default=1.0, ge=0.0, le=1.0)
     top_k: Optional[int] = Field(default=None, ge=1)
     top_p: Optional[float] = Field(default=None, ge=0.0, le=1.0)
@@ -213,10 +214,13 @@ class AnthropicClient:
             params, "temperature", (float, int), False, 1.0, (0.0, 1.0), None
         )
         anthropic_params["max_tokens"] = validate_parameter(params, "max_tokens", int, False, 4096, (1, None), None)
+        anthropic_params["timeout"] = validate_parameter(params, "timeout", int, True, None, (1, None), None)
         anthropic_params["top_k"] = validate_parameter(params, "top_k", int, True, None, (1, None), None)
         anthropic_params["top_p"] = validate_parameter(params, "top_p", (float, int), True, None, (0.0, 1.0), None)
         anthropic_params["stop_sequences"] = validate_parameter(params, "stop_sequences", list, True, None, None, None)
         anthropic_params["stream"] = validate_parameter(params, "stream", bool, False, False, None, None)
+        if "thinking" in params:
+            anthropic_params["thinking"] = params["thinking"]
 
         if anthropic_params["stream"]:
             warnings.warn(

--- a/website/docs/user-guide/models/anthropic.mdx
+++ b/website/docs/user-guide/models/anthropic.mdx
@@ -54,7 +54,7 @@ Example:
         "model": "claude-3-7-sonnet-20250219",
         "api_key": "your api key",
         "api_type": "anthropic",
-        "max_tokens": 8192, # ovveride the default value of 4096, max tokens must be greater than thinking budget
+        "max_tokens": 8192, # overide the default value of 4096, max tokens must be greater than thinking budget
         "timeout": 600, # for larger thinking budgets, increase the timeout OR enable streaming
         "thinking": {"type": "enabled", "budget_tokens": 2048},
     }

--- a/website/docs/user-guide/models/anthropic.mdx
+++ b/website/docs/user-guide/models/anthropic.mdx
@@ -12,6 +12,7 @@ In this notebook, we demonstrate how to use Anthropic Claude model for AgentChat
 - Function/tool calling
 - Structured Outputs ([Notebook example](/docs/use-cases/notebooks/notebooks/agentchat_structured_outputs))
 - Token usage and cost correctly as per Anthropic's API costs (as of December 2024)
+- [Extended thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking?q=extended_thinking#pricing-and-token-usage-for-extended-thinking)
 
 ## Requirements
 To use Anthropic Claude with AG2, first you need to install the `ag2[anthropic]` package.
@@ -46,12 +47,20 @@ Example:
 [
     {
         "model": "claude-3-5-sonnet-20240620",
-        "api_key": "your Anthropic API Key goes here",
+        "api_key": "your api key",
         "api_type": "anthropic",
     },
     {
+        "model": "claude-3-7-sonnet-20250219",
+        "api_key": "your api key",
+        "api_type": "anthropic",
+        "max_tokens": 8192, # ovveride the default value of 4096, max tokens must be greater than thinking budget
+        "timeout": 600, # for larger thinking budgets, increase the timeout OR enable streaming
+        "thinking": {"type": "enabled", "budget_tokens": 2048},
+    }
+    {
         "model": "claude-3-sonnet-20240229",
-        "api_key": "your Anthropic API Key goes here",
+        "api_key": "your api key",
         "api_type": "anthropic",
         "temperature": 0.5,
         "top_p": 0.2, # Note: It is recommended to set temperature or top_p but not both.

--- a/website/docs/user-guide/models/anthropic.mdx
+++ b/website/docs/user-guide/models/anthropic.mdx
@@ -54,7 +54,7 @@ Example:
         "model": "claude-3-7-sonnet-20250219",
         "api_key": "your api key",
         "api_type": "anthropic",
-        "max_tokens": 8192, # overide the default value of 4096, max tokens must be greater than thinking budget
+        "max_tokens": 8192, # override the default value of 4096, max tokens must be greater than thinking budget
         "timeout": 600, # for larger thinking budgets, increase the timeout OR enable streaming
         "thinking": {"type": "enabled", "budget_tokens": 2048},
     }
@@ -823,4 +823,44 @@ The continued progress and competition in the field, exemplified by this announc
 As always, it will be crucial to balance the pursuit of technological advancement with careful consideration of the ethical, social, and economic implications of these powerful new AI systems.
 
 --------------------------------------------------------------------------------
+```
+
+## Thinking mode
+
+You can utilize Anthropic's thinking mode by setting it in the configuration.
+
+```
+from autogen import ConversableAgent
+
+# Here we configure the thinking mode and the token budget for thinking
+llm_config = {
+    "config_list": [
+        {
+            "model": "claude-3-7-sonnet-20250219",
+            "api_type": "anthropic",
+            "max_tokens": 8192, # override the default value of 4096, max tokens must be greater than thinking budget
+            "timeout": 600, # for larger thinking budgets, increase the timeout OR enable streaming
+            "thinking": {"type": "enabled", "budget_tokens": 2048},
+        }
+    ],
+    # Note: don't pass in temperature or top_p to avoid exceptions in thinking mode
+}
+
+agent = ConversableAgent(
+    name="test",
+    llm_config=llm_config,
+)
+
+# Create the run
+response = agent.run(
+    message="Please provide a comparison of JS and TS",
+    user_input=False,
+    max_turns=1,
+)
+
+# Process the run
+response.process()
+
+# Print out the final response (thinking tokens are not shown)
+print(response.summary)
 ```


### PR DESCRIPTION
## Why are these changes needed?

Support for "thinking" section in LLM Config to allow using Claude 3.7 [Extended Thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking?q=extended_thinking#pricing-and-token-usage-for-extended-thinking).

```
llm_config = {
    "config_list": [
        {
            "model": "claude-3-7-sonnet-20250219",
            "api_key": "your key",
            "api_type": "anthropic",
            "max_tokens": 8192, # ovveride the default value of 4096, max tokens must be greater than thinking budget
            "timeout": 600, # for larger thinking budgets, increase the timeout OR enable streaming
            "thinking": {"type": "enabled", "budget_tokens": 2048},
        }
    ],
    # don't pass in temperature or top_p to avoid exceptions in thinking mode
    # "temperature": 1.0,
    # "top_p": 1.0,
    "cache_seed": None,
}

agent = ConversableAgent(
    name="test",
    llm_config=llm_config,
)

response = agent.generate_reply(
    messages=[{"role": "user", "content": "Please provide a comparison of JS and TS"}]
)

print(response)
```

Anthropic provider only, no Bedrock or Vertex.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
