### PR TITLE
Fix Structured Output documentation example

### DIFF
--- a/website/snippets/python-examples/structured_output.mdx
+++ b/website/snippets/python-examples/structured_output.mdx
@@ -5,18 +5,15 @@ from pydantic import BaseModel
 
 from autogen import ConversableAgent, LLMConfig
 
-
 # 1. Define our lesson plan structure, a lesson with a number of objectives
 class LearningObjective(BaseModel):
     title: str
     description: str
 
-
 class LessonPlan(BaseModel):
     title: str
     learning_objectives: list[LearningObjective]
     script: str
-
 
 # 2. Add our lesson plan structure to the LLM configuration
 llm_config = LLMConfig(
@@ -37,7 +34,11 @@ with llm_config:
     )
 
 # 4. Chat directly with our agent
-response = my_agent.run(message="In one sentence, what's the big deal about AI?")
+response = my_agent.run(
+    message="Let's learn about the solar system!",
+    user_input=True,
+    max_turns=1
+    )
 
 # 5. Iterate through the chat automatically with console output
 response.process()


### PR DESCRIPTION
## Why are these changes needed?

The example for Structured Output didn't have the correct `max_turns` set. Also have set `user_input` to `True` incase a developer changes `max_turns` to more than 1.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
