### PR TITLE
OpenAI ChatCompletion alignment, Tavily test fix, Anthropic test fix

### DIFF
--- a/autogen/oai/oai_models/chat_completion.py
+++ b/autogen/oai/oai_models/chat_completion.py
@@ -66,7 +66,7 @@ class ChatCompletion(BaseModel):
     object: Literal["chat.completion"]
     """The object type, which is always `chat.completion`."""
 
-    service_tier: Optional[Literal["scale", "default"]] = None
+    service_tier: Optional[Literal["auto", "default", "flex"]] = None
     """The service tier used for processing the request."""
 
     system_fingerprint: Optional[str] = None

--- a/test/oai/test_anthropic.py
+++ b/test/oai/test_anthropic.py
@@ -172,6 +172,7 @@ def test_load_config(anthropic_client):
         "model": "claude-3-5-sonnet-latest",
         "stream": False,
         "temperature": 1,
+        "timeout": None,
         "top_p": 0.8,
         "max_tokens": 100,
         "stop_sequences": None,

--- a/test/tools/experimental/tavily/test_tavily.py
+++ b/test/tools/experimental/tavily/test_tavily.py
@@ -194,12 +194,13 @@ class TestTavilySearchTool:
         )
         search_tool.register_for_llm(assistant)
         with patch("autogen.tools.experimental.tavily.tavily_search._execute_tavily_query") as mock_execute_query:
-            assistant.run(
-                message="Get me the latest news on a topic",
+            response = assistant.run(
+                message="Get me the latest news on hurricanes",
                 tools=assistant.tools,
-                max_turns=3,
+                max_turns=2,
                 user_input=False,
             )
+            response.process()
             assert mock_execute_query.called
         assert isinstance(assistant.tools[0], TavilySearchTool)
         assert assistant.tools[0].name == "tavily_search"


### PR DESCRIPTION
## Why are these changes needed?

OpenAI's ChatCompletion `service_tier` parameter was updated, this aligns with that. As well as fixes some test failures for TavilySearchTool and Anthropic.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
