### PR TITLE
Google Drive tools - Add ability to download to a subfolder

### DIFF
--- a/autogen/tools/experimental/google/drive/toolkit.py
+++ b/autogen/tools/experimental/google/drive/toolkit.py
@@ -60,6 +60,10 @@ class GoogleDriveToolkit(Toolkit, GoogleToolkitProtocol):
         @tool(description="download a file from Google Drive")
         def download_file_from_drive(
             file_info: Annotated[GoogleFileInfo, "The file info to download."],
+            subfolder_path: Annotated[
+                Optional[str],
+                "The subfolder path to save the file in. If not provided, saves in the main download folder.",
+            ] = None,
         ) -> str:
             return download_file(
                 service=self.service,
@@ -67,6 +71,7 @@ class GoogleDriveToolkit(Toolkit, GoogleToolkitProtocol):
                 file_name=file_info.name,
                 mime_type=file_info.mime_type,
                 download_folder=download_folder,
+                subfolder_path=subfolder_path,
             )
 
         if exclude is None:


### PR DESCRIPTION
## Why are these changes needed?

The current `download_file_from_drive` tool in the GoogleDriveToolkit will download a file to the configured download directory but you can't provide an option to download it to a sub folder within that directory. This PR adds that ability.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
