### PR TITLE
Typo in agent example: initiate_chat has wrong recipient

### DIFF
--- a/website/docs/contributor-guide/how-ag2-works/initiate-chat.mdx
+++ b/website/docs/contributor-guide/how-ag2-works/initiate-chat.mdx
@@ -16,7 +16,7 @@ with llm_config:
   agent_b = ConversableAgent(name="agent_b")
 
 agent_a.initiate_chat(
-    recipient=agent_a,
+    recipient=agent_b,
     message="Tell me a joke",
     max_turns=2
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes a minor typo and improves clarity in the Chat workflow documentation example. Also corrects a code snippet to ensure the recipient agent is correctly set in initiate_chat.

## Related issue number

Closes #1677 

## Checks

- [o] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [o] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [o] I've made sure all auto checks have passed.



This PR includes:
- Correction to the initiate_chat example (recipient=agent_a → recipient=agent_b)