### PR TITLE
Fix missing context_variables in Swarm notebook

### DIFF
--- a/notebook/agentchat_swarm.ipynb
+++ b/notebook/agentchat_swarm.ipynb
@@ -369,6 +369,8 @@
     "    user_agent=user,\n",
     "    messages=\"I want to cancel flight\",\n",
     "    after_work=AfterWorkOption.REVERT_TO_USER,\n",
+    "    max_rounds=50,\n",
+    "    context_variables=context_variables,\n",
     ")"
    ]
   }
@@ -383,7 +385,7 @@
    ]
   },
   "kernelspec": {
-   "display_name": "autodev",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -397,7 +399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Why are these changes needed?

Emmanual A on Discord noted that the Swarm notebook example is not updating the context variables. Looking at the notebook, the `context_variables` parameter is missing from the `initiate_swarm_chat`:
https://docs.ag2.ai/0.9dev/docs/use-cases/notebooks/notebooks/agentchat_swarm/?h=swarm+orchestrat#run-the-code

This PR updates that (and increases `max_rounds` as 20 is too short)

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
