### PR TITLE
Don't add existing tool to _tools on ConversableAgent

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -3619,7 +3619,8 @@ class ConversableAgent(LLMAgent):
             tool = self._create_tool_if_needed(func_or_tool, name, description)
 
             self._register_for_llm(tool, api_style, silent_override=silent_override)
-            self._tools.append(tool)
+            if tool not in self._tools:
+                self._tools.append(tool)
 
             return tool
 


### PR DESCRIPTION
## Why are these changes needed?

Tools can be duplicated on ConversableAgent's `_tools` parameter, this fixes that.

This was occurring when running an agent's run multiple times inside a loop, it kept adding the tools over and over to the agent's `_tools` parameter. 

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
