### PR TITLE
Check group-level afterwork when validating group manager's LLM Config

### DIFF
--- a/autogen/agentchat/group/patterns/pattern.py
+++ b/autogen/agentchat/group/patterns/pattern.py
@@ -149,7 +149,7 @@ class Pattern(ABC):
         )
 
         # Create the group manager
-        manager = create_group_manager(groupchat, self.group_manager_args, self.agents)
+        manager = create_group_manager(groupchat, self.group_manager_args, self.agents, self.group_after_work)
 
         # Point all agent's context variables to this function's context_variables
         setup_context_variables(tool_executor, self.agents, manager, self.context_variables)


### PR DESCRIPTION
## Why are these changes needed?

The new group chat functionality was not checking if the LLM config was required if the group had an after work target of GroupManagerTarget. This fixes that.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
