### PR TITLE
Fix typos: "finanical" -> "financial" and "reove" -> "remove"

### DIFF
--- a/notebook/agentchat_tabular_data_rag_workflow.ipynb
+++ b/notebook/agentchat_tabular_data_rag_workflow.ipynb
@@ -79,7 +79,7 @@
     "**Skip and use parsed files to run the rest.**\n",
     "This step is expensive and time consuming, please skip if you don't need to generate the full data set. The **estimated cost is from $10 to $15 to parse the pdf file and build the knowledge graph with entire parsed output**.\n",
     "\n",
-    "For the notebook, we use a common finanical document, [Nvidia 2024 10-K](https://investor.nvidia.com/financial-info/sec-filings/sec-filings-details/default.aspx?FilingId=17293267) as an example ([file download link](https://d18rn0p25nwr6d.cloudfront.net/CIK-0001045810/1cbe8fe7-e08a-46e3-8dcc-b429fc06c1a4.pdf)).\n",
+    "For the notebook, we use a common financial document, [Nvidia 2024 10-K](https://investor.nvidia.com/financial-info/sec-filings/sec-filings-details/default.aspx?FilingId=17293267) as an example ([file download link](https://d18rn0p25nwr6d.cloudfront.net/CIK-0001045810/1cbe8fe7-e08a-46e3-8dcc-b429fc06c1a4.pdf)).\n",
     "\n",
     "We use Unstructured-IO to parse the PDF, the table and image from the PDF are extracted out as .jpg files.\n",
     "\n",

--- a/website/user-guide/captainagent/tool_library.mdx
+++ b/website/user-guide/captainagent/tool_library.mdx
@@ -82,7 +82,7 @@ nested_config = {
     ...
     "autobuild_tool_config": {
         "tool_root": "Your tool root here",
-        "retriever": "all-mpnet-base-v2", # This is the default embedding model, you can reove this line if you are not intending to change it
+        "retriever": "all-mpnet-base-v2", # This is the default embedding model, you can remove this line if you are not intending to change it
     },
     ...
 }


### PR DESCRIPTION
This PR fixes two minor typos:
1. Corrects "finanical" to "financial" in the notebook example text
2. Fixes "reove" to "remove" in the tool library documentation comment