### PR TITLE
Fixing typos in Reasoning Blog post

### DIFF
--- a/website/docs/_blogs/2025-04-16-Reasoning/index.mdx
+++ b/website/docs/_blogs/2025-04-16-Reasoning/index.mdx
@@ -67,7 +67,7 @@ The first research question above is still relevant in this path.
 
 While it is attractive to embed the reasoning process into a model based on next token prediction, the nonlinearity nature we analyzed above challenges that goal. Trying to capture the backtracking, the "Aha!" moments, the integration of external feedback, and the critical self-assessment inherent in human reasoning within a purely sequential generation process seems fundamentally limited. A single pass, even a very sophisticated one, struggles to replicate a process defined by loops, revisions, and strategic exploration.
 
-Many potentially improvements in modeling can be made. For example, one can design a model that repeats the same architecture and weights to mimic the "iterative refinement" effect partially inside the model. Fundamentally, it does not perform the kind of refinement that requires information outside the model.
+Many potential improvements in modeling can be made. For example, one can design a model that repeats the same architecture and weights to mimic the "iterative refinement" effect partially inside the model. Fundamentally, it does not perform the kind of refinement that requires information outside the model.
 
 An alternative approach might be to conceptualize advanced AI reasoning not as a monolithic "reasoning model" but as a "reasoning system." Such a system could orchestrate multiple components, including LLMs, in a structured yet flexible workflow that mirrors human iterative refinement.
 
@@ -78,7 +78,7 @@ Think of a system where:
 * Based on the critique, the system might query external knowledge bases or request further clarification (simulating seeking feedback or information).
 * The initial arguments are then revised and refined, potentially through multiple cycles.
 
-This system-level approach directly addresses the second research question: designing an architecture that explicitly implements iterative refinement. Success would depend heavily on understanding the elementary capabilities (the first research question) – knowing which tasks current LLMs excel at (e.g., generation, summarization, pattern matching) and where other components might be needed (e.g., rigorous logical verification, causal inference, planning). If we can find a simple architecture plus necessary improvements in modeling to make this approach work, it will allow us reaching a higher level of intelligence without increasing the opaqueness of the mechanism.
+This system-level approach directly addresses the second research question: designing an architecture that explicitly implements iterative refinement. Success would depend heavily on understanding the elementary capabilities (the first research question) – knowing which tasks current LLMs excel at (e.g., generation, summarization, pattern matching) and where other components might be needed (e.g., rigorous logical verification, causal inference, planning). If we can find a simple architecture plus necessary improvements in modeling to make this approach work, it will allow us to reach a higher level of intelligence without increasing the opaqueness of the mechanism.
 
 ![iter](img/iter.jpg)
 
@@ -90,6 +90,6 @@ The myth of linear human reasoning has perhaps led us down a path of evaluating 
 
 Ultimately, understanding reasoning as an emergent capability of an iterative system, rather than an atomic skill, might be the key to both evaluating current AI more accurately and building more genuinely intelligent machines in the future.
 
-_This post itself is an artifact initiated by an improvised idea when I had a little personal time on a Wednesday morning, although a lot of background thinking has been made since years ago, sometimes subconciously. I can't count how many iterative refinements have been made implicitly or explicitly, and it will continue evolve with your feedback. Please share your feedback on AG2 [Discord](https://discord.gg/pAbnFJrkgZ) server.
+_This post itself is an artifact initiated by an improvised idea when I had a little personal time on a Wednesday morning, although a lot of background thinking has been made since years ago, sometimes subconsciously. I can't count how many iterative refinements have been made implicitly or explicitly, and it will continue to evolve with your feedback. Please share your feedback on AG2 [Discord](https://discord.gg/pAbnFJrkgZ) server.
 I appreciate the feedback from [Davor Runje](https://github.com/davorrunje), [George Sideris](https://github.com/giorgossideris).
 _


### PR DESCRIPTION
## Why are these changes needed?
In reading through The Myth of Reasoning blog post (https://docs.ag2.ai/latest/docs/_blogs/2025-04-16-Reasoning/), I noticed a few small typos. Created this small PR to fix them.

## Related issue number
n/a

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
