### PR TITLE
Fix typo in Pattern Cookbook - Pipeline

### DIFF
--- a/website/docs/user-guide/advanced-concepts/pattern-cookbook/pipeline.mdx
+++ b/website/docs/user-guide/advanced-concepts/pattern-cookbook/pipeline.mdx
@@ -213,7 +213,7 @@ def complete_validation(validation_result: ValidationResult, context_variables: 
         return ReplyResult(
             message=f"Validation failed: {validation_result.error_message or 'Unknown error'}",
             context_variables=context_variables,
-            target=RevertToUserTarget
+            target=RevertToUserTarget()
         )
 
     return ReplyResult(


### PR DESCRIPTION
## Why are these changes needed?

The cookbook code for the Pipeline pattern has a typo.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
