### PR TITLE
Fix the tool description in CrewAI file read tool test

### DIFF
--- a/test/interop/crewai/test_crewai.py
+++ b/test/interop/crewai/test_crewai.py
@@ -59,9 +59,10 @@ class TestCrewAIInteroperability:
                 file.write("Hello, World!")
 
             assert tool.name == "Read_a_file_s_content"
+            # Check CrewAI tool description here: https://github.com/crewAIInc/crewAI-tools/blob/974b224eb7c4c2148571787cb987460a585d7df9/crewai_tools/tools/file_read_tool/file_read_tool.py#L40C25-L40C282
             assert (
                 tool.description
-                == "A tool that reads the content of a file. To use this tool, provide a 'file_path' parameter with the path to the file you want to read. (IMPORTANT: When using arguments, put them all in an `args` dictionary)"
+                == "A tool that reads the content of a file. To use this tool, provide a 'file_path' parameter with the path to the file you want to read. Optionally, provide 'start_line' to start reading from a specific line and 'line_count' to limit the number of lines read. (IMPORTANT: When using arguments, put them all in an `args` dictionary)"
             )
 
             args = model_type(file_path=file_path)


### PR DESCRIPTION
## Why are these changes needed?

Fix the tool description for the CrewAI file read tool as it has changed and it's failing tests.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
