### PR TITLE
Fix broken installation documentation link

### DIFF
--- a/announcements.md
+++ b/announcements.md
@@ -24,7 +24,7 @@ We adopt the Apache 2.0 license from v0.3. This enhances our commitment to open-
 
 🎉 Dec 31, 2023: [AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversation Framework](https://arxiv.org/abs/2308.08155) is selected by [TheSequence: My Five Favorite AI Papers of 2023](https://thesequence.substack.com/p/my-five-favorite-ai-papers-of-2023).
 
-🔥 Nov 24: pyautogen [v0.2](https://github.com/ag2ai/ag2/releases/tag/v0.2.0) is released with many updates and new features compared to v0.1.1. It switches to using openai-python v1. Please read the [migration guide](https://docs.ag2.ai/docs/installation/Installation).
+🔥 Nov 24: pyautogen [v0.2](https://github.com/ag2ai/ag2/releases/tag/v0.2.0) is released with many updates and new features compared to v0.1.1. It switches to using openai-python v1. Please read the [migration guide](https://docs.ag2.ai/latest/docs/user-guide/basic-concepts/installing-ag2/).
 
 🔥 Nov 11: OpenAI's Assistants are available in AutoGen and interoperatable with other AutoGen agents! Checkout our [blogpost](https://docs.ag2.ai/latest/docs/blog/2023/11/13/OAI-assistants/) for details and examples.
 


### PR DESCRIPTION
This PR fixes a broken link in announcements.md pointing to the installation documentation.

The link https://docs.ag2.ai/docs/installation/Installation (404) has been updated to the current working URL: https://docs.ag2.ai/latest/docs/user-guide/basic-concepts/installing-ag2/

This ensures users are directed to the proper installation instructions for AG2.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
