### PR TITLE
improved azure openai deployment name parsing (fixes the "gpt-4.1" turning to "gpt-41")

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -832,8 +832,14 @@ class OpenAIWrapper:
     def _configure_azure_openai(self, config: dict[str, Any], openai_config: dict[str, Any]) -> None:
         openai_config["azure_deployment"] = openai_config.get("azure_deployment", config.get("model"))
         if openai_config["azure_deployment"] is not None:
-            # Preserve dots in version numbers (e.g., gpt-4.1) while removing other dots
-            openai_config["azure_deployment"] = re.sub(r'\.(?![0-9])', '', openai_config["azure_deployment"])
+            # Preserve dots for specific model versions that require them
+            deployment_name = openai_config["azure_deployment"]
+            if deployment_name in ["gpt-4.1"]:  # Add more as needed, Whitelist approach so as to not break existing deployments
+                # Keep the deployment name as-is for these specific models
+                pass
+            else:
+                # Remove dots for all other models (existing behavior)
+                openai_config["azure_deployment"] = deployment_name.replace(".", "")
         openai_config["azure_endpoint"] = openai_config.get("azure_endpoint", openai_config.pop("base_url", None))
 
         # Create a default Azure token provider if requested

--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -834,11 +834,13 @@ class OpenAIWrapper:
         if openai_config["azure_deployment"] is not None:
             # Preserve dots for specific model versions that require them
             deployment_name = openai_config["azure_deployment"]
-            if deployment_name in ["gpt-4.1"]:  # Add more as needed, Whitelist approach so as to not break existing deployments
+            if deployment_name in [
+                "gpt-4.1"
+            ]:  # Add more as needed, Whitelist approach so as to not break existing deployments
                 # Keep the deployment name as-is for these specific models
                 pass
             else:
-                # Remove dots for all other models (existing behavior)
+                # Remove dots for all other models (maintain existing behavior)
                 openai_config["azure_deployment"] = deployment_name.replace(".", "")
         openai_config["azure_endpoint"] = openai_config.get("azure_endpoint", openai_config.pop("base_url", None))
 

--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -832,7 +832,8 @@ class OpenAIWrapper:
     def _configure_azure_openai(self, config: dict[str, Any], openai_config: dict[str, Any]) -> None:
         openai_config["azure_deployment"] = openai_config.get("azure_deployment", config.get("model"))
         if openai_config["azure_deployment"] is not None:
-            openai_config["azure_deployment"] = openai_config["azure_deployment"].replace(".", "")
+            # Preserve dots in version numbers (e.g., gpt-4.1) while removing other dots
+            openai_config["azure_deployment"] = re.sub(r'\.(?![0-9])', '', openai_config["azure_deployment"])
         openai_config["azure_endpoint"] = openai_config.get("azure_endpoint", openai_config.pop("base_url", None))
 
         # Create a default Azure token provider if requested


### PR DESCRIPTION
The changes in this PR address the issue: https://github.com/ag2ai/ag2/issues/1778

## Why are these changes needed?

At this moment we are unable to use the "gpt-4.1" model with AG2 as the _configure_azure_openai function replaces the dots within the deployment name and converts it to "gpt-41" which does not work.

## Related issue number
https://github.com/ag2ai/ag2/issues/1778

## Checks
- [ ✔️] I've made sure all auto checks have passed.
