### PR TITLE
Resolves deprecated provider error when using WebSurferAgent 

### DIFF
--- a/autogen/interop/litellm/litellm_config_factory.py
+++ b/autogen/interop/litellm/litellm_config_factory.py
@@ -18,8 +18,8 @@ T = TypeVar("T", bound="LiteLLmConfigFactory")
 def get_crawl4ai_version():
     """Get the installed crawl4ai version."""
     try:
-        import crawl4ai.__version__
-        return crawl4ai.__version__.__version__
+        import crawl4ai
+        return getattr(crawl4ai, "__version__", None)
     except ImportError:
         return None
 

--- a/autogen/interop/litellm/litellm_config_factory.py
+++ b/autogen/interop/litellm/litellm_config_factory.py
@@ -19,6 +19,7 @@ def get_crawl4ai_version() -> Optional[str]:
     """Get the installed crawl4ai version."""
     try:
         import crawl4ai
+
         version = getattr(crawl4ai, "__version__", None)
         return version if isinstance(version, str) else None
     except (ImportError, AttributeError):

--- a/autogen/interop/litellm/litellm_config_factory.py
+++ b/autogen/interop/litellm/litellm_config_factory.py
@@ -4,7 +4,7 @@
 
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Callable, TypeVar, Union
+from typing import Any, Callable, Optional, TypeVar, Union
 
 from ...doc_utils import export_module
 from ...llm_config import LLMConfig
@@ -15,25 +15,27 @@ __all__ = ["LiteLLmConfigFactory"]
 T = TypeVar("T", bound="LiteLLmConfigFactory")
 
 
-def get_crawl4ai_version():
+def get_crawl4ai_version() -> Optional[str]:
     """Get the installed crawl4ai version."""
     try:
         import crawl4ai
-        return getattr(crawl4ai, "__version__", None)
-    except ImportError:
+        version = getattr(crawl4ai, "__version__", None)
+        return version if isinstance(version, str) else None
+    except (ImportError, AttributeError):
         return None
 
 
-def is_crawl4ai_v05_or_higher():
+def is_crawl4ai_v05_or_higher() -> bool:
     """Check if crawl4ai version is 0.5 or higher."""
     version = get_crawl4ai_version()
     if version is None:
         return False
-    
+
     # Parse version string (e.g., "0.5.0" -> [0, 5, 0])
     try:
-        version_parts = [int(x) for x in version.split('.')]
-        return version_parts[0] > 0 or (version_parts[0] == 0 and version_parts[1] >= 5)
+        version_parts = [int(x) for x in version.split(".")]
+        # Check if version >= 0.5.0
+        return version_parts >= [0, 5, 0]
     except (ValueError, IndexError):
         return False
 
@@ -46,7 +48,7 @@ class LiteLLmConfigFactory(ABC):
     def create_lite_llm_config(cls, llm_config: Union[LLMConfig, dict[str, Any]]) -> dict[str, Any]:
         """
         Create a lite LLM config compatible with the installed crawl4ai version.
-        
+
         For crawl4ai >=0.5: Returns config with llmConfig parameter
         For crawl4ai <0.5: Returns config with provider parameter (legacy)
         """
@@ -54,7 +56,7 @@ class LiteLLmConfigFactory(ABC):
         for factory in LiteLLmConfigFactory._factories:
             if factory.accepts(first_llm_config):
                 base_config = factory.create(first_llm_config)
-                
+
                 # Check crawl4ai version and adapt config accordingly
                 if is_crawl4ai_v05_or_higher():
                     return cls._adapt_for_crawl4ai_v05(base_config)
@@ -70,25 +72,25 @@ class LiteLLmConfigFactory(ABC):
         into an llmConfig object.
         """
         adapted_config = base_config.copy()
-        
+
         # Extract deprecated parameters
         llm_config_params = {}
-        
-        if 'provider' in adapted_config:
-            llm_config_params['provider'] = adapted_config.pop('provider')
-        
-        if 'api_token' in adapted_config:
-            llm_config_params['api_token'] = adapted_config.pop('api_token')
-        
+
+        if "provider" in adapted_config:
+            llm_config_params["provider"] = adapted_config.pop("provider")
+
+        if "api_token" in adapted_config:
+            llm_config_params["api_token"] = adapted_config.pop("api_token")
+
         # Add other parameters that should be in llmConfig
-        for param in ['base_url', 'api_base', 'api_version']:
+        for param in ["base_url", "api_base", "api_version"]:
             if param in adapted_config:
                 llm_config_params[param] = adapted_config.pop(param)
-        
+
         # Create the llmConfig object if we have parameters for it
         if llm_config_params:
-            adapted_config['llmConfig'] = llm_config_params
-        
+            adapted_config["llmConfig"] = llm_config_params
+
         return adapted_config
 
     @classmethod

--- a/autogen/interop/litellm/litellm_config_factory.py
+++ b/autogen/interop/litellm/litellm_config_factory.py
@@ -15,18 +15,81 @@ __all__ = ["LiteLLmConfigFactory"]
 T = TypeVar("T", bound="LiteLLmConfigFactory")
 
 
+def get_crawl4ai_version():
+    """Get the installed crawl4ai version."""
+    try:
+        import crawl4ai.__version__
+        return crawl4ai.__version__.__version__
+    except ImportError:
+        return None
+
+
+def is_crawl4ai_v05_or_higher():
+    """Check if crawl4ai version is 0.5 or higher."""
+    version = get_crawl4ai_version()
+    if version is None:
+        return False
+    
+    # Parse version string (e.g., "0.5.0" -> [0, 5, 0])
+    try:
+        version_parts = [int(x) for x in version.split('.')]
+        return version_parts[0] > 0 or (version_parts[0] == 0 and version_parts[1] >= 5)
+    except (ValueError, IndexError):
+        return False
+
+
 @export_module("autogen.interop")
 class LiteLLmConfigFactory(ABC):
     _factories: set["LiteLLmConfigFactory"] = set()
 
     @classmethod
     def create_lite_llm_config(cls, llm_config: Union[LLMConfig, dict[str, Any]]) -> dict[str, Any]:
+        """
+        Create a lite LLM config compatible with the installed crawl4ai version.
+        
+        For crawl4ai >=0.5: Returns config with llmConfig parameter
+        For crawl4ai <0.5: Returns config with provider parameter (legacy)
+        """
         first_llm_config = get_first_llm_config(llm_config)
         for factory in LiteLLmConfigFactory._factories:
             if factory.accepts(first_llm_config):
-                return factory.create(first_llm_config)
+                base_config = factory.create(first_llm_config)
+                
+                # Check crawl4ai version and adapt config accordingly
+                if is_crawl4ai_v05_or_higher():
+                    return cls._adapt_for_crawl4ai_v05(base_config)
+                else:
+                    return base_config  # Use legacy format
 
         raise ValueError("Could not find a factory for the given config.")
+
+    @classmethod
+    def _adapt_for_crawl4ai_v05(cls, base_config: dict[str, Any]) -> dict[str, Any]:
+        """
+        Adapt the config for crawl4ai >=0.5 by moving deprecated parameters
+        into an llmConfig object.
+        """
+        adapted_config = base_config.copy()
+        
+        # Extract deprecated parameters
+        llm_config_params = {}
+        
+        if 'provider' in adapted_config:
+            llm_config_params['provider'] = adapted_config.pop('provider')
+        
+        if 'api_token' in adapted_config:
+            llm_config_params['api_token'] = adapted_config.pop('api_token')
+        
+        # Add other parameters that should be in llmConfig
+        for param in ['base_url', 'api_base', 'api_version']:
+            if param in adapted_config:
+                llm_config_params[param] = adapted_config.pop(param)
+        
+        # Create the llmConfig object if we have parameters for it
+        if llm_config_params:
+            adapted_config['llmConfig'] = llm_config_params
+        
+        return adapted_config
 
     @classmethod
     def register_factory(cls) -> Callable[[type[T]], type[T]]:

--- a/test/interop/litellm/test_litellm_config_factory.py
+++ b/test/interop/litellm/test_litellm_config_factory.py
@@ -4,7 +4,7 @@
 
 
 from typing import Any
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -76,14 +76,14 @@ class TestCrawl4aiCompatibility:
         # Mock crawl4ai being installed with version 0.5.0
         mock_crawl4ai = MagicMock()
         mock_crawl4ai.__version__ = "0.5.0"
-        
-        with patch.dict('sys.modules', {'crawl4ai': mock_crawl4ai}):
+
+        with patch.dict("sys.modules", {"crawl4ai": mock_crawl4ai}):
             version = get_crawl4ai_version()
             assert version == "0.5.0"
 
     def test_get_crawl4ai_version_when_not_installed(self) -> None:
         """Test version detection when crawl4ai is not installed."""
-        with patch.dict('sys.modules', {'crawl4ai': None}):
+        with patch.dict("sys.modules", {"crawl4ai": None}):
             version = get_crawl4ai_version()
             assert version is None
 
@@ -103,13 +103,13 @@ class TestCrawl4aiCompatibility:
     )
     def test_is_crawl4ai_v05_or_higher(self, version: str | None, expected: bool) -> None:
         """Test version comparison logic."""
-        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value=version):
+        with patch("autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version", return_value=version):
             result = is_crawl4ai_v05_or_higher()
             assert result == expected
 
     def test_is_crawl4ai_v05_or_higher_invalid_version(self) -> None:
         """Test version comparison with invalid version string."""
-        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value="invalid"):
+        with patch("autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version", return_value="invalid"):
             result = is_crawl4ai_v05_or_higher()
             assert result is False
 
@@ -160,7 +160,9 @@ class TestCrawl4aiCompatibility:
         self, crawl4ai_version: str | None, config_list: list[dict[str, Any]], expected: dict[str, Any]
     ) -> None:
         """Test that config is properly adapted based on crawl4ai version."""
-        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value=crawl4ai_version):
+        with patch(
+            "autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version", return_value=crawl4ai_version
+        ):
             lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
             assert lite_llm_config == expected
 
@@ -175,7 +177,7 @@ class TestCrawl4aiCompatibility:
                 "api_version": "2023-12-01-preview",
             }
         ]
-        
+
         expected_v05 = {
             "llmConfig": {
                 "api_token": "test-key",
@@ -184,21 +186,21 @@ class TestCrawl4aiCompatibility:
                 "api_version": "2023-12-01-preview",
             }
         }
-        
+
         expected_legacy = {
             "api_token": "test-key",
             "provider": "azure/gpt-4o-mini",
             "base_url": "https://test.openai.azure.com/",
             "api_version": "2023-12-01-preview",
         }
-        
+
         # Test with crawl4ai >=0.5
-        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value="0.5.0"):
+        with patch("autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version", return_value="0.5.0"):
             lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
             assert lite_llm_config == expected_v05
-        
+
         # Test with crawl4ai <0.5
-        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value="0.4.247"):
+        with patch("autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version", return_value="0.4.247"):
             lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
             assert lite_llm_config == expected_legacy
 
@@ -212,9 +214,9 @@ class TestCrawl4aiCompatibility:
                 "tags": ["test-tag"],
             }
         ]
-        
+
         # Test with crawl4ai >=0.5 - tags should remain at top level
-        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value="0.5.0"):
+        with patch("autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version", return_value="0.5.0"):
             lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
             assert "tags" in lite_llm_config
             assert lite_llm_config["tags"] == ["test-tag"]
@@ -235,17 +237,17 @@ class TestCrawl4aiCompatibility:
     def test_provider_format_in_adapted_config(self, api_type: str, model: str, expected_provider: str) -> None:
         """Test that provider format is correct in adapted config for different API types."""
         config_list = [{"api_type": api_type, "model": model, "api_key": "test-key"}]
-        
-        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value="0.5.0"):
+
+        with patch("autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version", return_value="0.5.0"):
             lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
             assert lite_llm_config["llmConfig"]["provider"] == expected_provider
 
     def test_backward_compatibility_no_crawl4ai(self) -> None:
         """Test that the fix doesn't break anything when crawl4ai is not installed."""
         config_list = [{"api_type": "openai", "model": "gpt-4o-mini", "api_key": "test-key"}]
-        
+
         # Mock crawl4ai not being installed
-        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value=None):
+        with patch("autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version", return_value=None):
             lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
             # Should use legacy format
             assert lite_llm_config == {"api_token": "test-key", "provider": "openai/gpt-4o-mini"}

--- a/test/interop/litellm/test_litellm_config_factory.py
+++ b/test/interop/litellm/test_litellm_config_factory.py
@@ -4,10 +4,12 @@
 
 
 from typing import Any
+from unittest.mock import patch, MagicMock
 
 import pytest
 
 from autogen.interop import LiteLLmConfigFactory
+from autogen.interop.litellm.litellm_config_factory import get_crawl4ai_version, is_crawl4ai_v05_or_higher
 
 
 class TestLiteLLmConfigFactory:
@@ -64,3 +66,187 @@ class TestLiteLLmConfigFactory:
     def test_get_provider_and_api_key(self, config_list: list[dict[str, Any]], expected: dict[str, Any]) -> None:
         lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
         assert lite_llm_config == expected
+
+
+class TestCrawl4aiCompatibility:
+    """Test suite for crawl4ai version compatibility fix."""
+
+    def test_get_crawl4ai_version_when_installed(self) -> None:
+        """Test version detection when crawl4ai is installed."""
+        # Mock crawl4ai being installed with version 0.5.0
+        mock_crawl4ai = MagicMock()
+        mock_crawl4ai.__version__ = "0.5.0"
+        
+        with patch.dict('sys.modules', {'crawl4ai': mock_crawl4ai}):
+            version = get_crawl4ai_version()
+            assert version == "0.5.0"
+
+    def test_get_crawl4ai_version_when_not_installed(self) -> None:
+        """Test version detection when crawl4ai is not installed."""
+        with patch.dict('sys.modules', {'crawl4ai': None}):
+            version = get_crawl4ai_version()
+            assert version is None
+
+    @pytest.mark.parametrize(
+        ("version", "expected"),
+        [
+            ("0.5.0", True),
+            ("0.5.1", True),
+            ("0.6.0", True),
+            ("0.6.3", True),  # Latest version from PyPI
+            ("0.4.247", False),
+            ("0.4.999", False),
+            ("0.3.0", False),
+            ("0.0.1", False),
+            (None, False),
+        ],
+    )
+    def test_is_crawl4ai_v05_or_higher(self, version: str | None, expected: bool) -> None:
+        """Test version comparison logic."""
+        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value=version):
+            result = is_crawl4ai_v05_or_higher()
+            assert result == expected
+
+    def test_is_crawl4ai_v05_or_higher_invalid_version(self) -> None:
+        """Test version comparison with invalid version string."""
+        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value="invalid"):
+            result = is_crawl4ai_v05_or_higher()
+            assert result is False
+
+    @pytest.mark.parametrize(
+        ("crawl4ai_version", "config_list", "expected"),
+        [
+            # Test with crawl4ai >=0.5 - should adapt config
+            (
+                "0.5.0",
+                [{"api_type": "openai", "model": "gpt-4o-mini", "api_key": "test-key"}],
+                {"llmConfig": {"api_token": "test-key", "provider": "openai/gpt-4o-mini"}},
+            ),
+            (
+                "0.5.1",
+                [{"api_type": "openai", "model": "gpt-4o-mini", "api_key": "test-key"}],
+                {"llmConfig": {"api_token": "test-key", "provider": "openai/gpt-4o-mini"}},
+            ),
+            (
+                "1.0.0",
+                [{"api_type": "openai", "model": "gpt-4o-mini", "api_key": "test-key"}],
+                {"llmConfig": {"api_token": "test-key", "provider": "openai/gpt-4o-mini"}},
+            ),
+            # Test with crawl4ai <0.5 - should use legacy format
+            (
+                "0.4.247",
+                [{"api_type": "openai", "model": "gpt-4o-mini", "api_key": "test-key"}],
+                {"api_token": "test-key", "provider": "openai/gpt-4o-mini"},
+            ),
+            (
+                "0.4.999",
+                [{"api_type": "openai", "model": "gpt-4o-mini", "api_key": "test-key"}],
+                {"api_token": "test-key", "provider": "openai/gpt-4o-mini"},
+            ),
+            (
+                "0.3.0",
+                [{"api_type": "openai", "model": "gpt-4o-mini", "api_key": "test-key"}],
+                {"api_token": "test-key", "provider": "openai/gpt-4o-mini"},
+            ),
+            # Test when crawl4ai is not installed - should use legacy format
+            (
+                None,
+                [{"api_type": "openai", "model": "gpt-4o-mini", "api_key": "test-key"}],
+                {"api_token": "test-key", "provider": "openai/gpt-4o-mini"},
+            ),
+        ],
+    )
+    def test_config_adaptation_based_on_crawl4ai_version(
+        self, crawl4ai_version: str | None, config_list: list[dict[str, Any]], expected: dict[str, Any]
+    ) -> None:
+        """Test that config is properly adapted based on crawl4ai version."""
+        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value=crawl4ai_version):
+            lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
+            assert lite_llm_config == expected
+
+    def test_config_adaptation_with_multiple_parameters(self) -> None:
+        """Test config adaptation with multiple parameters that should be moved to llmConfig."""
+        config_list = [
+            {
+                "api_type": "azure",
+                "model": "gpt-4o-mini",
+                "api_key": "test-key",
+                "base_url": "https://test.openai.azure.com/",
+                "api_version": "2023-12-01-preview",
+            }
+        ]
+        
+        expected_v05 = {
+            "llmConfig": {
+                "api_token": "test-key",
+                "provider": "azure/gpt-4o-mini",
+                "base_url": "https://test.openai.azure.com/",
+                "api_version": "2023-12-01-preview",
+            }
+        }
+        
+        expected_legacy = {
+            "api_token": "test-key",
+            "provider": "azure/gpt-4o-mini",
+            "base_url": "https://test.openai.azure.com/",
+            "api_version": "2023-12-01-preview",
+        }
+        
+        # Test with crawl4ai >=0.5
+        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value="0.5.0"):
+            lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
+            assert lite_llm_config == expected_v05
+        
+        # Test with crawl4ai <0.5
+        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value="0.4.247"):
+            lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
+            assert lite_llm_config == expected_legacy
+
+    def test_config_adaptation_preserves_other_parameters(self) -> None:
+        """Test that config adaptation preserves parameters that shouldn't be moved to llmConfig."""
+        config_list = [
+            {
+                "api_type": "openai",
+                "model": "gpt-4o-mini",
+                "api_key": "test-key",
+                "tags": ["test-tag"],
+            }
+        ]
+        
+        # Test with crawl4ai >=0.5 - tags should remain at top level
+        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value="0.5.0"):
+            lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
+            assert "tags" in lite_llm_config
+            assert lite_llm_config["tags"] == ["test-tag"]
+            assert "llmConfig" in lite_llm_config
+            assert "provider" in lite_llm_config["llmConfig"]
+            assert "api_token" in lite_llm_config["llmConfig"]
+
+    @pytest.mark.parametrize(
+        ("api_type", "model", "expected_provider"),
+        [
+            ("openai", "gpt-4o-mini", "openai/gpt-4o-mini"),
+            ("anthropic", "claude-3-sonnet", "anthropic/claude-3-sonnet"),
+            ("google", "gemini-pro", "gemini/gemini-pro"),  # Note: google gets converted to gemini
+            ("azure", "gpt-4", "azure/gpt-4"),
+            ("ollama", "llama2", "ollama/llama2"),
+        ],
+    )
+    def test_provider_format_in_adapted_config(self, api_type: str, model: str, expected_provider: str) -> None:
+        """Test that provider format is correct in adapted config for different API types."""
+        config_list = [{"api_type": api_type, "model": model, "api_key": "test-key"}]
+        
+        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value="0.5.0"):
+            lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
+            assert lite_llm_config["llmConfig"]["provider"] == expected_provider
+
+    def test_backward_compatibility_no_crawl4ai(self) -> None:
+        """Test that the fix doesn't break anything when crawl4ai is not installed."""
+        config_list = [{"api_type": "openai", "model": "gpt-4o-mini", "api_key": "test-key"}]
+        
+        # Mock crawl4ai not being installed
+        with patch('autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version', return_value=None):
+            lite_llm_config = LiteLLmConfigFactory.create_lite_llm_config({"config_list": config_list})
+            # Should use legacy format
+            assert lite_llm_config == {"api_token": "test-key", "provider": "openai/gpt-4o-mini"}
+            assert "llmConfig" not in lite_llm_config

--- a/test/interop/litellm/test_litellm_config_factory.py
+++ b/test/interop/litellm/test_litellm_config_factory.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -101,7 +101,7 @@ class TestCrawl4aiCompatibility:
             (None, False),
         ],
     )
-    def test_is_crawl4ai_v05_or_higher(self, version: str | None, expected: bool) -> None:
+    def test_is_crawl4ai_v05_or_higher(self, version: Optional[str], expected: bool) -> None:
         """Test version comparison logic."""
         with patch("autogen.interop.litellm.litellm_config_factory.get_crawl4ai_version", return_value=version):
             result = is_crawl4ai_v05_or_higher()
@@ -157,7 +157,7 @@ class TestCrawl4aiCompatibility:
         ],
     )
     def test_config_adaptation_based_on_crawl4ai_version(
-        self, crawl4ai_version: str | None, config_list: list[dict[str, Any]], expected: dict[str, Any]
+        self, crawl4ai_version: Optional[str], config_list: list[dict[str, Any]], expected: dict[str, Any]
     ) -> None:
         """Test that config is properly adapted based on crawl4ai version."""
         with patch(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When using AG2's WebSurferAgent with crawl4ai >=0.5, the following error occurs:

```
Error: Setting 'provider' is deprecated. Instead, use llm_config=LLMConfig(provider="...")
```

## Related issue number

https://github.com/ag2ai/ag2/issues/1776

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
