### PR TITLE
fix dead link in extra.css

### DIFF
--- a/website/mkdocs/docs/stylesheets/extra.css
+++ b/website/mkdocs/docs/stylesheets/extra.css
@@ -1,6 +1,6 @@
 /*
 all variables
-https://github.com/squidfunk/mkdocs-material/blob/master/src/assets/stylesheets/main/_colors.scss
+https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/assets/stylesheets/main/_colors.scss
 */
 
 /* Load Jersey 10 font*/


### PR DESCRIPTION
Hi, I fixed dead link in the documentation and replaced them with working ones.

https://github.com/squidfunk/mkdocs-material/blob/master/src/assets/stylesheets/main/_colors.scss - old link
https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/assets/stylesheets/main/_colors.scss - new link

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
