### PR TITLE
feat: unpin mcp version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ twilio = [
 mcp = [
     # mcp 1.6.0 keeps hanging in stdio_client context manager
     # test_mcp_issue_with_stdio_client_context_manager is failing for mcp=1.6.0
-    "mcp>=1.4.0,<1.6; python_version>='3.10'",
+    "mcp>=1.7.0; python_version>='3.10'",
 ]
 
 mcp-proxy-gen = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Hi! I'm here because I'm working on the google a2a-samples repo here: https://github.com/google-a2a/a2a-samples/tree/main/samples/python/agents/ag2 

Ag2 is pinning the max version of MCP which is an issue when trying to work alongside other frameworks which require newer versions of MCP. I believe that the issue you encountered for the original reason for pinning MCP should be resolved by now, so it's no longer necessary. Thanks!

Found while working on https://github.com/mozilla-ai/any-agent/issues/410 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
