### PR TITLE
Add streaming output option to LLMConfig

### DIFF
--- a/autogen/events/client_events.py
+++ b/autogen/events/client_events.py
@@ -159,9 +159,9 @@ class StreamEvent(BaseEvent):
         f = f or print
 
         # Set the terminal text color to green
-        f("\033[32m", end="")
+        # f("\033[32m", end="")
 
         f(self.content, end="", flush=True)
 
         # Reset the terminal text color
-        f("\033[0m\n")
+        # f("\033[0m\n")

--- a/autogen/llm_config.py
+++ b/autogen/llm_config.py
@@ -76,6 +76,12 @@ class LLMConfig(metaclass=MetaLLMConfig):
         modified_kwargs["config_list"] = [
             _add_default_api_type(v) if isinstance(v, dict) else v for v in modified_kwargs["config_list"]
         ]
+        # Propagate stream setting to all config entries if set at top level
+        if "stream" in modified_kwargs:
+            stream_value = modified_kwargs["stream"]
+            modified_kwargs["config_list"] = [
+                {**v, "stream": stream_value} if isinstance(v, dict) else v for v in modified_kwargs["config_list"]
+            ]
         for x in ["max_tokens", "top_p"]:
             if x in modified_kwargs:
                 modified_kwargs["config_list"] = [{**v, x: modified_kwargs[x]} for v in modified_kwargs["config_list"]]
@@ -259,6 +265,7 @@ class LLMConfig(metaclass=MetaLLMConfig):
                 response_format: Optional[Union[str, dict[str, Any], BaseModel, Type[BaseModel]]] = None
                 timeout: Optional[int] = None
                 cache_seed: Optional[int] = None
+                stream: Optional[bool] = None
 
                 tools: list[Any] = Field(default_factory=list)
                 functions: list[Any] = Field(default_factory=list)

--- a/test/test_streaming.py
+++ b/test/test_streaming.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Portions derived from  https://github.com/microsoft/autogen are under the MIT License.
+# SPDX-License-Identifier: MIT
+
+import os
+import warnings
+
+from autogen import ConversableAgent, LLMConfig
+
+warnings.simplefilter("always", UserWarning)
+
+llm_config = LLMConfig(
+    api_type="openai",
+    model="gpt-4o-mini",
+    api_key=os.getenv("OPENAI_API_KEY"),
+    stream=True,  # Enable streaming globally
+)
+
+agent = ConversableAgent("test", llm_config=llm_config)
+
+response = agent.run(
+    message="Write a couple sentences about something niche in ML evals.", max_turns=1, user_input=False
+)
+
+# Output will be streamed, also works for multi-agent conversations
+# TODO: check why IOStream reads it twice (likely sending final message somewhere)
+# TODO: can check with pytest, currently doing manually
+response.process()


### PR DESCRIPTION
While implementing streaming (following this [tutorial](https://docs.ag2.ai/latest/docs/use-cases/notebooks/notebooks/agentchat_websockets/)), Pydantic validation errors prevented the `stream` parameter from being passed into `LLMConfig`. This PR allows for setting `stream=True` at the top level of `LLMConfig`, which is then propagated to all entries in `config_list`. The output tokens are then streamed (both in single-agent and multi-agent conversations) by modifying the `StreamEvent` class to create the message in real time. Some notes about limitations accompany the test.
