### PR TITLE
Update google-genai version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,7 +229,7 @@ lmm = ["replicate", "pillow"]
 graph = ["networkx", "matplotlib"]
 gemini = [
     "google-api-core",
-    "google-genai>=1.2.0",
+    "google-genai>=1.20.0",
     "google-cloud-aiplatform",
     "google-auth",
     "pillow",


### PR DESCRIPTION
## Why are these changes needed?

Google's `google-genai` was failing with version 1.18.0 as per #1843. Version 1.20 fixed it.

## Related issue number

Closes #1843 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
