### PR TITLE
Change After Works on handoffs to a list of OnContextConditions

### DIFF
--- a/autogen/agentchat/group/group_utils.py
+++ b/autogen/agentchat/group/group_utils.py
@@ -82,6 +82,46 @@ def link_agents_to_group_manager(agents: list[Agent], group_chat_manager: Agent)
         agent._group_manager = group_chat_manager  # type: ignore[attr-defined]
 
 
+def _evaluate_after_works_conditions(
+    agent: "ConversableAgent",
+    groupchat: GroupChat,
+    user_agent: Optional["ConversableAgent"],
+) -> Optional[Union[Agent, str]]:
+    """Evaluate after_works context conditions for an agent.
+
+    Args:
+        agent: The agent to evaluate after_works conditions for
+        groupchat: The current group chat
+        user_agent: Optional user proxy agent
+
+    Returns:
+        The resolved speaker selection result if a condition matches, None otherwise
+    """
+    if not hasattr(agent, "handoffs") or not agent.handoffs.after_works:  # type: ignore[attr-defined]
+        return None
+
+    for after_work_condition in agent.handoffs.after_works:  # type: ignore[attr-defined]
+        # Check if condition is available
+        is_available = (
+            after_work_condition.available.is_available(agent, groupchat.messages)
+            if after_work_condition.available
+            else True
+        )
+
+        # Evaluate the condition (None condition means always true)
+        if is_available and (
+            after_work_condition.condition is None or after_work_condition.condition.evaluate(agent.context_variables)
+        ):
+            # Condition matched, resolve and return
+            return after_work_condition.target.resolve(
+                groupchat,
+                agent,
+                user_agent,
+            ).get_speaker_selection_result(groupchat)
+
+    return None
+
+
 def _run_oncontextconditions(
     agent: "ConversableAgent",
     messages: Optional[list[dict[str, Any]]] = None,
@@ -94,7 +134,9 @@ def _run_oncontextconditions(
             on_condition.available.is_available(agent, messages if messages else []) if on_condition.available else True
         )
 
-        if is_available and on_condition.condition.evaluate(agent.context_variables):
+        if is_available and (
+            on_condition.condition is None or on_condition.condition.evaluate(agent.context_variables)
+        ):
             # Condition has been met, we'll set the Tool Executor's next target
             # attribute and that will be picked up on the next iteration when
             # _determine_next_agent is called
@@ -161,12 +203,13 @@ def ensure_handoff_agents_in_group(agents: list["ConversableAgent"]) -> None:
                 and context_conditions.target.agent_name not in agent_names
             ):
                 raise ValueError("Agent in OnContextCondition Hand-offs must be in the agents list")
-        if (
-            agent.handoffs.after_work is not None
-            and isinstance(agent.handoffs.after_work, (AgentTarget, AgentNameTarget))
-            and agent.handoffs.after_work.agent_name not in agent_names
-        ):
-            raise ValueError("Agent in after work target Hand-offs must be in the agents list")
+        # Check after_works targets
+        for after_work_condition in agent.handoffs.after_works:
+            if (
+                isinstance(after_work_condition.target, (AgentTarget, AgentNameTarget))
+                and after_work_condition.target.agent_name not in agent_names
+            ):
+                raise ValueError("Agent in after work target Hand-offs must be in the agents list")
 
 
 def prepare_exclude_transit_messages(agents: list["ConversableAgent"]) -> None:
@@ -426,22 +469,25 @@ def determine_next_agent(
 
     # If the user last spoke, return to the agent prior to them (if they don't have an after work, otherwise it's treated like any other agent)
     if user_agent and last_speaker == user_agent:
-        if user_agent.handoffs.after_work is None:
+        if not user_agent.handoffs.after_works:
             return last_agent_speaker
         else:
             last_agent_speaker = user_agent
 
     # AFTER WORK:
 
-    # Get the appropriate After Work condition (from the agent if they have one, otherwise the group level one)
-    after_work_condition = (
-        last_agent_speaker.handoffs.after_work  # type: ignore[attr-defined]
-        if last_agent_speaker.handoffs.after_work is not None  # type: ignore[attr-defined]
-        else group_after_work
+    # First, try to evaluate after_works context conditions
+    after_works_result = _evaluate_after_works_conditions(
+        last_agent_speaker,  # type: ignore[arg-type]
+        groupchat,
+        user_agent,
     )
+    if after_works_result is not None:
+        return after_works_result
 
+    # If no after_works conditions matched, use the group-level after_work
     # Resolve the next agent, termination, or speaker selection method
-    resolved_speaker_selection_result = after_work_condition.resolve(
+    resolved_speaker_selection_result = group_after_work.resolve(
         groupchat,
         last_agent_speaker,  # type: ignore[arg-type]
         user_agent,
@@ -525,10 +571,7 @@ def create_group_manager(
                 if (
                     len(agent.handoffs.get_context_conditions_by_target_type(GroupManagerTarget)) > 0
                     or len(agent.handoffs.get_llm_conditions_by_target_type(GroupManagerTarget)) > 0
-                    or (
-                        agent.handoffs.after_work is not None
-                        and isinstance(agent.handoffs.after_work, GroupManagerTarget)
-                    )
+                    or any(isinstance(aw.target, GroupManagerTarget) for aw in agent.handoffs.after_works)
                 ):
                     has_group_manager_target = True
                     break

--- a/autogen/agentchat/group/on_context_condition.py
+++ b/autogen/agentchat/group/on_context_condition.py
@@ -24,12 +24,12 @@ class OnContextCondition(BaseModel):  # noqa: N801
 
     Args:
         target (TransitionTarget): The transition (essentially an agent) to hand off to.
-        condition (ContextCondition): The context variable based condition for transitioning to the target agent.
+        condition (Optional[ContextCondition]): The context variable based condition for transitioning to the target agent. If None, the condition always evaluates to True.
         available (AvailableCondition): Optional condition to determine if this OnCondition is included for the LLM to evaluate based on context variables using classes like StringAvailableCondition and ContextExpressionAvailableCondition.
     """
 
     target: TransitionTarget
-    condition: ContextCondition
+    condition: Optional[ContextCondition] = None
     available: Optional[AvailableCondition] = None
 
     def has_target_type(self, target_type: type) -> bool:

--- a/test/agentchat/group/test_group_utils.py
+++ b/test/agentchat/group/test_group_utils.py
@@ -72,7 +72,7 @@ def create_mock_agent(name: str, handoffs: Optional[Handoffs] = None) -> MagicMo
         agent.handoffs = MagicMock(spec=Handoffs)
         agent.handoffs.llm_conditions = []
         agent.handoffs.context_conditions = []
-        agent.handoffs.after_work = None
+        agent.handoffs.after_works = []
         agent.handoffs.get_llm_conditions_requiring_wrapping = MagicMock(return_value=[])
         agent.handoffs.get_context_conditions_requiring_wrapping = MagicMock(return_value=[])
         agent.handoffs.set_llm_function_names = MagicMock()
@@ -107,7 +107,7 @@ def user_proxy() -> MagicMock:
     agent._group_manager = None
 
     agent.handoffs = MagicMock()
-    agent.handoffs.after_work = None
+    agent.handoffs.after_works = []
 
     # Mock initiate_chat
     chat_result = ChatResult(chat_history=[], cost={"cost": {}}, summary="", human_input=[])
@@ -302,7 +302,9 @@ class TestHelperFunctions:
         target = AgentTarget(agent=agent2)
         cond = OnCondition(target=target, condition=StringLLMCondition(prompt="prompt"))
         agent1.handoffs.llm_conditions = [cond]
-        agent1.handoffs.after_work = AgentNameTarget(agent_name=agent1.name)
+        agent1.handoffs.after_works = [
+            OnContextCondition(target=AgentNameTarget(agent_name=agent1.name), condition=None)
+        ]
         ensure_handoff_agents_in_group([agent1, agent2])  # Should not raise
 
         # Invalid case (LLM condition)
@@ -640,7 +642,7 @@ class TestHelperFunctions:
 
         # Case 6: After Work (Agent level - stay)
         mock_group_chat.messages = [{"role": "assistant", "name": "agent1", "content": "..."}]
-        agent1.handoffs.after_work = StayTarget()
+        agent1.handoffs.after_works = [OnContextCondition(target=StayTarget(), condition=None)]
         next_agent = determine_next_agent(
             agent1,
             mock_group_chat,
@@ -654,7 +656,7 @@ class TestHelperFunctions:
         assert next_agent == agent1
 
         # Case 7: After Work (Group level - terminate)
-        agent1.handoffs.after_work = None  # Remove agent level
+        agent1.handoffs.after_works = []  # Remove agent level
         group_after_work = TerminateTarget()
         next_agent = determine_next_agent(
             agent1, mock_group_chat, agent1, False, mock_tool_executor, group_agent_names, user_proxy, group_after_work

--- a/test/agentchat/group/test_handoffs.py
+++ b/test/agentchat/group/test_handoffs.py
@@ -75,7 +75,7 @@ class TestHandoffs:
         handoffs = Handoffs()
         assert handoffs.context_conditions == []
         assert handoffs.llm_conditions == []
-        assert handoffs.after_work is None
+        assert handoffs.after_works == []
 
     def test_init_with_conditions(
         self,
@@ -87,11 +87,13 @@ class TestHandoffs:
         handoffs = Handoffs(
             context_conditions=[mock_on_context_condition],
             llm_conditions=[mock_on_condition],
-            after_work=mock_after_work,
+            after_works=[OnContextCondition(target=mock_after_work, condition=None)],
         )
         assert handoffs.context_conditions == [mock_on_context_condition]
         assert handoffs.llm_conditions == [mock_on_condition]
-        assert handoffs.after_work == mock_after_work
+        assert len(handoffs.after_works) == 1
+        assert handoffs.after_works[0].target == mock_after_work
+        assert handoffs.after_works[0].condition is None
 
     def test_add_context_condition(self, mock_on_context_condition: OnContextCondition) -> None:
         """Test adding a single context condition."""
@@ -176,7 +178,9 @@ class TestHandoffs:
         handoffs = Handoffs()
         result = handoffs.set_after_work(mock_after_work)
 
-        assert handoffs.after_work == mock_after_work
+        assert len(handoffs.after_works) == 1
+        assert handoffs.after_works[0].target == mock_after_work
+        assert handoffs.after_works[0].condition is None
         assert result == handoffs  # Method should return self for chaining
 
     def test_set_after_work_invalid_type(self) -> None:
@@ -200,7 +204,9 @@ class TestHandoffs:
         handoffs.set_after_work(mock_target2)
 
         # Only the second value should be kept
-        assert handoffs.after_work == mock_target2
+        assert len(handoffs.after_works) == 1
+        assert handoffs.after_works[0].target == mock_target2
+        assert handoffs.after_works[0].condition is None
 
     def test_add_on_context_condition(self, mock_on_context_condition: OnContextCondition) -> None:
         """Test adding an OnContextCondition using the generic add method."""
@@ -272,14 +278,14 @@ class TestHandoffs:
         handoffs = Handoffs(
             context_conditions=[mock_on_context_condition],
             llm_conditions=[mock_on_condition],
-            after_work=mock_after_work,
+            after_works=[OnContextCondition(target=mock_after_work, condition=None)],
         )
 
         result = handoffs.clear()
 
         assert handoffs.context_conditions == []
         assert handoffs.llm_conditions == []
-        assert handoffs.after_work is None
+        assert handoffs.after_works == []
         assert result == handoffs  # Method should return self for chaining
 
     def test_adding_after_clear(
@@ -308,7 +314,9 @@ class TestHandoffs:
 
         assert handoffs.context_conditions == [new_context_condition]
         assert handoffs.llm_conditions == [new_llm_condition]
-        assert handoffs.after_work == new_after_work
+        assert len(handoffs.after_works) == 1
+        assert handoffs.after_works[0].target == new_after_work
+        assert handoffs.after_works[0].condition is None
 
     def test_get_llm_conditions_by_target_type(
         self, mock_on_condition: OnCondition, mock_agent_target: AgentTarget
@@ -466,7 +474,9 @@ class TestHandoffs:
         # Verify the operations were applied
         assert handoffs.context_conditions == [mock_on_context_condition]
         assert handoffs.llm_conditions == [mock_on_condition]
-        assert handoffs.after_work == mock_after_work
+        assert len(handoffs.after_works) == 1
+        assert handoffs.after_works[0].target == mock_after_work
+        assert handoffs.after_works[0].condition is None
 
         # Verify the result is the handoffs instance for chaining
         assert result == handoffs

--- a/test/agentchat/group/test_on_context_condition.py
+++ b/test/agentchat/group/test_on_context_condition.py
@@ -109,6 +109,7 @@ class TestOnContextCondition:
         mock_context_variables = MagicMock()
 
         # Call evaluate through the condition
+        assert on_context_condition.condition is not None
         result = on_context_condition.condition.evaluate(mock_context_variables)
 
         # Verify the mock was called correctly


### PR DESCRIPTION
## Why are these changes needed?

After works can now be a set of conditional OnContextCondition. Made `condition` optional on OnContextCondition so an OnContextCondition can be triggered without a condition (defaults to True) to support the existing set_after_work in setting a condition for transfer. 

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
