### PR TITLE
Add context variables to the user proxy agent in group chat

### DIFF
--- a/autogen/agentchat/group/group_utils.py
+++ b/autogen/agentchat/group/group_utils.py
@@ -320,17 +320,19 @@ def setup_context_variables(
     tool_execution: "ConversableAgent",
     agents: list["ConversableAgent"],
     manager: GroupChatManager,
+    user_agent: Optional["ConversableAgent"],
     context_variables: ContextVariables,
 ) -> None:
-    """Assign a common context_variables reference to all agents in the group, including the tool executor and group chat manager.
+    """Assign a common context_variables reference to all agents in the group, including the tool executor, group chat manager, and user proxy agent.
 
     Args:
         tool_execution: The tool execution agent.
         agents: List of all agents in the conversation.
         manager: GroupChatManager instance.
+        user_agent: Optional user proxy agent.
         context_variables: Context variables to assign to all agents.
     """
-    for agent in agents + [tool_execution] + [manager]:
+    for agent in agents + [tool_execution] + [manager] + ([user_agent] if user_agent else []):
         agent.context_variables = context_variables
 
 

--- a/autogen/agentchat/group/patterns/pattern.py
+++ b/autogen/agentchat/group/patterns/pattern.py
@@ -152,7 +152,13 @@ class Pattern(ABC):
         manager = create_group_manager(groupchat, self.group_manager_args, self.agents, self.group_after_work)
 
         # Point all agent's context variables to this function's context_variables
-        setup_context_variables(tool_executor, self.agents, manager, self.context_variables)
+        setup_context_variables(
+            tool_execution=tool_executor,
+            agents=self.agents,
+            manager=manager,
+            user_agent=self.user_agent,
+            context_variables=self.context_variables,
+        )
 
         # Link all agents with the GroupChatManager to allow access to the group chat
         link_agents_to_group_manager(groupchat.agents, manager)

--- a/test/agentchat/group/test_group_utils.py
+++ b/test/agentchat/group/test_group_utils.py
@@ -467,17 +467,19 @@ class TestHelperFunctions:
         agent2: MagicMock,
         mock_tool_executor: MagicMock,
         mock_group_chat_manager: MagicMock,
+        user_proxy: MagicMock,
         context_vars: ContextVariables,
     ) -> None:
         """Test assigning the common context variables object."""
         agents = [agent1, agent2]
         typed_agents = cast(list[ConversableAgent], agents)
-        setup_context_variables(mock_tool_executor, typed_agents, mock_group_chat_manager, context_vars)
+        setup_context_variables(mock_tool_executor, typed_agents, mock_group_chat_manager, user_proxy, context_vars)
 
         assert agent1.context_variables is context_vars
         assert agent2.context_variables is context_vars
         assert mock_tool_executor.context_variables is context_vars
         assert mock_group_chat_manager.context_variables is context_vars
+        assert user_proxy.context_variables is context_vars
 
     def test_cleanup_temp_user_messages(self) -> None:
         """Test removing the temporary user name from messages."""


### PR DESCRIPTION
## Why are these changes needed?

In the new group chat the context variables do not get associated with the user_agent of the pattern. This fixes that.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
