### PR TITLE
feat: Add sender and recipient fields to TerminationEvent

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1471,7 +1471,11 @@ class ConversableAgent(LLMAgent):
                 self.send(msg2send, recipient, request_reply=True, silent=silent)
 
             else:  # No breaks in the for loop, so we have reached max turns
-                iostream.send(TerminationEvent(termination_reason=f"Maximum turns ({max_turns}) reached"))
+                iostream.send(TerminationEvent(
+                    termination_reason=f"Maximum turns ({max_turns}) reached",
+                    sender=self,
+                    recipient=recipient
+                ))
         else:
             self._prepare_chat(recipient, clear_history)
             if isinstance(message, Callable):
@@ -1651,7 +1655,11 @@ class ConversableAgent(LLMAgent):
                     break
                 await self.a_send(msg2send, recipient, request_reply=True, silent=silent)
             else:  # No breaks in the for loop, so we have reached max turns
-                iostream.send(TerminationEvent(termination_reason=f"Maximum turns ({max_turns}) reached"))
+                iostream.send(TerminationEvent(
+                    termination_reason=f"Maximum turns ({max_turns}) reached",
+                    sender=self,
+                    recipient=recipient
+                ))
         else:
             self._prepare_chat(recipient, clear_history)
             if isinstance(message, Callable):
@@ -2587,7 +2595,11 @@ class ConversableAgent(LLMAgent):
             self._consecutive_auto_reply_counter[sender] = 0
 
             if termination_reason:
-                iostream.send(TerminationEvent(termination_reason=termination_reason))
+                iostream.send(TerminationEvent(
+                    termination_reason=termination_reason,
+                    sender=self,
+                    recipient=sender
+                ))
 
             return True, None
 
@@ -2727,7 +2739,11 @@ class ConversableAgent(LLMAgent):
             self._consecutive_auto_reply_counter[sender] = 0
 
             if termination_reason:
-                iostream.send(TerminationEvent(termination_reason=termination_reason))
+                iostream.send(TerminationEvent(
+                    termination_reason=termination_reason,
+                    sender=self,
+                    recipient=sender
+                ))
 
             return True, None
 

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1471,11 +1471,11 @@ class ConversableAgent(LLMAgent):
                 self.send(msg2send, recipient, request_reply=True, silent=silent)
 
             else:  # No breaks in the for loop, so we have reached max turns
-                iostream.send(TerminationEvent(
-                    termination_reason=f"Maximum turns ({max_turns}) reached",
-                    sender=self,
-                    recipient=recipient
-                ))
+                iostream.send(
+                    TerminationEvent(
+                        termination_reason=f"Maximum turns ({max_turns}) reached", sender=self, recipient=recipient
+                    )
+                )
         else:
             self._prepare_chat(recipient, clear_history)
             if isinstance(message, Callable):
@@ -1655,11 +1655,11 @@ class ConversableAgent(LLMAgent):
                     break
                 await self.a_send(msg2send, recipient, request_reply=True, silent=silent)
             else:  # No breaks in the for loop, so we have reached max turns
-                iostream.send(TerminationEvent(
-                    termination_reason=f"Maximum turns ({max_turns}) reached",
-                    sender=self,
-                    recipient=recipient
-                ))
+                iostream.send(
+                    TerminationEvent(
+                        termination_reason=f"Maximum turns ({max_turns}) reached", sender=self, recipient=recipient
+                    )
+                )
         else:
             self._prepare_chat(recipient, clear_history)
             if isinstance(message, Callable):
@@ -2595,11 +2595,7 @@ class ConversableAgent(LLMAgent):
             self._consecutive_auto_reply_counter[sender] = 0
 
             if termination_reason:
-                iostream.send(TerminationEvent(
-                    termination_reason=termination_reason,
-                    sender=self,
-                    recipient=sender
-                ))
+                iostream.send(TerminationEvent(termination_reason=termination_reason, sender=self, recipient=sender))
 
             return True, None
 
@@ -2739,11 +2735,7 @@ class ConversableAgent(LLMAgent):
             self._consecutive_auto_reply_counter[sender] = 0
 
             if termination_reason:
-                iostream.send(TerminationEvent(
-                    termination_reason=termination_reason,
-                    sender=self,
-                    recipient=sender
-                ))
+                iostream.send(TerminationEvent(termination_reason=termination_reason, sender=self, recipient=sender))
 
             return True, None
 

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1233,7 +1233,11 @@ class GroupChatManager(ConversableAgent):
                 a.previous_cache = None
 
         if termination_reason:
-            iostream.send(TerminationEvent(termination_reason=termination_reason))
+            iostream.send(TerminationEvent(
+                termination_reason=termination_reason,
+                sender=self,
+                recipient=speaker if speaker else None
+            ))
 
         return True, None
 
@@ -1317,7 +1321,11 @@ class GroupChatManager(ConversableAgent):
                 a.previous_cache = None
 
         if termination_reason:
-            iostream.send(TerminationEvent(termination_reason=termination_reason))
+            iostream.send(TerminationEvent(
+                termination_reason=termination_reason,
+                sender=self,
+                recipient=speaker if speaker else None
+            ))
 
         return True, None
 

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1233,11 +1233,11 @@ class GroupChatManager(ConversableAgent):
                 a.previous_cache = None
 
         if termination_reason:
-            iostream.send(TerminationEvent(
-                termination_reason=termination_reason,
-                sender=self,
-                recipient=speaker if speaker else None
-            ))
+            iostream.send(
+                TerminationEvent(
+                    termination_reason=termination_reason, sender=self, recipient=speaker if speaker else None
+                )
+            )
 
         return True, None
 
@@ -1321,11 +1321,11 @@ class GroupChatManager(ConversableAgent):
                 a.previous_cache = None
 
         if termination_reason:
-            iostream.send(TerminationEvent(
-                termination_reason=termination_reason,
-                sender=self,
-                recipient=speaker if speaker else None
-            ))
+            iostream.send(
+                TerminationEvent(
+                    termination_reason=termination_reason, sender=self, recipient=speaker if speaker else None
+                )
+            )
 
         return True, None
 

--- a/autogen/events/agent_events.py
+++ b/autogen/events/agent_events.py
@@ -669,16 +669,22 @@ class TerminationEvent(BaseEvent):
     """When a workflow termination condition is met"""
 
     termination_reason: str
+    sender: str
+    recipient: Optional[str] = None
 
     def __init__(
         self,
         *,
         uuid: Optional[UUID] = None,
+        sender: Union["Agent", str],
+        recipient: Optional[Union["Agent", str]] = None,
         termination_reason: str,
     ):
         super().__init__(
             uuid=uuid,
             termination_reason=termination_reason,
+            sender=sender.name if hasattr(sender, "name") else sender,
+            recipient=recipient.name if hasattr(recipient, "name") else recipient if recipient else None,
         )
 
     def print(self, f: Optional[Callable[..., Any]] = None) -> None:

--- a/autogen/events/helpers.py
+++ b/autogen/events/helpers.py
@@ -13,12 +13,15 @@ logger = logging.getLogger(__name__)
 def deprecated_by(
     new_class: type[BaseModel],
     param_mapping: dict[str, str] = None,
+    default_params: dict[str, any] = None,
 ) -> Callable[[type[BaseModel]], Callable[..., BaseModel]]:
     param_mapping = param_mapping or {}
+    default_params = default_params or {}
 
     def decorator(
         old_class: type[BaseModel],
         param_mapping: dict[str, str] = param_mapping,
+        default_params: dict[str, any] = default_params,
     ) -> Callable[..., BaseModel]:
         @wraps(old_class)
         def wrapper(*args, **kwargs) -> BaseModel:
@@ -27,6 +30,11 @@ def deprecated_by(
             )
             # Translate old parameters to new parameters
             new_kwargs = {param_mapping.get(k, k): v for k, v in kwargs.items()}
+
+            # Add default parameters if not already present
+            for key, value in default_params.items():
+                if key not in new_kwargs:
+                    new_kwargs[key] = value
 
             # Pass the translated parameters to the new class
             return new_class(*args, **new_kwargs)

--- a/autogen/messages/agent_messages.py
+++ b/autogen/messages/agent_messages.py
@@ -647,7 +647,7 @@ class UsingAutoReplyMessage(BaseMessage):
         f(colored("\n>>>>>>>> USING AUTO REPLY...", "red"), flush=True)
 
 
-@deprecated_by(TerminationEvent)
+@deprecated_by(TerminationEvent, default_params={"sender": "system"})
 @wrap_message
 class TerminationMessage(BaseMessage):
     """When a workflow termination condition is met"""

--- a/test/events/test_agent_events.py
+++ b/test/events/test_agent_events.py
@@ -1141,12 +1141,14 @@ class TestTerminationAndHumanReplyEvent:
 
 
 class TestTerminationEvent:
-    def test_print(self, uuid: UUID) -> None:
+    def test_print(self, uuid: UUID, sender: ConversableAgent, recipient: ConversableAgent) -> None:
         termination_reason = "User requested to end the conversation."
 
         actual = TerminationEvent(
             uuid=uuid,
             termination_reason=termination_reason,
+            sender=sender,
+            recipient=recipient,
         )
         assert isinstance(actual, TerminationEvent)
 
@@ -1155,6 +1157,8 @@ class TestTerminationEvent:
             "content": {
                 "uuid": uuid,
                 "termination_reason": termination_reason,
+                "sender": "sender",
+                "recipient": "recipient",
             },
         }
         assert actual.model_dump() == expected_model_dump
@@ -1169,12 +1173,14 @@ class TestTerminationEvent:
         ]
         assert mock.call_args_list == expected_call_args_list
 
-    def test_serialization_and_deserialization(self, uuid: UUID) -> None:
+    def test_serialization_and_deserialization(self, uuid: UUID, sender: ConversableAgent, recipient: ConversableAgent) -> None:
         termination_reason = "User requested to end the conversation."
 
         actual = TerminationEvent(
             uuid=uuid,
             termination_reason=termination_reason,
+            sender=sender,
+            recipient=recipient,
         )
         assert isinstance(actual, TerminationEvent)
 
@@ -1183,6 +1189,8 @@ class TestTerminationEvent:
             "content": {
                 "uuid": uuid,
                 "termination_reason": termination_reason,
+                "sender": "sender",
+                "recipient": "recipient",
             },
         }
         assert actual.model_dump() == expected_model_dump
@@ -1190,6 +1198,31 @@ class TestTerminationEvent:
         # Test serialization
         d = actual.model_dump()
         assert actual == EVENT_CLASSES[d["type"]].model_validate(d)
+
+    def test_with_string_sender_recipient(self, uuid: UUID) -> None:
+        termination_reason = "User requested to end the conversation."
+
+        actual = TerminationEvent(
+            uuid=uuid,
+            termination_reason=termination_reason,
+            sender="agent1",
+            recipient="agent2",
+        )
+        assert isinstance(actual, TerminationEvent)
+        assert actual.content.sender == "agent1"
+        assert actual.content.recipient == "agent2"
+
+    def test_with_optional_recipient(self, uuid: UUID, sender: ConversableAgent) -> None:
+        termination_reason = "Maximum turns reached."
+
+        actual = TerminationEvent(
+            uuid=uuid,
+            termination_reason=termination_reason,
+            sender=sender,
+        )
+        assert isinstance(actual, TerminationEvent)
+        assert actual.content.sender == "sender"
+        assert actual.content.recipient is None
 
 
 class TestUsingAutoReplyEvent:

--- a/test/events/test_agent_events.py
+++ b/test/events/test_agent_events.py
@@ -1173,7 +1173,9 @@ class TestTerminationEvent:
         ]
         assert mock.call_args_list == expected_call_args_list
 
-    def test_serialization_and_deserialization(self, uuid: UUID, sender: ConversableAgent, recipient: ConversableAgent) -> None:
+    def test_serialization_and_deserialization(
+        self, uuid: UUID, sender: ConversableAgent, recipient: ConversableAgent
+    ) -> None:
         termination_reason = "User requested to end the conversation."
 
         actual = TerminationEvent(


### PR DESCRIPTION
- Updated TerminationEvent class to include sender and optional recipient fields
- Modified all TerminationEvent instantiations in conversable_agent.py and groupchat.py
- Updated tests to cover the new fields
- Follows the same pattern as other events like PostCarryoverProcessingEvent

This allows users to identify which agent triggered the termination, addressing the feature request in issue #1903.

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #1903

<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
