### PR TITLE
Update link index.mdx

### DIFF
--- a/website/docs/_blogs/2025-01-31-WebSurferAgent/index.mdx
+++ b/website/docs/_blogs/2025-01-31-WebSurferAgent/index.mdx
@@ -589,7 +589,7 @@ Here is the extracted information from the AG2 documentation website:
 - [Advanced Concepts: Explore topics such as RAG, Code Execution, and complex GroupChats and Swarms.](https://docs.ag2.ai/docs/user-guide/advanced-concepts)
 - [Use Cases: Experiment with workflows in areas like Customer Service, Travel Planning, and Game Design.](https://docs.ag2.ai/docs/use-cases/use-cases)
 - [Notebook Examples: Access a collection of interactive notebooks covering all AG2 topics.](https://docs.ag2.ai/docs/use-cases/notebooks/Notebooks)
-- [API Reference: Detailed exploration of the AG2 API reference.](https://docs.ag2.ai/docs/api-reference)
+- [API Reference: Detailed exploration of the AG2 API reference.](https://docs.ag2.ai/latest/docs/api-reference/autogen/Agent/)
 - [How to Contribute: Guidelines for getting involved with AG2 and enhancing the framework.](https://docs.ag2.ai/latest/docs/contributor-guide/contributing)
 
 ### Popular Resources


### PR DESCRIPTION
Found and fixed dead link in **website/docs/_blogs/2025-01-31-WebSurferAgent/index.mdx**

https://docs.ag2.ai/docs/api-reference - old link
https://docs.ag2.ai/latest/docs/api-reference/autogen/Agent/ - new link

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
