### PR TITLE
[Bug fix] Add guardrails page to the sidebar

### DIFF
--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -133,7 +133,8 @@
                     "docs/user-guide/advanced-concepts/orchestration/group-chat/agent-tools-functions",
                     "docs/user-guide/advanced-concepts/orchestration/group-chat/context-variables",
                     "docs/user-guide/advanced-concepts/orchestration/group-chat/handoffs",
-                    "docs/user-guide/advanced-concepts/orchestration/group-chat/patterns"
+                    "docs/user-guide/advanced-concepts/orchestration/group-chat/patterns",
+                    "docs/user-guide/advanced-concepts/orchestration/group-chat/guardrails"
                   ]
                 },
                 {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
for guardrail documentation, I can't find it from side bar. 
I built it from local. 
http://localhost:8000/docs/user-guide/advanced-concepts/orchestration/group-chat/introduction/

I can search and find the page
http://localhost:8000/docs/user-guide/advanced-concepts/orchestration/group-chat/guardrails/
I did './scripts/docs_build_mkdocs.sh' and './scripts/docs_serve_mkdocs.sh'

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
