### PR TITLE
feat: Add fixed_order and round_robin routing to LLMConfig

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -212,6 +212,7 @@ OPENAI_FALLBACK_KWARGS = {
     "default_query",
     "http_client",
     "_strict_response_validation",
+    "webhook_secret",
 }
 
 AOPENAI_FALLBACK_KWARGS = {
@@ -231,6 +232,7 @@ AOPENAI_FALLBACK_KWARGS = {
     "_strict_response_validation",
     "base_url",
     "project",
+    "webhook_secret",
 }
 
 

--- a/autogen/oai/oai_models/chat_completion.py
+++ b/autogen/oai/oai_models/chat_completion.py
@@ -66,7 +66,7 @@ class ChatCompletion(BaseModel):
     object: Literal["chat.completion"]
     """The object type, which is always `chat.completion`."""
 
-    service_tier: Optional[Literal["auto", "default", "flex", "scale"]] = None
+    service_tier: Optional[Literal["auto", "default", "flex", "scale", "priority"]] = None
     """The service tier used for processing the request."""
 
     system_fingerprint: Optional[str] = None

--- a/test/oai/test_anthropic.py
+++ b/test/oai/test_anthropic.py
@@ -76,6 +76,7 @@ def test_anthropic_llm_config_entry():
     )
     assert llm_config.model_dump() == {
         "config_list": [expected],
+        "routing_method": "fixed_order",
     }
 
 

--- a/test/oai/test_bedrock.py
+++ b/test/oai/test_bedrock.py
@@ -70,6 +70,7 @@ def test_bedrock_llm_config_entry():
     )
     assert llm_config.model_dump() == {
         "config_list": [expected],
+        "routing_method": "fixed_order",
     }
 
     with pytest.raises(ValidationError) as e:

--- a/test/oai/test_cerebras.py
+++ b/test/oai/test_cerebras.py
@@ -63,6 +63,7 @@ def test_cerebras_llm_config_entry():
     )
     assert llm_config.model_dump() == {
         "config_list": [expected],
+        "routing_method": "fixed_order",
     }
 
     with pytest.raises(ValidationError) as e:

--- a/test/oai/test_client.py
+++ b/test/oai/test_client.py
@@ -466,6 +466,7 @@ def test_azure_llm_config_entry() -> None:
     )
     assert llm_config.model_dump() == {
         "config_list": [expected],
+        "routing_method": "fixed_order",
     }
 
 
@@ -492,6 +493,7 @@ def test_deepseek_llm_config_entry() -> None:
     )
     assert llm_config.model_dump() == {
         "config_list": [expected],
+        "routing_method": "fixed_order",
     }
 
     with pytest.raises(ValidationError) as e:

--- a/test/oai/test_cohere.py
+++ b/test/oai/test_cohere.py
@@ -46,6 +46,7 @@ def test_cohere_llm_config_entry():
     )
     assert llm_config.model_dump() == {
         "config_list": [expected],
+        "routing_method": "fixed_order",
     }
 
 

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -48,6 +48,7 @@ def test_gemini_llm_config_entry():
     )
     assert llm_config.model_dump() == {
         "config_list": [expected],
+        "routing_method": "fixed_order",
     }
 
 

--- a/test/oai/test_groq.py
+++ b/test/oai/test_groq.py
@@ -51,6 +51,7 @@ def test_groq_llm_config_entry():
     )
     assert llm_config.model_dump() == {
         "config_list": [expected],
+        "routing_method": "fixed_order",
     }
 
 

--- a/test/oai/test_mistral.py
+++ b/test/oai/test_mistral.py
@@ -55,6 +55,7 @@ def test_mistral_llm_config_entry():
     )
     assert llm_config.model_dump() == {
         "config_list": [expected],
+        "routing_method": "fixed_order",
     }
 
 

--- a/test/oai/test_ollama.py
+++ b/test/oai/test_ollama.py
@@ -86,6 +86,7 @@ def test_ollama_llm_config_entry():
     )
     assert llm_config.model_dump() == {
         "config_list": [expected],
+        "routing_method": "fixed_order",
     }
 
 

--- a/test/oai/test_together.py
+++ b/test/oai/test_together.py
@@ -56,6 +56,7 @@ def test_together_llm_config_entry():
     )
     assert llm_config.model_dump() == {
         "config_list": [expected],
+        "routing_method": "fixed_order",
     }
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a `routing_method` parameter to `LLMConfig` and `OpenAIWrapper` to control how configurations are selected from a list.

Supported methods:
- `fixed_order`: (Default) Tries configurations sequentially, providing failover.
- `round_robin`: Determines a starting configuration using a round-robin index and then attempts to use configurations sequentially from that point (wrapping around the list) until one succeeds or all fail. The round-robin index for the starting point is advanced for the next operation.
- smarter routing can be added in future. @DujianDing 

Changes:
- `LLMConfig` now has a `routing_method` attribute (default: "fixed_order") and an internal `_config_list_index` for its `get_configs_to_try` method.
- `OpenAIWrapper`'s `__init__` now accepts `routing_method`.
- `OpenAIWrapper.create` now uses the specified `routing_method` to select which client configuration(s) to attempt.
  - For "fixed_order", it retains its existing behavior of trying all clients in sequence upon failure.
  - For "round_robin", it determines a starting client via an internal index, then attempts all clients in sequence (wrapping around) from that starting point until one succeeds. The starting index is advanced for the next `create` call.
- Removed a redundant `if not self._clients` check in `OpenAIWrapper.create`.
- Added comprehensive tests for `LLMConfig`'s routing attributes/methods and `OpenAIWrapper`'s new routing behavior in `test/test_llm_config.py`.
- Updated existing tests in `test/test_llm_config.py` (serialization, items, keys, values, unpack, repr) to account for the new `routing_method` field in `LLMConfig`.
- Adjusted `test_get_configs_to_try_empty_list` to reflect Pydantic's `min_length=1` validation on `config_list`.
- Updated `LLMConfig.model_dump()` assertions in various `test/oai/test_*.py` files (e.g., anthropic, bedrock, cerebras, cohere, gemini, groq, mistral, ollama, together) to include the new `routing_method` default.
- Corrected `OPENAI_FALLBACK_KWARGS` and `AOPENAI_FALLBACK_KWARGS` in `autogen/oai/client.py`.
- Updated `autogen/oai/oai_models/chat_completion.py` to include 'priority' in `service_tier` Literal to align with the official OpenAI schema.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
