### PR TITLE
feat: Add configurable routing method to LLMConfig and OpenAIWrapper

### DIFF
--- a/autogen/llm_config.py
+++ b/autogen/llm_config.py
@@ -303,13 +303,15 @@ class LLMConfigEntry(BaseModel, ABC):
     @field_validator("base_url", mode="before")
     @classmethod
     def check_base_url(cls, v: Any, info: ValidationInfo) -> Any:
+        if v is None:  # Handle None case explicitly
+            return None
         if not str(v).startswith("https://") and not str(v).startswith("http://"):
             v = f"http://{str(v)}"
         return v
 
-    @field_serializer("base_url")
+    @field_serializer("base_url", when_used="unless-none")  # Ensure serializer also respects None
     def serialize_base_url(self, v: Any) -> Any:
-        return str(v)
+        return str(v) if v is not None else None
 
     @field_serializer("api_key", when_used="unless-none")
     def serialize_api_key(self, v: SecretStr) -> Any:

--- a/autogen/llm_config.py
+++ b/autogen/llm_config.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from contextvars import ContextVar
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Mapping, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Mapping, Optional, Type, TypeVar, Union
 
 from httpx import Client as httpxClient
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, SecretStr, ValidationInfo, field_serializer, field_validator
@@ -268,6 +268,7 @@ class LLMConfig(metaclass=MetaLLMConfig):
                     list[Annotated[Union[llm_config_classes], Field(discriminator="api_type")]],
                     Field(default_factory=list, min_length=1),
                 ]
+                routing_method: Optional[Literal["fixed_order", "round_robin"]] = None
 
                 # Following field is configuration for pydantic to disallow extra fields
                 model_config = ConfigDict(extra="forbid")

--- a/test/oai/test_client.py
+++ b/test/oai/test_client.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import time
 from collections.abc import Generator
+from typing import Any  # Added import for Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -31,9 +32,207 @@ from autogen.oai.client import (
     OpenAIClient,
     OpenAILLMConfigEntry,
 )
-from autogen.oai.oai_models import ChatCompletion
+from autogen.oai.oai_models import ChatCompletion, ChatCompletionMessage, Choice, CompletionUsage
+from autogen.oai.openai_utils import APIError
 
 from ..conftest import Credentials
+
+
+class MockModelClient:
+    def __init__(self, config: dict, name: str = "mock_client"):
+        self.config = config
+        self.name = name  # Store the name if provided in config, else use default
+        self.call_count = 0
+
+    def create(self, params: dict[str, Any]):
+        self.call_count += 1
+        # Simulate a successful response or raise an exception based on config
+        if self.config.get("should_fail", False):
+            raise APIError(
+                message="Mock API Error", request=None, body=None
+            )  # Use openai.APIError or a general Exception
+
+        client_name_to_respond = self.config.get("name", self.name)
+        # Simulate a ChatCompletion response
+        return ChatCompletion(
+            id="chatcmpl-test",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(content=f"Response from {client_name_to_respond}", role="assistant"),
+                )
+            ],
+            created=1677652288,
+            model=params.get("model", "gpt-3.5-turbo"),
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=10, prompt_tokens=10, total_tokens=20),
+        )
+
+    def message_retrieval(self, response):
+        return [choice.message.content for choice in response.choices]
+
+    def cost(self, response):
+        return 0.02  # Example cost
+
+    @staticmethod
+    def get_usage(response):
+        return {
+            "prompt_tokens": response.usage.prompt_tokens,
+            "completion_tokens": response.usage.completion_tokens,
+            "total_tokens": response.usage.total_tokens,
+            "cost": response.cost if hasattr(response, "cost") else 0,
+            "model": response.model,
+        }
+
+
+# Fixture for OpenAIWrapper with mocked clients
+@pytest.fixture
+def mock_openai_wrapper_fixed_order_default():
+    # Test case where routing_method is not specified in OpenAIWrapper constructor,
+    # so it should default to "fixed_order".
+    config_list = [
+        {"model": "gpt-3.5-turbo", "api_key": "key1", "model_client_cls": "MockModelClient", "name": "client1"},
+        {"model": "gpt-4", "api_key": "key2", "model_client_cls": "MockModelClient", "name": "client2"},
+    ]
+    wrapper = OpenAIWrapper(config_list=config_list)
+    assert wrapper.routing_method == "fixed_order"
+
+    for i in range(len(config_list)):
+        wrapper._clients[i] = MockModelClient(config=wrapper._config_list[i])
+    return wrapper
+
+
+@pytest.fixture
+def mock_openai_wrapper_fixed_order_explicit():
+    # Test case where routing_method IS specified as "fixed_order" in OpenAIWrapper constructor.
+    config_list = [
+        {"model": "gpt-3.5-turbo", "api_key": "key1", "model_client_cls": "MockModelClient", "name": "client1"},
+        {"model": "gpt-4", "api_key": "key2", "model_client_cls": "MockModelClient", "name": "client2"},
+    ]
+    wrapper = OpenAIWrapper(config_list=config_list, routing_method="fixed_order")
+    assert wrapper.routing_method == "fixed_order"
+    for i in range(len(config_list)):
+        wrapper._clients[i] = MockModelClient(config=wrapper._config_list[i])
+    return wrapper
+
+
+@pytest.fixture
+def mock_openai_wrapper_round_robin():
+    config_list = [
+        {"model": "gpt-3.5-turbo", "api_key": "key1", "model_client_cls": "MockModelClient", "name": "client1"},
+        {"model": "gpt-4", "api_key": "key2", "model_client_cls": "MockModelClient", "name": "client2"},
+        {"model": "gpt-4o", "api_key": "key3", "model_client_cls": "MockModelClient", "name": "client3"},
+    ]
+    wrapper = OpenAIWrapper(config_list=config_list, routing_method="round_robin")
+    assert wrapper.routing_method == "round_robin"
+    for i in range(len(config_list)):
+        wrapper._clients[i] = MockModelClient(config=wrapper._config_list[i])
+    return wrapper
+
+
+@pytest.mark.parametrize(
+    "fixture_name", ["mock_openai_wrapper_fixed_order_default", "mock_openai_wrapper_fixed_order_explicit"]
+)
+def test_fixed_order_routing_successful_first_client(fixture_name: str, request: pytest.FixtureRequest):
+    wrapper = request.getfixturevalue(fixture_name)
+    response = wrapper.create(messages=[{"role": "user", "content": "Hello"}])
+    assert "Response from client1" in response.choices[0].message.content
+    assert wrapper._clients[0].call_count == 1
+    assert wrapper._clients[1].call_count == 0
+
+
+@pytest.mark.parametrize(
+    "fixture_name", ["mock_openai_wrapper_fixed_order_default", "mock_openai_wrapper_explicit_fixed_order"]
+)
+def test_fixed_order_routing_first_client_fails(fixture_name: str, request: pytest.FixtureRequest):
+    wrapper = request.getfixturevalue(fixture_name)
+    # Make the first client fail
+    wrapper._clients[0].config["should_fail"] = True
+    response = wrapper.create(messages=[{"role": "user", "content": "Hello"}])
+    assert "Response from client2" in response.choices[0].message.content
+    assert wrapper._clients[0].call_count == 1
+    assert wrapper._clients[1].call_count == 1
+
+
+def test_round_robin_routing(mock_openai_wrapper_round_robin: OpenAIWrapper):
+    # First call
+    response1 = mock_openai_wrapper_round_robin.create(messages=[{"role": "user", "content": "Hello 1"}])
+    assert "Response from client1" in response1.choices[0].message.content
+    assert mock_openai_wrapper_round_robin._clients[0].call_count == 1
+    assert mock_openai_wrapper_round_robin._clients[1].call_count == 0
+    assert mock_openai_wrapper_round_robin._clients[2].call_count == 0
+    assert mock_openai_wrapper_round_robin._round_robin_index == 1
+
+    # Second call
+    response2 = mock_openai_wrapper_round_robin.create(messages=[{"role": "user", "content": "Hello 2"}])
+    assert "Response from client2" in response2.choices[0].message.content
+    assert mock_openai_wrapper_round_robin._clients[0].call_count == 1
+    assert mock_openai_wrapper_round_robin._clients[1].call_count == 1
+    assert mock_openai_wrapper_round_robin._clients[2].call_count == 0
+    assert mock_openai_wrapper_round_robin._round_robin_index == 2
+
+    # Third call
+    response3 = mock_openai_wrapper_round_robin.create(messages=[{"role": "user", "content": "Hello 3"}])
+    assert "Response from client3" in response3.choices[0].message.content
+    assert mock_openai_wrapper_round_robin._clients[0].call_count == 1
+    assert mock_openai_wrapper_round_robin._clients[1].call_count == 1
+    assert mock_openai_wrapper_round_robin._clients[2].call_count == 1
+    assert mock_openai_wrapper_round_robin._round_robin_index == 0
+
+    # Fourth call (wraps around)
+    response4 = mock_openai_wrapper_round_robin.create(messages=[{"role": "user", "content": "Hello 4"}])
+    assert "Response from client1" in response4.choices[0].message.content
+    assert mock_openai_wrapper_round_robin._clients[0].call_count == 2
+    assert mock_openai_wrapper_round_robin._clients[1].call_count == 1
+    assert mock_openai_wrapper_round_robin._clients[2].call_count == 1
+    assert mock_openai_wrapper_round_robin._round_robin_index == 1
+
+
+def test_round_robin_routing_with_failures(mock_openai_wrapper_round_robin: OpenAIWrapper):
+    # Make client2 fail
+    mock_openai_wrapper_round_robin._clients[1].config["should_fail"] = True
+
+    # First call (client1)
+    response1 = mock_openai_wrapper_round_robin.create(messages=[{"role": "user", "content": "Hello 1"}])
+    assert "Response from client1" in response1.choices[0].message.content
+    assert mock_openai_wrapper_round_robin._clients[0].call_count == 1
+    assert mock_openai_wrapper_round_robin._clients[1].call_count == 0
+    assert mock_openai_wrapper_round_robin._clients[2].call_count == 0
+    assert mock_openai_wrapper_round_robin._round_robin_index == 1
+
+    # Second call (client2 fails, client3 should be called)
+    response2 = mock_openai_wrapper_round_robin.create(messages=[{"role": "user", "content": "Hello 2"}])
+    assert "Response from client3" in response2.choices[0].message.content
+    assert mock_openai_wrapper_round_robin._clients[0].call_count == 1  # Not called again
+    assert mock_openai_wrapper_round_robin._clients[1].call_count == 1  # Called and failed
+    assert mock_openai_wrapper_round_robin._clients[2].call_count == 1  # Called
+    assert mock_openai_wrapper_round_robin._round_robin_index == 2
+
+    # Third call (client3 is the start of this round)
+    # Reset call counts for clarity for this specific call
+    client1_prev_calls = mock_openai_wrapper_round_robin._clients[0].call_count
+    client2_prev_calls = mock_openai_wrapper_round_robin._clients[1].call_count
+    client3_prev_calls = mock_openai_wrapper_round_robin._clients[2].call_count
+
+    response3 = mock_openai_wrapper_round_robin.create(messages=[{"role": "user", "content": "Hello 3"}])
+    assert "Response from client3" in response3.choices[0].message.content
+    assert mock_openai_wrapper_round_robin._clients[0].call_count == client1_prev_calls
+    assert mock_openai_wrapper_round_robin._clients[1].call_count == client2_prev_calls
+    assert mock_openai_wrapper_round_robin._clients[2].call_count == client3_prev_calls + 1
+    assert mock_openai_wrapper_round_robin._round_robin_index == 0  # Wraps around
+
+    # Fourth call (client1 is the start of this round)
+    client1_prev_calls = mock_openai_wrapper_round_robin._clients[0].call_count
+    client2_prev_calls = mock_openai_wrapper_round_robin._clients[1].call_count
+    client3_prev_calls = mock_openai_wrapper_round_robin._clients[2].call_count
+    response4 = mock_openai_wrapper_round_robin.create(messages=[{"role": "user", "content": "Hello 4"}])
+    assert "Response from client1" in response4.choices[0].message.content
+    assert mock_openai_wrapper_round_robin._clients[0].call_count == client1_prev_calls + 1
+    assert mock_openai_wrapper_round_robin._clients[1].call_count == client2_prev_calls
+    assert mock_openai_wrapper_round_robin._clients[2].call_count == client3_prev_calls
+    assert mock_openai_wrapper_round_robin._round_robin_index == 1
+
 
 TOOL_ENABLED = False
 

--- a/test/oai/test_client.py
+++ b/test/oai/test_client.py
@@ -33,7 +33,11 @@ from autogen.oai.client import (
     OpenAILLMConfigEntry,
 )
 from autogen.oai.oai_models import ChatCompletion, ChatCompletionMessage, Choice, CompletionUsage
-from autogen.oai.openai_utils import APIError
+
+with optional_import_block(suppress_error=True) as openai_import_result:  # Allow test to run if openai not installed
+    from openai import APIError
+if not openai_import_result.is_successful:
+    APIError = Exception  # Fallback if openai is not installed, MockModelClient will raise this
 
 from ..conftest import Credentials
 

--- a/test/oai/test_client.py
+++ b/test/oai/test_client.py
@@ -149,7 +149,7 @@ def test_fixed_order_routing_successful_first_client(fixture_name: str, request:
 
 
 @pytest.mark.parametrize(
-    "fixture_name", ["mock_openai_wrapper_fixed_order_default", "mock_openai_wrapper_explicit_fixed_order"]
+    "fixture_name", ["mock_openai_wrapper_fixed_order_default", "mock_openai_wrapper_fixed_order_explicit"]
 )
 def test_fixed_order_routing_first_client_fails(fixture_name: str, request: pytest.FixtureRequest):
     wrapper = request.getfixturevalue(fixture_name)

--- a/test/oai/test_client.py
+++ b/test/oai/test_client.py
@@ -34,10 +34,12 @@ from autogen.oai.client import (
 )
 from autogen.oai.oai_models import ChatCompletion, ChatCompletionMessage, Choice, CompletionUsage
 
-with optional_import_block(suppress_error=True) as openai_import_result:  # Allow test to run if openai not installed
+# Attempt to import APIError from openai, define as base Exception if openai is not available.
+try:
     from openai import APIError
-if not openai_import_result.is_successful:
-    APIError = Exception  # Fallback if openai is not installed, MockModelClient will raise this
+except ImportError:
+    APIError = Exception
+
 
 from ..conftest import Credentials
 

--- a/test/test_llm_config.py
+++ b/test/test_llm_config.py
@@ -768,19 +768,22 @@ class TestLLMConfig:
         # Case 1: routing_method is None (default)
         config_default_routing = LLMConfig(config_list=[openai_llm_config_entry])
         actual_repr_default = repr(config_default_routing)
-        # Check that routing_method is None and not in the repr string
         assert config_default_routing.routing_method is None
         assert "routing_method" not in actual_repr_default
-        # Check that other parts are there
-        entry_repr = repr(OpenAILLMConfigEntry(**openai_llm_config_entry.model_dump(exclude_none=False)))
-        assert f"config_list=[{entry_repr}]" in actual_repr_default
+        # Construct expected entry repr without base_url if it's None
+        expected_entry_dict = openai_llm_config_entry.model_dump(exclude_none=True)
+        expected_entry_repr = repr(OpenAILLMConfigEntry(**expected_entry_dict))
+        assert f"config_list=[{expected_entry_repr}]" in actual_repr_default
 
         # Case 2: routing_method is explicitly set
-        config_custom_routing = LLMConfig(config_list=[openai_llm_config_entry], routing_method="round_robin")
+        config_custom_routing = LLMConfig(
+            config_list=[openai_llm_config_entry], routing_method="round_robin", temperature=0.77
+        )
         actual_repr_custom = repr(config_custom_routing)
         assert config_custom_routing.routing_method == "round_robin"
         assert "routing_method='round_robin'" in actual_repr_custom
-        assert f"config_list=[{entry_repr}]" in actual_repr_custom
+        assert f"config_list=[{expected_entry_repr}]" in actual_repr_custom
+        assert "temperature=0.77" in actual_repr_custom
 
     def test_str(self, openai_llm_config_entry: OpenAILLMConfigEntry) -> None:
         # Case 1: routing_method is None (default)
@@ -788,15 +791,19 @@ class TestLLMConfig:
         actual_str_default = str(config_default_routing)
         assert config_default_routing.routing_method is None
         assert "routing_method" not in actual_str_default
-        entry_repr = repr(OpenAILLMConfigEntry(**openai_llm_config_entry.model_dump(exclude_none=False)))
-        assert f"config_list=[{entry_repr}]" in actual_str_default
+        expected_entry_dict = openai_llm_config_entry.model_dump(exclude_none=True)
+        expected_entry_repr = repr(OpenAILLMConfigEntry(**expected_entry_dict))
+        assert f"config_list=[{expected_entry_repr}]" in actual_str_default
 
         # Case 2: routing_method is explicitly set
-        config_custom_routing = LLMConfig(config_list=[openai_llm_config_entry], routing_method="round_robin")
+        config_custom_routing = LLMConfig(
+            config_list=[openai_llm_config_entry], routing_method="round_robin", temperature=0.77
+        )
         actual_str_custom = str(config_custom_routing)
         assert config_custom_routing.routing_method == "round_robin"
         assert "routing_method='round_robin'" in actual_str_custom
-        assert f"config_list=[{entry_repr}]" in actual_str_custom
+        assert f"config_list=[{expected_entry_repr}]" in actual_str_custom
+        assert "temperature=0.77" in actual_str_custom
 
     def test_routing_method_default(self, openai_llm_config_entry: OpenAILLMConfigEntry) -> None:
         llm_config = LLMConfig(config_list=[openai_llm_config_entry])

--- a/test/test_llm_config.py
+++ b/test/test_llm_config.py
@@ -770,10 +770,10 @@ class TestLLMConfig:
         actual_repr_default = repr(config_default_routing)
         assert config_default_routing.routing_method is None
         assert "routing_method" not in actual_repr_default
-        # Construct expected entry repr without base_url if it's None
-        expected_entry_dict = openai_llm_config_entry.model_dump(exclude_none=True)
-        expected_entry_repr = repr(OpenAILLMConfigEntry(**expected_entry_dict))
-        assert f"config_list=[{expected_entry_repr}]" in actual_repr_default
+        # LLMConfig.__repr__ uses model_dump(), which for config_list items (which are LLMConfigEntry models)
+        # will produce dicts. So we expect a list of dicts.
+        expected_config_list_repr = repr([openai_llm_config_entry.model_dump(exclude_none=True)])
+        assert f"config_list={expected_config_list_repr}" in actual_repr_default
 
         # Case 2: routing_method is explicitly set
         config_custom_routing = LLMConfig(
@@ -782,7 +782,7 @@ class TestLLMConfig:
         actual_repr_custom = repr(config_custom_routing)
         assert config_custom_routing.routing_method == "round_robin"
         assert "routing_method='round_robin'" in actual_repr_custom
-        assert f"config_list=[{expected_entry_repr}]" in actual_repr_custom
+        assert f"config_list={expected_config_list_repr}" in actual_repr_custom  # Should be the same list of dicts
         assert "temperature=0.77" in actual_repr_custom
 
     def test_str(self, openai_llm_config_entry: OpenAILLMConfigEntry) -> None:
@@ -791,9 +791,8 @@ class TestLLMConfig:
         actual_str_default = str(config_default_routing)
         assert config_default_routing.routing_method is None
         assert "routing_method" not in actual_str_default
-        expected_entry_dict = openai_llm_config_entry.model_dump(exclude_none=True)
-        expected_entry_repr = repr(OpenAILLMConfigEntry(**expected_entry_dict))
-        assert f"config_list=[{expected_entry_repr}]" in actual_str_default
+        expected_config_list_repr = repr([openai_llm_config_entry.model_dump(exclude_none=True)])
+        assert f"config_list={expected_config_list_repr}" in actual_str_default
 
         # Case 2: routing_method is explicitly set
         config_custom_routing = LLMConfig(
@@ -802,7 +801,7 @@ class TestLLMConfig:
         actual_str_custom = str(config_custom_routing)
         assert config_custom_routing.routing_method == "round_robin"
         assert "routing_method='round_robin'" in actual_str_custom
-        assert f"config_list=[{expected_entry_repr}]" in actual_str_custom
+        assert f"config_list={expected_config_list_repr}" in actual_str_custom
         assert "temperature=0.77" in actual_str_custom
 
     def test_routing_method_default(self, openai_llm_config_entry: OpenAILLMConfigEntry) -> None:

--- a/test/test_llm_config.py
+++ b/test/test_llm_config.py
@@ -9,6 +9,7 @@ from copy import copy, deepcopy
 from typing import Any
 
 import pytest
+from pydantic import ValidationError  # Added import
 
 from autogen.llm_config import LLMConfig
 from autogen.oai.anthropic import AnthropicLLMConfigEntry
@@ -806,7 +807,7 @@ class TestLLMConfig:
         assert llm_config.routing_method == "round_robin"
 
     def test_routing_method_invalid(self, openai_llm_config_entry: OpenAILLMConfigEntry) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):  # Changed from ValueError to ValidationError
             LLMConfig(config_list=[openai_llm_config_entry], routing_method="invalid_method")
 
     def test_from_json_env(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR introduces a `routing_method` parameter to `LLMConfig` and `OpenAIWrapper`, allowing users to define the strategy for selecting language model configurations from a list.

Supported routing methods:
- `fixed_order`: (Default) Always tries configurations in the order they are defined in the `config_list`.
- `round_robin`: Rotates the starting configuration in the `config_list` for each API call, continuing through the list sequentially if earlier attempts fail.
- smarter routing can be added in future. @DujianDing

The `routing_method` is a wrapper-level parameter, determining how the entire list of configurations is traversed. It defaults to `None` in `LLMConfig` and is handled as `fixed_order` by `OpenAIWrapper` if not specified or `None`.

Individual configurations within the `config_list` do not have their own `routing_method`; this is solely controlled at the `LLMConfig` / `OpenAIWrapper` level.

Includes comprehensive unit tests for the new parameter and routing logic, covering default behavior, explicit settings, and failure scenarios.

This PR also addresses test failures identified in CI and refines LLMConfigEntry behavior:
`LLMConfigEntry.base_url` validator and serializer:
    - Modified `check_base_url` to correctly return `None` if the input is `None`, preventing it from becoming 'http://None'.
    - Ensured `serialize_base_url` also handles `None` correctly and uses `when_used="unless-none"`.
    - This fixes the `repr` and `str` representations for `LLMConfig` when an entry has `base_url=None`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
