### PR TITLE
Bugfix: Register MCP Tools Like MCP Resources

### DIFF
--- a/autogen/tools/tool.py
+++ b/autogen/tools/tool.py
@@ -96,8 +96,7 @@ class Tool:
         """
         if self._func_schema:
             agent.update_tool_signature(self._func_schema, is_remove=False)
-        else:
-            agent.register_for_llm()(self)
+        agent.register_for_llm()(self)
 
     def register_for_execution(self, agent: "ConversableAgent") -> None:
         """Registers the tool for direct execution by a ConversableAgent.

--- a/test/mcp/test_mcp.py
+++ b/test/mcp/test_mcp.py
@@ -137,6 +137,24 @@ class TestMCPClient:
             assert result.contents == expected_result
 
     @pytest.mark.asyncio
+    async def test_register_for_llm_tool(
+        self, server_params: "StdioServerParameters", credentials_gpt_4o_mini: Credentials
+    ) -> None:  # type: ignore[no-any-unimported]
+        async with (
+            stdio_client(server_params) as (read, write),
+            ClientSession(read, write, read_timeout_seconds=timedelta(seconds=30)) as session,
+        ):
+            # Initialize the connection
+            await session.initialize()
+            toolkit = await create_toolkit(session=session)
+            agent = AssistantAgent(
+                name="agent",
+                llm_config=credentials_gpt_4o_mini.llm_config,
+            )
+            toolkit.register_for_llm(agent)
+            assert len(agent.tools) == len(toolkit.tools)
+
+    @pytest.mark.asyncio
     async def test_convert_resource_with_download_folder(self, server_params: "StdioServerParameters") -> None:  # type: ignore[no-any-unimported]
         async with (
             stdio_client(server_params) as (read, write),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The goal of this PR is to resolve https://github.com/ag2ai/ag2/issues/1947 by registering MCP tools in a similar way to resources, rather than skipping them.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ag2ai/ag2/issues/1947

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
