### PR TITLE
Add support for seed parameter for Gemini client

### DIFF
--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -126,6 +126,7 @@ class GeminiClient:
     PARAMS_MAPPING = {
         "max_tokens": "max_output_tokens",
         # "n": "candidate_count", # Gemini supports only `n=1`
+        "seed": "seed",
         "stop_sequences": "stop_sequences",
         "temperature": "temperature",
         "top_p": "top_p",


### PR DESCRIPTION
## Why are these changes needed?

Add support for the use of the `seed` value in the base `LLMConfig` in the Gemini client.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
