### PR TITLE
Repo: Adjust schedule for workflows requiring review

### DIFF
--- a/.github/workflows/contrib-graph-rag-tests.yml
+++ b/.github/workflows/contrib-graph-rag-tests.yml
@@ -5,7 +5,7 @@ name: ContribGraphRagTests
 
 on:
   schedule:
-    - cron: "0 0 * * *" # daily at midnight UTC
+    - cron: "0 0 * * 0" # weekly on Sunday at midnight UTC
   workflow_dispatch: # allows manual triggering of the workflow
   # pull_request_target:
   #   branches: ["main"]

--- a/.github/workflows/contrib-llm-test.yml
+++ b/.github/workflows/contrib-llm-test.yml
@@ -5,7 +5,7 @@ name: Contrib tests with LLMs
 
 on:
   schedule:
-    - cron: "0 0 * * *" # daily at midnight UTC
+    - cron: "0 0 * * 0" # weekly on Sunday at midnight UTC
   workflow_dispatch: # allows manual triggering of the workflow
   # pull_request_target:
   #   branches: ["main"]

--- a/.github/workflows/core-llm-test.yml
+++ b/.github/workflows/core-llm-test.yml
@@ -5,7 +5,7 @@ name: Core tests with LLMs
 
 on:
   schedule:
-    - cron: "0 0 * * *" # daily at midnight UTC
+    - cron: "0 0 * * 0" # weekly on Sunday at midnight UTC
   workflow_dispatch: # allows manual triggering of the workflow
   # pull_request_target:
   #   branches: ["main"]

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,7 +5,7 @@ name: Integration tests
 
 on:
   schedule:
-    - cron: "0 0 * * *" # daily at midnight UTC
+    - cron: "0 0 * * 0" # weekly on Sunday at midnight UTC
   workflow_dispatch: # allows manual triggering of the workflow
   # pull_request_target:
   #   branches: ["main"]


### PR DESCRIPTION
## Why are these changes needed?

Four workflows are running, that require review, on a daily basis. It's not necessary to run these so frequently and this PR changes the schedule for these workflows to weekly (Sunday midnight UTC).

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
