### PR TITLE
lint: fix ExceptionGroup imports

### DIFF
--- a/autogen/fast_depends/_compat.py
+++ b/autogen/fast_depends/_compat.py
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: MIT
 
 import sys
-from importlib.metadata import version as get_version
 from typing import Any, Dict, Optional, Tuple, Type
 
 from pydantic import BaseModel, create_model
@@ -69,12 +68,8 @@ else:
             arbitrary_types_allowed = True
 
 
-ANYIO_V3 = get_version("anyio").startswith("3.")
+if sys.version_info < (3, 11):
+    from exceptiongroup import ExceptionGroup as ExceptionGroup
 
-if ANYIO_V3:
-    from anyio import ExceptionGroup as ExceptionGroup  # type: ignore[attr-defined]
 else:
-    if sys.version_info < (3, 11):
-        from exceptiongroup import ExceptionGroup as ExceptionGroup
-    else:
-        ExceptionGroup = ExceptionGroup
+    ExceptionGroup = ExceptionGroup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -479,6 +479,8 @@ convention = "google"
 
 
 [tool.mypy]
+python_version = "3.9"
+
 files = [
     "autogen/agentchat/agent.py",
 #    "autogen/agentchat/cenversable_agent.py",


### PR DESCRIPTION
Mypy couldn't resolve anyio imports, so we should type exception groups using sys-only

Fixes #1978 