### PR TITLE
docs: fix list rendering in contribution guide part of docs

### DIFF
--- a/website/docs/contributor-guide/building/creating-a-tool.mdx
+++ b/website/docs/contributor-guide/building/creating-a-tool.mdx
@@ -163,6 +163,7 @@ Put your tool tests in a folder under [`test/tools/contrib`](https://github.com/
 ## Documentation
 
 As a way for other developers to learn about and understand how to use your tool, it is recommended to create a Jupyter notebook that:
+
 - Explains what the tool is
 - How to install AG2 for the tool (e.g. with extras)
 - Has sample codes, simple to advanced

--- a/website/docs/contributor-guide/building/creating-an-agent.mdx
+++ b/website/docs/contributor-guide/building/creating-an-agent.mdx
@@ -20,12 +20,14 @@ Creating a new agent in AG2 is easy and there are two main approaches you can ta
 ### Tools-based agents
 
 Pros:
+
 - Easier to implement
 - Can work well with a small distinct set of tools
 - Easy to add another tool
 - If you create tools, they can be used by other agents as well
 
 Cons:
+
 - Too many tools may confuse the LLM
 - Multiple tool calls can be triggered from one LLM response, this may produce undesired results if the sequence isn't right
 - Your agent must have an associated LLM as it needs to recommend tool calls
@@ -33,9 +35,11 @@ Cons:
 ### Reply-based agents
 
 Pros:
+
 - Most flexibility over how the agent works
 
 Cons:
+
 - More code required, more error handling, more tests
 - If using a tool or two is possible, this may be more complexity than necessary
 - Functionality encapsulated within the agent, can't be easily used by other agents
@@ -282,6 +286,7 @@ For tools tests, put them in a folder under [`test/tools/contrib`](https://githu
 ## Documentation
 
 As a way for other developers to learn about and understand how to use your agent, it is recommended to create a Jupyter notebook that:
+
 - Explains what the agent is
 - How to install AG2 for the agent (e.g. with extras)
 - Has sample codes, simple to advanced

--- a/website/docs/contributor-guide/contributing.mdx
+++ b/website/docs/contributor-guide/contributing.mdx
@@ -9,12 +9,13 @@ title: Contributing to AG2
 - **Impact the Future**: 2025 is the year of AI agents. And we believe 2025-2035 will be the decade of AI agents. You can help shape how AI Agents are created, used, deployed, and governed in production environments. And how multiple AI agents collaborate, communicate, and solve complex problems together. Your work will influence how organizations deploy and orchestrate AI agent systems at scale.
 
 - **Learn & Grow**: Work directly with cutting-edge AI agent technologies and receive mentorship from experienced researchers and developers in the field. Understand how to:
-  - Design sophisticated multi-agent systems
-  - Create novel agent interaction patterns
-  - Build scalable agent architectures
-  - Develop robust testing and evaluation frameworks
-  - Build real-world use cases and applications with AI agents
-  - Participate in research projects to advance the field of AI agents
+
+    - Design sophisticated multi-agent systems
+    - Create novel agent interaction patterns
+    - Build scalable agent architectures
+    - Develop robust testing and evaluation frameworks
+    - Build real-world use cases and applications with AI agents
+    - Participate in research projects to advance the field of AI agents
 
 - **Build Your Portfolio**: Gain hands-on experience in a leading open-source AI agent framework project. Your contributions will demonstrate real expertise in one of the most exciting areas of AI development, while earning acknowledgment from the AG2 community.
 
@@ -47,11 +48,13 @@ If you are new to GitHub, [here](https://docs.github.com/en/pull-requests/collab
 We believe everyone has something valuable to contribute. Here's how you can get started:
 
 **For New Contributors:**
+
 - Begin with our curated [good first issues](https://github.com/ag2ai/ag2/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
 - Perfect for those new to open source or AG2
 - Experienced maintainers and contributors are ready to guide you through your first PR
 
 **For Experienced Contributors:**
+
 - Dive into our [roadmap issues](https://github.com/ag2ai/ag2/issues?q=is%3Aissue%20state%3Aopen%20label%3Aroadmap) to tackle complex challenges
 - Shape core features and architectural decisions
 - Mentor newcomers and help build our community
@@ -60,19 +63,23 @@ We believe everyone has something valuable to contribute. Here's how you can get
 ### Ways to Contribute
 
 Your skills can make a difference in many ways:
+
 - Submit Pull Requests (PRs) to improve our codebase
 - Review [existing PRs](https://github.com/ag2ai/ag2/pulls) and help maintain code quality
 - Share your knowledge in our [AG2 community Discord](https://discord.gg/RjUPCW7s) channels
 - Enrich our [documentation](https://docs.ag2.ai) to help others learn
 - Add cool examples and use cases
+
   - Get inspired by existing [notebook examples](/docs/use-cases/notebooks/Notebooks) and [video demos](https://www.youtube.com/@ag2ai)
 - Report bugs and suggest feature improvements:
+
   - [Bug report](https://github.com/ag2ai/ag2/issues/new?template=bug_report.yml)
   - [Feature request](https://github.com/ag2ai/ag2/issues/new?template=feature_request.yml)
 
 ## Step 2: Join Contributor Scrum Meetings
 
 Be part of our vibrant community through regular collaboration:
+
 - Daily meetings with core contributors
 - Tuesday/Friday scrum meetings with community contributors
 - Regular technical discussions and knowledge sharing sessions
@@ -83,6 +90,7 @@ Be part of our vibrant community through regular collaboration:
 ## Recognition Program
 
 We value our contributors and celebrate their achievements through:
+
 - Regular contributor spotlights on our blog
 - Acknowledgment in release notes
 - Opportunities to become core maintainers

--- a/website/docs/contributor-guide/file-bug-report.mdx
+++ b/website/docs/contributor-guide/file-bug-report.mdx
@@ -16,10 +16,10 @@ feedback:
   your **Python, autogen, scikit-learn versions**. The version of autogen
   can be found by running the following code snippet:
 
-```python
-import autogen
-print(autogen.__version__)
-```
+    ```python
+    import autogen
+    print(autogen.__version__)
+    ```
 
 - Please ensure all **code snippets and error messages are formatted in
   appropriate code blocks**.  See [Creating and highlighting code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks)

--- a/website/docs/contributor-guide/how-ag2-works/generate-reply.mdx
+++ b/website/docs/contributor-guide/how-ag2-works/generate-reply.mdx
@@ -21,29 +21,35 @@ Let's look at how the standard ConversableAgent's [generate_reply](/docs/api-ref
 3. The final step is the evaluation of the reply functions, these are done in order and the default functions are shown. Setting your own reply functions using ConversableAgent's [register_reply](/docs/api-reference/autogen/ConversableAgent#register-reply) method.
 
     - Check Termination and Human Reply
-      - Before replying, the agent will check if we meet any termination conditions. It's important to understand that termination occurs on the following agent, so if you are expecting an agent to include a keyword like `TERMINATE` in their text, the following agent's `is_termination_msg` condition should evaluate for that keyword.
-      - The maximum consecutive auto-reply limit for an agent and this will cause a termination.
-      - If it is to terminate but the agent's human input mode is `ALWAYS` or `TERMINATE` ([ConversableAgent.human_input_mode](/docs/api-reference/autogen/ConversableAgent#conversableagent)), it will prompt the user for input where they can continue the conversation or terminate by typing `exit`.
-      - If the termination condition is met and the user doesn't continue the conversation, no further reply functions will be evaluated and the result will be returned.
+
+        - Before replying, the agent will check if we meet any termination conditions. It's important to understand that termination occurs on the following agent, so if you are expecting an agent to include a keyword like `TERMINATE` in their text, the following agent's `is_termination_msg` condition should evaluate for that keyword.
+        - The maximum consecutive auto-reply limit for an agent and this will cause a termination.
+        - If it is to terminate but the agent's human input mode is `ALWAYS` or `TERMINATE` ([ConversableAgent.human_input_mode](/docs/api-reference/autogen/ConversableAgent#conversableagent)), it will prompt the user for input where they can continue the conversation or terminate by typing `exit`.
+        - If the termination condition is met and the user doesn't continue the conversation, no further reply functions will be evaluated and the result will be returned.
 
     - Generate Function Call Reply
-      - The latest message in the messages list is checked to see if it contains function call recommendations and, if so, it will try to execute the function calls. If the functions are registered for execution with the current agent they will execute normally but if they are not registered with the agent it will respond with an error message as the function result.
-      - If functions are executed, no further reply functions will be evaluated and the result of the function(s) will be returned.
-      - Note: This function has been largely superseded by the next function as tool calls are more typical than function calls with LLMs.
+
+        - The latest message in the messages list is checked to see if it contains function call recommendations and, if so, it will try to execute the function calls. If the functions are registered for execution with the current agent they will execute normally but if they are not registered with the agent it will respond with an error message as the function result.
+        - If functions are executed, no further reply functions will be evaluated and the result of the function(s) will be returned.
+        - Note: This function has been largely superseded by the next function as tool calls are more typical than function calls with LLMs.
 
     - Generate Tool Call Reply
-      - This behaves the same way as the previous reply function but for tools, the same logic applies.
+
+        - This behaves the same way as the previous reply function but for tools, the same logic applies.
 
     - Generate Code Execution Reply
-      - If the agent is configured for code execution (see more on [Code Execution](/docs/user-guide/advanced-concepts/code-execution)), it will look for code blocks in the previous messages (configurable, defaults to all messages since the agent last spoke) and execute all the code blocks, returning the result of the execution as the reply.
-      - If code blocks are found, no further reply functions will be evaluated and it will return the result of the execution(s).
+
+        - If the agent is configured for code execution (see more on [Code Execution](/docs/user-guide/advanced-concepts/code-execution)), it will look for code blocks in the previous messages (configurable, defaults to all messages since the agent last spoke) and execute all the code blocks, returning the result of the execution as the reply.
+        - If code blocks are found, no further reply functions will be evaluated and it will return the result of the execution(s).
 
     - Generate LLM Reply
-      - If none of the previous reply functions are final and the agent has an LLM configured, an LLM-based reply will be generated.
-      - Each of the LLMs configured in the agent's LLM configuration will be attempted in order until one successfully returns a response (typically the first one).
+
+        - If none of the previous reply functions are final and the agent has an LLM configured, an LLM-based reply will be generated.
+        - Each of the LLMs configured in the agent's LLM configuration will be attempted in order until one successfully returns a response (typically the first one).
 
     - If no reply is generated
-      - If none of the reply functions generate a final result, the agent's [`ConversableAgent.default_auto_reply`](/docs/api-reference/autogen/ConversableAgent#conversableagent) value will be returned. The default for this property is an empty string and this denotes no reply.
+
+        - If none of the reply functions generate a final result, the agent's [`ConversableAgent.default_auto_reply`](/docs/api-reference/autogen/ConversableAgent#conversableagent) value will be returned. The default for this property is an empty string and this denotes no reply.
 
 ### Registering your own reply functions
 

--- a/website/docs/contributor-guide/how-ag2-works/initiate-chat.mdx
+++ b/website/docs/contributor-guide/how-ag2-works/initiate-chat.mdx
@@ -40,14 +40,14 @@ Breakdown of the **first turn**:
 
 6. The agent generates a reply given the message(s) received. This is a critical step in the process, see [Generating a reply](/docs/contributor-guide/how-ag2-works/generate-reply) for an in-depth look at this step.
 
-  - Evaluate our "update_agent_state", "process_last_received_message", and "process_all_messages_before_reply" hooks (see [Hooks](/docs/contributor-guide/how-ag2-works/hooks)). These allow agent and message state to be updated before the following reply functions are evaluated.
+    - Evaluate our "update_agent_state", "process_last_received_message", and "process_all_messages_before_reply" hooks (see [Hooks](/docs/contributor-guide/how-ag2-works/hooks)). These allow agent and message state to be updated before the following reply functions are evaluated.
 
-  - Evaluate the agent's reply functions, this is where the actual reply from an agent is generated.
+    - Evaluate the agent's reply functions, this is where the actual reply from an agent is generated.
 
-    - Check termination and human reply
-    - Run function and tool calls
-    - Execute code blocks
-    - Generate LLM response
+        - Check termination and human reply
+        - Run function and tool calls
+        - Execute code blocks
+        - Generate LLM response
 
 7. If no reply is generated, we finish this turn
 

--- a/website/docs/contributor-guide/maintainer.mdx
+++ b/website/docs/contributor-guide/maintainer.mdx
@@ -23,10 +23,11 @@ title: Guidance for Maintainers
 - For new contributors who have not signed the contributing agreement, remind them to sign before reviewing.
 - For multiple PRs which may have conflict, coordinate them to figure out the right order.
 - Pay special attention to:
-  - Breaking changes. Don’t make breaking changes unless necessary. Don’t merge to main until enough headsup is provided and a new release is ready.
-  - Test coverage decrease.
-  - Changes that may cause performance degradation. Do regression test when test suites are available.
-  - Discourage **change to the core library** when there is an alternative.
+
+    - Breaking changes. Don’t make breaking changes unless necessary. Don’t merge to main until enough headsup is provided and a new release is ready.
+    - Test coverage decrease.
+    - Changes that may cause performance degradation. Do regression test when test suites are available.
+    - Discourage **change to the core library** when there is an alternative.
 
 ## Issues and Discussions
 


### PR DESCRIPTION
## Why are these changes needed?

Fix list rendering in contribution guide part of docs:
- Lists need empty string if they used right after plain text (not special blocks like heading / tab / code example)
- Nested lists need additional indent (4 spaces)

| Before | After |
|---|---|
|<img width="814" height="887" alt="image" src="https://github.com/user-attachments/assets/40f7440c-d155-4e53-95a5-7ce6e26eb36f" /> | <img width="814" height="887" alt="image" src="https://github.com/user-attachments/assets/aa9e6c7e-4d41-425b-aa71-187d04c9c4bd" /> |
| <img width="803" height="272" alt="image" src="https://github.com/user-attachments/assets/fc98f7ed-5456-4983-a0a1-2e2a4da92442" /> | <img width="803" height="272" alt="image" src="https://github.com/user-attachments/assets/9a7ab7bc-0af4-4b03-bb20-2de224dd35f9" /> |

## Related issue number

Relevant to #1985, but this issue not quite about that particular problem.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
