### PR TITLE
fix: improve openai response format handling for json_object type

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -513,7 +513,10 @@ class OpenAIClient:
                 if "stream" in kwargs:
                     kwargs.pop("stream")
 
-                if isinstance(kwargs["response_format"], dict):
+                if (
+                    isinstance(kwargs["response_format"], dict)
+                    and kwargs["response_format"].get("type") != "json_object"
+                ):
                     kwargs["response_format"] = {
                         "type": "json_schema",
                         "json_schema": {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The OpenAI API accepts `{"type": "json_object"}` for `response_format` to return any valid JSON object without enforcing a strict schema. However, the code here assumes all dicts in `response_format` are full JSON schemas. This causes the API to reject it with a 400 BadRequest error in #1990.

> source: https://platform.openai.com/docs/api-reference/chat/create#chat_create-response_format

## Related issue number

Closes #1990

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
