### PR TITLE
Cerebras, support for reasoning_effort, minor typos

### DIFF
--- a/autogen/oai/cerebras.py
+++ b/autogen/oai/cerebras.py
@@ -57,6 +57,7 @@ class CerebrasLLMConfigEntry(LLMConfigEntry):
     top_p: Optional[float] = None
     hide_tools: Literal["if_all_run", "if_any_run", "never"] = "never"
     tool_choice: Optional[Literal["none", "auto", "required"]] = None
+    reasoning_effort: Optional[str] = None
 
     @field_validator("top_p", mode="before")
     @classmethod
@@ -89,7 +90,7 @@ class CerebrasClient:
         )
 
         if "response_format" in kwargs and kwargs["response_format"] is not None:
-            warnings.warn("response_format is not supported for Crebras, it will be ignored.", UserWarning)
+            warnings.warn("response_format is not supported for Cerebras, it will be ignored.", UserWarning)
 
     def message_retrieval(self, response: ChatCompletion) -> list:
         """Retrieve and return a list of strings or a list of Choice.Message from the response.
@@ -132,9 +133,11 @@ class CerebrasClient:
         cerebras_params["seed"] = validate_parameter(params, "seed", int, True, None, None, None)
         cerebras_params["stream"] = validate_parameter(params, "stream", bool, True, False, None, None)
         cerebras_params["temperature"] = validate_parameter(
-            params, "temperature", (int, float), True, 1, (0, 1.5), None
+            params, "temperature", (int, float), True, 1.0, (0, 1.5), None
         )
-        cerebras_params["top_p"] = validate_parameter(params, "top_p", (int, float), True, None, None, None)
+        cerebras_params["top_p"] = validate_parameter(
+            params, "top_p", (int, float), True, None, (0.0, 1.0), None
+        )
         cerebras_params["tool_choice"] = validate_parameter(
             params, "tool_choice", str, True, None, None, ["none", "auto", "required"]
         )

--- a/autogen/oai/cerebras.py
+++ b/autogen/oai/cerebras.py
@@ -135,9 +135,7 @@ class CerebrasClient:
         cerebras_params["temperature"] = validate_parameter(
             params, "temperature", (int, float), True, 1.0, (0, 1.5), None
         )
-        cerebras_params["top_p"] = validate_parameter(
-            params, "top_p", (int, float), True, None, (0.0, 1.0), None
-        )
+        cerebras_params["top_p"] = validate_parameter(params, "top_p", (int, float), True, None, (0.0, 1.0), None)
         cerebras_params["tool_choice"] = validate_parameter(
             params, "tool_choice", str, True, None, None, ["none", "auto", "required"]
         )


### PR DESCRIPTION
Added support for reasoning_effort param for Cerebras API provider - before the change supplying the param lead to LLM Config validation issues. With the change I got qwen-3-235b-a22b-thinking-2507 running.

Beside the effort fixed a typo and a few inconsistencies (e.g. using float as default val for temp) 

## Checks

- [N/A ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [N/A ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [N/A ] I've made sure all auto checks have passed.
