### PR TITLE
mcp_proxy: FastMCP init uses name= (not title=)

### DIFF
--- a/autogen/mcp/mcp_proxy/mcp_proxy.py
+++ b/autogen/mcp/mcp_proxy/mcp_proxy.py
@@ -118,13 +118,15 @@ class MCPProxy:
         return q_params, path_params, body, security
 
     def get_mcp(self, **settings: Any) -> "FastMCP":
-        mcp = FastMCP(title=self._title, **settings)
+        mcp = FastMCP(name=self._title, **settings)
 
         for func in self._registered_funcs:
             try:
-                mcp.tool()(func)  # type: ignore [no-untyped-call]
+                mcp.tool()(func)
             except PydanticInvalidForJsonSchema as e:
-                logger.warning("Could not register function %s: %s", func.__name__, e)
+                logger.warning(
+                    "Could not register function %s: %s", func.__name__, e
+                )
 
         return mcp
 

--- a/autogen/mcp/mcp_proxy/mcp_proxy.py
+++ b/autogen/mcp/mcp_proxy/mcp_proxy.py
@@ -116,17 +116,19 @@ class MCPProxy:
         q_params = set(params_names) - path_params - {body} - {"security"}
 
         return q_params, path_params, body, security
-
+    
     def get_mcp(self, **settings: Any) -> "FastMCP":
-        mcp = FastMCP(name=self._title, **settings)
+        # Try new signature first (name=). Fall back to old (title=).
+        try:
+            mcp = FastMCP(name=self._title, **settings)   # newer mcp
+        except TypeError:
+            mcp = FastMCP(title=self._title, **settings)  # older mcp
 
         for func in self._registered_funcs:
             try:
                 mcp.tool()(func)
             except PydanticInvalidForJsonSchema as e:
-                logger.warning(
-                    "Could not register function %s: %s", func.__name__, e
-                )
+                logger.warning("Could not register function %s: %s", func.__name__, e)
 
         return mcp
 

--- a/autogen/mcp/mcp_proxy/mcp_proxy.py
+++ b/autogen/mcp/mcp_proxy/mcp_proxy.py
@@ -118,11 +118,7 @@ class MCPProxy:
         return q_params, path_params, body, security
 
     def get_mcp(self, **settings: Any) -> "FastMCP":
-        # Try new signature first (name=). Fall back to old (title=).
-        try:
-            mcp = FastMCP(name=self._title, **settings)  # newer mcp
-        except TypeError:  # pragma: no cover
-            mcp = FastMCP(title=self._title, **settings)  # older mcp
+        mcp = FastMCP(name=self._title, **settings)  # newer mcp
 
         for func in self._registered_funcs:
             try:

--- a/autogen/mcp/mcp_proxy/mcp_proxy.py
+++ b/autogen/mcp/mcp_proxy/mcp_proxy.py
@@ -116,12 +116,12 @@ class MCPProxy:
         q_params = set(params_names) - path_params - {body} - {"security"}
 
         return q_params, path_params, body, security
-    
+
     def get_mcp(self, **settings: Any) -> "FastMCP":
         # Try new signature first (name=). Fall back to old (title=).
         try:
-            mcp = FastMCP(name=self._title, **settings)   # newer mcp
-        except TypeError:
+            mcp = FastMCP(name=self._title, **settings)  # newer mcp
+        except TypeError:  # pragma: no cover
             mcp = FastMCP(title=self._title, **settings)  # older mcp
 
         for func in self._registered_funcs:


### PR DESCRIPTION
**Why are these changes needed?**
The FastMCP class in newer versions no longer accepts a title keyword argument.
This was causing a TypeError in MCPProxy.get_mcp when trying to initialize FastMCP.
This change updates the call to use name= instead, which matches the current constructor signature,
allowing MCP clients to initialize without error.

**Related issue number**
Closes #<issue-number-if-any>
(No existing issue found — discovered during local testing.)

**Checks**

 I've reviewed whether any doc changes are needed for https://docs.ag2.ai/. (No doc changes required.)


