### PR TITLE
feat: Implement new FunctionTarget

### DIFF
--- a/autogen/agentchat/group/__init__.py
+++ b/autogen/agentchat/group/__init__.py
@@ -32,6 +32,7 @@ from .targets.transition_target import (
     RevertToUserTarget,
     StayTarget,
     TerminateTarget,
+    FunctionTarget,
 )
 
 __all__ = [
@@ -61,4 +62,5 @@ __all__ = [
     "StringContextCondition",
     "StringLLMCondition",
     "TerminateTarget",
+    "FunctionTarget",
 ]

--- a/test/agentchat/test_function_targets.py
+++ b/test/agentchat/test_function_targets.py
@@ -1,0 +1,87 @@
+# seo_workflow.py
+"""
+Minimal FunctionTarget test wiring for a two-agent group chat.
+"""
+
+import os
+from typing import Any, Optional
+
+from dotenv import load_dotenv
+
+from autogen import LLMConfig, ConversableAgent
+from autogen.agentchat import initiate_group_chat
+from autogen.agentchat.group import ContextVariables, AgentTarget, FunctionTarget, ReplyResult
+from autogen.agentchat.group.patterns import DefaultPattern
+
+load_dotenv()
+
+
+def main(session_id: Optional[str] = None) -> dict:
+    # LLM config
+    cfg = LLMConfig(api_type="openai", model="gpt-4o", api_key=os.environ["OPENAI_API_KEY"])
+
+    # Shared context
+    ctx = ContextVariables(data={"variable": "value1"})
+
+    # Agents
+    first_agent = ConversableAgent(
+        name="first_agent",
+        llm_config=cfg,
+        system_message="Output a sample email you would send to apply to a job in tech. "
+                       "Listen to the specifics of the instructions.",
+    )
+
+    second_agent = ConversableAgent(
+        name="second_agent",
+        llm_config=cfg,
+        system_message="Do whatever the message sent to you tells you to do.",
+    )
+
+    user_agent = ConversableAgent(
+        name="user",
+        human_input_mode="ALWAYS",
+    )
+
+    # After-work hook
+    def afterwork_function(output: str, context_variables: Any) -> ReplyResult:
+        """
+        Switches a context variable and routes the next turn.
+        """
+        if context_variables.get("variable") == "value1":
+            context_variables["variable"] = "value2"
+            return ReplyResult(
+                message="The job you are applying to is specifically in GPU optimization",
+                target=AgentTarget(first_agent),
+                context_variables=context_variables,
+            )
+
+        return ReplyResult(
+            message="The job you are applying to is specifically in agentic open source development",
+            target=AgentTarget(second_agent),
+            context_variables=context_variables,
+        )
+
+    # Conversation pattern
+    pattern = DefaultPattern(
+        initial_agent=first_agent,
+        agents=[first_agent, second_agent],
+        user_agent=user_agent,
+        context_variables=ctx,
+        group_manager_args={"llm_config": cfg},
+    )
+
+    # Register after-work handoff
+    first_agent.handoffs.set_after_work(FunctionTarget(afterwork_function))
+
+    # Run
+    initiate_group_chat(
+        pattern=pattern,
+        messages="the job you are applying to is specifically in machine learning",
+        max_rounds=60,
+    )
+
+    return {"session_id": session_id}
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why are these changes needed?

The FunctionTarget represents a logical next step in the development of the AG2 Framework. It is very often useful or even critical to pass an agent's output into a function, whether to validate the output, parse it, extract it, save it to context, allow for more complex routing, or anything else. Traditionally, in order to have an agent pass to a function upon completion, you would have to explicitly instruct it in its prompt to call the tool and instruct the agent regarding what to pass in. There are two main problems with this approach:

1. Consistency - sometimes agents don't listen to instructions well, particularly if the task is complex or confusing in some way. For larger flows with multiple agents, even one mistake like this can break a flow and make failure handling very difficult.
2. Output quality - agents may shape their responses in a “tool call” context, leading to truncated or less natural outputs. I have experienced this very often.

The FunctionTarget solves this problem elegantly. Subclassing the TransitionTarget class, it is easy to define in the same way that we would an AgentTarget:

`agent.handoffs.set_after_work(FunctionTarget(afterwork_function))`

The afterwork_function must have the following signature:

`def afterwork_function(agent_output: str, context_variables: Any) -> ReplyResult:`

When the agent finishes its turn, its output (along with context_variables) is automatically passed to this function, where you can implement any custom logic.

Potential use cases:
- Validating output and retrying if needed
- Parsing and transforming results before passing them on
- Gracefully handling failures with corrective feedback
- Routing dynamically based on output content

The returned ReplyResult works like any other, and by default only sends the resulting message to the target agent. Broadcasting can be customized via the broadcast_recipients parameter.

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
