### PR TITLE
Fix markdown formatting in GPT-5 verbosity example notebook

### DIFF
--- a/notebook/agentchat_gpt-5_verbosity_example.ipynb
+++ b/notebook/agentchat_gpt-5_verbosity_example.ipynb
@@ -22,9 +22,9 @@
    "id": "2",
    "metadata": {},
    "source": [
-    " ## Key Feature: Verbosity Parameter\n",
+    "## Key Feature: Verbosity Parameter\n",
     " \n",
-    " The **verbosity** parameter allows you to control how detailed or concise the model's responses are, without needing to rewrite your prompts. This is especially useful for adapting the agent's communication style to different use cases."
+    "The **verbosity** parameter allows you to control how detailed or concise the model's responses are, without needing to rewrite your prompts. This is especially useful for adapting the agent's communication style to different use cases."
    ]
   },
   {
@@ -32,12 +32,12 @@
    "id": "3",
    "metadata": {},
    "source": [
-    " The verbosity parameter has three levels:\n",
-    " - **Low**: Produces short, minimal, and to-the-point responses. This is ideal for user experience scenarios, quick answers, or when you need concise summaries.\n",
-    " - **Medium**: Offers a balanced amount of detail and is the default setting. Use this for general purposes and most conversations.\n",
-    " - **High**: Generates very detailed, explanatory, and verbose replies. This level is best suited for audits, teaching, documentation, or when handing off information.\n",
-    " \n",
-    " **Tip:** Keep your prompts consistent and simply use the `verbosity` parameter to adjust the response style as needed."
+    "The verbosity parameter has three levels:\n",
+    "- **Low**: Produces short, minimal, and to-the-point responses. This is ideal for user experience scenarios, quick answers, or when you need concise summaries.\n",
+    "- **Medium**: Offers a balanced amount of detail and is the default setting. Use this for general purposes and most conversations.\n",
+    "- **High**: Generates very detailed, explanatory, and verbose replies. This level is best suited for audits, teaching, documentation, or when handing off information.\n",
+    "\n",
+    "**Tip:** Keep your prompts consistent and simply use the `verbosity` parameter to adjust the response style as needed."
    ]
   },
   {
@@ -65,7 +65,7 @@
    "source": [
     "### Agent Setup Instructions\n",
     "\n",
-    " 1. **Install Required Packages**:\n",
+    "1. **Install Required Packages**:\n",
     "    Make sure you have installed the required packages:\n",
     "    ```\n",
     "    pip install ag2\n",
@@ -77,7 +77,7 @@
    "id": "6",
    "metadata": {},
    "source": [
-    " 2. **Set Up Environment Variables**:\n",
+    "2. **Set Up Environment Variables**:\n",
     "    Create a `.env` file in your project directory and add your OpenAI API key:\n",
     "    ```\n",
     "    OPENAI_API_KEY=your_openai_api_key_here\n",
@@ -197,7 +197,7 @@
    "id": "14",
    "metadata": {},
    "source": [
-    " ### Example: Using 'medium' verbosity setting\n",
+    "### Example: Using 'medium' verbosity setting\n",
     " In this example, we set the verbosity parameter to 'medium' when configuring the LLM.\n",
     " This instructs the model to provide responses that are more detailed than the default,\n",
     " but not as exhaustive as the 'high' verbosity setting. The model will include some\n",


### PR DESCRIPTION
# Fix markdown formatting in GPT-5 verbosity example notebook

## Summary

This PR fixes markdown formatting issues in the `agentchat_gpt-5_verbosity_example.ipynb` notebook to improve documentation readability and ensure proper bullet point rendering.

## Changes Made

- **Fixed bullet point formatting**: Removed leading space before "**Tip:**" line that was preventing proper markdown rendering
- **Improved verbosity level descriptions**: Enhanced formatting for Low/Medium/High verbosity level bullet points
- **Enhanced documentation clarity**: Ensured markdown formatting follows proper conventions for notebook integration with documentation system

## Type of Change

- [x] Documentation improvement
- [x] Bug fix (formatting issue)

## Testing

- [x] Verified notebook renders correctly in Jupyter environment
- [x] Confirmed markdown formatting displays properly in documentation build
- [x] Validated that bullet points now render correctly without formatting issues