### PR TITLE
fix: fix version comparison in autogen/import_utils

### DIFF
--- a/autogen/import_utils.py
+++ b/autogen/import_utils.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from functools import wraps
 from logging import getLogger
 from pathlib import Path
+from packaging.version import Version
 from typing import Any, Generic, Optional, TypeVar
 
 __all__ = [
@@ -61,16 +62,16 @@ class ModuleInfo:
 
         if self.min_version:
             msg = f"'{self.name}' is installed, but the installed version {installed_version} is too low (required '{self}')."
-            if not self.min_inclusive and installed_version == self.min_version:
+            if not self.min_inclusive and Version(installed_version) == Version(self.min_version):
                 return msg
-            if self.min_inclusive and installed_version < self.min_version:  # type: ignore[operator]
+            if self.min_inclusive and Version(installed_version) < Version(self.min_version):  # type: ignore[operator]
                 return msg
 
         if self.max_version:
             msg = f"'{self.name}' is installed, but the installed version {installed_version} is too high (required '{self}')."
-            if not self.max_inclusive and installed_version == self.max_version:
+            if not self.max_inclusive and Version(installed_version) == Version(self.max_version):
                 return msg
-            if self.max_inclusive and installed_version > self.max_version:  # type: ignore[operator]
+            if self.max_inclusive and Version(installed_version) > Version(self.max_version):  # type: ignore[operator]
                 return msg
 
         return None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Version comparison in the autogen/import_utils.py uses string comparison, causing "1.100"<"1.66"

## Related issue number

None

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
