### PR TITLE
fix: remove temperature & top_p restriction

### DIFF
--- a/autogen/llm_config/entry.py
+++ b/autogen/llm_config/entry.py
@@ -37,20 +37,6 @@ class ApplicationConfig(BaseModel):
     top_p: float | None = Field(default=None, gt=0, lt=1)
     temperature: float | None = Field(default=None, ge=0, le=1)
 
-    @field_validator("top_p", mode="before")
-    @classmethod
-    def check_top_p(cls, v: float | None, info: ValidationInfo) -> float | None:
-        if v is not None and info.data.get("temperature") is not None:
-            raise ValueError("temperature and top_p cannot be set at the same time.")
-        return v
-
-    @field_validator("temperature", mode="before")
-    @classmethod
-    def check_temperature(cls, v: float | None, info: ValidationInfo) -> float | None:
-        if v is not None and info.data.get("top_p") is not None:
-            raise ValueError("temperature and top_p cannot be set at the same time.")
-        return v
-
 
 class LLMConfigEntry(ApplicationConfig, ABC):
     api_type: str

--- a/test/oai/test_cerebras.py
+++ b/test/oai/test_cerebras.py
@@ -7,7 +7,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pydantic import ValidationError
 
 from autogen.import_utils import run_for_optional_imports
 from autogen.llm_config import LLMConfig
@@ -64,13 +63,6 @@ def test_cerebras_llm_config_entry():
     assert llm_config.model_dump() == {
         "config_list": [expected],
     }
-
-    with pytest.raises(ValidationError, match="Value error, temperature and top_p cannot be set at the same time"):
-        cerebras_llm_config = CerebrasLLMConfigEntry(
-            model="llama3.1-8b",
-            temperature=1,
-            top_p=0.8,
-        )
 
 
 # Test initialization and configuration

--- a/test/oai/test_client.py
+++ b/test/oai/test_client.py
@@ -16,7 +16,6 @@ from typing import Any  # Added import for Any
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic import ValidationError
 
 from autogen import OpenAIWrapper
 from autogen.cache.cache import Cache
@@ -710,13 +709,6 @@ def test_deepseek_llm_config_entry() -> None:
     assert llm_config.model_dump() == {
         "config_list": [expected],
     }
-
-    with pytest.raises(ValidationError, match="Value error, temperature and top_p cannot be set at the same time"):
-        deepseek_llm_config = DeepSeekLLMConfigEntry(
-            model="deepseek-chat",
-            temperature=1,
-            top_p=0.8,
-        )
 
 
 class TestOpenAIClientBadRequestsError:


### PR DESCRIPTION
## Why are these changes needed?

Remove LLMConfig `temperature` and `top_p` options constraint.

It was a good idea to validate user-provided options before passing them to the outer LLM client, but I don't think such validation should be too strict. We can simply validate the option types and pass them on to the external config as they are.

I propose this change for one reason: the external provider could change their API, option restrictions, and other things. By making our validation a replica of these constraints, we are heavily dependent on the external API that we cannot control. Therefore, if the LLM provider changes their options, our constraints may no longer be relevant.

This is why we provide users with the ability to pass additional options to config, and this is why we should not validate user input too strictly - let users enter whatever they want, and let the LLM provider raise an API error if there are conflicting options. In this way, we make any restrictions to the LLM up to the provider - and that's good, because they are already there and we can't control them.

Moreover, config type validation could be just a `mypy` check, so I don't see a reason to use **Pydantic** for LLMConfig. In the future I suggest to move it to regular `dataclass`.

Alternatively, we could warn users about inconsistent options. However, the problem of the actuality of warnings still exists.

## Related issue number

Fixes #2049

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
