### PR TITLE
Events for handoffs

### DIFF
--- a/autogen/agentchat/group/events/handoff_events.py
+++ b/autogen/agentchat/group/events/handoff_events.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Callable
+from typing import Any
+from uuid import UUID
+
+from autogen.agentchat.agent import Agent
+from autogen.agentchat.group.targets.transition_target import TransitionTarget
+from autogen.events.base_event import BaseEvent, wrap_event
+from autogen.formatting_utils import colored
+
+
+@wrap_event
+class AfterWorksTransitionEvent(BaseEvent):
+    """Event for after works handoffs"""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    source_agent: Agent
+    transition_target: TransitionTarget
+
+    def __init__(self, source_agent: Agent, transition_target: TransitionTarget, uuid: UUID | None = None):
+        super().__init__(uuid=uuid, source_agent=source_agent, transition_target=transition_target)
+
+    def print(self, f: Callable[..., Any] | None = None) -> None:
+        f = f or print
+        super().print(f)
+
+        f(
+            colored(
+                f"***** AfterWork handoff ({self.source_agent.name if hasattr(self.source_agent, 'name') else self.source_agent}): {self.transition_target.display_name()} *****",
+                "blue",
+            ),
+            flush=True,
+        )
+
+
+@wrap_event
+class OnContextConditionTransitionEvent(BaseEvent):
+    """Event for OnContextCondition handoffs"""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    source_agent: Agent
+    transition_target: TransitionTarget
+
+    def __init__(self, source_agent: Agent, transition_target: TransitionTarget, uuid: UUID | None = None):
+        super().__init__(uuid=uuid, source_agent=source_agent, transition_target=transition_target)
+
+    def print(self, f: Callable[..., Any] | None = None) -> None:
+        f = f or print
+        super().print(f)
+
+        f(
+            colored(
+                f"***** OnContextCondition handoff ({self.source_agent.name if hasattr(self.source_agent, 'name') else self.source_agent}): {self.transition_target.display_name()} *****",
+                "blue",
+            ),
+            flush=True,
+        )
+
+
+@wrap_event
+class OnConditionLLMTransitionEvent(BaseEvent):
+    """Event for LLM-based OnCondition handoffs"""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    source_agent: Agent
+    transition_target: TransitionTarget
+
+    def __init__(self, source_agent: Agent, transition_target: TransitionTarget, uuid: UUID | None = None):
+        super().__init__(uuid=uuid, source_agent=source_agent, transition_target=transition_target)
+
+    def print(self, f: Callable[..., Any] | None = None) -> None:
+        f = f or print
+        super().print(f)
+
+        f(
+            colored(
+                f"***** LLM-based OnCondition handoff ({self.source_agent.name if hasattr(self.source_agent, 'name') else self.source_agent}): {self.transition_target.display_name()} *****",
+                "blue",
+            ),
+            flush=True,
+        )

--- a/autogen/agentchat/group/group_tool_executor.py
+++ b/autogen/agentchat/group/group_tool_executor.py
@@ -7,6 +7,9 @@ from collections.abc import Callable
 from copy import deepcopy
 from typing import Annotated, Any
 
+from autogen.agentchat.group.events.handoff_events import OnConditionLLMTransitionEvent
+from autogen.io.base import IOStream
+
 from ...oai import OpenAIWrapper
 from ...tools import Depends, Tool
 from ...tools.dependency_injection import inject_params, on
@@ -32,6 +35,8 @@ class GroupToolExecutor(ConversableAgent):
 
         # Store the next target from a tool call
         self._group_next_target: TransitionTarget | None = None
+        # Group manager will be set by link_agents_to_group_manager
+        self._group_manager: Any = None
 
         # Primary tool reply function for handling the tool reply and the ReplyResult and TransitionTarget returns
         self.register_reply([Agent, None], self._generate_group_tool_reply, remove_other_reply_funcs=True)
@@ -126,6 +131,73 @@ class GroupToolExecutor(ConversableAgent):
             for tool in agent.tools:
                 self.register_for_execution(serialize=False, silent_override=True)(tool)
 
+    def function_is_agent_llm_handoff(self, agent_name: str, function_name: str) -> bool:
+        """Determines if a function name is an LLM handoff.
+
+        Args:
+            agent_name (str): The name of the agent the conditions against
+            function_name (str): The function name to check.
+
+        Returns:
+            bool: True if the function is an LLM handoff, False otherwise.
+        """
+        agent = self._group_manager.groupchat.agent_by_name(agent_name)
+        if agent is None:
+            return False
+        # Check if agent is a ConversableAgent with handoffs
+        if not isinstance(agent, ConversableAgent) or not hasattr(agent, "handoffs"):
+            return False
+        return any(on_condition.llm_function_name == function_name for on_condition in agent.handoffs.llm_conditions)
+
+    def get_sender_agent_for_message(self, message: dict[str, Any]) -> Agent | None:
+        """Gets the sender agent from the message.
+
+        Args:
+            message: The message containing the tool call and source agent
+
+        Returns:
+            The sender agent, or None if not found
+        """
+        if "name" in message and self._group_manager:
+            agent = self._group_manager.groupchat.agent_by_name(message.get("name"))
+            return agent  # type: ignore[no-any-return]
+        return None
+
+    def is_handoff_function(self, message: dict[str, Any]) -> bool:
+        """Checks if the tool call is a handoff function.
+
+        Args:
+            message: The message containing the tool call and source agent
+        """
+        if "name" in message:
+            agent_name = message.get("name")
+
+            if agent_name and "tool_calls" in message and self._group_manager:
+                for tool_call in message["tool_calls"]:
+                    if "function" in tool_call and "name" in tool_call["function"]:
+                        function_name = tool_call["function"]["name"]
+                        if self.function_is_agent_llm_handoff(agent_name, function_name):
+                            return True
+        return False
+
+    def _send_llm_handoff_event(self, message: dict[str, Any], transition_target: TransitionTarget) -> None:
+        """Send an LLM OnCondition handoff event.
+
+        Args:
+            message: The message containing the tool call and source agent
+            transition_target: The target to transition to
+        """
+        if self.is_handoff_function(message):
+            source_agent = self.get_sender_agent_for_message(message)
+            if source_agent:
+                iostream = IOStream.get_default()
+                iostream.send(
+                    OnConditionLLMTransitionEvent(
+                        source_agent=source_agent,
+                        transition_target=transition_target,
+                    )
+                )
+
     def _generate_group_tool_reply(
         self,
         agent: ConversableAgent,
@@ -172,13 +244,15 @@ class GroupToolExecutor(ConversableAgent):
                 for tool_response in tool_message["tool_responses"]:
                     content = tool_response.get("content")
 
-                    # Tool Call returns that are a target are either a ReplyResult or a TransitionTarget are the next agent
+                    # Tool Call returns that are a target are either a ReplyResult or a TransitionTarget
                     if isinstance(content, ReplyResult):
                         if content.context_variables and content.context_variables.to_dict() != {}:
                             agent.context_variables.update(content.context_variables.to_dict())
                         if content.target is not None:
+                            self._send_llm_handoff_event(message_copy, content.target)
                             next_target = content.target
                     elif isinstance(content, TransitionTarget):
+                        self._send_llm_handoff_event(message_copy, content)
                         next_target = content
 
                     # Serialize the content to a string

--- a/autogen/agentchat/group/group_utils.py
+++ b/autogen/agentchat/group/group_utils.py
@@ -8,6 +8,9 @@ from functools import partial
 from types import MethodType
 from typing import TYPE_CHECKING, Any, Optional
 
+from autogen.agentchat.group.events.handoff_events import AfterWorksTransitionEvent, OnContextConditionTransitionEvent
+from autogen.io.base import IOStream
+
 from ..agent import Agent
 from ..groupchat import GroupChat, GroupChatManager
 from .context_variables import ContextVariables
@@ -114,11 +117,16 @@ def _evaluate_after_works_conditions(
             after_work_condition.condition is None or after_work_condition.condition.evaluate(agent.context_variables)
         ):
             # Condition matched, resolve and return
-            return after_work_condition.target.resolve(
+            after_works_speaker = after_work_condition.target.resolve(
                 groupchat,
                 agent,
                 user_agent,
             ).get_speaker_selection_result(groupchat)
+
+            iostream = IOStream.get_default()
+            iostream.send(AfterWorksTransitionEvent(source_agent=agent, transition_target=after_work_condition.target))
+
+            return after_works_speaker
 
     return None
 
@@ -141,6 +149,9 @@ def _run_oncontextconditions(
             on_condition.target.activate_target(agent._group_manager.groupchat)  # type: ignore[attr-defined]
 
             transfer_name = on_condition.target.display_name()
+
+            iostream = IOStream.get_default()
+            iostream.send(OnContextConditionTransitionEvent(source_agent=agent, transition_target=on_condition.target))
 
             return True, "[Handing off to " + transfer_name + "]"
 

--- a/test/agentchat/group/test_group_tool_executor.py
+++ b/test/agentchat/group/test_group_tool_executor.py
@@ -364,3 +364,194 @@ class TestGroupToolExecutor:
                 executor._generate_group_tool_reply(agent=executor, messages=messages)
 
             assert "Tool call did not return a message" in str(excinfo.value)
+
+    def test_function_is_agent_llm_handoff(self, executor: GroupToolExecutor) -> None:
+        """Test function_is_agent_llm_handoff method."""
+        # Setup mock group manager and groupchat
+        mock_group_manager = MagicMock()
+        mock_groupchat = MagicMock()
+        mock_group_manager.groupchat = mock_groupchat
+        executor._group_manager = mock_group_manager
+
+        # Test case 1: Agent not found
+        mock_groupchat.agent_by_name.return_value = None
+        result = executor.function_is_agent_llm_handoff("NonExistentAgent", "some_function")
+        assert result is False
+        mock_groupchat.agent_by_name.assert_called_with("NonExistentAgent")
+
+        # Test case 2: Agent found but not a ConversableAgent
+        mock_agent = MagicMock()
+        mock_agent.__class__.__name__ = "NotConversableAgent"
+        mock_groupchat.agent_by_name.return_value = mock_agent
+        result = executor.function_is_agent_llm_handoff("SomeAgent", "some_function")
+        assert result is False
+
+        # Test case 3: ConversableAgent but no handoffs attribute
+        mock_conversable = MagicMock(spec=ConversableAgent)
+        del mock_conversable.handoffs  # Remove handoffs attribute
+        mock_groupchat.agent_by_name.return_value = mock_conversable
+        result = executor.function_is_agent_llm_handoff("SomeAgent", "some_function")
+        assert result is False
+
+        # Test case 4: Agent with handoffs but function not found
+        mock_conversable = MagicMock(spec=ConversableAgent)
+        mock_handoffs = MagicMock()
+        mock_condition1 = MagicMock()
+        mock_condition1.llm_function_name = "other_function"
+        mock_condition2 = MagicMock()
+        mock_condition2.llm_function_name = "another_function"
+        mock_handoffs.llm_conditions = [mock_condition1, mock_condition2]
+        mock_conversable.handoffs = mock_handoffs
+        mock_groupchat.agent_by_name.return_value = mock_conversable
+        result = executor.function_is_agent_llm_handoff("SomeAgent", "target_function")
+        assert result is False
+
+        # Test case 5: Function found in handoffs
+        mock_condition3 = MagicMock()
+        mock_condition3.llm_function_name = "target_function"
+        mock_handoffs.llm_conditions.append(mock_condition3)
+        result = executor.function_is_agent_llm_handoff("SomeAgent", "target_function")
+        assert result is True
+
+    def test_get_sender_agent_for_message(self, executor: GroupToolExecutor) -> None:
+        """Test get_sender_agent_for_message method."""
+        # Setup mock group manager and groupchat
+        mock_group_manager = MagicMock()
+        mock_groupchat = MagicMock()
+        mock_group_manager.groupchat = mock_groupchat
+        executor._group_manager = mock_group_manager
+
+        # Test case 1: No 'name' in message
+        message = {"content": "some content"}
+        result = executor.get_sender_agent_for_message(message)
+        assert result is None
+        mock_groupchat.agent_by_name.assert_not_called()
+
+        # Test case 2: No group manager
+        executor._group_manager = None
+        message = {"name": "SomeAgent", "content": "some content"}
+        result = executor.get_sender_agent_for_message(message)
+        assert result is None
+
+        # Test case 3: Agent found successfully
+        executor._group_manager = mock_group_manager
+        mock_agent = MagicMock()
+        mock_agent.name = "SomeAgent"
+        mock_groupchat.agent_by_name.return_value = mock_agent
+        message = {"name": "SomeAgent", "content": "some content"}
+        result = executor.get_sender_agent_for_message(message)
+        assert result == mock_agent
+        mock_groupchat.agent_by_name.assert_called_with("SomeAgent")
+
+        # Test case 4: Agent not found in groupchat
+        mock_groupchat.agent_by_name.return_value = None
+        message = {"name": "NonExistentAgent", "content": "some content"}
+        result = executor.get_sender_agent_for_message(message)
+        assert result is None
+
+    def test_is_handoff_function(self, executor: GroupToolExecutor) -> None:
+        """Test is_handoff_function method."""
+        # Setup mock group manager and groupchat
+        mock_group_manager = MagicMock()
+        mock_groupchat = MagicMock()
+        mock_group_manager.groupchat = mock_groupchat
+        executor._group_manager = mock_group_manager
+
+        # Test case 1: No 'name' in message
+        message = {"content": "some content"}
+        result = executor.is_handoff_function(message)
+        assert result is False
+
+        # Test case 2: No tool_calls in message
+        message = {"name": "SomeAgent", "content": "some content"}
+        result = executor.is_handoff_function(message)
+        assert result is False
+
+        # Test case 3: No group manager
+        executor._group_manager = None
+        message3: dict[str, Any] = {"name": "SomeAgent", "tool_calls": [{"function": {"name": "some_function"}}]}
+        result = executor.is_handoff_function(message3)
+        assert result is False
+
+        # Test case 4: Tool call without function key
+        executor._group_manager = mock_group_manager
+        message4: dict[str, Any] = {"name": "SomeAgent", "tool_calls": [{"id": "call1"}]}
+        result = executor.is_handoff_function(message4)
+        assert result is False
+
+        # Test case 5: Tool call without function name
+        message5: dict[str, Any] = {"name": "SomeAgent", "tool_calls": [{"function": {"arguments": "{}"}}]}
+        result = executor.is_handoff_function(message5)
+        assert result is False
+
+        # Test case 6: Valid tool call but not a handoff function
+        with patch.object(executor, "function_is_agent_llm_handoff", return_value=False) as mock_check:
+            message6: dict[str, Any] = {"name": "SomeAgent", "tool_calls": [{"function": {"name": "regular_function"}}]}
+            result = executor.is_handoff_function(message6)
+            assert result is False
+            mock_check.assert_called_with("SomeAgent", "regular_function")
+
+        # Test case 7: Valid handoff function
+        with patch.object(executor, "function_is_agent_llm_handoff", return_value=True) as mock_check:
+            message7: dict[str, Any] = {"name": "SomeAgent", "tool_calls": [{"function": {"name": "handoff_function"}}]}
+            result = executor.is_handoff_function(message7)
+            assert result is True
+            mock_check.assert_called_with("SomeAgent", "handoff_function")
+
+        # Test case 8: Multiple tool calls, one is a handoff
+        with patch.object(executor, "function_is_agent_llm_handoff") as mock_check:
+            mock_check.side_effect = [False, True]  # First returns False, second returns True
+            message8: dict[str, Any] = {
+                "name": "SomeAgent",
+                "tool_calls": [{"function": {"name": "regular_function"}}, {"function": {"name": "handoff_function"}}],
+            }
+            result = executor.is_handoff_function(message8)
+            assert result is True
+            assert mock_check.call_count == 2
+
+    @patch("autogen.agentchat.group.group_tool_executor.IOStream")
+    def test_send_llm_handoff_event(self, mock_iostream: MagicMock, executor: GroupToolExecutor) -> None:
+        """Test _send_llm_handoff_event method."""
+        from autogen.agentchat.group.events.handoff_events import OnConditionLLMTransitionEvent
+
+        # Setup mock iostream
+        mock_iostream_instance = MagicMock()
+        mock_iostream.get_default.return_value = mock_iostream_instance
+
+        # Test case 1: Not a handoff function
+        with patch.object(executor, "is_handoff_function", return_value=False):
+            message = {"name": "SomeAgent", "content": "test"}
+            transition_target = MagicMock(spec=TransitionTarget)
+            executor._send_llm_handoff_event(message, transition_target)
+            mock_iostream_instance.send.assert_not_called()
+
+        # Test case 2: Handoff function but no sender agent
+        with (
+            patch.object(executor, "is_handoff_function", return_value=True),
+            patch.object(executor, "get_sender_agent_for_message", return_value=None),
+        ):
+            message = {"name": "SomeAgent", "content": "test"}
+            transition_target = MagicMock(spec=TransitionTarget)
+            executor._send_llm_handoff_event(message, transition_target)
+            mock_iostream_instance.send.assert_not_called()
+
+        # Test case 3: Valid handoff function with sender agent
+        mock_agent = MagicMock()
+        mock_agent.name = "TestAgent"
+        with (
+            patch.object(executor, "is_handoff_function", return_value=True),
+            patch.object(executor, "get_sender_agent_for_message", return_value=mock_agent),
+        ):
+            message = {"name": "TestAgent", "content": "test"}
+            transition_target = MagicMock(spec=TransitionTarget)
+            executor._send_llm_handoff_event(message, transition_target)
+
+            # Verify IOStream.send was called
+            mock_iostream_instance.send.assert_called_once()
+
+            # Verify the event object passed to send
+            sent_event = mock_iostream_instance.send.call_args[0][0]
+            assert isinstance(sent_event, OnConditionLLMTransitionEvent)
+            # The wrapped event has a 'content' field that contains the actual event data
+            assert sent_event.content.source_agent == mock_agent  # type: ignore[attr-defined]
+            assert sent_event.content.transition_target == transition_target  # type: ignore[attr-defined]


### PR DESCRIPTION
## Why are these changes needed?

Events are not emitted for handoffs and these are useful to know so you can monitor your orchestrations and diagnose flows.

Handoff events so far for AfterWorks, OnContextCondition, and LLM-based OnCondition

Events are simple one-liners, e.g.:
```***** AfterWork handoff (agent_b): agent_c *****```
```***** OnContextCondition handoff (coordinator_agent): weather_specialist *****```
```***** LLM-based OnCondition handoff (coordinator_agent): traffic_specialist *****```

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
