### PR TITLE
[Fix] OAI_CONFIG_LIST for tests

### DIFF
--- a/.github/workflows/contrib-llm-test.yml
+++ b/.github/workflows/contrib-llm-test.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Install packages and dependencies
         run: |
           docker --version
-          uv pip install --system -e ".[test,openai,autobuild,captainagent]"
+          uv pip install --system -e ".[test,openai,autobuild,captainagent,gemini]"
       - name: Create OAI_CONFIG_LIST from Secret
         run: |
           cat > OAI_CONFIG_LIST << 'EOF'

--- a/.github/workflows/contrib-llm-test.yml
+++ b/.github/workflows/contrib-llm-test.yml
@@ -119,6 +119,12 @@ jobs:
         run: |
           docker --version
           uv pip install --system -e ".[test,openai,autobuild,captainagent]"
+      - name: Create OAI_CONFIG_LIST from Secret
+        run: |
+          cat > OAI_CONFIG_LIST << 'EOF'
+          ${{ secrets.OAI_CONFIG_LIST }}
+          EOF
+        shell: bash
       - name: Run tests
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
In the Contributor LLM test put OAI_CONFIG_LIST secret to disk

## Why are these changes needed?

AgentBuilder tests failing due to OAI_CONFIG_LIST file missing.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
