### PR TITLE
added logic to extract text from ThinkingBlock

### DIFF
--- a/autogen/oai/anthropic.py
+++ b/autogen/oai/anthropic.py
@@ -89,7 +89,7 @@ from .oai_models import ChatCompletion, ChatCompletionMessage, ChatCompletionMes
 with optional_import_block():
     from anthropic import Anthropic, AnthropicBedrock, AnthropicVertex
     from anthropic import __version__ as anthropic_version
-    from anthropic.types import Message, TextBlock, ToolUseBlock
+    from anthropic.types import Message, TextBlock, ToolUseBlock,ThinkingBlock
 
     TOOL_ENABLED = anthropic_version >= "0.23.1"
     if TOOL_ENABLED:
@@ -486,7 +486,14 @@ Ensure the JSON is properly formatted and matches the schema exactly."""
             return response
 
         # Extract content from response
-        content = response.content[0].text if response.content else ""
+        if response.content:
+            if type(response.content[0]) == TextBlock:
+                content = response.content[0].text
+
+            elif type(response.content[0]) == ThinkingBlock:
+                content = response.content[0].thinking
+        else:
+            content = ""
 
         # Try to extract JSON from tags first
         json_match = re.search(r"<json_response>(.*?)</json_response>", content, re.DOTALL)


### PR DESCRIPTION
This pull request updates the handling of Anthropic message responses by supporting the new `ThinkingBlock` type introduced in Anthropic version 0.23.1 and improving the extraction logic for JSON responses. The changes ensure that the code can correctly parse both `TextBlock` and `ThinkingBlock` content types.

Support for new Anthropic content types:

* Imported the `ThinkingBlock` type from `anthropic.types` to enable handling of messages that use this new block type.

Improved response extraction logic:

* Updated the `_extract_json_response` method in `autogen/oai/anthropic.py` to check the type of the first item in the `response.content` list, extracting text from `TextBlock` or thinking from `ThinkingBlock` as appropriate.