### PR TITLE
fix: claude-code-review OIDC handshake for forked branches

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,12 +7,6 @@ on:
       - opened
       - synchronize
       - ready_for_review
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
   # For PRs from forked repositories (secure path with secrets)
   pull_request_target:
     types:
@@ -21,14 +15,12 @@ on:
       - ready_for_review
 
 jobs:
-  claude-review:
-    # Skip draft PRs and prevent duplicate runs
+  # Job for same-repo PRs (can use OIDC if needed)
+  claude-review-same-repo:
     if: |
-      github.event.pull_request.draft == false &&
-      (
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
-      )
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
 
     runs-on: ubuntu-latest
     permissions:
@@ -47,12 +39,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
-            echo "⚠️  Forked PR detected - running in secure mode"
-            echo "PR from: ${{ github.event.pull_request.head.repo.full_name }}"
-            echo "Base repo: ${{ github.repository }}"
-          fi
-
           echo "Checking out PR #${{ github.event.pull_request.number }}"
           gh pr checkout ${{ github.event.pull_request.number }}
           echo "✅ PR branch checked out successfully"
@@ -61,6 +47,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
@@ -73,10 +60,71 @@ jobs:
             - Security concerns
             - Test coverage
 
+            # Steps to run a Review:
+              1) Check if previous review is already done by Claude. If so, perform a re-reivew with the latest changes referring previous review.
+              2) If no previous review is found, perform a new review with the latest changes.
+
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+
+  # Job for forked PRs (no OIDC, token-based only)
+  claude-review-forked:
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      github.event.pull_request.draft == false
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      # Explicitly disable id-token to avoid OIDC flow
+
+    steps:
+      - name: Checkout repository (no credentials persisted)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout PR branch (forked PR)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "⚠️  Forked PR detected - running in secure mode"
+          echo "PR from: ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "Base repo: ${{ github.repository }}"
+          echo "Checking out PR #${{ github.event.pull_request.number }}"
+          gh pr checkout ${{ github.event.pull_request.number }}
+          echo "✅ PR branch checked out successfully"
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            # Steps to run a Review:
+              1) Check if previous review is already done by Claude. If so, perform a re-reivew with the latest changes referring previous review.
+              2) If no previous review is found, perform a new review with the latest changes.
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR solves the OIDC handshake bug by enforcing Github Token auth for Claude review on forked branches.
This PR also solves the Claude review hallucinations , by referenced review approach.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
