### PR TITLE
docs: AG2xA2A banner image

### DIFF
--- a/website/docs/_blogs/2025-10-27-A2A-Protocol-Support/img/ag2-a2a-banner.png
+++ b/website/docs/_blogs/2025-10-27-A2A-Protocol-Support/img/ag2-a2a-banner.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca1d53dec64673da0f2a79f2c980de1706b29f87de66b8413a313abfe07c2768
+size 177358


### PR DESCRIPTION
## Why are these changes needed?

Added missing AG2 x A2A banner image for blog post

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
