### PR TITLE
chore: update Anthropic Sonnet model to 4.5 for tests

### DIFF
--- a/autogen/token_count_utils.py
+++ b/autogen/token_count_utils.py
@@ -155,6 +155,9 @@ def _num_token_from_messages(messages: list[str] | dict[str, Any], model="gpt-3.
     elif "gpt-4" in model:
         logger.info("gpt-4 may update over time. Returning num tokens assuming gpt-4-0613.")
         return _num_token_from_messages(messages, model="gpt-4-0613")
+    elif "gpt-5" in model:
+        logger.info("gpt-5 may update over time. Returning num tokens assuming gpt-4-0613.")
+        return _num_token_from_messages(messages, model="gpt-4-0613")
     elif "gemini" in model:
         logger.info("Gemini is not supported in tiktoken. Returning num tokens assuming gpt-4-0613.")
         return _num_token_from_messages(messages, model="gpt-4-0613")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -296,7 +296,7 @@ def credentials_gemini_flash_exp() -> Credentials:
 def credentials_anthropic_claude_sonnet() -> Credentials:
     return get_credentials(
         "ANTHROPIC_API_KEY",
-        model="claude-3-5-sonnet-latest",
+        model="claude-sonnet-4-5",
         api_type="anthropic",
         filter_dict={"tags": ["anthropic-claude-sonnet"]},
     )

--- a/test/interop/litellm/test_litellm_config_factory.py
+++ b/test/interop/litellm/test_litellm_config_factory.py
@@ -228,7 +228,7 @@ class TestCrawl4aiCompatibility:
         ("api_type", "model", "expected_provider"),
         [
             ("openai", "gpt-4o-mini", "openai/gpt-4o-mini"),
-            ("anthropic", "claude-3-sonnet", "anthropic/claude-3-sonnet"),
+            ("anthropic", "claude-sonnet-4-5", "anthropic/claude-sonnet-4-5"),
             ("google", "gemini-pro", "gemini/gemini-pro"),  # Note: google gets converted to gemini
             ("azure", "gpt-4", "azure/gpt-4"),
             ("ollama", "llama2", "ollama/llama2"),

--- a/test/oai/test_anthropic.py
+++ b/test/oai/test_anthropic.py
@@ -52,7 +52,7 @@ def anthropic_client():
 
 def test_anthropic_llm_config_entry():
     anthropic_llm_config = AnthropicLLMConfigEntry(
-        model="claude-3-5-sonnet-latest",
+        model="claude-sonnet-4-5",
         api_key="dummy_api_key",
         stream=False,
         temperature=1.0,
@@ -60,7 +60,7 @@ def test_anthropic_llm_config_entry():
     )
     expected = {
         "api_type": "anthropic",
-        "model": "claude-3-5-sonnet-latest",
+        "model": "claude-sonnet-4-5",
         "api_key": "dummy_api_key",
         "stream": False,
         "temperature": 1.0,
@@ -158,14 +158,14 @@ def test_cost_calculation(mock_completion):
 @run_for_optional_imports(["anthropic"], "anthropic")
 def test_load_config(anthropic_client):
     params = {
-        "model": "claude-3-5-sonnet-latest",
+        "model": "claude-sonnet-4-5",
         "stream": False,
         "temperature": 1,
         "top_p": 0.8,
         "max_tokens": 100,
     }
     expected_params = {
-        "model": "claude-3-5-sonnet-latest",
+        "model": "claude-sonnet-4-5",
         "stream": False,
         "temperature": 1,
         "timeout": None,
@@ -210,7 +210,7 @@ def test_extract_json_response(anthropic_client):
                 type="text",
             )
         ],
-        model="claude-3-5-sonnet-latest",
+        model="claude-sonnet-4-5",
         role="assistant",
         stop_reason="end_turn",
         type="message",
@@ -238,7 +238,7 @@ def test_extract_json_response(anthropic_client):
                 type="text",
             )
         ],
-        model="claude-3-5-sonnet-latest",
+        model="claude-sonnet-4-5",
         role="assistant",
         stop_reason="end_turn",
         type="message",
@@ -266,7 +266,7 @@ def test_extract_json_response(anthropic_client):
                 type="text",
             )
         ],
-        model="claude-3-5-sonnet-latest",
+        model="claude-sonnet-4-5",
         role="assistant",
         stop_reason="end_turn",
         type="message",
@@ -282,7 +282,7 @@ def test_extract_json_response(anthropic_client):
     no_json_response = Message(
         id="msg_123",
         content=[TextBlock(text="This response contains no JSON at all.", type="text")],
-        model="claude-3-5-sonnet-latest",
+        model="claude-sonnet-4-5",
         role="assistant",
         stop_reason="end_turn",
         type="message",

--- a/test/oai/test_bedrock.py
+++ b/test/oai/test_bedrock.py
@@ -40,7 +40,7 @@ def bedrock_client():
 
 def test_bedrock_llm_config_entry():
     bedrock_llm_config = BedrockLLMConfigEntry(
-        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        model="anthropic.claude-sonnet-4-5-20250929-v1:0",
         aws_region="us-east-1",
         aws_access_key="test_access_key_id",
         aws_secret_key="test_secret_access_key",
@@ -49,7 +49,7 @@ def test_bedrock_llm_config_entry():
     )
     expected = {
         "api_type": "bedrock",
-        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
         "aws_region": "us-east-1",
         "aws_access_key": "test_access_key_id",
         "aws_secret_key": "test_secret_access_key",
@@ -67,7 +67,7 @@ def test_bedrock_llm_config_entry():
 
     with pytest.raises(ValidationError, match="List should have at least 2 items after validation, not 1"):
         bedrock_llm_config = BedrockLLMConfigEntry(
-            model="anthropic.claude-3-sonnet-20240229-v1:0",
+            model="anthropic.claude-sonnet-4-5-20250929-v1:0",
             aws_region="us-east-1",
             price=["0.1"],
         )
@@ -75,7 +75,7 @@ def test_bedrock_llm_config_entry():
 
 def test_bedrock_llm_config_entry_repr():
     bedrock_llm_config = BedrockLLMConfigEntry(
-        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        model="anthropic.claude-sonnet-4-5-20250929-v1:0",
         aws_region="us-east-1",
         aws_access_key="test_access_key_id",
         aws_secret_key="test_secret_access_key",
@@ -84,14 +84,14 @@ def test_bedrock_llm_config_entry_repr():
     )
 
     actual = repr(bedrock_llm_config)
-    expected = "BedrockLLMConfigEntry(api_type='bedrock', model='anthropic.claude-3-sonnet-20240229-v1:0', tags=[], aws_region='us-east-1', aws_access_key='**********', aws_secret_key='**********', aws_session_token='**********', aws_profile_name='test_profile_name', supports_system_prompts=True)"
+    expected = "BedrockLLMConfigEntry(api_type='bedrock', model='anthropic.claude-sonnet-4-5-20250929-v1:0', tags=[], aws_region='us-east-1', aws_access_key='**********', aws_secret_key='**********', aws_session_token='**********', aws_profile_name='test_profile_name', supports_system_prompts=True)"
 
     assert actual == expected, actual
 
 
 def test_bedrock_llm_config_entry_str():
     bedrock_llm_config = BedrockLLMConfigEntry(
-        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        model="anthropic.claude-sonnet-4-5-20250929-v1:0",
         aws_region="us-east-1",
         aws_access_key="test_access_key_id",
         aws_secret_key="test_secret_access_key",
@@ -100,7 +100,7 @@ def test_bedrock_llm_config_entry_str():
     )
 
     actual = str(bedrock_llm_config)
-    expected = "BedrockLLMConfigEntry(api_type='bedrock', model='anthropic.claude-3-sonnet-20240229-v1:0', tags=[], aws_region='us-east-1', aws_access_key='**********', aws_secret_key='**********', aws_session_token='**********', aws_profile_name='test_profile_name', supports_system_prompts=True)"
+    expected = "BedrockLLMConfigEntry(api_type='bedrock', model='anthropic.claude-sonnet-4-5-20250929-v1:0', tags=[], aws_region='us-east-1', aws_access_key='**********', aws_secret_key='**********', aws_session_token='**********', aws_profile_name='test_profile_name', supports_system_prompts=True)"
 
     assert actual == expected, actual
 
@@ -117,7 +117,7 @@ def test_initialization():
 def test_parsing_params(bedrock_client: BedrockClient):
     # All parameters (with default values)
     assert bedrock_client.parse_params({
-        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
         "temperature": 0.8,
         "top_p": 0.6,
         "max_tokens": 250,
@@ -137,7 +137,7 @@ def test_parsing_params(bedrock_client: BedrockClient):
     # Incorrect types, defaults should be set, will show warnings but not trigger assertions
     with pytest.warns(UserWarning, match=r"Config error - .*"):
         assert bedrock_client.parse_params({
-            "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "temperature": "0.5",
             "top_p": "0.6",
             "max_tokens": "250",
@@ -155,12 +155,12 @@ def test_parsing_params(bedrock_client: BedrockClient):
 
     with pytest.warns(UserWarning, match="Streaming is not currently supported, streaming will be disabled"):
         bedrock_client.parse_params({
-            "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "stream": True,
         })
 
     assert bedrock_client.parse_params({
-        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
     }) == ({}, {})
 
     with pytest.raises(AssertionError, match="Please provide the 'model` in the config_list to use Amazon Bedrock"):
@@ -177,7 +177,7 @@ def test_create_response(mock_chat, bedrock_client: BedrockClient):
         MagicMock(finish_reason="stop", message=MagicMock(content="Example Bedrock response", tool_calls=None))
     ]
     mock_bedrock_response.id = "mock_bedrock_response_id"
-    mock_bedrock_response.model = "anthropic.claude-3-sonnet-20240229-v1:0"
+    mock_bedrock_response.model = "anthropic.claude-sonnet-4-5-20250929-v1:0"
     mock_bedrock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=20)  # Example token usage
 
     mock_chat.return_value = mock_bedrock_response
@@ -185,7 +185,7 @@ def test_create_response(mock_chat, bedrock_client: BedrockClient):
     # Test parameters
     params = {
         "messages": [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "World"}],
-        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
     }
 
     # Call the create method
@@ -196,7 +196,7 @@ def test_create_response(mock_chat, bedrock_client: BedrockClient):
         "Response content should match expected output"
     )
     assert response.id == "mock_bedrock_response_id", "Response ID should match the mocked response ID"
-    assert response.model == "anthropic.claude-3-sonnet-20240229-v1:0", (
+    assert response.model == "anthropic.claude-sonnet-4-5-20250929-v1:0", (
         "Response model should match the mocked response model"
     )
     assert response.usage.prompt_tokens == 10, "Response prompt tokens should match the mocked response usage"
@@ -230,7 +230,7 @@ def test_create_response_with_tool_call(mock_chat, bedrock_client: BedrockClient
             )
         ],
         id="mock_bedrock_response_id",
-        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        model="anthropic.claude-sonnet-4-5-20250929-v1:0",
         usage=MagicMock(prompt_tokens=10, completion_tokens=20),
     )
 
@@ -260,7 +260,7 @@ def test_create_response_with_tool_call(mock_chat, bedrock_client: BedrockClient
     response = bedrock_client.create({
         "messages": bedrock_messages,
         "tools": converted_functions,
-        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
     })
 
     # Assertions to check if the functions and content are included in the response

--- a/test/test_llm_config.py
+++ b/test/test_llm_config.py
@@ -198,7 +198,7 @@ class TestLLMConfig:
             pytest.param(
                 {
                     "api_type": "anthropic",
-                    "model": "claude-3-5-sonnet-latest",
+                    "model": "claude-sonnet-4-5",
                     "api_key": "dummy_api_key",
                     "stream": False,
                     "temperature": 1.0,
@@ -206,19 +206,19 @@ class TestLLMConfig:
                 },
                 LLMConfig(
                     AnthropicLLMConfigEntry(
-                        model="claude-3-5-sonnet-latest",
+                        model="claude-sonnet-4-5",
                         api_key="dummy_api_key",
                         stream=False,
                         temperature=1.0,
                         max_tokens=100,
                     )
                 ),
-                id="anthropic claude-3-5-sonnet-latest",
+                id="anthropic claude-sonnet-4-5",
             ),
             pytest.param(
                 {
                     "api_type": "bedrock",
-                    "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                    "model": "anthropic.claude-4-5-sonnet-20250929-v1:0",
                     "aws_region": "us-east-1",
                     "aws_access_key": "test_access_key_id",
                     "aws_secret_key": "test_secret_access_key",
@@ -228,7 +228,7 @@ class TestLLMConfig:
                 },
                 LLMConfig(
                     BedrockLLMConfigEntry(
-                        model="anthropic.claude-3-sonnet-20240229-v1:0",
+                        model="anthropic.claude-4-5-sonnet-20250929-v1:0",
                         aws_region="us-east-1",
                         aws_access_key="test_access_key_id",
                         aws_secret_key="test_secret_access_key",
@@ -236,7 +236,7 @@ class TestLLMConfig:
                         temperature=0.8,
                     )
                 ),
-                id="bedrock claude-3-sonnet",
+                id="bedrock claude-4-5-sonnet",
             ),
             pytest.param(
                 {


### PR DESCRIPTION
## Why are these changes needed?

Anthropic deprecated Sonnet 3.5 Oct 2025, updating to Sonnet 4.5.

Includes adding GPT 5 to token count for streaming.

## Related issue number



## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
