### PR TITLE
docs: DocAgent documentation fixes, documentation fix for tables

### DIFF
--- a/autogen/agents/experimental/document_agent/document_agent.py
+++ b/autogen/agents/experimental/document_agent/document_agent.py
@@ -73,7 +73,7 @@ TASK_MANAGER_SYSTEM_MESSAGE = """
 
     New ingestions and queries may be raised from time to time, so use the initiate_tasks again if you see new ingestions/queries.
 
-    Transfer to the summary agent if all ingestion and query tasks are done.
+    Once the ingestion and query tasks are done, return to the summary agent, do not ask questions of the user.
     """
 
 DEFAULT_ERROR_GROUP_CHAT_MESSAGE: str = """

--- a/notebook/agents_docagent.ipynb
+++ b/notebook/agents_docagent.ipynb
@@ -172,7 +172,7 @@
     "# Create a document agent and ask them to ingest the document and answer the question\n",
     "document_agent = DocAgent(llm_config=llm_config, collection_name=\"toast_report\", query_engine=query_engine)\n",
     "run_response = document_agent.run(\n",
-    "    \"could you ingest ../test/agentchat/contrib/graph_rag/Toast_financial_report.pdf? What is the fiscal year 2024 financial summary?\",\n",
+    "    message=\"could you ingest ../test/agentchat/contrib/graph_rag/Toast_financial_report.pdf? What is the fiscal year 2024 financial summary?\",\n",
     "    max_turns=1,\n",
     ")\n",
     "run_response.process()"
@@ -194,7 +194,7 @@
     "# Create a document agent and ask them to summarize a web page article\n",
     "document_agent = DocAgent(llm_config=llm_config, collection_name=\"news_reports\")\n",
     "run_response = document_agent.run(\n",
-    "    \"could you read 'https://www.independent.co.uk/space/earth-core-inner-shape-change-b2695585.html' and summarize the article?\",\n",
+    "    message=\"could you read 'https://www.independent.co.uk/space/earth-core-inner-shape-change-b2695585.html' and summarize the article?\",\n",
     "    max_turns=1,\n",
     ")\n",
     "run_response.process()"

--- a/website/docs/user-guide/reference-agents/docagent.mdx
+++ b/website/docs/user-guide/reference-agents/docagent.mdx
@@ -152,7 +152,7 @@ document_agent = DocAgent(llm_config=llm_config)
 
 # Update this path to suit your environment
 response = document_agent.run(
-    "Can you ingest ../test/agentchat/contrib/graph_rag/Toast_financial_report.pdf and tell me the fiscal year 2024 financial summary?",
+    message="Can you ingest ../test/agentchat/contrib/graph_rag/Toast_financial_report.pdf and tell me the fiscal year 2024 financial summary?",
     max_turns=1
 )
 


### PR DESCRIPTION
## Why are these changes needed?

Fixes example in DocAgent that missed the `message` parameter (and would take the message as the `recipient` instead.

Tweak for DocAgent TaskManager prompt as it was prone to asking for HITL feedback.

Fix for building documentation for notebooks that contained tables.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
