### PR TITLE
fix: Incorrect `isinstance` use in Anthropic LLM class

### DIFF
--- a/autogen/oai/anthropic.py
+++ b/autogen/oai/anthropic.py
@@ -489,10 +489,10 @@ Ensure the JSON is properly formatted and matches the schema exactly."""
 
         # Extract content from response
         if response.content:
-            if isinstance(response.content[0]) == TextBlock:
+            if isinstance(response.content[0], TextBlock):
                 content = response.content[0].text
 
-            elif isinstance(response.content[0]) == ThinkingBlock:
+            elif isinstance(response.content[0], ThinkingBlock):
                 content = response.content[0].thinking
 
             else:


### PR DESCRIPTION
## Why are these changes needed?

`isinstance` is used correctly in the `anthropic.py` class, this corrects it.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
