### PR TITLE
fix: Handling of img tags for MultimodalConversableAgent

### DIFF
--- a/autogen/agentchat/contrib/multimodal_conversable_agent.py
+++ b/autogen/agentchat/contrib/multimodal_conversable_agent.py
@@ -70,6 +70,30 @@ class MultimodalConversableAgent(ConversableAgent):
         self._oai_system_message[0]["content"] = self._message_to_dict(system_message)["content"]
         self._oai_system_message[0]["role"] = "system"
 
+    def _append_oai_message(
+        self,
+        message: dict[str, Any] | str,
+        conversation_id: Agent,
+        role: str = "assistant",
+        name: str | None = None,
+    ) -> bool:
+        """Append a message to the ChatCompletion conversation.
+
+        This override processes <img> tags in string messages using gpt4v_formatter
+        before appending to the conversation.
+
+        Args:
+            message (dict or str): message to be appended to the ChatCompletion conversation.
+            conversation_id (Agent): id of the conversation, should be the recipient or sender.
+            role (str): role of the message, can be "assistant" or "function".
+            name (str | None): name of the message author.
+
+        Returns:
+            bool: whether the message is appended to the ChatCompletion conversation.
+        """
+        processed_message = self._message_to_dict(message)
+        return super()._append_oai_message(processed_message, conversation_id, role, name)
+
     @staticmethod
     def _message_to_dict(message: dict[str, Any] | list[str] | str) -> dict:
         """Convert a message to a dictionary. This implementation


### PR DESCRIPTION
## Why are these changes needed?

From 0.10.x the handling of `img` tags by `MultimodalConversableAgent` was accidentally bypassed.

The regression was introduced in #2055 (v0.10.0). The `_append_oai_message` method in `ConversableAgent` was refactored from a method on an agent:
`message = self._message_to_dict(message)`
to a standalone function:
`valid, oai_message = normilize_message_to_oai(message, ...)`

This broke MultimodalConversableAgent because its overridden `_message_to_dict` method (which calls `gpt4v_formatter` to process <img> tags) was no longer being called.

This fix will override the `_append_oai_message` in `MultimodalConversableAgent` to handle the `img` tag before passing to the parent `_append_oai_message` tag.

**Note:** In this update instead of `<img filename>` tags being replaced with `<image>` in the outputs, they will keep the `<img filename>` display. These were not before and are still not being sent to the LLM, they are purely for output.

## Related issue number

Closes #2246 

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
