### PR TITLE
Documentation: Fix A2A Document Parsing Errors

### DIFF
--- a/website/docs/_blogs/2025-10-27-A2A-Protocol-Support/index.mdx
+++ b/website/docs/_blogs/2025-10-27-A2A-Protocol-Support/index.mdx
@@ -10,7 +10,7 @@ AG2 v0.10 introduces native support for the [Agent2Agent (A2A) Protocol](https:/
 
 This article walks through implementing A2A in AG2, with a focus on practical patterns for building distributed agent systems.
 
-<!-- more -->
+{/* more */}
 
 ## What is A2A?
 

--- a/website/docs/user-guide/a2a/client.mdx
+++ b/website/docs/user-guide/a2a/client.mdx
@@ -3,8 +3,6 @@ title: "A2A Client Usage"
 description: "Learn how to connect to and interact with remote A2A agents from your local applications."
 ---
 
-# A2A Client Usage
-
 The A2A client allows you to connect to remote A2A agent servers and interact with them as if they were local agents. This guide covers everything you need to know about using A2A clients.
 
 !!! warning
@@ -178,9 +176,9 @@ remote_agent = A2aRemoteAgent(
 
 ## Interoperability with other frameworks
 
-A2A is also supported [by other frameworks](https://a2a-protocol.org/latest/community/#a2a-integrations){.external-link target="_blank"}, so you can use `A2aRemoteAgent` with them, too.
+A2A is also supported <a href="https://a2a-protocol.org/latest/community/#a2a-integrations" className="external-link" target="_blank" rel="noopener noreferrer">by other frameworks</a>, so you can use `A2aRemoteAgent` with them, too.
 
-As an example, you can connect your AG2 agents with [Pydantic AI](https://ai.pydantic.dev/a2a/){.external-link target="_blank"} agents. Here we create a Pydantic AI agent:
+As an example, you can connect your AG2 agents with <a href="https://ai.pydantic.dev/a2a/" className="external-link" target="_blank" rel="noopener noreferrer">Pydantic AI</a> agents. Here we create a Pydantic AI agent:
 
 ```python title="server.py" linenums="1"
 from pydantic_ai import Agent

--- a/website/docs/user-guide/a2a/index.mdx
+++ b/website/docs/user-guide/a2a/index.mdx
@@ -3,9 +3,7 @@ title: "A2A (Agent2Agent) Communication"
 description: "Learn how to enable agents to communicate across different processes and machines using the A2A protocol."
 ---
 
-# A2A (Agent2Agent) Communication
-
-The [A2A (Agent2Agent Protocol)](https://a2a-protocol.org/latest/){.external-link target="_blank"} communication system in AG2 enables agents to communicate across different processes, machines, applications, or even different frameworks and languages. This powerful feature allows you to build distributed agent systems where agents can be deployed as separate services and interact with each other seamlessly.
+The <a href="https://a2a-protocol.org/latest/" className="external-link" target="_blank" rel="noopener noreferrer">A2A (Agent2Agent Protocol)</a> communication system in AG2 enables agents to communicate across different processes, machines, applications, or even different frameworks and languages. This powerful feature allows you to build distributed agent systems where agents can be deployed as separate services and interact with each other seamlessly.
 
 Consider using A2A when:
 
@@ -16,7 +14,7 @@ Consider using A2A when:
 * You need **Human in the Loop (HITL)** support for interactive workflows across distributed agents
 
 !!! note
-    We are using official [A2A python sdk](https://github.com/a2aproject/a2a-python){.external-link target="_blank"} to implement A2A in AG2.
+    We are using official <a href="https://github.com/a2aproject/a2a-python" className="external-link" target="_blank" rel="noopener noreferrer">A2A python sdk</a> to implement A2A in AG2.
 
     You can check their documentation for more details on how to use A2A in your own projects.
 
@@ -47,7 +45,7 @@ Now you can start it using any ASGI server, for example:
 uvicorn server:server
 ```
 
-To read more about how to configure an A2A server, please refer to [A2A Server Setup](./server){.internal-link} documentation.
+To read more about how to configure an A2A server, please refer to <a href="./server" className="internal-link">A2A Server Setup</a> documentation.
 
 ## Creating an A2A Client
 
@@ -88,13 +86,13 @@ await review_agent.a_initiate_chat(
 !!! warning
     `A2aRemoteAgent` supports only asynchronous methods - this is the limitation of the A2A client we use.
 
-To read more about how to use `A2aRemoteAgent`, please refer to [A2A Client Usage](./client){.internal-link} documentation.
+To read more about how to use `A2aRemoteAgent`, please refer to <a href="./client" className="internal-link">A2A Client Usage</a> documentation.
 
 ## Interoperability with other frameworks
 
-A2A is supported [by other frameworks](https://a2a-protocol.org/latest/community/#a2a-integrations){.external-link target="_blank"}, so you can use `A2aRemoteAgent` with them, too.
+A2A is supported <a href="https://a2a-protocol.org/latest/community/#a2a-integrations" className="external-link" target="_blank" rel="noopener noreferrer">by other frameworks</a>, so you can use `A2aRemoteAgent` with them, too.
 
-As an example, you can easily connect your AG2 agents with [Pydantic AI](https://ai.pydantic.dev/a2a/){.external-link target="_blank"} agents:
+As an example, you can easily connect your AG2 agents with <a href="https://ai.pydantic.dev/a2a/" className="external-link" target="_blank" rel="noopener noreferrer">Pydantic AI</a> agents:
 
 ```python title="server.py" linenums="1"
 from pydantic_ai import Agent

--- a/website/docs/user-guide/a2a/server.mdx
+++ b/website/docs/user-guide/a2a/server.mdx
@@ -3,8 +3,6 @@ title: "A2A Server Setup"
 description: "Learn how to set up and configure A2A agent servers for distributed communication."
 ---
 
-# A2A Server Setup
-
 The A2A server allows you to expose your AG2 agents as web services that can be accessed by remote clients. This guide covers everything you need to know about setting up and configuring A2A servers.
 
 ## Simple Server Setup
@@ -44,7 +42,7 @@ uvicorn server:server --host 0.0.0.0 --port 8000
 
 ### Remote Tools execution details
 
-AG2 has a great feature - [Tools](/docs/user-guide/advanced-concepts/tools){.internal-link}. Our A2A agent executor allows your remote agents to execute any tool by themselves. So, if your client calls an agent with a tool, their tools will be executed and the result processed by the remote agent, with a final result returned to the client.
+AG2 has a great feature - <a href="/docs/user-guide/advanced-concepts/tools" className="internal-link">Tools</a>. Our A2A agent executor allows your remote agents to execute any tool by themselves. So, if your client calls an agent with a tool, their tools will be executed and the result processed by the remote agent, with a final result returned to the client.
 
 ```python title="remote.py" linenums="1" hl_lines="17-23"
 from datetime import datetime
@@ -179,8 +177,8 @@ server = A2aAgentServer(agent).build()
 
 Additionally, remote agents support AG2's Group Chat features without needing any additional configuration:
 
-- [Context Variables](/docs/user-guide/advanced-concepts/orchestration/group-chat/context-variables/){.internal-link}
-- [Guardrails](/docs/user-guide/advanced-concepts/orchestration/group-chat/guardrails/){.internal-link}
+- <a href="/docs/user-guide/advanced-concepts/orchestration/group-chat/context-variables/" className="internal-link">Context Variables</a>
+- <a href="/docs/user-guide/advanced-concepts/orchestration/group-chat/guardrails/" className="internal-link">Guardrails</a>
 
 Just use these features with your remote `ConversableAgent` agent, wrap it in `A2aAgentServer`, and let the magic happen!
 
@@ -242,11 +240,11 @@ general_agent = A2aRemoteAgent(
 
 ## Advanced A2A Configuration
 
-AG2 doesn't limit A2A to a default implementation. You can specify any and all parts of the server that you need. To enable this, we provide a way to use the native [A2A python sdk](https://github.com/a2aproject/a2a-python){.external-link target="_blank"} to fully customize your server.
+AG2 doesn't limit A2A to a default implementation. You can specify any and all parts of the server that you need. To enable this, we provide a way to use the native <a href="https://github.com/a2aproject/a2a-python" className="external-link" target="_blank" rel="noopener noreferrer">A2A python sdk</a> to fully customize your server.
 
 ### Agent Card
 
-The Agent Card describes your agent's capabilities and is [automatically discovered by clients](https://a2a-protocol.org/latest/topics/agent-discovery/){.external-link target="_blank"}.
+The Agent Card describes your agent's capabilities and is <a href="https://a2a-protocol.org/latest/topics/agent-discovery/" className="external-link" target="_blank" rel="noopener noreferrer">automatically discovered by clients</a>.
 
 To configure an Agent Card, you can use the `agent_card` and `extended_agent_card` parameters.
 
@@ -323,4 +321,4 @@ app = A2AFastAPIApplication(
 ).build()
 ```
 
-Please refer to the [A2A python sdk](https://github.com/a2aproject/a2a-python){.external-link target="_blank"} documentation for more details on how to use it.
+Please refer to the <a href="https://github.com/a2aproject/a2a-python" className="external-link" target="_blank" rel="noopener noreferrer">A2A python sdk</a> documentation for more details on how to use it.

--- a/website/docs/user-guide/advanced-concepts/code-execution.mdx
+++ b/website/docs/user-guide/advanced-concepts/code-execution.mdx
@@ -455,7 +455,7 @@ code_executor_agent = ConversableAgent(
 # Test execution
 task = """
 Run this Python code:
-```python
+\`\`\`python
 import pandas as pd
 import numpy as np
 
@@ -474,7 +474,7 @@ return {
     "x_mean": round(data['x'].mean(), 2),
     "y_mean": round(data['y'].mean(), 2)
 }
-```
+\`\`\`
 """
 
 reply = code_executor_agent.generate_reply(messages=[{"role": "user", "content": task}])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR fixes parse error on A2A Documentation
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number


<!-- For example: "Closes #1234" -->
<img width="830" height="151" alt="Screenshot 2025-12-22 at 3 09 44 PM" src="https://github.com/user-attachments/assets/1d93e000-d446-4657-b781-81a2e34535aa" />

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
