### PR TITLE
fix: claude reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,27 +1,25 @@
 name: Claude Code Review
 
 on:
-  # For PRs from the same repository (fast path)
+  # For PRs from the same repository
   pull_request:
     types:
       - opened
       - synchronize
       - ready_for_review
-  # For PRs from forked repositories (secure path with secrets)
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - ready_for_review
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
 
 jobs:
-  # Job for same-repo PRs (can use OIDC if needed)
-  claude-review-same-repo:
+  claude-review:
     if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false
-
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,15 +33,39 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Checkout PR branch
+      - name: Check PR and checkout branch
+        id: check-pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Checking out PR #${{ github.event.pull_request.number }}"
-          gh pr checkout ${{ github.event.pull_request.number }}
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            PR_NUMBER="${{ github.event.inputs.pr_number }}"
+          else
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          fi
+
+          echo "Checking PR #$PR_NUMBER"
+
+          # Check if it's a forked PR
+          PR_INFO=$(gh pr view $PR_NUMBER --json isCrossRepository,headRepositoryOwner,headRepository 2>/dev/null || echo '{}')
+          IS_FORK=$(echo "$PR_INFO" | jq -r '.isCrossRepository // false')
+          HEAD_REPO=$(echo "$PR_INFO" | jq -r '.headRepository.nameWithOwner // ""')
+
+          # Skip (don't fail) forked PRs on automatic triggers, but allow manual triggers
+          if [ "${{ github.event_name }}" == "pull_request" ] && ([ "$IS_FORK" = "true" ] || [ "$HEAD_REPO" != "${{ github.repository }}" ]); then
+            echo "⏭️  Skipping review: PR #$PR_NUMBER is from a forked repository"
+            echo "Forked PRs are skipped for automatic reviews. Use workflow_dispatch to manually trigger a review."
+            echo "skip_review=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Checking out PR #$PR_NUMBER"
+          gh pr checkout $PR_NUMBER
           echo "✅ PR branch checked out successfully"
+          echo "skip_review=false" >> $GITHUB_OUTPUT
 
       - name: Run Claude Code Review
+        if: steps.check-pr.outputs.skip_review != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
@@ -51,66 +73,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-
-            # Steps to run a Review:
-              1) Check if previous review is already done by Claude. If so, perform a re-reivew with the latest changes referring previous review.
-              2) If no previous review is found, perform a new review with the latest changes.
-
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
-
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-
-  # Job for forked PRs (no OIDC, token-based only)
-  claude-review-forked:
-    if: |
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      github.event.pull_request.draft == false
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: read
-      # Explicitly disable id-token to avoid OIDC flow
-
-    steps:
-      - name: Checkout repository (no credentials persisted)
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Checkout PR branch (forked PR)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "⚠️  Forked PR detected - running in secure mode"
-          echo "PR from: ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "Base repo: ${{ github.repository }}"
-          echo "Checking out PR #${{ github.event.pull_request.number }}"
-          gh pr checkout ${{ github.event.pull_request.number }}
-          echo "✅ PR branch checked out successfully"
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event.pull_request.number }}
 
             Please review this pull request and provide feedback on:
             - Code quality and best practices


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Removed the claude-review-forked job and pull_request_target trigger
- Renamed claude-review-same-repo to claude-review
- Added workflow_dispatch with a pr_number input
- Added a step that checks if the PR is forked:
- On automatic pull_request triggers: skips (exits 0) for forked PRs
- On manual workflow_dispatch triggers: allows forked PRs
- The review step runs only if skip_review != 'true'
This results in:
- A single job that skips forked PRs on automatic triggers (no failure)
- Manual triggers via workflow_dispatch work for forked PRs
- Same-repo PRs are reviewed automatically
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
