### PR TITLE
fix link in doc

### DIFF
--- a/website/docs/user-guide/advanced-concepts/orchestration/group-chat/handoffs.mdx
+++ b/website/docs/user-guide/advanced-concepts/orchestration/group-chat/handoffs.mdx
@@ -102,7 +102,7 @@ Function Targets allow you to fetch that information and include it explicitly a
 
 #### Example
 
-Refer to this [example](https://github.com/ag2ai/ag2/blob/main/notebook/function_target_example.ipynb), demonstrating a `FunctionTarget` being used to inspect and validate agent output.
+Refer to this [example](https://github.com/ag2ai/ag2/blob/main/notebook/agentchat_function_target_example.ipynb), demonstrating a `FunctionTarget` being used to inspect and validate agent output.
 
 ### ReplyResults and Transitions
 


### PR DESCRIPTION
## Why are these changes needed?

I found a broken link in the documentation that appeared after renaming the files. I decided to fix it quickly.


## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
