### PR TITLE
fix: Ignore OpenTelemetry tests for core tests with llms

### DIFF
--- a/scripts/test-core-llm.sh
+++ b/scripts/test-core-llm.sh
@@ -28,4 +28,4 @@ done
 echo "Running tests with mark: $MARK"
 
 # Call the test script with the correct mark and any remaining arguments
-bash scripts/test.sh "$@" -m "$MARK" --ignore=test/agentchat/contrib
+bash scripts/test.sh "$@" -m "$MARK" --ignore=test/agentchat/contrib --ignore=test/opentelemetry


### PR DESCRIPTION
## Why are these changes needed?

OpenTelemetry not required for llm tests

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
