### PR TITLE
Fixed sample code. Improved error message when docker is not running

### DIFF
--- a/website/docs/user-guide/advanced-concepts/code-execution.mdx
+++ b/website/docs/user-guide/advanced-concepts/code-execution.mdx
@@ -131,6 +131,8 @@ To use docker execution, you need to [install Docker](https://docs.docker.com/en
 Once you have Docker installed and running, you can set up your code executor agent as follow:
 
 ```python
+import tempfile
+from autogen import ConversableAgent
 from autogen.coding import DockerCommandLineCodeExecutor
 
 # Create a temporary directory to store the code files.


### PR DESCRIPTION

## Why are these changes needed?

https://docs.ag2.ai/latest/docs/user-guide/advanced-concepts/code-execution/#docker-execution
was not working until I added missing imports and started docker. 

Without running docker service, error message is not easy to understand:

Traceback (most recent call last):
  File "/Users/VasiliyR/GitHub/demo6/test3.py", line 8, in <module>
    executor = DockerCommandLineCodeExecutor(
        image="python:3.12-slim",  # Execute code using the given docker image name.
    ...<7 lines>...
        },
    )
  File "/Users/VasiliyR/GitHub/demo6/.venv/lib/python3.13/site-packages/autogen/coding/docker_commandline_code_executor.py", line 121, in __init__
    client = docker.from_env()
  File "/Users/VasiliyR/GitHub/demo6/.venv/lib/python3.13/site-packages/docker/client.py", line 94, in from_env
    return cls(
        timeout=timeout,
    ...<3 lines>...
        **kwargs_from_env(**kwargs)
    )
  File "/Users/VasiliyR/GitHub/demo6/.venv/lib/python3.13/site-packages/docker/client.py", line 45, in __init__
    self.api = APIClient(*args, **kwargs)
               ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/VasiliyR/GitHub/demo6/.venv/lib/python3.13/site-packages/docker/api/client.py", line 207, in __init__
    self._version = self._retrieve_server_version()
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/VasiliyR/GitHub/demo6/.venv/lib/python3.13/site-packages/docker/api/client.py", line 230, in _retrieve_server_version
    raise DockerException(
        f'Error while fetching server API version: {e}'
    ) from e
docker.errors.DockerException: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))



## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
