### PR TITLE
Pydantic copy to model_copy

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -853,7 +853,9 @@ class OpenAIWrapper:
         extra_kwargs.pop("routing_method", None)
 
         if config_list:
-            config_list = [config.copy() for config in config_list]  # make a copy before modifying
+            config_list = [
+                config.model_dump() if hasattr(config, "model_dump") else config.copy() for config in config_list
+            ]  # make a copy before modifying
             for config_item in config_list:
                 self._register_default_client(config_item, openai_config)
                 # Construct current_config_extra_kwargs using the cleaned extra_kwargs

--- a/test/oai/test_client.py
+++ b/test/oai/test_client.py
@@ -226,6 +226,24 @@ def test_round_robin_routing_with_failures(mock_openai_wrapper_round_robin: Open
     assert mock_openai_wrapper_round_robin._round_robin_index == 1
 
 
+def test_config_list_with_pydantic_models():
+    """Test that OpenAIWrapper handles Pydantic model config items from LLMConfig unpacking."""
+    config = LLMConfig({"api_type": "openai", "model": "gpt-5-nano", "api_key": "test_key"})
+    wrapper = OpenAIWrapper(**config)
+
+    assert len(wrapper._config_list) == 1
+    assert wrapper._config_list[0]["model"] == "gpt-5-nano"
+
+
+def test_config_list_with_dict_items():
+    """Test that OpenAIWrapper still handles plain dict config items correctly."""
+    config_list = [{"model": "gpt-5-nano", "api_key": "test_key"}]
+    wrapper = OpenAIWrapper(config_list=config_list)
+
+    assert len(wrapper._config_list) == 1
+    assert wrapper._config_list[0]["model"] == "gpt-5-nano"
+
+
 TOOL_ENABLED = False
 
 with optional_import_block() as result:


### PR DESCRIPTION
## Why are these changes needed?

Update Pydantic code use to use `model_copy` from the soon to be deprecated `copy`. 

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
