### PR TITLE
fix: Support parallel tool calls in Gemini client

### DIFF
--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -1249,8 +1249,6 @@ async def _test_function_registration_e2e_async(credentials: Credentials) -> Non
 async def test_function_registration_e2e_async(
     credentials_from_test_param: Credentials,
 ) -> None:
-    if credentials_from_test_param.api_type == "google":
-        pytest.skip("This test currently fails with gemini flash model")
     await _test_function_registration_e2e_async(credentials_from_test_param)
 
 

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -240,6 +240,84 @@ class TestGeminiClient:
         assert converted_messages[2].role == "user", "Message without role should default to 'user'"
         assert converted_messages[2].parts[0].text == "Another message without role"
 
+    def test_parallel_function_responses_merged(self, gemini_client):
+        """Test that consecutive tool response messages are merged into a single Content object.
+
+        Gemini requires that the number of FunctionResponse parts equals the number of
+        FunctionCall parts in the preceding model turn. When parallel function calls are
+        made, AG2 unrolls the tool_responses into separate messages, but they must be
+        recombined into a single Content for Gemini.
+        """
+
+        # Set up tool_call_function_map as would happen during a real conversation
+        gemini_client.tool_call_function_map["1777"] = "timer"
+        gemini_client.tool_call_function_map["1778"] = "stopwatch"
+
+        messages = [
+            {"role": "user", "content": "Create a timer for 1 second and then a stopwatch for 2 seconds."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "1777",
+                        "type": "function",
+                        "function": {"name": "timer", "arguments": '{"num_seconds": "1"}'},
+                    },
+                    {
+                        "id": "1778",
+                        "type": "function",
+                        "function": {"name": "stopwatch", "arguments": '{"num_seconds": "2"}'},
+                    },
+                ],
+            },
+            # These are the unrolled tool_responses — two separate messages
+            {"role": "tool", "tool_call_id": "1777", "content": "Timer is done!"},
+            {"role": "tool", "tool_call_id": "1778", "content": "Stopwatch is done!"},
+        ]
+
+        converted = gemini_client._oai_messages_to_gemini_messages(messages)
+
+        # Should be: user message, model tool_call, single user with 2 FunctionResponse parts
+        assert len(converted) == 3, f"Expected 3 Content objects, got {len(converted)}"
+
+        # The third Content should have 2 FunctionResponse parts merged together
+        tool_response_content = converted[2]
+        assert tool_response_content.role == "user"
+        assert len(tool_response_content.parts) == 2, (
+            f"Expected 2 FunctionResponse parts in one Content, got {len(tool_response_content.parts)}"
+        )
+        assert tool_response_content.parts[0].function_response.name == "timer"
+        assert tool_response_content.parts[1].function_response.name == "stopwatch"
+
+    def test_single_function_response_not_affected(self, gemini_client):
+        """Test that a single tool response still works correctly."""
+        gemini_client.tool_call_function_map["123"] = "my_func"
+
+        messages = [
+            {"role": "user", "content": "Call my_func"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "123",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "123", "content": "done"},
+        ]
+
+        converted = gemini_client._oai_messages_to_gemini_messages(messages)
+
+        assert len(converted) == 3
+        tool_response_content = converted[2]
+        assert tool_response_content.role == "user"
+        assert len(tool_response_content.parts) == 1
+        assert tool_response_content.parts[0].function_response.name == "my_func"
+
     def test_vertexai_safety_setting_conversion(self):
         safety_settings = [
             {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_ONLY_HIGH"},


### PR DESCRIPTION
## Why are these changes needed?

When Gemini returns parallel function calls (e.g., timer + stopwatch in a single turn), ConversableAgent unrolls the tool responses into separate messages — one per function response. The Gemini API then rejects this because it requires all function responses to be bundled in a single message matching the number of function calls.

The fix: When building the Gemini message history, consecutive tool response messages are now merged into a single `Content` object with multiple `FunctionResponse` parts, instead of creating separate `Content` objects for each one.

## Related issue number

#678

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
