### PR TITLE
feat: Add extra_headers support to OpenAILLMConfigEntry and AzureOpenAILLMConfigEntry

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -254,6 +254,7 @@ class OpenAIEntryDict(LLMConfigEntryDict, total=False):
     stream: bool
     verbosity: Literal["low", "medium", "high"] | None
     extra_body: dict[str, Any] | None
+    extra_headers: dict[str, str] | None
     reasoning_effort: Literal["none", "low", "minimal", "medium", "high", "xhigh"] | None
     max_completion_tokens: int | None
 
@@ -274,6 +275,9 @@ class OpenAILLMConfigEntry(LLMConfigEntry):
     extra_body: dict[str, Any] | None = (
         None  # For VLLM - See here: https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-parameters
     )
+    extra_headers: dict[str, str] | None = (
+        None  # For VLLM and other OpenAI-compatible servers - See: https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-http-headers
+    )
     # reasoning models - see: https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort
     reasoning_effort: Literal["none", "low", "minimal", "medium", "high", "xhigh"] | None = None
     max_completion_tokens: int | None = None
@@ -289,6 +293,7 @@ class AzureOpenAIEntryDict(LLMConfigEntryDict, total=False):
     stream: bool
     tool_choice: Literal["none", "auto", "required"] | None
     user: str | None
+    extra_headers: dict[str, str] | None
     reasoning_effort: Literal["low", "minimal", "medium", "high"] | None
     max_completion_tokens: int | None
 
@@ -300,6 +305,7 @@ class AzureOpenAILLMConfigEntry(LLMConfigEntry):
     stream: bool = False
     tool_choice: Literal["none", "auto", "required"] | None = None
     user: str | None = None
+    extra_headers: dict[str, str] | None = None
     # reasoning models - see:
     # - https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/reasoning
     # - https://learn.microsoft.com/en-us/azure/ai-services/openai/reference-preview

--- a/test/oai/test_client.py
+++ b/test/oai/test_client.py
@@ -1085,3 +1085,50 @@ class TestO1:
     @pytest.mark.skip(reason="Wait for o1 to be available in CI")
     def test_completion_o1(self, o1_client: OpenAIWrapper, messages: list[dict[str, str]]) -> None:
         self._test_completion(o1_client, messages)
+
+
+def test_openai_llm_config_entry_extra_headers():
+    """Test that extra_headers is stored correctly on OpenAILLMConfigEntry."""
+    headers = {"X-Custom-Header": "test-value", "Authorization": "Bearer token123"}
+    entry = OpenAILLMConfigEntry(
+        model="gpt-4o-mini",
+        api_key="sk-mockopenaiAPIkeysinexpectedformatsfortestingonly",
+        extra_headers=headers,
+    )
+    assert entry.extra_headers == headers
+
+
+def test_openai_llm_config_entry_extra_headers_default_none():
+    """Test that extra_headers defaults to None."""
+    entry = OpenAILLMConfigEntry(
+        model="gpt-4o-mini",
+        api_key="sk-mockopenaiAPIkeysinexpectedformatsfortestingonly",
+    )
+    assert entry.extra_headers is None
+
+
+def test_azure_llm_config_entry_extra_headers():
+    """Test that extra_headers is stored correctly on AzureOpenAILLMConfigEntry."""
+    headers = {"X-Custom-Header": "test-value"}
+    entry = AzureOpenAILLMConfigEntry(
+        model="gpt-4o-mini",
+        api_key="sk-mockopenaiAPIkeysinexpectedformatsfortestingonly",
+        base_url="https://api.openai.com/v1",
+        api_version="2024-02-01",
+        extra_headers=headers,
+    )
+    assert entry.extra_headers == headers
+
+
+@run_for_optional_imports("openai", "openai")
+@run_for_optional_imports(["openai"], "openai")
+def test_extra_headers_chat_completion(credentials_gpt_4o_mini: Credentials):
+    """Test that extra_headers flows through to the API without error."""
+    config_list = [
+        {**config, "extra_headers": {"X-Custom-Test": "ag2-extra-headers"}}
+        for config in credentials_gpt_4o_mini.config_list
+    ]
+    client = OpenAIWrapper(config_list=config_list)
+    response = client.create(messages=[{"role": "user", "content": "1+1="}], cache_seed=None)
+    print(response)
+    print(client.extract_text_or_completion_object(response))

--- a/website/docs/user-guide/models/grok-and-oai-compatible-models.mdx
+++ b/website/docs/user-guide/models/grok-and-oai-compatible-models.mdx
@@ -251,6 +251,7 @@ llm_config = LLMConfig({
 - Use the correct `api_type` for your provider (`"openai"` for most compatible services)
 - Place common parameters like `temperature` at the top level of `LLMConfig`
 - Use `extra_body` for provider-specific features like Grok's search parameters
+- Use `extra_headers` for custom HTTP headers required by your server (e.g., authentication tokens, routing headers for [VLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-http-headers) or other OpenAI-compatible servers)
 
 ### 3. Function Registration
 - Register functions with `ConversableAgent.functions`, not `LLMConfig.tools`

--- a/website/docs/user-guide/models/openai.mdx
+++ b/website/docs/user-guide/models/openai.mdx
@@ -66,6 +66,27 @@ Interested in trying out image generation with the new OpenAI Responses API? Che
 </Tip>
 
 
+## Extra Headers
+
+You can pass custom HTTP headers on each API request using the `extra_headers` parameter. This is useful when working through API gateways, proxies, or OpenAI-compatible servers that require additional headers for authentication, routing, or observability.
+
+```python
+from autogen import LLMConfig
+
+llm_config = LLMConfig(
+    api_type="openai",
+    model="gpt-4o-mini",
+    api_key="your OpenAI Key goes here",
+    extra_headers={
+        "X-Custom-Header": "my-value",
+    },
+)
+```
+
+<Note>
+`extra_headers` is a per-request parameter passed on each call. This is different from `default_headers`, which is set once on the client constructor and applies to all requests made by that client.
+</Note>
+
 ## Examples
 
 See the [ConversableAgent example](/docs/user-guide/basic-concepts/conversable-agent) in our [Basic Concepts](/docs/user-guide/basic-concepts/installing-ag2) documentation to see OpenAI's LLMs in use.


### PR DESCRIPTION
## Why are these changes needed?

As per Issue #1671, this adds support for `extra_headers` support to OpenAILLMConfigEntry and AzureOpenAILLMConfigEntry

## Related issue number

Closes #1671

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
