### PR TITLE
chore: Change PDF used in tests

### DIFF
--- a/test/const.py
+++ b/test/const.py
@@ -25,8 +25,8 @@ WIKIPEDIA_STRING = "Redmond"
 PLAIN_TEXT_URL = "https://raw.githubusercontent.com/ag2ai/ag2/main/README.md"
 IMAGE_URL = "https://github.com/afourney.png"
 
-PDF_URL = "https://arxiv.org/pdf/2308.08155.pdf"
-PDF_STRING = "Figure 1: AutoGen enables diverse LLM-based applications using multi-agent conversations."
+PDF_URL = "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
+PDF_STRING = "Dummy PDF file"
 
 BING_QUERY = "Microsoft"
 BING_TITLE = f"{BING_QUERY} - Search"


### PR DESCRIPTION
## Why are these changes needed?

The PDF used in tests that try and retrieve it is now raising a CAPTCHA. Changed to a dummy PDF that doesn't have a CAPTCHA.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
