### PR TITLE
docs: CircuitBreakerCapability + SAFE_MODE integration examples

### DIFF
--- a/notebook/tools_veronica_circuit_breaker.ipynb
+++ b/notebook/tools_veronica_circuit_breaker.ipynb
@@ -1,0 +1,267 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Veronica Core: Circuit Breaker for AG2 Agents\n",
+    "\n",
+    "Production multi-agent systems fail in two distinct ways:\n",
+    "\n",
+    "- **Individual agent failure** - one LLM endpoint degrades while others are healthy.\n",
+    "- **System-wide emergency** - something is deeply wrong and every agent must stop immediately.\n",
+    "\n",
+    "The [veronica-core](https://github.com/amabito/veronica-core) library handles both with a single\n",
+    "`CircuitBreakerCapability` that attaches to any AG2 agent via the standard `add_to_agent()` pattern.\n",
+    "\n",
+    "1. **Basic circuit breaker** - an agent trips after repeated failures; callers receive `None` instead of hanging.\n",
+    "2. **System-wide SAFE_MODE** - a shared `VeronicaIntegration` blocks all agents instantly on anomaly detection, then recovers in two steps.\n",
+    "3. **Per-agent isolation** - a broken agent's open circuit does not affect healthy agents sharing the same capability instance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "```bash\n",
+    "pip install -U \"autogen[openai]\" veronica-core\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors\n",
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "\n",
+    "from veronica_core import (\n",
+    "    CircuitBreakerCapability,\n",
+    "    MemoryBackend,\n",
+    "    VeronicaIntegration,\n",
+    "    VeronicaState,\n",
+    ")\n",
+    "\n",
+    "from autogen import ConversableAgent"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Demo 1: Basic Circuit Breaker\n",
+    "\n",
+    "A `CircuitBreakerCapability` wraps `agent.generate_reply()` transparently.\n",
+    "When an agent returns `None` (the AG2 convention for \"I have no reply\"),\n",
+    "the breaker counts it as a failure. After `failure_threshold` consecutive\n",
+    "failures the circuit opens, and subsequent calls return `None` immediately\n",
+    "without invoking the agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# An agent whose backend is completely broken (always returns None)\n",
+    "planner = ConversableAgent(\"planner\", llm_config=False)\n",
+    "planner.register_reply(\n",
+    "    trigger=lambda _: True,\n",
+    "    reply_func=lambda agent, messages, sender, config: (True, None),\n",
+    "    position=0,\n",
+    "    remove_other_reply_funcs=True,\n",
+    ")\n",
+    "\n",
+    "cap = CircuitBreakerCapability(failure_threshold=3)\n",
+    "cap.add_to_agent(planner)\n",
+    "\n",
+    "breaker = cap.get_breaker(\"planner\")\n",
+    "print(f\"initial state  : {breaker.state}\")  # CircuitState.CLOSED\n",
+    "\n",
+    "msg = [{\"role\": \"user\", \"content\": \"test\"}]\n",
+    "\n",
+    "# Three None replies trip the circuit\n",
+    "for _ in range(3):\n",
+    "    planner.generate_reply(msg)\n",
+    "\n",
+    "print(f\"after 3 failures: {breaker.state}\")  # CircuitState.OPEN\n",
+    "print(f\"failure count   : {breaker.failure_count}\")  # 3\n",
+    "\n",
+    "# Subsequent calls are short-circuited -- the agent is never invoked\n",
+    "reply = planner.generate_reply(msg)\n",
+    "print(f\"reply when open : {reply!r}\")  # None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## Demo 2: System-wide SAFE_MODE\n",
+    "\n",
+    "When multiple agents share a single `VeronicaIntegration`, any component can\n",
+    "trigger a system-wide halt by transitioning to `SAFE_MODE`. All agents are\n",
+    "blocked immediately — no code changes at call sites.\n",
+    "\n",
+    "Recovery requires two explicit transitions (`SAFE_MODE → IDLE → SCREENING`) —\n",
+    "skipping straight to SCREENING isn't valid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _always_ok(agent, messages, sender, config):\n",
+    "    return True, f\"{agent.name}: ok\"\n",
+    "\n",
+    "\n",
+    "# MemoryBackend keeps state in-process -- no files written during the demo\n",
+    "veronica = VeronicaIntegration(backend=MemoryBackend())\n",
+    "cap2 = CircuitBreakerCapability(failure_threshold=5, veronica=veronica)\n",
+    "\n",
+    "msg = [{\"role\": \"user\", \"content\": \"test\"}]\n",
+    "\n",
+    "planner2 = ConversableAgent(\"planner\", llm_config=False)\n",
+    "executor2 = ConversableAgent(\"executor\", llm_config=False)\n",
+    "for agent in (planner2, executor2):\n",
+    "    agent.register_reply(\n",
+    "        trigger=lambda _: True,\n",
+    "        reply_func=_always_ok,\n",
+    "        position=0,\n",
+    "        remove_other_reply_funcs=True,\n",
+    "    )\n",
+    "    cap2.add_to_agent(agent)\n",
+    "\n",
+    "# Both agents are healthy\n",
+    "print(planner2.generate_reply(msg))  # planner: ok\n",
+    "print(executor2.generate_reply(msg))  # executor: ok\n",
+    "\n",
+    "# Anomaly detected -- halt everything immediately\n",
+    "# VeronicaIntegration starts in SCREENING, so SCREENING -> SAFE_MODE is valid\n",
+    "veronica.state.transition(VeronicaState.SAFE_MODE, reason=\"anomaly detected\")\n",
+    "print(planner2.generate_reply(msg))  # None -- blocked by SAFE_MODE\n",
+    "print(executor2.generate_reply(msg))  # None -- blocked by SAFE_MODE\n",
+    "\n",
+    "# Two-step recovery: confirm stability (IDLE), then resume screening\n",
+    "veronica.state.transition(VeronicaState.IDLE, reason=\"anomaly resolved\")\n",
+    "veronica.state.transition(VeronicaState.SCREENING, reason=\"resuming\")\n",
+    "print(planner2.generate_reply(msg))  # planner: ok\n",
+    "print(executor2.generate_reply(msg))  # executor: ok"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## Demo 3: Per-agent Isolation\n",
+    "\n",
+    "Each call to `add_to_agent()` creates an independent `CircuitBreaker` for that\n",
+    "agent. A broken agent's circuit opening does not affect any other agent, even\n",
+    "when they share the same `CircuitBreakerCapability` instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cap3 = CircuitBreakerCapability(failure_threshold=2)\n",
+    "\n",
+    "healthy = ConversableAgent(\"healthy\", llm_config=False)\n",
+    "healthy.register_reply(\n",
+    "    trigger=lambda _: True,\n",
+    "    reply_func=lambda agent, messages, sender, config: (True, \"healthy: ok\"),\n",
+    "    position=0,\n",
+    "    remove_other_reply_funcs=True,\n",
+    ")\n",
+    "\n",
+    "broken = ConversableAgent(\"broken\", llm_config=False)\n",
+    "broken.register_reply(\n",
+    "    trigger=lambda _: True,\n",
+    "    reply_func=lambda agent, messages, sender, config: (True, None),\n",
+    "    position=0,\n",
+    "    remove_other_reply_funcs=True,\n",
+    ")\n",
+    "\n",
+    "cap3.add_to_agent(healthy)\n",
+    "cap3.add_to_agent(broken)\n",
+    "\n",
+    "msg = [{\"role\": \"user\", \"content\": \"test\"}]\n",
+    "\n",
+    "# Trip the broken agent's circuit\n",
+    "broken.generate_reply(msg)\n",
+    "broken.generate_reply(msg)\n",
+    "print(f\"broken  state: {cap3.get_breaker('broken').state}\")  # CircuitState.OPEN\n",
+    "\n",
+    "# The healthy agent is completely unaffected -- same cap, independent breaker\n",
+    "print(f\"healthy reply: {healthy.generate_reply(msg)!r}\")  # 'healthy: ok'\n",
+    "print(f\"healthy state: {cap3.get_breaker('healthy').state}\")  # CircuitState.CLOSED"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Feature | API |\n",
+    "|---------|-----|\n",
+    "| Protect an agent | `cap.add_to_agent(agent)` |\n",
+    "| Inspect circuit state | `cap.get_breaker(agent.name).state` |\n",
+    "| System-wide halt | `veronica.state.transition(VeronicaState.SAFE_MODE, ...)` |\n",
+    "| Recovery | `SAFE_MODE -> IDLE -> SCREENING` (two explicit transitions) |\n",
+    "| Backend for demos | `MemoryBackend()` (no file I/O) |\n",
+    "\n",
+    "Existing `agent.generate_reply(messages)` calls need no changes."
+   ]
+  }
+ ],
+ "metadata": {
+  "front_matter": {
+   "description": "Use veronica-core's CircuitBreakerCapability to add per-agent circuit breakers and system-wide SAFE_MODE to AG2 multi-agent workflows.",
+   "tags": [
+    "tools",
+    "veronica",
+    "circuit-breaker",
+    "local-llm",
+    "reliability"
+   ]
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- Adds `CircuitBreakerCapability` 窶? an AG2 `AgentCapability`-compatible circuit breaker that protects against runaway agent loops without changing call sites
- AG2 retries failed agents indefinitely; this integration lets you stop that at `failure_threshold` consecutive `None` replies, or halt all agents system-wide via `SAFE_MODE`
- Includes working demos and a README covering the recommended capability pattern and the lower-level wrapper pattern (for reference)

## What this adds

`CircuitBreakerCapability` follows AG2's `AgentCapability` pattern 窶? drop it in at setup time; existing `generate_reply()` call sites don't change.

```python
from veronica_core import CircuitBreakerCapability

cap = CircuitBreakerCapability(failure_threshold=3, recovery_timeout=60)
cap.add_to_agent(planner)
cap.add_to_agent(executor)

# Ordinary AG2 call 窶? circuit breaker is transparent:
reply = planner.generate_reply(messages)
```

Each agent tracks its own failures independently. Hit `failure_threshold` consecutive `None` replies and that agent's circuit opens (OPEN state) 窶? further calls return `None` immediately without touching the agent. After `recovery_timeout` seconds the circuit moves to HALF_OPEN and allows one test call; a success closes it, another failure re-opens it.

A shared `VeronicaIntegration` can be passed for system-wide `SAFE_MODE` support.

## Usage

### Basic circuit breaker

```python
from autogen import ConversableAgent
from veronica_core import CircuitBreakerCapability

planner = ConversableAgent(
    name="planner",
    llm_config={"model": "gpt-4o-mini"},
)

cap = CircuitBreakerCapability(failure_threshold=3, recovery_timeout=60)
cap.add_to_agent(planner)

reply = planner.generate_reply(messages)  # unchanged call site

# Inspect state at any time:
breaker = cap.get_breaker("planner")
print(breaker.state)          # CircuitState.CLOSED / OPEN / HALF_OPEN
print(breaker.failure_count)  # consecutive failures
```

### With SAFE_MODE (system-wide halt)

```python
from veronica_core import CircuitBreakerCapability, VeronicaIntegration
from veronica_core.backends import MemoryBackend
from veronica_core.state import VeronicaState

veronica = VeronicaIntegration(backend=MemoryBackend())
cap = CircuitBreakerCapability(failure_threshold=3, veronica=veronica)
cap.add_to_agent(planner)
cap.add_to_agent(executor)

# Block all agents instantly from your orchestrator:
veronica.state.transition(VeronicaState.SAFE_MODE, reason="Cost spike detected")

# Clear once resolved (two-step; SAFE_MODE -> IDLE -> SCREENING):
veronica.state.transition(VeronicaState.IDLE, reason="Manual review passed")
veronica.state.transition(VeronicaState.SCREENING, reason="Resuming")
```

## Design notes

### How `add_to_agent` works today

`add_to_agent` wraps `agent.generate_reply` via direct attribute replacement. Intentional 窶? keeps things compatible with anything that has `generate_reply`, not just a specific AG2 version.

The closest native AG2 equivalent for the "before" side would be:

```python
agent.register_reply(
    trigger=lambda _: True,
    reply_func=self._circuit_breaker_reply,
    position=0,
)
```

but `register_reply` only fires *before* the reply is generated 窶? there's no hook to observe the *result*. Chaining two `register_reply` calls doesn't help 窶? the second fires before the first has resolved, not after. Circuit state transitions (`record_success` / `record_failure`) need the result, so we wrap `generate_reply` directly for now.

### Interfaces that would make this cleaner

Native hooks would look something like:

```python
# Hypothetical: ReplyInterceptor protocol
class ReplyInterceptor(Protocol):
    def before_reply(
        self,
        agent: ConversableAgent,
        messages: list[dict],
        sender: Optional[Agent],
    ) -> Optional[Any]: ...

    def after_reply(
        self,
        agent: ConversableAgent,
        reply: Any,
        messages: list[dict],
        sender: Optional[Agent],
    ) -> None: ...

# Hypothetical: LLMCallMiddleware protocol
@dataclass
class LLMCallContext:
    model: str
    messages: list[dict]
    request_id: str

class LLMCallMiddleware(Protocol):
    def before_llm_call(self, ctx: LLMCallContext) -> Decision: ...
    def after_llm_call(self, ctx: LLMCallContext) -> None: ...
```

`CircuitBreakerCapability` fits either sketch directly: `before_reply`/`before_llm_call` handles the OPEN-circuit and SAFE_MODE checks; `after_reply`/`after_llm_call` records success or failure.

The `TokenBudgetHook` integration (already in this PR) covers the "LLM middleware" side at the `generate_reply` level: `before_llm_call()` is checked before each agent call, and `record_usage()` is called on success. Full middleware belongs in the LLM client layer eventually, but this works today without touching AG2 internals.

Happy to discuss whether either direction fits AG2's roadmap 窶? or to adapt this implementation if there's a preferred pattern.

## Test plan

- [ ] `notebook/tools_veronica_circuit_breaker.ipynb` runs top to bottom without errors
- [ ] Demo 1 (Basic): circuit opens after `failure_threshold` failures; OPEN circuit returns `None` without invoking the agent
- [ ] Demo 2 (SAFE_MODE): `SAFE_MODE` blocks all agents; two-step recovery restores normal operation
- [ ] Demo 3 (Isolation): healthy agent continues while broken agent's circuit is open
- [ ] `cap.get_breaker(name)` returns the correct `CircuitBreaker` with accurate `state` and `failure_count`
- [ ] Calling `add_to_agent` twice on the same agent logs a warning and returns the existing breaker (no double-wrap)
- [ ] Works with a real `autogen.ConversableAgent` (not just stub agents)
- [ ] `TokenBudgetHook` with `max_output_tokens=0` blocks all calls; agent `_call_count` stays 0
- [ ] `TokenBudgetHook` with headroom: after a successful reply, `hook.output_total > 0`