### PR TITLE
fix: replace 3 bare excepts with except Exception (thanks @haosenwang1018)

### DIFF
--- a/autogen/agentchat/contrib/society_of_mind_agent.py
+++ b/autogen/agentchat/contrib/society_of_mind_agent.py
@@ -193,7 +193,7 @@ class SocietyOfMindAgent(ConversableAgent):
 
         try:
             self.initiate_chat(self.chat_manager, message=messages[-1], clear_history=False)
-        except:
+        except Exception:
             traceback.print_exc()
 
         response_preparer = self.response_preparer

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1494,7 +1494,7 @@ class GroupChatManager(ConversableAgent):
 
         try:
             self._valid_resume_messages(messages)
-        except:
+        except Exception:
             raise
 
         # Load the messages into the group chat
@@ -1597,7 +1597,7 @@ class GroupChatManager(ConversableAgent):
 
         try:
             self._valid_resume_messages(messages)
-        except:
+        except Exception:
             raise
 
         # Load the messages into the group chat


### PR DESCRIPTION
## Summary
- Replace 3 bare `except:` clauses with `except Exception:` in `society_of_mind_agent.py` and `groupchat.py`
- Bare except catches `KeyboardInterrupt` and `SystemExit`, masking real errors

Based on #2428 by @haosenwang1018