### PR TITLE
Fix awaiting awaitable tool results in async execution

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -3597,6 +3597,8 @@ class ConversableAgent(LLMAgent):
                     else:
                         # Fallback to sync function if the function is not async
                         content = func(**arguments)
+                    if inspect.isawaitable(content):
+                        content = await content
                     is_exec_success = True
                 except Exception as e:
                     content = f"Error: {e}"

--- a/test/agentchat/test_function_call.py
+++ b/test/agentchat/test_function_call.py
@@ -209,6 +209,26 @@ async def test_a_execute_function():
     assert (await user.a_execute_function(func_call))[1]["content"] == "42"
 
 
+@pytest.mark.asyncio
+async def test_a_execute_function_awaits_awaitable_returned_by_sync_callable():
+    from autogen.agentchat import UserProxyAgent
+
+    async def add_num_async(num_to_be_added):
+        await asyncio.sleep(0)
+        return str(num_to_be_added + 10)
+
+    def add_num(num_to_be_added):
+        return add_num_async(num_to_be_added)
+
+    user = UserProxyAgent(name="test", function_map={"add_num": add_num})
+    func_call = {"name": "add_num", "arguments": '{ "num_to_be_added": 5 }'}
+
+    is_success, result = await user.a_execute_function(func_call=func_call)
+
+    assert is_success is True
+    assert result["content"] == "15"
+
+
 @run_for_optional_imports("openai", "openai")
 @pytest.mark.skipif(
     not sys.version.startswith("3.10"),


### PR DESCRIPTION
## Why are these changes needed?

Async tool execution worked in v0.10.3 but regressed in v0.11.1.

`a_execute_function()` correctly awaited tools declared as async, but it did not await values returned by sync callables. In practice, this breaks cases where a registered tool is exposed as a synchronous callable but returns an awaitable internally, which affects async execution paths such as `AutoPattern`.

This change awaits awaitable return values and adds a regression test covering that scenario.

## Related issue number

Closes #2434

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.