### PR TITLE
docs: SEO-optimized similar pages

### DIFF
--- a/website/docs/user-guide/models/amazon-bedrock.mdx
+++ b/website/docs/user-guide/models/amazon-bedrock.mdx
@@ -1,6 +1,7 @@
 ---
-title: Amazon Bedrock
+title: Amazon Bedrock Guide | Multi-Agent Framework
 sidebarTitle: Amazon Bedrock
+description: "How to use Amazon Bedrock models with AG2. IAM setup, configuration, and code examples for building multi-agent systems on AWS."
 ---
 
 AG2 allows you to use Amazon's generative AI Bedrock service to run inference with a number of open-weight models and as well as their own models.

--- a/website/docs/user-guide/models/anthropic.mdx
+++ b/website/docs/user-guide/models/anthropic.mdx
@@ -1,6 +1,7 @@
 ---
-title: Anthropic
+title: Anthropic Claude API Guide | Multi-Agent Framework
 sidebarTitle: Anthropic
+description: "How to use Anthropic Claude models with AG2. Configuration, extended thinking, and code examples for building multi-agent systems with Claude."
 ---
 
 Anthropic's Claude is a family of large language models developed by Anthropic and designed to revolutionize the way you interact with AI. Claude excels at a wide variety of tasks involving language, reasoning, analysis, coding, and more. The models are highly capable, easy to use, and can be customized to suit your needs.

--- a/website/docs/user-guide/models/cerebras.mdx
+++ b/website/docs/user-guide/models/cerebras.mdx
@@ -1,6 +1,7 @@
 ---
-title: Cerebras
+title: Cerebras API Guide | Multi-Agent Framework
 sidebarTitle: Cerebras
+description: "How to use Cerebras fast inference with AG2. Configuration and code examples for building high-speed multi-agent systems."
 ---
 
 [Cerebras](https://cerebras.ai) has developed the world's largest and fastest AI processor, the Wafer-Scale Engine-3 (WSE-3). Notably, the CS-3 system can run large language models like Llama-3.1-8B and Llama-3.1-70B at extremely fast speeds, making it an ideal platform for demanding AI workloads.

--- a/website/docs/user-guide/models/cohere.mdx
+++ b/website/docs/user-guide/models/cohere.mdx
@@ -1,6 +1,7 @@
 ---
-title: Cohere
+title: Cohere API Guide | Multi-Agent Framework
 sidebarTitle: Cohere
+description: "How to use Cohere models with AG2. Configuration and code examples for building multi-agent systems with Cohere Command models."
 ---
 
 [Cohere](https://cohere.com/) is a cloud based platform serving their own LLMs, in particular the Command family of models.

--- a/website/docs/user-guide/models/deepseek-v3.mdx
+++ b/website/docs/user-guide/models/deepseek-v3.mdx
@@ -1,6 +1,7 @@
 ---
-title: DeepSeek
+title: DeepSeek API Guide | Multi-Agent Framework
 sidebarTitle: DeepSeek
+description: "How to use DeepSeek models with AG2. Configuration, API setup, and code examples for building multi-agent systems with DeepSeek."
 ---
 
 [DeepSeek-V3](https://github.com/deepseek-ai/DeepSeek-V3) is a strong Mixture-of-Experts (MoE) language model that delivers exceptional performance and speed, surpassing its predecessors. With its advanced capabilities, DeepSeek-V3 ranks among the top open-source models and matches the performance of leading closed-source models.

--- a/website/docs/user-guide/models/google-gemini.mdx
+++ b/website/docs/user-guide/models/google-gemini.mdx
@@ -1,6 +1,7 @@
 ---
-title: Google Gemini
+title: Google Gemini API Guide | Multi-Agent Framework
 sidebarTitle: Google Gemini
+description: "How to use Google Gemini models with AG2. Configuration, API keys, and code examples for building multi-agent systems with Gemini."
 ---
 
 ## Installation

--- a/website/docs/user-guide/models/google-vertexai.mdx
+++ b/website/docs/user-guide/models/google-vertexai.mdx
@@ -1,6 +1,7 @@
 ---
-title: Google Vertex AI
+title: Google Vertex AI Guide | Multi-Agent Framework
 sidebarTitle: Google Vertex AI
+description: "How to use Google Vertex AI with AG2. Authentication, configuration, and code examples for enterprise multi-agent deployments on GCP."
 ---
 
 This notebook demonstrates how to use AG2 with Gemini via Vertex AI, which enables enhanced authentication method that also supports enterprise requirements using service accounts or even a personal Google cloud account.

--- a/website/docs/user-guide/models/groq.mdx
+++ b/website/docs/user-guide/models/groq.mdx
@@ -1,6 +1,7 @@
 ---
-title: Groq
+title: Groq API Guide | Multi-Agent Framework
 sidebarTitle: Groq
+description: "How to use Groq's fast inference API with AG2. Configuration and code examples for building multi-agent systems with Groq."
 ---
 
 [Groq](https://groq.com/) is a cloud based platform serving a number of popular open weight models at high inference speeds. Models include Meta's Llama 3, Mistral AI's Mixtral, and Google's Gemma.

--- a/website/docs/user-guide/models/huggingface.mdx
+++ b/website/docs/user-guide/models/huggingface.mdx
@@ -1,5 +1,6 @@
 ---
-title: HuggingFace (Custom Models)
+title: HuggingFace Custom Models Guide | Multi-Agent Framework
+description: "How to use HuggingFace models with AG2. Setup and code examples for building multi-agent systems with custom and open-source models."
 ---
 
 ## Installation

--- a/website/docs/user-guide/models/litellm-proxy-server/azure.mdx
+++ b/website/docs/user-guide/models/litellm-proxy-server/azure.mdx
@@ -1,6 +1,7 @@
 ---
-title: LiteLLM with Azure
+title: LiteLLM with Azure OpenAI Guide | Multi-Agent Framework
 sidebarTitle: LiteLLM with Azure
+description: "How to use Azure OpenAI models with AG2 via LiteLLM proxy. Configuration and code examples for multi-agent systems on Azure."
 ---
 
 Before starting this guide, ensure you have completed the [Installation Guide](/docs/user-guide/models/litellm-proxy-server/installation) and installed all required dependencies.

--- a/website/docs/user-guide/models/litellm-proxy-server/installation.mdx
+++ b/website/docs/user-guide/models/litellm-proxy-server/installation.mdx
@@ -1,6 +1,7 @@
 ---
-title: Installation
+title: LiteLLM Proxy Server Installation | Multi-Agent Framework
 sidebarTitle: Installation
+description: "How to install and configure LiteLLM proxy server for AG2. Step-by-step setup guide for routing multi-agent LLM requests through LiteLLM."
 ---
 
 [LiteLLM Proxy Server](https://docs.litellm.ai/docs/simple_proxy) is an open-source, self-hosted proxy server that offers an OpenAI-compatible API, enabling seamless interaction with multiple LLM providers like OpenAI, Azure, IBM WatsonX etc.

--- a/website/docs/user-guide/models/litellm-proxy-server/openai.mdx
+++ b/website/docs/user-guide/models/litellm-proxy-server/openai.mdx
@@ -1,6 +1,7 @@
 ---
-title: LiteLLM with OpenAI
+title: LiteLLM with OpenAI Guide | Multi-Agent Framework
 sidebarTitle: LiteLLM with OpenAI
+description: "How to use OpenAI models with AG2 via LiteLLM proxy. Configuration and code examples for proxied multi-agent LLM requests."
 ---
 
 Before starting this guide, ensure you have completed the [Installation Guide](/docs/user-guide/models/litellm-proxy-server/installation) and installed all required dependencies.

--- a/website/docs/user-guide/models/litellm-proxy-server/watsonx.mdx
+++ b/website/docs/user-guide/models/litellm-proxy-server/watsonx.mdx
@@ -1,6 +1,7 @@
 ---
-title: LiteLLM with WatsonX
+title: LiteLLM with IBM WatsonX Guide | Multi-Agent Framework
 sidebarTitle: LiteLLM with WatsonX
+description: "How to use IBM WatsonX models with AG2 via LiteLLM proxy. Configuration and code examples for enterprise multi-agent systems."
 ---
 
 Before starting this guide, ensure you have completed the [Installation Guide](/docs/user-guide/models/litellm-proxy-server/installation) and installed all required dependencies.

--- a/website/docs/user-guide/models/lm-studio.mdx
+++ b/website/docs/user-guide/models/lm-studio.mdx
@@ -1,6 +1,7 @@
 ---
-title: LM Studio
+title: LM Studio Guide | Multi-Agent Framework
 sidebarTitle: LM Studio
+description: "How to use LM Studio local models with AG2. Setup, configuration, and examples for running multi-agent systems with local LLMs."
 ---
 
 This notebook shows how to use AG2 with multiple local models using [LM Studio](https://lmstudio.ai/)'s multi-model serving feature, which is available since version 0.2.17 of LM Studio.

--- a/website/docs/user-guide/models/mistralai.mdx
+++ b/website/docs/user-guide/models/mistralai.mdx
@@ -1,6 +1,7 @@
 ---
-title: Mistral AI
+title: Mistral AI API Guide | Multi-Agent Framework
 sidebarTitle: Mistral AI
+description: "How to use Mistral AI models with AG2. Configuration, API setup, and code examples for building multi-agent systems with Mistral."
 ---
 
 [Mistral AI](https://mistral.ai/) is a cloud based platform serving their own LLMs, like Mistral, Mixtral, and Codestral.

--- a/website/docs/user-guide/models/ollama.mdx
+++ b/website/docs/user-guide/models/ollama.mdx
@@ -1,6 +1,7 @@
 ---
-title: Ollama
+title: Ollama Local LLM Guide | Multi-Agent Framework
 sidebarTitle: Ollama
+description: "How to run local LLMs with AG2 using Ollama. Setup, configuration, and examples for building multi-agent systems with local models."
 ---
 
 [Ollama](https://ollama.com/) is a local inference engine that enables you to run open-weight LLMs in your environment. It has native support for a large number of models such as Google's Gemma, Meta's Llama 2/3/3.1, Microsoft's Phi 3, Mistral.AI's Mistral/Mixtral, and Cohere's Command R models.

--- a/website/docs/user-guide/models/openai.mdx
+++ b/website/docs/user-guide/models/openai.mdx
@@ -1,6 +1,7 @@
 ---
-title: OpenAI
+title: OpenAI API Integration Guide | Multi-Agent Framework
 sidebarTitle: OpenAI
+description: "How to use OpenAI models with AG2. Configuration, API setup, and code examples for building multi-agent systems with GPT-4o, o1, and other OpenAI models."
 ---
 
 [OpenAI](https://openai.com/)'s API and models are fully supported in AG2. You will need an OpenAI account and to create an API key. [See their website for further details](https://openai.com/).

--- a/website/docs/user-guide/models/openai_responses.mdx
+++ b/website/docs/user-guide/models/openai_responses.mdx
@@ -1,6 +1,7 @@
 ---
-title: OpenAI Responses API
+title: OpenAI Responses API Guide | Multi-Agent Framework
 sidebarTitle: OpenAI Responses
+description: "How to use the OpenAI Responses API with AG2. Configuration for web search, code execution, and built-in tools in multi-agent systems."
 ---
 
 [OpenAI](https://openai.com/)'s Responses API is a significant evolution from the Chat Completions and Assistants APIs, offering support for both stateless interactions and structured, stateful conversations.

--- a/website/docs/user-guide/models/togetherai.mdx
+++ b/website/docs/user-guide/models/togetherai.mdx
@@ -1,6 +1,7 @@
 ---
-title: Together AI
+title: Together AI API Guide | Multi-Agent Framework
 sidebarTitle: Together AI
+description: "How to use Together AI models with AG2. Configuration and examples for building multi-agent systems with open-source models on Together AI."
 ---
 
 [Together.AI](https://www.together.ai/) is a cloud based platform serving many open-weight LLMs such as Google's Gemma, Meta's Llama 2/3, Qwen, Mistral.AI's Mistral/Mixtral, and NousResearch's Hermes models.

--- a/website/docs/user-guide/models/vLLM.mdx
+++ b/website/docs/user-guide/models/vLLM.mdx
@@ -1,7 +1,8 @@
 ---
-title: vLLM
+title: vLLM Serving Guide | Multi-Agent Framework
 sidebarTitle: vLLM
 render_macros: false
+description: "How to use vLLM-served models with AG2. Configuration and examples for high-throughput multi-agent inference with vLLM."
 ---
 
 [vLLM](https://github.com/vllm-project/vllm) is a locally run proxy and inference server, providing an OpenAI-compatible API. As it performs both the proxy and the inferencing, you don't need to install an additional inference server.


### PR DESCRIPTION
**Summary**
Add SEO-optimized title and description frontmatter to all 20 model provider documentation pages.

**Why**
The docs site previously had no per-page meta descriptions — every page used the generic site-wide description ("A programming framework for agentic AI"). This results in poor CTR from search results because users can't tell what each page offers before clicking.

The previous PR added per-page description support to the template (main.html). This PR populates that metadata across all model provider pages.

**What changed**
Added title and description frontmatter to all 20 model pages in website/docs/user-guide/models/:

Title pattern: {Provider} API Guide | Multi-Agent Framework — keeps AG2 branding via "Multi-Agent Framework" while leading with the provider name that searchers are looking for.

Description pattern: Concise, action-oriented descriptions (~150 chars) that include the provider name, "AG2", and key differentiators (e.g., "extended thinking" for Anthropic, "local LLMs" for Ollama, "fast inference" for Groq/Cerebras).

No content or code changes — only frontmatter metadata