### PR TITLE
Updated docs for 5 more model providers

### DIFF
--- a/website/docs/user-guide/models/cohere.mdx
+++ b/website/docs/user-guide/models/cohere.mdx
@@ -14,7 +14,7 @@ You will need a Cohere account and create an API key. [See their website for fur
 
 When using this client class, AG2's messages are automatically tailored to accommodate the specific requirements of Cohere's API.
 
-Additionally, this client class provides support for function/tool calling and will track token usage and cost correctly as per Cohere's API costs (as of July 2024).
+Additionally, this client class provides support for function/tool calling and will track token usage and cost correctly as per Cohere's API costs.
 
 ## Getting started
 
@@ -43,18 +43,6 @@ See the sample `OAI_CONFIG_LIST` below showing how the Cohere client class is us
 ```python
 [
     {
-        "model": "gpt-35-turbo",
-        "api_key": "your OpenAI Key goes here",
-    },
-    {
-        "model": "gpt-4-vision-preview",
-        "api_key": "your OpenAI Key goes here",
-    },
-    {
-        "model": "dalle",
-        "api_key": "your OpenAI Key goes here",
-    },
-    {
         "model": "command-r-plus",
         "api_key": "your Cohere API Key goes here",
         "api_type": "cohere"
@@ -65,7 +53,7 @@ See the sample `OAI_CONFIG_LIST` below showing how the Cohere client class is us
         "api_type": "cohere"
     },
     {
-        "model": "command",
+        "model": "command-nightly",
         "api_key": "your Cohere API Key goes here",
         "api_type": "cohere"
     }
@@ -244,7 +232,7 @@ from typing_extensions import Annotated
 
 import autogen
 
-llm_config = autogen.LLMConfig(config_list={
+llm_config = autogen.LLMConfig({
     "api_type": "cohere",
     "model": "command-r-plus",
     "api_key": os.getenv("COHERE_API_KEY"),

--- a/website/docs/user-guide/models/google-vertexai.mdx
+++ b/website/docs/user-guide/models/google-vertexai.mdx
@@ -109,29 +109,23 @@ The config could look like the following (change `project_id` and `google_applic
 ```python
 config_list = [
     {
-        "model": "gemini-pro",
+        "model": "gemini-2.5-pro",
         "api_type": "google",
         "project_id": "ag2-with-gemini",
         "location": "us-west1"
     },
     {
-        "model": "gemini-1.5-pro-001",
+        "model": "gemini-2.5-flash",
         "api_type": "google",
         "project_id": "ag2-with-gemini",
         "location": "us-west1"
     },
     {
-        "model": "gemini-1.5-pro",
+        "model": "gemini-2.0-flash",
         "api_type": "google",
         "project_id": "ag2-with-gemini",
         "location": "us-west1",
         "google_application_credentials": "ag2-with-gemini-service-account-key.json"
-    },
-    {
-        "model": "gemini-pro-vision",
-        "api_type": "google",
-        "project_id": "ag2-with-gemini",
-        "location": "us-west1"
     }
 ]
 ```
@@ -155,9 +149,9 @@ from autogen.agentchat.contrib.multimodal_conversable_agent import MultimodalCon
 from autogen.code_utils import content_str
 
 seed = 25  # for caching
-llm_config_gemini = LLMConfig(path="OAI_CONFIG_LIST", seed=seed).where(model="gemini-1.5-pro")
+llm_config_gemini = LLMConfig.from_json(path="OAI_CONFIG_LIST", seed=seed).where(model="gemini-2.5-flash")
 
-llm_config_gemini_vision = autogen.LLMConfig(path="OAI_CONFIG_LIST").where(model="gemini-pro-vision")
+llm_config_gemini_vision = LLMConfig.from_json(path="OAI_CONFIG_LIST").where(model="gemini-2.0-flash")
 
 for llm_config in [llm_config_gemini, llm_config_gemini_vision]:
     for config_list_item in llm_config.config_list:
@@ -252,7 +246,7 @@ We also need to set the Google cloud project, which is `ag2-with-gemini` in this
 Note, we could also run `gcloud auth application-default login` to use our personal Google account instead of a service account.
 In this case we need to run the following commands:
 ```bash
-gcloud gcloud auth application-default login
+gcloud auth application-default login
 gcloud config set project ag2-with-gemini
 ```
 
@@ -264,7 +258,7 @@ scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 credentials, project_id = google.auth.default(scopes)
 
 llm_config_gemini_vision = LLMConfig({
-    "model": "gemini-pro-vision",
+    "model": "gemini-2.0-flash",
     "api_type": "google",
     "project_id": project_id,
     "credentials": credentials,
@@ -337,7 +331,7 @@ completion_token_price_per_1k = (
 )
 
 llm_config_openai_gemini = LLMConfig({
-    "model": "google/gemini-1.5-pro-001",
+    "model": "google/gemini-2.5-flash",
     "api_type": "openai",
     "base_url": f"https://{location}-aiplatform.googleapis.com/v1beta1/projects/{project}/locations/{location}/endpoints/openapi",
     "api_key": creds.token,

--- a/website/docs/user-guide/models/groq.mdx
+++ b/website/docs/user-guide/models/groq.mdx
@@ -39,18 +39,6 @@ See the sample `OAI_CONFIG_LIST` below showing how the Groq client class is used
 ```python
 [
     {
-        "model": "gpt-35-turbo",
-        "api_key": "your OpenAI Key goes here",
-    },
-    {
-        "model": "gpt-4-vision-preview",
-        "api_key": "your OpenAI Key goes here",
-    },
-    {
-        "model": "dalle",
-        "api_key": "your OpenAI Key goes here",
-    },
-    {
         "model": "llama3-8b-8192",
         "api_key": "your Groq API Key goes here",
         "api_type": "groq"
@@ -61,7 +49,7 @@ See the sample `OAI_CONFIG_LIST` below showing how the Groq client class is used
         "api_type": "groq"
     },
     {
-        "model": "Mixtral 8x7b",
+        "model": "mixtral-8x7b-32768",
         "api_key": "your Groq API Key goes here",
         "api_type": "groq"
     },
@@ -250,7 +238,7 @@ from typing_extensions import Annotated
 
 import autogen
 
-llm_config = autogen.LLMConfig(config_list={
+llm_config = autogen.LLMConfig({
     "api_type": "groq",
     "model": "llama3-8b-8192",
     "api_key": os.getenv("GROQ_API_KEY"),

--- a/website/docs/user-guide/models/mistralai.mdx
+++ b/website/docs/user-guide/models/mistralai.mdx
@@ -14,7 +14,7 @@ You will need a Mistral.AI account and create an API key. [See their website for
 
 When using this client class, messages are automatically tailored to accommodate the specific requirements of Mistral AI's API (such as role orders), which have become more strict than OpenAI's API.
 
-Additionally, this client class provides support for function/tool calling and will track token usage and cost correctly as per Mistral AI's API costs (as of June 2024).
+Additionally, this client class provides support for function/tool calling and will track token usage and cost correctly as per Mistral AI's API costs.
 
 ## Getting started
 
@@ -43,27 +43,7 @@ See the sample `OAI_CONFIG_LIST` below showing how the Mistral AI client class i
 ```python
 [
     {
-        "model": "open-mistral-7b",
-        "api_key": "your Mistral AI API Key goes here",
-        "api_type": "mistral"
-    },
-    {
-        "model": "open-mixtral-8x7b",
-        "api_key": "your Mistral AI API Key goes here",
-        "api_type": "mistral"
-    },
-    {
-        "model": "open-mixtral-8x22b",
-        "api_key": "your Mistral AI API Key goes here",
-        "api_type": "mistral"
-    },
-    {
         "model": "mistral-small-latest",
-        "api_key": "your Mistral AI API Key goes here",
-        "api_type": "mistral"
-    },
-    {
-        "model": "mistral-medium-latest",
         "api_key": "your Mistral AI API Key goes here",
         "api_type": "mistral"
     },
@@ -73,7 +53,12 @@ See the sample `OAI_CONFIG_LIST` below showing how the Mistral AI client class i
         "api_type": "mistral"
     },
     {
-        "model": "codestral-latest",
+        "model": "open-mistral-nemo-2407",
+        "api_key": "your Mistral AI API Key goes here",
+        "api_type": "mistral"
+    },
+    {
+        "model": "codestral-2405",
         "api_key": "your Mistral AI API Key goes here",
         "api_type": "mistral"
     }
@@ -106,7 +91,7 @@ Example:
 ```python
 [
     {
-        "model": "codestral-latest",
+        "model": "codestral-2405",
         "api_key": "your Mistral AI API Key goes here",
         "api_type": "mistral",
         "temperature": 0.5,
@@ -122,7 +107,7 @@ Example:
 
 In this example, we run a two-agent chat with an AssistantAgent (primarily a coding agent) to generate code to count the number of prime numbers between 1 and 10,000 and then it will be executed.
 
-We'll use Mistral's Mixtral 8x22B model which is suitable for coding.
+We'll use Mistral AI's large model which is suitable for coding.
 
 ```python
 import os
@@ -141,8 +126,8 @@ code_executor = LocalCommandLineCodeExecutor(work_dir=workdir)
 
 # Setting up the LLM configuration
 llm_config = LLMConfig({
-    # Let's choose the Mixtral 8x22B model
-    "model": "open-mixtral-8x22b",
+    # Let's choose Mistral's large model
+    "model": "mistral-large-latest",
     # Provide your Mistral AI API key here or put it into the MISTRAL_API_KEY environment variable.
     "api_key": os.environ.get("MISTRAL_API_KEY"),
     # We specify the API Type as 'mistral' so it uses the Mistral AI client class

--- a/website/docs/user-guide/models/togetherai.mdx
+++ b/website/docs/user-guide/models/togetherai.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Together AI
 description: "How to use Together AI models with AG2. Configuration and examples for building multi-agent systems with open-source models on Together AI."
 ---
 
-[Together.AI](https://www.together.ai/) is a cloud based platform serving many open-weight LLMs such as Google's Gemma, Meta's Llama 2/3, Qwen, Mistral.AI's Mistral/Mixtral, and NousResearch's Hermes models.
+[Together.AI](https://www.together.ai/) is a cloud based platform serving many open-weight LLMs such as Google's Gemma, Meta's Llama 3, Qwen, Mistral.AI's Mistral/Mixtral, and NousResearch's Hermes models.
 
 Although AG2 can be used with Together.AI's API directly by changing the `base_url` to their url, it does not cater for some differences between messaging and it is recommended to use the Together.AI Client class as shown in this notebook.
 
@@ -12,7 +12,7 @@ You will need a Together.AI account and create an API key. [See their website fo
 
 ## Features
 
-When using this client class, messages are tailored to accommodate the specific requirements of Together.AI's API and provide native support for function/tool calling, token usage, and accurate costs (as of June 2024).
+When using this client class, messages are tailored to accommodate the specific requirements of Together.AI's API and provide native support for function/tool calling, token usage, and accurate costs.
 
 ## Getting started
 
@@ -41,22 +41,17 @@ See the sample `OAI_CONFIG_LIST` below showing how the Together.AI client class 
 ```python
 [
     {
-        "model": "google/gemma-7b-it",
+        "model": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
         "api_key": "your Together.AI API Key goes here",
         "api_type": "together"
     },
     {
-        "model": "codellama/CodeLlama-70b-Instruct-hf",
+        "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
         "api_key": "your Together.AI API Key goes here",
         "api_type": "together"
     },
     {
-        "model": "meta-llama/Llama-2-13b-chat-hf",
-        "api_key": "your Together.AI API Key goes here",
-        "api_type": "together"
-    },
-    {
-        "model": "Qwen/Qwen2-72B-Instruct",
+        "model": "Qwen/Qwen2.5-72B-Instruct-Turbo",
         "api_key": "your Together.AI API Key goes here",
         "api_type": "together"
     }
@@ -93,7 +88,7 @@ Example:
 ```python
 [
     {
-        "model": "microsoft/phi-2",
+        "model": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
         "api_key": "your Together.AI API Key goes here",
         "api_type": "together",
         "max_tokens": 1000,
@@ -114,7 +109,7 @@ Example:
 
 In this example, we run a two-agent chat with an AssistantAgent (primarily a coding agent) to generate code to count the number of prime numbers between 1 and 10,000 and then it will be executed.
 
-We'll use Mistral's Mixtral-8x7B instruct model which is suitable for coding.
+We'll use Mistral's Mixtral 8x7B instruct model which is suitable for coding.
 
 ```python
 import os
@@ -239,7 +234,7 @@ Here we are using `if_all_run`, indicating that we want to hide the tools if all
 
 ```python
 llm_config = LLMConfig({
-    # Let's choose Meta's CodeLlama 34b instruct model which supports function calling through the Together.AI API
+    # Let's choose Mistral's Mixtral 8x7B instruct model which supports function calling through the Together.AI API
     "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
     "api_key": os.environ.get("TOGETHER_API_KEY"),
     "api_type": "together",


### PR DESCRIPTION
Fixes broken code examples and updates outdated model references in the Google Vertex AI, Mistral AI, Groq, Cohere, and Together AI documentation pages.

**Critical Bug Fixes**

website/docs/user-guide/models/groq.mdx
- Fixed LLMConfig(config_list={...}) → LLMConfig({...}) — incorrect constructor that would cause a TypeError at runtime
- Removed unrelated OpenAI models (gpt-35-turbo, gpt-4-vision-preview, dalle) from the Groq config list example
- Fixed model name Mixtral 8x7b → mixtral-8x7b-32768 (correct Groq model ID)

website/docs/user-guide/models/cohere.mdx
- Fixed LLMConfig(config_list={...}) → LLMConfig({...}) — same constructor bug
- Removed unrelated OpenAI models from the Cohere config list example
- Replaced deprecated command model with command-nightly in examples
- Removed outdated "as of July 2024" date qualifier

website/docs/user-guide/models/google-vertexai.mdx
- Fixed LLMConfig(path=...) → LLMConfig.from_json(path=...) — path is not a constructor parameter, it's a class method parameter. Both occurrences (lines 158, 160) would cause a TypeError
- Fixed gcloud gcloud auth → gcloud auth — duplicate command
- Updated model names from deprecated gemini-pro, gemini-pro-vision, gemini-1.5-pro-001 to current gemini-2.5-pro, gemini-2.5-flash, gemini-2.0-flash (all present in AG2's pricing data)

website/docs/user-guide/models/mistralai.mdx
- Removed discontinued models (open-mistral-7b, open-mixtral-8x7b, open-mixtral-8x22b, mistral-medium-latest) from config list
- Updated to current models: mistral-small-latest, mistral-large-latest, open-mistral-nemo-2407, codestral-2405
- Updated coding example from open-mixtral-8x22b to mistral-large-latest
- Fixed codestral-latest → codestral-2405 in API parameters example
- Removed outdated "as of June 2024" date qualifier

website/docs/user-guide/models/togetherai.mdx
- Updated config list from very old models (google/gemma-7b-it, codellama/CodeLlama-70b-Instruct-hf, meta-llama/Llama-2-13b-chat-hf) to current models (meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo, Qwen/Qwen2.5-72B-Instruct-Turbo)
- Updated API parameters example from microsoft/phi-2 to meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo
- Updated intro text from "Llama 2/3" to "Llama 3"
- Fixed inaccurate comment referencing "CodeLlama 34b" in tool call example
- Removed outdated "as of June 2024" date qualifier
