### PR TITLE
update outdated model provider docs

### DIFF
--- a/website/docs/user-guide/models/amazon-bedrock.mdx
+++ b/website/docs/user-guide/models/amazon-bedrock.mdx
@@ -149,7 +149,7 @@ Typical use cases include (but are not limited to):
 
 For example, to enable Claude's 'thinking' mode:
 ```python
-llm_config_bedrock = autogen.LLMConfig(config_list={
+llm_config_bedrock = autogen.LLMConfig({
         "api_type": "bedrock",
         "model": "anthropic.claude-3-7-sonnet-20250219-v1:0",
         "aws_region": "us-east-1",
@@ -180,7 +180,7 @@ If you are using your AG2 code within an AWS Lambda function, you can utilise th
 The following example shows a basic configuration with default retry settings (5 total attempts, standard mode):
 
 ```python
-llm_config_default = autogen.LLMConfig(config_list={
+llm_config_default = autogen.LLMConfig({
     "api_type": "bedrock",
     "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
     "aws_region": "us-east-1",
@@ -195,7 +195,7 @@ llm_config_default = autogen.LLMConfig(config_list={
 For critical applications that need maximum retry attempts:
 
 ```python
-llm_config_reliable = autogen.LLMConfig(config_list={
+llm_config_reliable = autogen.LLMConfig({
     "api_type": "bedrock",
     "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
     "aws_region": "us-east-1",
@@ -211,7 +211,7 @@ llm_config_reliable = autogen.LLMConfig(config_list={
 For handling rate limits and throttling:
 
 ```python
-llm_config_rate_limit = autogen.LLMConfig(config_list={
+llm_config_rate_limit = autogen.LLMConfig({
     "api_type": "bedrock",
     "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
     "aws_region": "us-east-1",
@@ -227,7 +227,7 @@ llm_config_rate_limit = autogen.LLMConfig(config_list={
 For applications that need quick failure detection:
 
 ```python
-llm_config_fast_fail = autogen.LLMConfig(config_list={
+llm_config_fast_fail = autogen.LLMConfig({
     "api_type": "bedrock",
     "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
     "aws_region": "us-east-1",
@@ -253,7 +253,7 @@ from typing_extensions import Annotated
 
 import autogen
 
-llm_config_bedrock = autogen.LLMConfig(config_list={
+llm_config_bedrock = autogen.LLMConfig({
         "api_type": "bedrock",
         "model": "anthropic.claude-3-sonnet-20240229-v1:0",
         "api_key": BEDROCK_API_KEY,
@@ -344,7 +344,7 @@ from typing import Literal
 
 import autogen
 
-llm_config_bedrock = autogen.LLMConfig(config_list={
+llm_config_bedrock = autogen.LLMConfig({
         "api_type": "bedrock",
         "model": "meta.llama3-1-70b-instruct-v1:0",
         "aws_region": "us-west-2",
@@ -513,7 +513,7 @@ from typing import Annotated, Literal
 import autogen
 from autogen import AssistantAgent, GroupChat, GroupChatManager, UserProxyAgent
 
-llm_config_sonnet = autogen.LLMConfig(config_list={
+llm_config_sonnet = autogen.LLMConfig({
         "api_type": "bedrock",
         "model": "anthropic.claude-3-sonnet-20240229-v1:0",
         "aws_region": "us-east-1",
@@ -525,7 +525,7 @@ llm_config_sonnet = autogen.LLMConfig(config_list={
     cache_seed=None,  # turn off caching
 )
 
-llm_config_mistral = autogen.LLMConfig(config_list={
+llm_config_mistral = autogen.LLMConfig({
         "api_type": "bedrock",
         "model": "mistral.mistral-large-2407-v1:0",
         "aws_region": "us-west-2",
@@ -537,7 +537,7 @@ llm_config_mistral = autogen.LLMConfig(config_list={
     cache_seed=None,  # turn off caching
 )
 
-llm_config_llama31_70b = autogen.LLMConfig(config_list={
+llm_config_llama31_70b = autogen.LLMConfig({
         "api_type": "bedrock",
         "model": "meta.llama3-1-70b-instruct-v1:0",
         "aws_region": "us-west-2",

--- a/website/docs/user-guide/models/anthropic.mdx
+++ b/website/docs/user-guide/models/anthropic.mdx
@@ -100,7 +100,7 @@ from typing_extensions import Annotated
 
 import autogen
 
-llm_config_claude = autogen.LLMConfig(config_list={
+llm_config_claude = autogen.LLMConfig({
     # Choose your model name.
     "model": "claude-sonnet-4-5",
     # You need to provide your API key here.
@@ -321,17 +321,17 @@ TERMINATE
 ```python
 from autogen import AssistantAgent, GroupChat, GroupChatManager, UserProxyAgent, LLMConfig
 
-llm_config_gpt4 = autogen.LLMConfig(config_list={
+llm_config_gpt4o = autogen.LLMConfig({
     # Choose your model name.
-    "model": "gpt-4",
+    "model": "gpt-4o",
     # You need to provide your API key here.
     "api_key": os.getenv("OPENAI_API_KEY"),
     "api_type": "openai",
 })
 
-llm_config_gpt35 = autogen.LLMConfig(config_list={
+llm_config_gpt4o_mini = autogen.LLMConfig({
     # Choose your model name.
-    "model": "gpt-3.5-turbo",
+    "model": "gpt-4o-mini",
     # You need to provide your API key here.
     "api_key": os.getenv("OPENAI_API_KEY"),
     "api_type": "openai",
@@ -340,13 +340,13 @@ llm_config_gpt35 = autogen.LLMConfig(config_list={
 alice = AssistantAgent(
     "Openai_agent",
     system_message="You are from OpenAI. You make arguments to support your company's position.",
-    llm_config=llm_config_gpt4,
+    llm_config=llm_config_gpt4o,
 )
 
 dan = AssistantAgent(
     "Judge",
     system_message="You are a judge. You will evaluate the arguments and make a decision on which one is more convincing.",
-    llm_config=llm_config_gpt4,
+    llm_config=llm_config_gpt4o,
 )
 
 bob = autogen.AssistantAgent(
@@ -358,7 +358,7 @@ bob = autogen.AssistantAgent(
 charlie = AssistantAgent(
     "Research_Assistant",
     system_message="You are a helpful assistant to research the latest news and headlines.",
-    llm_config=llm_config_gpt35,
+    llm_config=llm_config_gpt4o_mini,
 )
 
 code_interpreter = UserProxyAgent(
@@ -394,7 +394,7 @@ groupchat = GroupChat(
 
 manager = GroupChatManager(
     groupchat=groupchat,
-    llm_config=llm_config_gpt4,
+    llm_config=llm_config_gpt4o,
 )
 
 task = "Analyze the potential of OpenAI and Anthropic to revolutionize the field of AI based on today's headlines. Today is 06202024."
@@ -596,7 +596,7 @@ groupchat = GroupChat(
 manager = GroupChatManager(
     groupchat=groupchat,
     # is_termination_msg=lambda x: x.get("content", "").find("TERMINATE") >= 0,
-    llm_config=llm_config_gpt4,
+    llm_config=llm_config_gpt4o,
 )
 
 user_proxy.initiate_chat(manager, message=task)
@@ -818,22 +818,18 @@ As always, it will be crucial to balance the pursuit of technological advancemen
 
 You can utilize Anthropic's thinking mode by setting it in the configuration.
 
-```
-from autogen import ConversableAgent
+```python
+from autogen import ConversableAgent, LLMConfig
 
 # Here we configure the thinking mode and the token budget for thinking
-llm_config = {
-    "config_list": [
-        {
-            "model": "claude-sonnet-4-5",
-            "api_type": "anthropic",
-            "max_tokens": 8192, # override the default value of 4096, max tokens must be greater than thinking budget
-            "timeout": 600, # for larger thinking budgets, increase the timeout OR enable streaming
-            "thinking": {"type": "enabled", "budget_tokens": 2048},
-        }
-    ],
-    # Note: don't pass in temperature or top_p to avoid exceptions in thinking mode
-}
+llm_config = LLMConfig({
+    "model": "claude-sonnet-4-5",
+    "api_type": "anthropic",
+    "max_tokens": 8192, # override the default value of 4096, max tokens must be greater than thinking budget
+    "timeout": 600, # for larger thinking budgets, increase the timeout OR enable streaming
+    "thinking": {"type": "enabled", "budget_tokens": 2048},
+})
+# Note: don't pass in temperature or top_p to avoid exceptions in thinking mode
 
 agent = ConversableAgent(
     name="test",

--- a/website/docs/user-guide/models/ollama.mdx
+++ b/website/docs/user-guide/models/ollama.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Ollama
 description: "How to run local LLMs with AG2 using Ollama. Setup, configuration, and examples for building multi-agent systems with local models."
 ---
 
-[Ollama](https://ollama.com/) is a local inference engine that enables you to run open-weight LLMs in your environment. It has native support for a large number of models such as Google's Gemma, Meta's Llama 2/3/3.1, Microsoft's Phi 3, Mistral.AI's Mistral/Mixtral, and Cohere's Command R models.
+[Ollama](https://ollama.com/) is a local inference engine that enables you to run open-weight LLMs in your environment. It has native support for a large number of models such as Google's Gemma, Meta's Llama 3, Microsoft's Phi, Mistral.AI's Mistral/Mixtral, and Cohere's Command R models.
 
 Note: Previously, to use Ollama with AG2 you required LiteLLM. Now it can be used directly and supports tool calling.
 
@@ -304,7 +304,7 @@ from typing_extensions import Annotated
 
 import autogen
 
-llm_config = autogen.LLMConfig(config_list={
+llm_config = autogen.LLMConfig({
     # Let's choose the Meta's Llama 3.1 model (model names must match Ollama exactly)
     "model": "llama3.1:8b",
     "api_type": "ollama",
@@ -416,51 +416,6 @@ print(f"LLM SUMMARY: {res.summary['content']}")
 ```
 
 ```console
-/usr/local/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html
-  from .autonotebook import tqdm as notebook_tqdm
-User (to Ollama Assistant):
-
-Provide code to count the number of prime numbers from 1 to 10000.
-
---------------------------------------------------------------------------------
-Ollama Assistant (to User):
-
-'''python
-def is_prime(n):
-    if n <= 1:
-        return False
-    for i in range(2, int(n**0.5) + 1):
-        if n % i == 0:
-            return False
-    return True
-
-count = sum(is_prime(i) for i in range(1, 10001))
-print(count)
-'''
-
-Please execute this code. I will wait for the result.
-
---------------------------------------------------------------------------------
-
->>>>>>>> NO HUMAN INPUT RECEIVED.
-
->>>>>>>> USING AUTO REPLY...
-
->>>>>>>> EXECUTING CODE BLOCK (inferred language is python)...
-User (to Ollama Assistant):
-
-exitcode: 0 (execution succeeded)
-Code output: 1229
-
-
---------------------------------------------------------------------------------
-Ollama Assistant (to User):
-
-FINISH
-
---------------------------------------------------------------------------------
-
->>>>>>>> NO HUMAN INPUT RECEIVED.
 user_proxy (to chatbot):
 
 What's the weather in New York and can you tell me how much is 123.45 EUR in USD so I can spend it on my holiday? Throw a few holiday tips in as well.


### PR DESCRIPTION
Fixes broken LLMConfig constructor usage and updates outdated model/code references in the Amazon Bedrock, Anthropic, and Ollama documentation pages.

**Critical Bug Fixes**
website/docs/user-guide/models/amazon-bedrock.mdx
- Fixed 10 instances of LLMConfig(config_list={...}) → LLMConfig({...}) — incorrect constructor that would cause a TypeError at runtime (lines 152, 183, 198, 214, 230, 256, 347, 516, 528, 540)

website/docs/user-guide/models/anthropic.mdx
- Fixed 3 instances of LLMConfig(config_list={...}) → LLMConfig({...}) — same constructor bug (lines 103, 324, 332)

website/docs/user-guide/models/ollama.mdx
- Fixed 1 instance of LLMConfig(config_list={...}) → LLMConfig({...}) — same constructor bug (line 307)

**Outdated Reference Updates**

website/docs/user-guide/models/anthropic.mdx
- Updated group chat example from gpt-4 → gpt-4o and gpt-3.5-turbo → gpt-4o-mini (both deprecated OpenAI models)
- Renamed variables llm_config_gpt4 → llm_config_gpt4o and llm_config_gpt35 → llm_config_gpt4o_mini to match
- Updated thinking mode example from old-style config_list dict to LLMConfig({...}) pattern with proper python code fence

website/docs/user-guide/models/ollama.mdx
- Updated intro text from "Llama 2/3/3.1" → "Llama 3" and "Phi 3" → "Phi"
- Removed duplicate console output from tool call section (coding example output was erroneously included before the actual tool call output)