### PR TITLE
fix: handle LLMConfig objects in AgentOptimizer

### DIFF
--- a/autogen/agentchat/contrib/agent_optimizer.py
+++ b/autogen/agentchat/contrib/agent_optimizer.py
@@ -209,6 +209,8 @@ class AgentOptimizer:
             raise ValueError("llm_config is required for AgentOptimizer")
         assert isinstance(llm_config, (dict, LLMConfig)), "llm_config must be a dict or LLMConfig"
         llm_config = copy.deepcopy(llm_config)
+        if isinstance(llm_config, LLMConfig):
+            llm_config = llm_config.model_dump()
         self.llm_config = llm_config
         if self.llm_config in [{}, {"config_list": []}, {"config_list": [{"model": ""}]}]:
             raise ValueError(


### PR DESCRIPTION
## Summary

Fixes #1780

When an `LLMConfig` object is passed to `AgentOptimizer.__init__()`, the constructor fails because it treats it as a plain dict:

1. `self.llm_config in [{}, {"config_list": []}, ...]` — `LLMConfig.__eq__` returns `NotImplemented` when comparing with a dict, so this check silently passes but doesn't validate correctly
2. `OpenAIWrapper(**self.llm_config)` — while `LLMConfig` supports `**` unpacking via `keys()` and `__getitem__`, the `filter_config` return value (a `list[dict]`) is set back via `__setitem__` which may cause type mismatches with the Pydantic model

### Fix

Convert `LLMConfig` to a plain dict via `model_dump()` before using it, right after `deepcopy`:

```python
if isinstance(llm_config, LLMConfig):
    llm_config = llm_config.model_dump()
```

This is consistent with how other parts of the codebase handle `LLMConfig` objects when dict operations are needed.

### Test

The existing `test_llm_config_current_property` test in `test_agent_optimizer.py` already covers this path — it creates an `LLMConfig` and passes it to `AgentOptimizer`. With this fix, that test should pass.
