### PR TITLE
fix: prevent IndexError in last_message() on empty conversation

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -999,13 +999,14 @@ class ConversableAgent(LLMAgent):
                 return None
             if n_conversations == 1:
                 for conversation in self._oai_messages.values():
-                    return conversation[-1]
+                    return conversation[-1] if conversation else None
             raise ValueError("More than one conversation is found. Please specify the sender to get the last message.")
         if agent not in self._oai_messages:
             raise KeyError(
                 f"The agent '{agent.name}' is not present in any conversation. No history available for this agent."
             )
-        return self._oai_messages[agent][-1]
+        messages = self._oai_messages[agent]
+        return messages[-1] if messages else None
 
     @property
     def use_docker(self) -> bool | str | None:


### PR DESCRIPTION
## Summary

`ConversableAgent.last_message()` raises `IndexError` when the conversation list exists but is empty. This can happen when:
- Messages are cleared via `clear_history()` but the agent key remains in `_oai_messages`
- `last_message()` is called before any messages are exchanged in an existing conversation entry

The method's return type is `dict[str, Any] | None`, but the empty list case was not handled — `conversation[-1]` and `self._oai_messages[agent][-1]` both raise `IndexError` on an empty list.

### Fix

Return `None` instead of raising `IndexError` when the conversation list is empty, which is consistent with:
- The method's return type annotation (`dict | None`)
- The existing behavior when `n_conversations == 0` (returns `None`)
- The docstring which says "The last message exchanged with the agent"

### Changes

```python
# Before (line 1002) - raises IndexError if conversation is []
return conversation[-1]

# After - returns None if conversation is []
return conversation[-1] if conversation else None
```

```python
# Before (line 1008) - raises IndexError if messages is []
return self._oai_messages[agent][-1]

# After - returns None if messages is []
messages = self._oai_messages[agent]
return messages[-1] if messages else None
```
