### PR TITLE
add Tavily Search page and SEO descriptions to reference tools

### DIFF
--- a/website/docs/user-guide/reference-tools/browser-use.mdx
+++ b/website/docs/user-guide/reference-tools/browser-use.mdx
@@ -1,5 +1,6 @@
 ---
 title: Browser Use
+description: "Enable AG2 agents to navigate websites, extract dynamic content, and interact with web pages using the Browser Use integration."
 ---
 
 AG2 now integrates [Browser Use](https://browser-use.com), allowing your agents to navigate websites, extract dynamic content, and interact with web pages. This makes automated data collection, web automation, and other tasks easier and more efficient.

--- a/website/docs/user-guide/reference-tools/code-execution.mdx
+++ b/website/docs/user-guide/reference-tools/code-execution.mdx
@@ -1,6 +1,7 @@
 ---
 title: Python Code Execution
 sidebarTitle: Code Execution
+description: "Execute Python code from AG2 agents using system, virtual, or Docker environments. Generate, run, and validate code with PythonCodeExecutionTool."
 ---
 
 Add code execution as a capability for your AG2 agents with the [`PythonCodeExecutionTool`](/docs/api-reference/autogen/tools/experimental/PythonCodeExecutionTool)! Utilizing a provided Python environment, whether that's the system one, a local virtual one, or a Docker container, your agents can generate, run and utilize the results of Python code.

--- a/website/docs/user-guide/reference-tools/crawl4ai.mdx
+++ b/website/docs/user-guide/reference-tools/crawl4ai.mdx
@@ -1,6 +1,7 @@
 ---
 title: Crawl4AI
 sidebarTitle: Crawl4AI
+description: "Integrate Crawl4AI, an open-source web crawler built for AI agents, with AG2 for real-time web data extraction and processing."
 ---
 
 AG2 now integrates [Crawl4AI](https://docs.crawl4ai.com), an open-source web crawler built for AI agents, language models, and data pipelines. This allows your agents to quickly access and process web data in real time, making automation and data collection more efficient.

--- a/website/docs/user-guide/reference-tools/deep-research.mdx
+++ b/website/docs/user-guide/reference-tools/deep-research.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deep Research
+description: "Autonomous deep research with AG2 using DeepResearchTool and GPT Researcher. Multi-step research tasks with Tavily-powered web search and structured report generation."
 ---
 
 AG2 recommends two approaches for autonomous deep research: the built-in [`DeepResearchTool`](/docs/api-reference/autogen/tools/experimental/DeepResearchTool) and the [GPT Researcher](https://docs.gptr.dev/) multi-agent integration.
@@ -51,7 +52,7 @@ export OPENAI_API_KEY={your_openai_key}
 export TAVILY_API_KEY={your_tavily_key}
 ```
 
-A [Tavily API key](https://tavily.com/) is required for web search.
+A [Tavily API key](https://tavily.com/) is required for web search. See [Tavily Search Tool](/docs/user-guide/reference-tools/tavily-search) for setup details and standalone usage with AG2 agents.
 
 ### Configure the Research Task
 

--- a/website/docs/user-guide/reference-tools/index.mdx
+++ b/website/docs/user-guide/reference-tools/index.mdx
@@ -1,6 +1,7 @@
 ---
 sidebarTitle: Overview
 title: Overview
+description: "Ready-to-use tools for AG2 agents: web search (Google, Tavily, Perplexity, SearxNG), web scraping (Crawl4AI, Firecrawl, Browser Use), deep research, code execution, and messaging (Discord, Slack, Telegram)."
 ---
 
 Our reference tools offer powerful, ready-to-use functionalities that seamlessly integrate with your agents, enabling them to gather real-time information and enhance decision-making.
@@ -39,6 +40,11 @@ Stay up to date with the latest news, extract dynamic web content, and answer qu
 [`Crawl4AITool`](/docs/api-reference/autogen/tools/experimental/Crawl4AITool) helps your agents quickly access and process real-time web data, making automation and data collection seamless.
 
 🔗 [Explore the Walk-through](/docs/user-guide/reference-tools/crawl4ai)
+
+### Tavily Search Tool
+[`TavilySearchTool`](/docs/api-reference/autogen/tools/experimental/TavilySearchTool) allows your agents to perform real-time, AI-powered web searches using the Tavily Search API — purpose-built for AI agents and RAG workflows.
+
+🔗 [Explore the Walk-through](/docs/user-guide/reference-tools/tavily-search)
 
 ### SearxNG Search Tool
 [`SearxngSearchTool`](/docs/api-reference/autogen/tools/experimental/SearxngSearchTool) allows your agents to perform real-time web searches using SearxNG, a privacy-friendly open-source metasearch engine.

--- a/website/docs/user-guide/reference-tools/perplexity-search.mdx
+++ b/website/docs/user-guide/reference-tools/perplexity-search.mdx
@@ -1,5 +1,6 @@
 ---
 title: Perplexity Search Tool
+description: "Integrate Perplexity AI search with AG2 agents for real-time web search and question-answering. Setup guide, API key configuration, and usage examples."
 ---
 
 The Perplexity AI search integration allows users to perform real-time web searches within the AG2 framework. Follow these steps to integrate `PerplexitySearchTool` with AG2 Agents.
@@ -101,7 +102,7 @@ response = user_proxy.initiate_chat(
     message="What is AG2?",
     max_turns=2,
 )
-````
+```
 
 ### Output
 
@@ -147,7 +148,7 @@ TERMINATE
 >>>>>>>> TERMINATING RUN (2ab104c4-cfe6-4ce7-88e3-fb83b9623a7a): Maximum turns (2) reached
 
 Process finished with exit code 0
-````
+```
 
 ### Key Considerations
 

--- a/website/docs/user-guide/reference-tools/searxng-search.mdx
+++ b/website/docs/user-guide/reference-tools/searxng-search.mdx
@@ -1,5 +1,6 @@
 ---
 title: SearxNG Search Tool
+description: "Use SearxNG, a privacy-friendly open-source metasearch engine, with AG2 agents for real-time web search. No API key required for public instances."
 ---
 
 The SearxNG Search integration in AG2 allows users to perform real-time web searches using a SearxNG instance. This is useful for retrieving up-to-date information from a privacy-friendly, open-source metasearch engine.

--- a/website/docs/user-guide/reference-tools/tavily-search.mdx
+++ b/website/docs/user-guide/reference-tools/tavily-search.mdx
@@ -1,0 +1,117 @@
+---
+title: Tavily Search Tool
+description: "Integrate Tavily Search API with AG2 agents for real-time AI-powered web search. Learn how to set up TAVILY_API_KEY, install the tool, and use TavilySearchTool in your multi-agent workflows."
+---
+
+The [Tavily Search](https://tavily.com/) integration allows AG2 agents to perform real-time, AI-powered web searches. Tavily is a search API purpose-built for AI agents and LLMs, delivering accurate and factual results optimized for retrieval-augmented generation (RAG) workflows.
+
+## Configuring Your Tavily API Key
+
+1. **Create a Tavily Account**:
+   - Visit [Tavily](https://tavily.com/)
+   - Click **Sign Up** and create an account
+
+2. **Get Your API Key**:
+   - Navigate to [Tavily API Dashboard](https://app.tavily.com/)
+   - Generate an API key under **API Keys**
+
+3. **Set the `TAVILY_API_KEY` Environment Variable**:
+   ```bash
+   export TAVILY_API_KEY="your_api_key_here"
+   ```
+
+## Package Installation
+
+Install AG2 with the `tavily` extra (and `openai` for the example below):
+
+```bash
+pip install -U "ag2[openai,tavily]"
+```
+
+> **Note:** `autogen` and `ag2` are aliases for the same PyPI package:
+> ```bash
+> pip install -U "autogen[openai,tavily]"
+> ```
+
+## Implementation
+
+### Imports
+
+```python
+import os
+from autogen import AssistantAgent, UserProxyAgent, LLMConfig
+from autogen.tools.experimental import TavilySearchTool
+```
+
+### Agent Configuration
+
+```python
+llm_config = LLMConfig({"api_type": "openai", "model": "gpt-4o"})
+
+assistant = AssistantAgent(
+    name="assistant",
+    llm_config=llm_config,
+)
+
+user_proxy = UserProxyAgent(
+    name="user_proxy",
+    human_input_mode="NEVER",
+)
+```
+
+### Tool Setup
+
+```python
+tavily_search_tool = TavilySearchTool(tavily_api_key=os.getenv("TAVILY_API_KEY"))
+
+# Register the tool for LLM recommendation and execution.
+tavily_search_tool.register_for_llm(assistant)
+tavily_search_tool.register_for_execution(user_proxy)
+```
+
+### Usage Example
+
+```python
+response = user_proxy.initiate_chat(
+    recipient=assistant,
+    message="What are the latest developments in multi-agent AI systems?",
+    max_turns=2,
+)
+print(f"Final Answer: {response.summary}")
+```
+
+## Parameters
+
+`TavilySearchTool` accepts the following search parameters at call time:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `query` | `str` | *required* | The search query string |
+| `search_depth` | `str` | `"basic"` | Search depth — `"basic"` for fast results or `"advanced"` for deeper, more comprehensive search |
+| `include_answer` | `str` | `"basic"` | Whether to include an AI-generated answer — `"basic"` or `"advanced"` |
+| `include_raw_content` | `bool` | `False` | Whether to include the raw page content in results |
+| `include_domains` | `list[str]` | `[]` | Restrict search to specific domains (e.g., `["arxiv.org", "github.com"]`) |
+| `num_results` | `int` | `5` | Maximum number of results to return |
+
+## Output
+
+Each search returns a list of dictionaries with:
+
+- `title` — the result title
+- `link` — the result URL
+- `snippet` — a relevant content excerpt
+
+## Deep Research with Tavily
+
+Tavily powers the web search layer in both of AG2's deep research approaches:
+
+- **[DeepResearchTool](/docs/user-guide/reference-tools/deep-research#deepresearchtool)** — AG2's built-in tool for multi-step research tasks. Uses Tavily under the hood for web retrieval, tightly integrated into your agent pipeline.
+- **[GPT Researcher](/docs/user-guide/reference-tools/deep-research#gpt-researcher)** — a standalone multi-agent research system that uses Tavily for recursive querying and produces structured reports (Markdown, PDF, Docx).
+
+Both approaches require a `TAVILY_API_KEY`. See the [Deep Research guide](/docs/user-guide/reference-tools/deep-research) for setup and configuration.
+
+## See Also
+
+- [Tavily API Documentation](https://docs.tavily.com/)
+- [Deep Research with AG2](/docs/user-guide/reference-tools/deep-research)
+- [Reference Tools Overview](/docs/user-guide/reference-tools)

--- a/website/docs/user-guide/reference-tools/wikipedia-search.mdx
+++ b/website/docs/user-guide/reference-tools/wikipedia-search.mdx
@@ -1,8 +1,9 @@
 ---
 title: Wikipedia Search Tools
+description: "Search Wikipedia from AG2 agents using WikipediaQueryRunTool and WikipediaPageLoadTool. Get page summaries or full content for knowledge retrieval."
 ---
 
-The Wikipedia search integration allows users to perform search in wikipedia pages within the AG2 framework.
+The Wikipedia search integration allows AG2 agents to search Wikipedia pages for knowledge retrieval.
 Follow these steps to integrate Wikipedia Tools with AG2 Agents.
 
 
@@ -34,11 +35,9 @@ You're all set! Now you can start using Wikipedia Search with AG2.
 
 ```python
 import os
-import autogen
 from autogen import AssistantAgent, UserProxyAgent, LLMConfig
 from autogen.tools.experimental import WikipediaQueryRunTool, WikipediaPageLoadTool
 from dotenv import load_dotenv
-import os
 load_dotenv()
 ```
 

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -298,7 +298,8 @@
             "docs/user-guide/reference-tools/crawl4ai",
             "docs/user-guide/reference-tools/deep-research",
             "docs/user-guide/reference-tools/firecrawl",
-            "docs/user-guide/reference-tools/searxng-search"
+            "docs/user-guide/reference-tools/searxng-search",
+            "docs/user-guide/reference-tools/tavily-search"
           ]
         },
         {


### PR DESCRIPTION
## Summary

- **New page: [Tavily Search Tool](website/docs/user-guide/reference-tools/tavily-search.mdx)** — dedicated documentation for `TavilySearchTool` with API key setup, installation, code examples, parameter reference, and cross-links to Deep Research
- **Added `description` meta tags** to all reference-tools pages that were missing them (index, perplexity-search, searxng-search, wikipedia-search, browser-use, crawl4ai, deep-research, code-execution) — controls the snippet Google shows in search results
- **Added Tavily to sidebar navigation** in `mint-json-template.json.jinja`
- **Added Tavily to reference-tools index** page alongside other search tools
- **Added cross-link from deep-research page** to the new Tavily page
- **Fixed content issues**: backtick typos in perplexity-search, grammar fix and duplicate import in wikipedia-search

## Why

Search Console shows impressions for queries with "tavily" with low CTR. Root cause: no dedicated Tavily page existed on the site — the only mention was buried in the deep-research page. The missing `description` meta tags across all reference-tools pages also mean Google auto-generates snippets, reducing click-through rate.
