### PR TITLE
Add Langfuse in documentation

### DIFF
--- a/website/docs/_blogs/2026-02-08-AG2-OpenTelemetry-Tracing/index.mdx
+++ b/website/docs/_blogs/2026-02-08-AG2-OpenTelemetry-Tracing/index.mdx
@@ -15,7 +15,7 @@ Key highlights:
 - **Four simple API functions** to instrument agents, LLM calls, group chats, and A2A servers
 - **Hierarchical traces** that mirror how agents process conversations
 - **Distributed tracing** across services using W3C Trace Context propagation
-- **Works with any backend** -- Jaeger, Grafana Tempo, Datadog, Honeycomb, and more
+- **Works with any backend** -- Jaeger, Grafana Tempo, Datadog, Honeycomb, Langfuse, and more
 - **Follows OpenTelemetry GenAI Semantic Conventions** for standard interoperability
 
 <!-- more -->
@@ -385,13 +385,35 @@ exporter = OTLPSpanExporter(
 
 Consult your vendor's documentation for the exact endpoint and authentication details.
 
+**[Langfuse](https://langfuse.com)** (open-source LLM observability):
+
+Langfuse is an open-source LLM engineering platform with native support for OpenTelemetry GenAI traces. It provides purpose-built visualization for multi-agent workflows including token usage, cost tracking, and message rendering. Langfuse uses OTLP over HTTP with Basic authentication:
+
+```python
+import base64
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+LANGFUSE_PUBLIC_KEY = "pk-lf-..."
+LANGFUSE_SECRET_KEY = "sk-lf-..."
+LANGFUSE_HOST = "https://cloud.langfuse.com"  # or your self-hosted URL
+
+auth = base64.b64encode(f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()).decode()
+
+exporter = OTLPSpanExporter(
+    endpoint=f"{LANGFUSE_HOST}/api/public/otel/v1/traces",
+    headers={"Authorization": f"Basic {auth}"},
+)
+```
+
+See the [Langfuse AG2 integration guide](https://langfuse.com/docs/integrations/frameworks/ag2) for a full walkthrough.
+
 ## Getting Started
 
 1. **Install**: `pip install "ag2[tracing]"`
 2. **Configure**: Create a `TracerProvider` with your chosen exporter
 3. **Instrument**: Call `instrument_llm_wrapper()` and `instrument_agent()` (or `instrument_pattern()` for group chats)
 4. **Run**: Execute your agent workflow as usual
-5. **Observe**: View traces in your backend (Grafana, Jaeger, Datadog, or the console)
+5. **Observe**: View traces in your backend (Grafana, Jaeger, Datadog, Langfuse, or the console)
 
 ## Additional Resources
 
@@ -400,6 +422,7 @@ Consult your vendor's documentation for the exact endpoint and authentication de
 - [Local OpenTelemetry Setup](/docs/user-guide/tracing/local-setup) -- Docker Compose stack configuration
 - [Tracing notebook](https://docs.ag2.ai/latest/docs/use-cases/notebooks/notebooks/agentchat_tracing_and_instrumentation) -- Interactive Jupyter notebook walkthrough
 - [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) -- The standard AG2 follows
+- [Langfuse AG2 integration guide](https://langfuse.com/docs/integrations/frameworks/ag2) -- Detailed setup for the Langfuse LLM observability platform
 
 ## Conclusion
 

--- a/website/docs/user-guide/tracing/opentelemetry.mdx
+++ b/website/docs/user-guide/tracing/opentelemetry.mdx
@@ -7,7 +7,7 @@ sidebarTitle: OpenTelemetry Tracing
 AG2 provides built-in <a href="https://opentelemetry.io/" className="external-link" target="_blank" rel="noopener noreferrer">OpenTelemetry</a> instrumentation for multi-agent workflows.
 The tracing module follows the <a href="https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/" className="external-link" target="_blank" rel="noopener noreferrer">OpenTelemetry GenAI Semantic Conventions</a> for agent spans, giving you structured observability into conversations, LLM calls, tool executions, code execution, and human-in-the-loop interactions.
 
-Because AG2 uses standard OpenTelemetry, traces can be exported to **any compatible backend** -- Jaeger, Grafana Tempo, Datadog, Honeycomb, Axiom, and many others.
+Because AG2 uses standard OpenTelemetry, traces can be exported to **any compatible backend** -- Jaeger, Grafana Tempo, Datadog, Honeycomb, Langfuse, Axiom, and many others.
 
 ## Installation
 
@@ -361,6 +361,41 @@ exporter = OTLPSpanExporter(
 ```
 
 Consult your vendor's documentation for the exact endpoint and authentication details. Popular options include <a href="https://docs.datadoghq.com/opentelemetry/" className="external-link" target="_blank" rel="noopener noreferrer">Datadog</a>, <a href="https://docs.honeycomb.io/send-data/opentelemetry/" className="external-link" target="_blank" rel="noopener noreferrer">Honeycomb</a>, and <a href="https://grafana.com/products/cloud/" className="external-link" target="_blank" rel="noopener noreferrer">Grafana Cloud</a>.
+
+### Langfuse
+
+<a href="https://langfuse.com" className="external-link" target="_blank" rel="noopener noreferrer">Langfuse</a> is an open-source LLM engineering platform with native support for OpenTelemetry GenAI traces. It provides purpose-built visualization for multi-agent workflows including token usage, cost tracking, and message rendering. Langfuse is available as a cloud service or can be self-hosted.
+
+Langfuse accepts OTLP traces over HTTP with Basic authentication:
+
+```python title="langfuse_setup.py"
+import base64
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+LANGFUSE_PUBLIC_KEY = "pk-lf-..."
+LANGFUSE_SECRET_KEY = "sk-lf-..."
+LANGFUSE_HOST = "https://cloud.langfuse.com"  # or your self-hosted URL
+
+auth = base64.b64encode(
+    f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()
+).decode()
+
+resource = Resource.create(attributes={"service.name": "my-ag2-service"})
+tracer_provider = TracerProvider(resource=resource)
+
+exporter = OTLPSpanExporter(
+    endpoint=f"{LANGFUSE_HOST}/api/public/otel/v1/traces",
+    headers={"Authorization": f"Basic {auth}"},
+)
+tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
+trace.set_tracer_provider(tracer_provider)
+```
+
+See the <a href="https://langfuse.com/docs/integrations/frameworks/ag2" className="external-link" target="_blank" rel="noopener noreferrer">Langfuse AG2 integration guide</a> for a full walkthrough including tool use and group chat examples.
 
 ## Local Development Stack
 


### PR DESCRIPTION
**Summary**
- Added Langfuse to the OTel blog post's "Connecting to Cloud Backends" section with OTLP HTTP exporter code example and Basic auth setup
- Added Langfuse to the "Getting Started" steps and "Additional Resources" links in the blog
- Added a new ### Langfuse subsection under "Backend Integration" in the OTel user guide with a complete TracerProvider setup example
- Updated intro text in both documents to list Langfuse alongside existing backends

**Why**
- Langfuse is a popular open-source LLM engineering platform that already supports OpenTelemetry GenAI traces natively. Adding it to AG2's tracing docs gives developers another first-class option for observing multi-agent workflows — alongside Jaeger, Grafana, and Datadog. Langfuse provides purpose-built LLM visualization (token usage, cost tracking, ChatML message rendering) that complements AG2's rich span hierarchy.