### PR TITLE
Mistral Client updated to Mistral v2 API

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -111,10 +111,10 @@ else:
     anthropic_import_exception = ImportError("anthropic not found")
 
 with optional_import_block() as mistral_result:
-    from mistralai.models import (  # noqa
+    from mistralai.client.errors.httpvalidationerror import (  # noqa
         HTTPValidationError as mistral_HTTPValidationError,
-        SDKError as mistral_SDKError,
     )
+    from mistralai.client.errors.sdkerror import SDKError as mistral_SDKError  # noqa
 
     from .mistral import MistralAIClient
 

--- a/autogen/oai/mistral.py
+++ b/autogen/oai/mistral.py
@@ -22,7 +22,7 @@ Install Mistral.AI python library using: pip install --upgrade mistralai
 Resources:
 - https://docs.mistral.ai/getting-started/quickstart/
 
-NOTE: Requires mistralai package version >= 1.0.1
+NOTE: Requires mistralai package version >= 2.0.0
 """
 
 import json
@@ -40,17 +40,15 @@ from .oai_models import ChatCompletion, ChatCompletionMessage, ChatCompletionMes
 
 with optional_import_block():
     # Mistral libraries
-    # pip install mistralai
-    from mistralai import (
-        AssistantMessage,
-        Function,
-        FunctionCall,
-        Mistral,
-        SystemMessage,
-        ToolCall,
-        ToolMessage,
-        UserMessage,
-    )
+    # pip install mistralai>=2.0.0
+    from mistralai.client.models.assistantmessage import AssistantMessage
+    from mistralai.client.models.function import Function
+    from mistralai.client.models.functioncall import FunctionCall
+    from mistralai.client.models.systemmessage import SystemMessage
+    from mistralai.client.models.toolcall import ToolCall
+    from mistralai.client.models.toolmessage import ToolMessage
+    from mistralai.client.models.usermessage import UserMessage
+    from mistralai.client.sdk import Mistral
 
 
 class MistralEntryDict(LLMConfigEntryDict, total=False):
@@ -128,7 +126,7 @@ class MistralAIClient:
         )
         mistral_params["random_seed"] = validate_parameter(params, "random_seed", int, True, None, False, None)
         mistral_params["tool_choice"] = validate_parameter(
-            params, "tool_choice", str, False, None, None, ["none", "auto", "any"]
+            params, "tool_choice", str, True, None, None, ["none", "auto", "any"]
         )
 
         # TODO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,7 +265,7 @@ yepcode = [
     "python-dotenv",
 ]
 remyx = ["remyxai>=0.2.0", "docker>=6.0.0"]
-mistral = ["mistralai>=1.0.1"]
+mistral = ["mistralai>=2.0.0"]
 groq = ["groq>=0.9.0"]
 cohere = ["cohere>=5.13.5"]
 ollama = ["ollama>=0.4.7", "fix_busted_json>=0.0.18"]

--- a/website/docs/user-guide/models/mistralai.mdx
+++ b/website/docs/user-guide/models/mistralai.mdx
@@ -18,7 +18,7 @@ Additionally, this client class provides support for function/tool calling and w
 
 ## Getting started
 
-First you need to install the AG2 package with the Mistral API extra.
+First you need to install the AG2 package with the Mistral API extra. This requires `mistralai>=2.0.0`.
 
 ``` bash
 pip install ag2[mistral]


### PR DESCRIPTION
## Why are these changes needed?

Mistral just released v2 and this PR updates our client to be minimum V2 compatible.

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
