### PR TITLE
fix(beta): send ClientToolCall to stream in ClientTool.register

### DIFF
--- a/autogen/beta/tools/final/client_tool.py
+++ b/autogen/beta/tools/final/client_tool.py
@@ -36,7 +36,8 @@ class ClientTool(Tool):
             execution = partial(mw.on_tool_execution, execution)
 
         async def execute(event: "ToolCall", context: "Context") -> None:
-            return await execution(event, context)
+            result = await execution(event, context)
+            await context.send(result)
 
         stack.enter_context(
             context.stream.where((ToolCall.name == self.schema.function.name) & ClientToolCall.not_()).sub_scope(

--- a/test/beta/tools/test_client_tool.py
+++ b/test/beta/tools/test_client_tool.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import ExitStack
+
+import pytest
+
+from autogen.beta.context import Context
+from autogen.beta.events import ClientToolCall, ToolCall
+from autogen.beta.tools.final.client_tool import ClientTool
+
+
+class _CapturingStream:
+    """Minimal stream implementation that records sent events."""
+
+    def __init__(self) -> None:
+        self.sent_events: list = []
+
+    async def send(self, event: object, context: object) -> None:
+        self.sent_events.append(event)
+
+    def where(self, condition: object) -> "_CapturingStream":
+        return self
+
+    def sub_scope(self, func: object, **kwargs: object) -> "_CapturingStream":
+        self._captured_func = func
+        return self
+
+    def __enter__(self) -> "_CapturingStream":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_client_tool_call_returns_client_tool_call() -> None:
+    """ClientTool.__call__ must return a ClientToolCall wrapping the original call."""
+    schema = {"function": {"name": "my_client_tool", "description": "desc", "parameters": {}}}
+    client_tool = ClientTool(schema)
+
+    stream = _CapturingStream()
+    context = Context(stream=stream)  # type: ignore[arg-type]
+
+    call = ToolCall(name="my_client_tool", arguments="{}")
+    result = await client_tool(call, context)
+
+    assert isinstance(result, ClientToolCall)
+    assert result.name == "my_client_tool"
+    assert result.parent_id == call.id
+
+
+@pytest.mark.asyncio
+async def test_client_tool_register_execute_sends_to_stream() -> None:
+    """The execute closure inside register() must send ClientToolCall to the stream.
+
+    Regression: the original code did `return await execution(...)` without
+    `await context.send(result)`, so ToolExecutor.execute_tools() would block
+    forever waiting for a ClientToolCall that was never sent to the stream.
+    """
+    schema = {"function": {"name": "my_tool", "description": "desc", "parameters": {}}}
+    client_tool = ClientTool(schema)
+
+    stream = _CapturingStream()
+    context = Context(stream=stream)  # type: ignore[arg-type]
+
+    with ExitStack() as stack:
+        client_tool.register(stack, context)
+
+    assert hasattr(stream, "_captured_func"), "sub_scope was never called -- register() is broken"
+
+    call = ToolCall(name="my_tool", arguments="{}")
+    await stream._captured_func(call, context)
+
+    assert len(stream.sent_events) == 1, (
+        f"Expected 1 event sent to stream, got {len(stream.sent_events)}. "
+        "ClientTool.register() execute callback must call context.send(result)."
+    )
+    sent = stream.sent_events[0]
+    assert isinstance(sent, ClientToolCall), f"Expected ClientToolCall, got {type(sent)}"
+    assert sent.parent_id == call.id
+    assert sent.name == call.name
+
+
+@pytest.mark.asyncio
+async def test_client_tool_register_with_middleware() -> None:
+    """execute closure must propagate through middleware before sending."""
+    schema = {"function": {"name": "mw_tool", "description": "desc", "parameters": {}}}
+    client_tool = ClientTool(schema)
+
+    stream = _CapturingStream()
+    context = Context(stream=stream)  # type: ignore[arg-type]
+
+    class TagMiddleware:
+        async def on_tool_execution(self, call_next: object, event: object, context: object) -> object:
+            result = await call_next(event, context)  # type: ignore[misc]
+            result._tag = "middleware_ran"  # type: ignore[attr-defined]
+            return result
+
+    with ExitStack() as stack:
+        client_tool.register(stack, context, middleware=[TagMiddleware()])
+
+    call = ToolCall(name="mw_tool", arguments="{}")
+    await stream._captured_func(call, context)
+
+    assert len(stream.sent_events) == 1
+    sent = stream.sent_events[0]
+    assert isinstance(sent, ClientToolCall)
+    assert getattr(sent, "_tag", None) == "middleware_ran"


### PR DESCRIPTION
## Why are these changes needed?

`ClientTool.register()` creates an `execute` callback that hangs the agent loop when a client tool is invoked.

### Reproduction

Register a `ClientTool` and trigger a tool call. `ToolExecutor.execute_tools()` blocks indefinitely at `await result` inside the `context.stream.get(... | ClientToolCall)` call.

The callback was:
```python
async def execute(event, context):
    return await execution(event, context)
```

Stream subscribers' return values are discarded by `Stream.send()` (line 179 of `stream.py` -- `await s.asolve(...)` without capturing the result). So the `ClientToolCall` produced by `__call__` is never emitted to the stream.

### Expected behavior

`execute_tools()` receives the `ClientToolCall` event and continues (wrapping it into a `ModelResponse` with `response_force=True`).

### Actual behavior

`execute_tools()` hangs forever on `await result` because no `ClientToolCall` event is ever sent to the stream.

### Root cause

`ClientTool.register()` does `return await execution(...)` instead of `await context.send(await execution(...))`. Compare with `FunctionTool.register()` (function_tool.py:93-95) which correctly sends the result:

```python
async def execute(event, context):
    result = await execution(event, context)
    await context.send(result)
```

### Fix

One-line change -- send the result to the stream instead of returning it:

```diff
-            return await execution(event, context)
+            result = await execution(event, context)
+            await context.send(result)
```

Added regression test that verifies `ClientToolCall` reaches the stream after `execute` runs, plus a middleware-passthrough test.

## Related issue number

N/A (found during code review of beta tool infrastructure)

## Checks

- [x] I've included any doc changes needed: N/A (no public docs for beta tools yet)
- [x] I've added tests for the fix
- [x] I've made sure all auto checks have passed