### PR TITLE
ci: add PR labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,43 @@
+A2A:
+  - changed-files:
+    - any-glob-to-any-file:
+      - autogen/a2a/**
+      - test/a2a/**
+      - website/docs/a2a/**
+
+beta:
+  - changed-files:
+    - any-glob-to-any-file:
+      - autogen/beta/**
+      - test/beta/**
+      - website/docs/beta/**
+
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+      - pyproject.toml
+
+documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - website/**
+      - docs/**
+      - notebook/**
+
+github_actions:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/workflows/**
+
+telemetry:
+  - changed-files:
+    - any-glob-to-any-file:
+      - autogen/opentelemetry/**
+      - test/opentelemetry/**
+
+ui:
+  - changed-files:
+    - any-glob-to-any-file:
+      - autogen/ag_ui/**
+      - test/ag_ui/**
+      - website/docs/ag-ui/**

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -1,0 +1,21 @@
+name: Label PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+        if: ${{ github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
+      - run: echo "Done adding labels"


### PR DESCRIPTION
## Summary
- Adds `actions/labeler@v6.0.1` workflow to automatically label PRs based on changed file paths
- Supports labels: `A2A`, `beta`, `dependencies`, `documentation`, `github_actions`, `telemetry`, `ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)