### PR TITLE
feat: add CodeExecutionTool and related schemas for code execution ca…

### DIFF
--- a/autogen/beta/config/anthropic/mappers.py
+++ b/autogen/beta/config/anthropic/mappers.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from autogen.beta.events import BaseEvent, ModelRequest, ModelResponse, ToolResults
 from autogen.beta.exceptions import UnsupportedToolError
+from autogen.beta.tools.builtin.code_execution import CodeExecutionToolSchema
 from autogen.beta.tools.builtin.web_search import WebSearchToolSchema
 from autogen.beta.tools.final import FunctionToolSchema
 from autogen.beta.tools.schemas import ToolSchema
@@ -44,6 +45,10 @@ def tool_to_api(t: ToolSchema) -> dict[str, Any]:
                 loc["timezone"] = t.user_location.timezone
             result["user_location"] = loc
         return result
+
+    elif isinstance(t, CodeExecutionToolSchema):
+        # https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool
+        return {"type": "code_execution_20250825", "name": "code_execution"}
 
     raise UnsupportedToolError(t.type, "anthropic")
 

--- a/autogen/beta/config/gemini/mappers.py
+++ b/autogen/beta/config/gemini/mappers.py
@@ -8,6 +8,7 @@ from google.genai import types
 
 from autogen.beta.events import BaseEvent, ModelRequest, ModelResponse, ToolResults
 from autogen.beta.exceptions import UnsupportedToolError
+from autogen.beta.tools.builtin.code_execution import CodeExecutionToolSchema
 from autogen.beta.tools.builtin.web_search import WebSearchToolSchema
 from autogen.beta.tools.final import FunctionToolSchema
 from autogen.beta.tools.schemas import ToolSchema
@@ -30,6 +31,9 @@ def build_tools(schemas: list[ToolSchema]) -> list[types.Tool] | None:
 
         elif isinstance(t, WebSearchToolSchema):
             extra_tools.append(types.Tool(google_search=types.GoogleSearch()))
+
+        elif isinstance(t, CodeExecutionToolSchema):
+            extra_tools.append(types.Tool(code_execution=types.ToolCodeExecution()))
 
         else:
             raise UnsupportedToolError(t.type, "gemini")

--- a/autogen/beta/config/openai/mappers.py
+++ b/autogen/beta/config/openai/mappers.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from autogen.beta.events import BaseEvent, ModelRequest, ModelResponse, ToolResults
 from autogen.beta.exceptions import UnsupportedToolError
+from autogen.beta.tools.builtin.code_execution import CodeExecutionToolSchema
 from autogen.beta.tools.builtin.web_search import WebSearchToolSchema
 from autogen.beta.tools.final import FunctionToolSchema
 from autogen.beta.tools.schemas import ToolSchema
@@ -120,5 +121,9 @@ def tool_to_responses_api(t: ToolSchema) -> dict[str, Any]:
                 loc["timezone"] = t.user_location.timezone
             result["user_location"] = loc
         return result
+
+    elif isinstance(t, CodeExecutionToolSchema):
+        # https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools
+        return {"type": "code_interpreter", "container": {"type": "auto"}}
 
     raise UnsupportedToolError(t.type, "openai-responses")

--- a/autogen/beta/tools/__init__.py
+++ b/autogen/beta/tools/__init__.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .builtin import UserLocation, WebSearchTool
+from .builtin import CodeExecutionTool, UserLocation, WebSearchTool
 from .final import Toolkit, tool
 
 __all__ = (
+    "CodeExecutionTool",
     "Toolkit",
     "UserLocation",
     "WebSearchTool",

--- a/autogen/beta/tools/builtin/__init__.py
+++ b/autogen/beta/tools/builtin/__init__.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from .code_execution import CodeExecutionTool
 from .web_search import UserLocation, WebSearchTool
 
-__all__ = ("UserLocation", "WebSearchTool")
+__all__ = ("CodeExecutionTool", "UserLocation", "WebSearchTool")

--- a/autogen/beta/tools/builtin/code_execution.py
+++ b/autogen/beta/tools/builtin/code_execution.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterable
+from contextlib import ExitStack
+from dataclasses import dataclass, field
+
+from autogen.beta.annotations import Context
+from autogen.beta.middleware import BaseMiddleware
+from autogen.beta.tools.schemas import ToolSchema
+from autogen.beta.tools.tool import Tool
+
+
+@dataclass(slots=True)
+class CodeExecutionToolSchema(ToolSchema):
+    """Provider-neutral capability flag for code execution."""
+
+    type: str = field(default="code_execution", init=False)
+
+
+class CodeExecutionTool(Tool):
+    """Provider-neutral code execution capability.
+
+    Each LLM client's mapper is responsible for converting this schema
+    into the correct provider-specific API format.
+    """
+
+    async def schemas(self, context: "Context") -> list[ToolSchema]:
+        return [CodeExecutionToolSchema()]
+
+    def register(
+        self,
+        stack: "ExitStack",
+        context: "Context",
+        *,
+        middleware: Iterable["BaseMiddleware"] = (),
+    ) -> None:
+        pass


### PR DESCRIPTION
Adds CodeExecutionTool — a provider-neutral built-in tool for code execution.

Each LLM client's mapper is responsible for converting CodeExecutionToolSchema into the correct provider-specific API format:

Anthropic → {"type": "code_execution_20250825", "name": "code_execution"}
OpenAI Responses API → {"type": "code_interpreter", "container": {"type": "auto"}}