### PR TITLE
fix(beta): correct three bugs in ToolCallEvent and ToolErrorEvent

### DIFF
--- a/autogen/beta/events/tool_events.py
+++ b/autogen/beta/events/tool_events.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import traceback
 from dataclasses import dataclass, field
-from traceback import format_exc
 from typing import Any, Generic
 from uuid import uuid4
 
@@ -66,13 +66,13 @@ class ToolCallEvent(ToolEvent):
     id: str = Field(default_factory=lambda: str(uuid4()))
     name: str
     arguments: str = "{}"
-    provider_data: dict[str, Any] = Field(default_factory=list)
+    provider_data: dict[str, Any] = Field(default_factory=dict)
 
-    _serialized_arguments: dict[str, Any] = Field(default_factory=dict)
+    _serialized_arguments: dict[str, Any] | None = Field(default=None)
 
     @property
     def serialized_arguments(self) -> dict[str, Any]:
-        if not self._serialized_arguments:
+        if self._serialized_arguments is None:
             self._serialized_arguments = json.loads(self.arguments)
         return self._serialized_arguments
 
@@ -152,7 +152,7 @@ class ToolErrorEvent(ToolResultEvent):
     @property
     def content(self) -> str:
         if not self._content:
-            self._content = format_exc(limit=3)
+            self._content = "".join(traceback.format_exception(type(self.error), self.error, self.error.__traceback__))
         return self._content
 
     @content.setter

--- a/test/beta/events/test_tool_events.py
+++ b/test/beta/events/test_tool_events.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from unittest.mock import patch
+
+from autogen.beta.events.tool_events import (
+    ClientToolCallEvent,
+    ToolCallEvent,
+    ToolErrorEvent,
+    ToolResult,
+)
+
+
+class TestToolCallEventProviderData:
+    """provider_data must default to dict, not list."""
+
+    def test_default_is_dict(self) -> None:
+        tc = ToolCallEvent(name="search")
+        assert isinstance(tc.provider_data, dict)
+
+    def test_dict_operations_work(self) -> None:
+        tc = ToolCallEvent(name="search")
+        tc.provider_data["key"] = "value"
+        assert tc.provider_data.get("key") == "value"
+
+    def test_each_instance_gets_own_dict(self) -> None:
+        tc1 = ToolCallEvent(name="a")
+        tc2 = ToolCallEvent(name="b")
+        tc1.provider_data["x"] = 1
+        assert "x" not in tc2.provider_data
+
+
+class TestClientToolCallEventFromCall:
+    """from_call must link back to the original call via parent_id."""
+
+    def test_parent_id_matches_original_id(self) -> None:
+        original = ToolCallEvent(name="search", arguments='{"q": "test"}')
+        client_call = ClientToolCallEvent.from_call(original)
+        assert client_call.parent_id == original.id
+
+    def test_name_and_arguments_preserved(self) -> None:
+        original = ToolCallEvent(name="calc", arguments='{"x": 1}')
+        client_call = ClientToolCallEvent.from_call(original)
+        assert client_call.name == original.name
+        assert client_call.arguments == original.arguments
+
+
+class TestToolErrorEventContent:
+    """content must capture the traceback from self.error, not sys.exc_info()."""
+
+    def test_content_contains_original_error(self) -> None:
+        try:
+            raise ValueError("test error message")
+        except Exception as e:
+            event = ToolErrorEvent(
+                parent_id="call-123",
+                name="test_tool",
+                error=e,
+                result=ToolResult(),
+            )
+
+        # Access content OUTSIDE the except block
+        assert "ValueError" in event.content
+        assert "test error message" in event.content
+
+    def test_content_does_not_return_none_type(self) -> None:
+        try:
+            raise RuntimeError("something broke")
+        except Exception as e:
+            event = ToolErrorEvent(
+                parent_id="x",
+                name="t",
+                error=e,
+                result=ToolResult(),
+            )
+
+        assert "NoneType" not in event.content
+
+
+class TestSerializedArgumentsCache:
+    """serialized_arguments must cache even when the result is an empty dict."""
+
+    def test_empty_dict_is_cached(self) -> None:
+        tc = ToolCallEvent(name="tool", arguments="{}")
+        with patch.object(json, "loads", wraps=json.loads) as mock_loads:
+            _ = tc.serialized_arguments
+            _ = tc.serialized_arguments
+            _ = tc.serialized_arguments
+            assert mock_loads.call_count == 1
+
+    def test_non_empty_dict_is_cached(self) -> None:
+        tc = ToolCallEvent(name="tool", arguments='{"key": "value"}')
+        with patch.object(json, "loads", wraps=json.loads) as mock_loads:
+            result = tc.serialized_arguments
+            _ = tc.serialized_arguments
+            assert mock_loads.call_count == 1
+            assert result == {"key": "value"}
+
+    def test_setter_updates_cache(self) -> None:
+        tc = ToolCallEvent(name="tool", arguments='{"a": 1}')
+        tc.serialized_arguments = {"b": 2}
+        assert tc.serialized_arguments == {"b": 2}


### PR DESCRIPTION
## Why are these changes needed?

Three independent bugs in `tool_events.py` found during code review.

**1. `ToolCallEvent.provider_data` defaults to `list` instead of `dict`**

`provider_data` is annotated as `dict[str, Any]` but uses
`Field(default_factory=list)`. When no explicit value is passed, the
field is a `list`, and dict operations raise at runtime:

```python
tc = ToolCallEvent(name="search")
type(tc.provider_data)       # <class 'list'>
tc.provider_data.get("key")  # AttributeError: 'list' object has no attribute 'get'
```

Fix: `default_factory=dict`.

**2. `ToolErrorEvent.content` returns wrong traceback**

The `content` property calls `format_exc()`, which reads the *current*
`sys.exc_info()` at the time the property is accessed -- not the
exception stored in `self.error`. `FunctionTool.__call__` creates the
event inside an `except` block, but `.content` is first read later
(via `to_api()`), outside the handler. At that point `format_exc()`
returns `"NoneType: None\n"`:

```python
try:
    raise ValueError("test error")
except Exception as e:
    event = ToolErrorEvent(parent_id="x", name="t", error=e, result=ToolResult())

event.content  # 'NoneType: None\n' -- original error info lost
```

Fix: use `traceback.format_exception()` on `self.error`, which retains
its `__traceback__` after the `except` block exits.

**3. `ToolCallEvent.serialized_arguments` cache misses on empty dict**

The cache check `if not self._serialized_arguments` treats `{}` as
falsy, so tools called with no arguments (`arguments="{}"`) re-parse
the JSON string on every property access:

```python
tc = ToolCallEvent(name="tool", arguments="{}")
# json.loads called 3 times for 3 accesses (expected 1)
```

Fix: use a `None` sentinel (`if self._serialized_arguments is None`).

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed
- [x] I've added tests for the changes
- [x] I've made sure all auto checks have passed