### PR TITLE
feat: add MemoryTool and integrate into existing tool schemas

### DIFF
--- a/autogen/beta/config/anthropic/mappers.py
+++ b/autogen/beta/config/anthropic/mappers.py
@@ -9,6 +9,7 @@ from typing import Any
 from autogen.beta.events import BaseEvent, ModelRequest, ModelResponse, ToolResultsEvent
 from autogen.beta.exceptions import UnsupportedToolError
 from autogen.beta.tools.builtin.code_execution import CodeExecutionToolSchema
+from autogen.beta.tools.builtin.memory import MemoryToolSchema
 from autogen.beta.tools.builtin.web_search import WebSearchToolSchema
 from autogen.beta.tools.final import FunctionToolSchema
 from autogen.beta.tools.schemas import ToolSchema
@@ -50,6 +51,10 @@ def tool_to_api(t: ToolSchema) -> dict[str, Any]:
     elif isinstance(t, CodeExecutionToolSchema):
         # https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool
         return {"type": "code_execution_20250825", "name": "code_execution"}
+
+    elif isinstance(t, MemoryToolSchema):
+        # https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool
+        return {"type": "memory_20250818", "name": "memory"}
 
     raise UnsupportedToolError(t.type, "anthropic")
 

--- a/autogen/beta/tools/__init__.py
+++ b/autogen/beta/tools/__init__.py
@@ -4,11 +4,12 @@
 
 from autogen.beta.events.tool_events import ToolResult
 
-from .builtin import CodeExecutionTool, UserLocation, WebSearchTool
+from .builtin import CodeExecutionTool, MemoryTool, UserLocation, WebSearchTool
 from .final import Toolkit, tool
 
 __all__ = (
     "CodeExecutionTool",
+    "MemoryTool",
     "ToolResult",
     "Toolkit",
     "UserLocation",

--- a/autogen/beta/tools/builtin/__init__.py
+++ b/autogen/beta/tools/builtin/__init__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .code_execution import CodeExecutionTool
+from .memory import MemoryTool
 from .web_search import UserLocation, WebSearchTool
 
-__all__ = ("CodeExecutionTool", "UserLocation", "WebSearchTool")
+__all__ = ("CodeExecutionTool", "MemoryTool", "UserLocation", "WebSearchTool")

--- a/autogen/beta/tools/builtin/memory.py
+++ b/autogen/beta/tools/builtin/memory.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterable
+from contextlib import ExitStack
+from dataclasses import dataclass, field
+
+from autogen.beta.annotations import Context
+from autogen.beta.middleware import BaseMiddleware
+from autogen.beta.tools.schemas import ToolSchema
+from autogen.beta.tools.tool import Tool
+
+
+@dataclass(slots=True)
+class MemoryToolSchema(ToolSchema):
+    """Provider-neutral capability flag for the memory tool."""
+
+    type: str = field(default="memory", init=False)
+
+
+class MemoryTool(Tool):
+    """Memory tool that enables Claude to store and retrieve information across conversations.
+
+    Claude can create, read, update, and delete files in the /memories directory to store
+    what it learns while working, then reference those memories in future conversations.
+
+    This is a client-side tool: the application is responsible for implementing the
+    handlers for each memory command (view, create, str_replace, insert, delete, rename).
+
+    See: https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool
+    """
+
+    async def schemas(self, context: "Context") -> list[ToolSchema]:
+        return [MemoryToolSchema()]
+
+    def register(
+        self,
+        stack: "ExitStack",
+        context: "Context",
+        *,
+        middleware: Iterable["BaseMiddleware"] = (),
+    ) -> None:
+        pass


### PR DESCRIPTION
Adds `MemoryTool` — a new builtin tool for the `autogen/beta` API that enables Claude to store and retrieve information across conversations using Anthropic's client-side memory protocol.


**What was added:**
- `MemoryToolSchema` and `MemoryTool` in `autogen/beta/tools/builtin/memory.py`, following the same pattern as `CodeExecutionTool` and `WebSearchTool`
- Anthropic mapper support: `MemoryToolSchema` → `{"type": "memory_20250818", "name": "memory"}`

```python
from autogen.beta import Agent
from autogen.beta.config import AnthropicConfig
from autogen.beta.tools import MemoryTool

agent = Agent(
    name="my-agent",
    config=AnthropicConfig(model="claude-opus-4-6", ...),
    tools=[MemoryTool()],
)