### PR TITLE
Add OSOP workflow example — multi-agent debate in portable format

### DIFF
--- a/notebook/osop/README.md
+++ b/notebook/osop/README.md
@@ -1,6 +1,6 @@
 # OSOP Workflow Examples for AutoGen
 
-[OSOP](https://github.com/osopcloud/osop-spec) (Open Standard for Orchestration Protocols) is a portable YAML format for describing multi-agent workflows — think OpenAPI, but for agent orchestration.
+[OSOP](https://github.com/Archie0125/osop-spec) (Open Standard for Orchestration Protocols) is a portable YAML format for describing multi-agent workflows — think OpenAPI, but for agent orchestration.
 
 ## What's Here
 
@@ -15,7 +15,7 @@ AutoGen excels at multi-agent conversation patterns. OSOP provides a **framework
 - **Documented** — readable YAML that non-developers can understand
 - **Validated** — check workflow structure before running it
 - **Ported** — same workflow definition works across AutoGen, CrewAI, LangGraph, etc.
-- **Visualized** — render the workflow as a graph in the [OSOP Editor](https://github.com/osopcloud/osop-editor)
+- **Visualized** — render the workflow as a graph in the [OSOP Editor](https://github.com/Archie0125/osop-editor)
 
 ## Quick Start
 
@@ -40,6 +40,6 @@ cat multi-agent-debate.osop.yaml
 
 ## Learn More
 
-- [OSOP Spec](https://github.com/osopcloud/osop-spec) — full specification
-- [OSOP Examples](https://github.com/osopcloud/osop-examples) — 30+ workflow templates
-- [OSOP Editor](https://github.com/osopcloud/osop-editor) — visual workflow editor
+- [OSOP Spec](https://github.com/Archie0125/osop-spec) — full specification
+- [OSOP Examples](https://github.com/Archie0125/osop-examples) — 30+ workflow templates
+- [OSOP Editor](https://github.com/Archie0125/osop-editor) — visual workflow editor

--- a/notebook/osop/README.md
+++ b/notebook/osop/README.md
@@ -1,0 +1,45 @@
+# OSOP Workflow Examples for AutoGen
+
+[OSOP](https://github.com/osopcloud/osop-spec) (Open Standard for Orchestration Protocols) is a portable YAML format for describing multi-agent workflows — think OpenAPI, but for agent orchestration.
+
+## What's Here
+
+| File | Description |
+|------|-------------|
+| `multi-agent-debate.osop.yaml` | A structured debate between pro/con agents with moderator synthesis and human judgment |
+
+## Why OSOP?
+
+AutoGen excels at multi-agent conversation patterns. OSOP provides a **framework-agnostic way to describe** those patterns so they can be:
+
+- **Documented** — readable YAML that non-developers can understand
+- **Validated** — check workflow structure before running it
+- **Ported** — same workflow definition works across AutoGen, CrewAI, LangGraph, etc.
+- **Visualized** — render the workflow as a graph in the [OSOP Editor](https://github.com/osopcloud/osop-editor)
+
+## Quick Start
+
+```bash
+# Validate the workflow
+pip install osop
+osop validate multi-agent-debate.osop.yaml
+
+# Or just read the YAML — it's self-documenting
+cat multi-agent-debate.osop.yaml
+```
+
+## How It Maps to AutoGen
+
+| OSOP Concept | AutoGen Equivalent |
+|---|---|
+| `node` with `type: agent` | `ConversableAgent` / `AssistantAgent` |
+| `node` with `type: human` | `UserProxyAgent` |
+| `edge` with `mode: parallel` | Parallel agent execution |
+| `edge` with `mode: sequential` | `initiate_chat()` chain |
+| `config.tools` | Agent tool registration |
+
+## Learn More
+
+- [OSOP Spec](https://github.com/osopcloud/osop-spec) — full specification
+- [OSOP Examples](https://github.com/osopcloud/osop-examples) — 30+ workflow templates
+- [OSOP Editor](https://github.com/osopcloud/osop-editor) — visual workflow editor

--- a/notebook/osop/multi-agent-debate.osop.yaml
+++ b/notebook/osop/multi-agent-debate.osop.yaml
@@ -1,0 +1,90 @@
+# AutoGen Multi-Agent Debate — OSOP Portable Workflow
+#
+# A structured debate between AI agents: a moderator poses a question,
+# pro and con agents argue in parallel, the moderator synthesizes both
+# sides, and a human judge delivers the final verdict.
+#
+# Run with AutoGen or validate: osop validate autogen-debate.osop.yaml
+
+osop_version: "1.0"
+id: "autogen-debate"
+name: "Multi-Agent Debate"
+description: "Structured debate with pro/con agents, moderator synthesis, and human judgment."
+version: "1.0.0"
+tags: [autogen, multi-agent, debate, reasoning]
+
+nodes:
+  - id: "pose_question"
+    type: "human"
+    name: "Pose Debate Question"
+    description: "User provides the debate topic and any constraints."
+
+  - id: "moderator_open"
+    type: "agent"
+    subtype: "llm"
+    name: "Moderator — Opening"
+    description: "Frames the question, defines scope, and sets debate rules."
+    config:
+      role: "Neutral Moderator"
+      model: "gpt-4o"
+
+  - id: "pro_agent"
+    type: "agent"
+    subtype: "llm"
+    name: "Pro Agent"
+    description: "Argues in favor of the proposition with evidence and reasoning."
+    config:
+      role: "Proponent"
+      tools: [web_search, cite_source]
+
+  - id: "con_agent"
+    type: "agent"
+    subtype: "llm"
+    name: "Con Agent"
+    description: "Argues against the proposition with counterevidence."
+    config:
+      role: "Opponent"
+      tools: [web_search, cite_source]
+
+  - id: "rebuttal_round"
+    type: "agent"
+    subtype: "llm"
+    name: "Rebuttal Round"
+    description: "Both agents respond to the other's arguments (2 iterations)."
+    config:
+      max_iterations: 2
+
+  - id: "moderator_synthesize"
+    type: "agent"
+    subtype: "llm"
+    name: "Moderator — Synthesis"
+    description: "Summarizes both sides, highlights strongest arguments and gaps."
+
+  - id: "human_judge"
+    type: "human"
+    subtype: "review"
+    name: "Human Judge"
+    description: "Reviews the debate transcript and declares a winner or draw."
+
+edges:
+  - from: "pose_question"
+    to: "moderator_open"
+    mode: "sequential"
+  - from: "moderator_open"
+    to: "pro_agent"
+    mode: "parallel"
+  - from: "moderator_open"
+    to: "con_agent"
+    mode: "parallel"
+  - from: "pro_agent"
+    to: "rebuttal_round"
+    mode: "sequential"
+  - from: "con_agent"
+    to: "rebuttal_round"
+    mode: "sequential"
+  - from: "rebuttal_round"
+    to: "moderator_synthesize"
+    mode: "sequential"
+  - from: "moderator_synthesize"
+    to: "human_judge"
+    mode: "sequential"


### PR DESCRIPTION
## Summary

- Adds a portable YAML workflow definition (`notebook/osop/multi-agent-debate.osop.yaml`) describing a structured multi-agent debate pattern with moderator, pro/con agents, and human judge
- Includes a README mapping OSOP concepts to AutoGen equivalents (`ConversableAgent`, `UserProxyAgent`, `initiate_chat()` chains, etc.)
- **Additive only** — no existing files are modified

## What is OSOP?

[OSOP](https://github.com/Archie0125/osop-spec) (Open Standard for Orchestration Protocols) is a portable YAML format for describing AI agent workflows — think **OpenAPI, but for agent orchestration**. It lets you document, validate, and visualize multi-agent patterns in a framework-agnostic way.

The `.osop.yaml` file is self-documenting and human-readable. It works standalone without any OSOP tooling installed.

## Files Added

| File | Description |
|------|-------------|
| `notebook/osop/README.md` | Explains OSOP + AutoGen integration with concept mapping table |
| `notebook/osop/multi-agent-debate.osop.yaml` | Debate workflow: moderator opens → pro/con argue in parallel → rebuttals → synthesis → human judge |

## Test Plan

- [ ] Verify YAML is valid: `python -c "import yaml; yaml.safe_load(open('notebook/osop/multi-agent-debate.osop.yaml'))"`
- [ ] Confirm no existing files were modified
- [ ] Review README for accuracy of AutoGen concept mappings