### PR TITLE
fix: correct token-to-char budget calculation in TokenLimiter

### DIFF
--- a/autogen/beta/middleware/builtin/token_limiter.py
+++ b/autogen/beta/middleware/builtin/token_limiter.py
@@ -21,7 +21,7 @@ class TokenLimiter(MiddlewareFactory):
             raise ValueError("max_tokens must be greater than 0")
         if chars_per_token < 1:
             raise ValueError("chars_per_token must be greater than 0")
-        self._max_chars = max_tokens // chars_per_token
+        self._max_chars = max_tokens * chars_per_token
 
     def __call__(self, event: "BaseEvent", context: "Context") -> "BaseMiddleware":
         return _TokenLimiter(event, context, self._max_chars)


### PR DESCRIPTION
## Summary

The `TokenLimiter` middleware converts a `max_tokens` budget into a character budget using `chars_per_token`. The formula was using integer division (`max_tokens // chars_per_token`) when it should use multiplication (`max_tokens * chars_per_token`).

**Example with defaults (`max_tokens=10000, chars_per_token=4`):**
- **Before (wrong):** `10000 // 4 = 2500` chars — only allows ~2500 characters of history
- **After (correct):** `10000 * 4 = 40000` chars — allows ~40000 characters, matching 10000 tokens

This caused the middleware to aggressively over-trim message history (by a factor of `chars_per_token²` = 16x with the default), discarding far more context than intended.

The bug was masked in tests because all test cases use `chars_per_token=1`, where `//` and `*` produce identical results.

## Test plan
- [x] Existing tests pass (they use `chars_per_token=1` so are unaffected by this change)
- [ ] Verify with `chars_per_token > 1` that the character budget is correctly calculated

🤖 Generated with [Claude Code](https://claude.com/claude-code)