### PR TITLE
fix: correct duplicate condition in speaker selection verbose logging

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -886,7 +886,7 @@ class GroupChat:
                         select_speaker_auto_verbose=self.select_speaker_auto_verbose,
                     )
                 )
-            elif no_of_mentions == 1:
+            elif no_of_mentions > 1:
                 iostream.send(
                     SpeakerAttemptFailedMultipleAgentsEvent(
                         mentions=mentions,


### PR DESCRIPTION
## Summary

- **Bug:** In `autogen/agentchat/groupchat.py`, the `elif` branch (line 889) used `no_of_mentions == 1`, duplicating the `if` condition on line 879. This made the `elif` block dead code — it could never execute.
- **Impact:** `SpeakerAttemptFailedMultipleAgentsEvent` was never emitted. When multiple agents were mentioned, execution fell through to the `else` branch and incorrectly fired `SpeakerAttemptFailedNoAgentsEvent`.
- **Fix:** Changed the condition from `no_of_mentions == 1` to `no_of_mentions > 1` so the three branches now correctly cover:
  - `== 1` → success (one agent mentioned)
  - `> 1` → failed, multiple agents mentioned
  - `else` (0) → failed, no agents mentioned

## Test plan

- [x] Verified the three branches are now mutually exclusive and exhaustive
- [ ] Run existing group chat tests to confirm no regressions
- [ ] Confirm `SpeakerAttemptFailedMultipleAgentsEvent` fires when multiple agents are mentioned in speaker selection