### PR TITLE
feat: add Semantic Scholar search tool

### DIFF
--- a/autogen/tools/experimental/__init__.py
+++ b/autogen/tools/experimental/__init__.py
@@ -22,6 +22,7 @@ from .perplexity import PerplexitySearchTool
 from .quick_research import QuickResearchTool
 from .reliable import ReliableTool, ReliableToolError, SuccessfulExecutionParameters, ToolExecutionDetails
 from .searxng import SearxngSearchTool
+from .semantic_scholar import SemanticScholarSearchTool
 from .tavily import TavilySearchTool
 from .tinyfish import TinyFishTool
 from .web_search_preview import WebSearchPreviewTool
@@ -42,6 +43,7 @@ __all__ = [
     "ReliableTool",
     "ReliableToolError",
     "SearxngSearchTool",
+    "SemanticScholarSearchTool",
     "SlackRetrieveRepliesTool",
     "SlackRetrieveTool",
     "SlackSendTool",

--- a/autogen/tools/experimental/semantic_scholar/__init__.py
+++ b/autogen/tools/experimental/semantic_scholar/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .semantic_scholar import SemanticScholarSearchTool
+
+__all__ = ["SemanticScholarSearchTool"]

--- a/autogen/tools/experimental/semantic_scholar/semantic_scholar.py
+++ b/autogen/tools/experimental/semantic_scholar/semantic_scholar.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Optional
+
+import requests
+from pydantic import BaseModel
+
+from autogen.tools import Tool
+
+# Base URL for the Semantic Scholar Academic Graph API.
+BASE_URL = "https://api.semanticscholar.org/graph/v1"
+
+# Maximum allowed length for a query string.
+MAX_QUERY_LENGTH = 300
+
+# Maximum number of results to retrieve from a search.
+MAX_RESULTS = 100
+
+# Default fields to retrieve for each paper.
+DEFAULT_FIELDS = "title,abstract,authors,year,citationCount,url,externalIds"
+
+
+class Paper(BaseModel):
+    """Pydantic model representing a Semantic Scholar paper.
+
+    Attributes:
+        paper_id (str): The Semantic Scholar paper ID.
+        title (str): Title of the paper.
+        abstract (Optional[str]): Abstract text, if available.
+        authors (list[str]): List of author names.
+        year (Optional[int]): Publication year, if available.
+        citation_count (Optional[int]): Number of citations.
+        url (Optional[str]): Semantic Scholar URL for the paper.
+        external_ids (dict[str, str]): External identifiers (e.g., DOI, ArXiv).
+    """
+
+    paper_id: str
+    title: str
+    abstract: Optional[str] = None
+    authors: list[str] = []
+    year: Optional[int] = None
+    citation_count: Optional[int] = None
+    url: Optional[str] = None
+    external_ids: dict[str, str] = {}
+
+
+class SemanticScholarClient:
+    """Client for interacting with the Semantic Scholar Academic Graph API.
+
+    Provides methods to search for papers by keyword query and to look up
+    individual papers by their Semantic Scholar ID or external ID (e.g., DOI, ArXiv).
+
+    Public methods:
+        search_papers(query, limit, fields) -> list[dict[str, Any]]
+        get_paper(paper_id, fields) -> dict[str, Any]
+
+    Attributes:
+        base_url (str): Base URL for the API.
+        headers (dict[str, str]): HTTP headers for requests.
+        api_key (Optional[str]): Optional API key for higher rate limits.
+    """
+
+    def __init__(self, api_key: Optional[str] = None, tool_name: str = "semantic-scholar-client") -> None:
+        """Initialize the SemanticScholarClient.
+
+        Args:
+            api_key (Optional[str]): Optional Semantic Scholar API key for higher rate limits.
+                The public API works without a key but has lower rate limits.
+            tool_name (str): Identifier for User-Agent header.
+        """
+        self.base_url = BASE_URL
+        self.headers: dict[str, str] = {"User-Agent": f"autogen.Agent ({tool_name})"}
+        if api_key:
+            self.headers["x-api-key"] = api_key
+
+    def search_papers(
+        self, query: str, limit: int = 10, fields: str = DEFAULT_FIELDS
+    ) -> list[dict[str, Any]]:
+        """Search Semantic Scholar for papers matching a query string.
+
+        Args:
+            query (str): The search keywords.
+            limit (int): Max number of results to return (capped at MAX_RESULTS).
+            fields (str): Comma-separated list of fields to retrieve.
+
+        Returns:
+            list[dict[str, Any]]: Each dict contains paper data with the requested fields.
+
+        Raises:
+            requests.HTTPError: If the HTTP request to the API fails.
+        """
+        params = {
+            "query": query,
+            "limit": str(min(limit, MAX_RESULTS)),
+            "fields": fields,
+        }
+
+        response = requests.get(
+            url=f"{self.base_url}/paper/search",
+            params=params,
+            headers=self.headers,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data.get("data", [])
+
+    def get_paper(self, paper_id: str, fields: str = DEFAULT_FIELDS) -> dict[str, Any]:
+        """Retrieve details for a specific paper by its ID.
+
+        The paper_id can be a Semantic Scholar ID, DOI (prefixed with "DOI:"),
+        ArXiv ID (prefixed with "ARXIV:"), or other supported external IDs.
+
+        Args:
+            paper_id (str): The paper identifier.
+            fields (str): Comma-separated list of fields to retrieve.
+
+        Returns:
+            dict[str, Any]: Paper data with the requested fields.
+
+        Raises:
+            requests.HTTPError: If the HTTP request fails (e.g., 404 for unknown paper).
+        """
+        params = {"fields": fields}
+
+        response = requests.get(
+            url=f"{self.base_url}/paper/{paper_id}",
+            params=params,
+            headers=self.headers,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def _parse_paper(raw: dict[str, Any]) -> Paper:
+    """Parse a raw API response dict into a Paper model.
+
+    Args:
+        raw (dict[str, Any]): Raw paper data from the Semantic Scholar API.
+
+    Returns:
+        Paper: A structured Paper object.
+    """
+    authors = []
+    for author in raw.get("authors", []) or []:
+        name = author.get("name")
+        if name:
+            authors.append(name)
+
+    external_ids = {}
+    for key, value in (raw.get("externalIds") or {}).items():
+        if value is not None:
+            external_ids[key] = str(value)
+
+    return Paper(
+        paper_id=raw.get("paperId", ""),
+        title=raw.get("title", ""),
+        abstract=raw.get("abstract"),
+        authors=authors,
+        year=raw.get("year"),
+        citation_count=raw.get("citationCount"),
+        url=raw.get("url"),
+        external_ids=external_ids,
+    )
+
+
+def _format_paper(paper: Paper) -> str:
+    """Format a Paper object into a human-readable string.
+
+    Args:
+        paper (Paper): The paper to format.
+
+    Returns:
+        str: Formatted string with paper details.
+    """
+    parts = [f"Title: {paper.title}"]
+    if paper.authors:
+        parts.append(f"Authors: {', '.join(paper.authors)}")
+    if paper.year is not None:
+        parts.append(f"Year: {paper.year}")
+    if paper.citation_count is not None:
+        parts.append(f"Citations: {paper.citation_count}")
+    if paper.abstract:
+        parts.append(f"Abstract: {paper.abstract}")
+    if paper.url:
+        parts.append(f"URL: {paper.url}")
+    if paper.external_ids:
+        ids_str = ", ".join(f"{k}: {v}" for k, v in paper.external_ids.items())
+        parts.append(f"External IDs: {ids_str}")
+    return "\n".join(parts)
+
+
+class SemanticScholarSearchTool(Tool):
+    """Tool for searching academic papers on Semantic Scholar.
+
+    This tool uses the Semantic Scholar Academic Graph API to search for
+    papers by keyword query and retrieve structured paper information
+    including title, authors, abstract, year, citation count, and external IDs.
+
+    The public API is free and does not require an API key, though providing
+    one increases rate limits (see https://www.semanticscholar.org/product/api).
+
+    Public methods:
+        search_papers(query: str) -> list[str] | str
+        get_paper(paper_id: str) -> str
+
+    Attributes:
+        max_results (int): Max number of papers returned per search.
+        fields (str): Comma-separated fields to request from the API.
+        verbose (bool): If True, enables debug logging to stdout.
+        client (SemanticScholarClient): Internal client for API calls.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        max_results: int = 10,
+        fields: str = DEFAULT_FIELDS,
+        verbose: bool = False,
+    ) -> None:
+        """Initialize the SemanticScholarSearchTool.
+
+        Args:
+            api_key (Optional[str]): Optional API key for higher rate limits.
+            max_results (int): Desired number of search results (capped by MAX_RESULTS).
+            fields (str): Comma-separated list of paper fields to retrieve.
+                Supported fields include: title, abstract, authors, year,
+                citationCount, url, externalIds, referenceCount, influentialCitationCount,
+                fieldsOfStudy, publicationTypes, publicationDate, journal, venue.
+            verbose (bool): If True, print debug information during searches.
+        """
+        self.tool_name = "semantic-scholar-search"
+        self.max_results = min(max_results, MAX_RESULTS)
+        self.fields = fields
+        self.verbose = verbose
+        self.client = SemanticScholarClient(api_key=api_key, tool_name=self.tool_name)
+        super().__init__(
+            name=self.tool_name,
+            description=(
+                "Search Semantic Scholar for academic papers by keyword query. "
+                "Returns paper titles, authors, abstracts, publication years, "
+                "citation counts, and external identifiers (DOI, ArXiv, etc.). "
+                "Useful for literature review, finding related work, or looking up "
+                "specific academic publications."
+            ),
+            func_or_tool=self.search_papers,
+        )
+
+    def search_papers(self, query: str) -> list[str] | str:
+        """Search Semantic Scholar and return formatted paper results.
+
+        Truncates the query to MAX_QUERY_LENGTH before searching.
+
+        Args:
+            query (str): Search term(s) to look up on Semantic Scholar.
+
+        Returns:
+            list[str]: Each element is a formatted string with paper details.
+            str: Error message if no results are found or on exception.
+
+        Note:
+            Automatically handles API exceptions and returns error strings
+            for robust operation in agent pipelines.
+        """
+        try:
+            truncated_query = query[:MAX_QUERY_LENGTH]
+            if self.verbose:
+                print(
+                    f"INFO\t [{self.tool_name}] search query='{truncated_query}' "
+                    f"max_results={self.max_results}"
+                )
+            raw_results = self.client.search_papers(
+                query=truncated_query,
+                limit=self.max_results,
+                fields=self.fields,
+            )
+            if not raw_results:
+                return "No papers found matching the query on Semantic Scholar"
+
+            formatted: list[str] = []
+            for raw in raw_results:
+                paper = _parse_paper(raw)
+                formatted.append(_format_paper(paper))
+            return formatted
+
+        except Exception as e:
+            return f"Semantic Scholar search failed: {str(e)}"
+
+    def get_paper(self, paper_id: str) -> str:
+        """Look up a specific paper by its ID on Semantic Scholar.
+
+        The paper_id can be:
+        - A Semantic Scholar paper ID (e.g., "649def34f8be52c8b66281af98ae884c09aef38b")
+        - A DOI prefixed with "DOI:" (e.g., "DOI:10.1234/example")
+        - An ArXiv ID prefixed with "ARXIV:" (e.g., "ARXIV:2106.01345")
+        - A Corpus ID prefixed with "CorpusId:" (e.g., "CorpusId:215416146")
+
+        Args:
+            paper_id (str): The paper identifier.
+
+        Returns:
+            str: Formatted string with paper details, or an error message.
+        """
+        try:
+            if self.verbose:
+                print(f"INFO\t [{self.tool_name}] get paper_id='{paper_id}'")
+            raw = self.client.get_paper(paper_id=paper_id, fields=self.fields)
+            paper = _parse_paper(raw)
+            return _format_paper(paper)
+
+        except Exception as e:
+            return f"Semantic Scholar paper lookup failed: {str(e)}"

--- a/test/tools/experimental/semantic_scholar/__init__.py
+++ b/test/tools/experimental/semantic_scholar/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/tools/experimental/semantic_scholar/test_semantic_scholar.py
+++ b/test/tools/experimental/semantic_scholar/test_semantic_scholar.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from autogen.tools.experimental.semantic_scholar.semantic_scholar import (
+    Paper,
+    SemanticScholarClient,
+    SemanticScholarSearchTool,
+    _format_paper,
+    _parse_paper,
+)
+
+
+# Sample raw paper data matching the Semantic Scholar API response format.
+SAMPLE_RAW_PAPER = {
+    "paperId": "abc123",
+    "title": "Attention Is All You Need",
+    "abstract": "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks.",
+    "authors": [
+        {"authorId": "1", "name": "Ashish Vaswani"},
+        {"authorId": "2", "name": "Noam Shazeer"},
+    ],
+    "year": 2017,
+    "citationCount": 90000,
+    "url": "https://www.semanticscholar.org/paper/abc123",
+    "externalIds": {"DOI": "10.5555/3295222.3295349", "ArXiv": "1706.03762", "CorpusId": "215416146"},
+}
+
+SAMPLE_RAW_PAPER_MINIMAL = {
+    "paperId": "def456",
+    "title": "A Minimal Paper",
+    "abstract": None,
+    "authors": None,
+    "year": None,
+    "citationCount": None,
+    "url": None,
+    "externalIds": None,
+}
+
+
+class TestParsePaper:
+    """Test suite for the _parse_paper helper function."""
+
+    def test_parse_full_paper(self) -> None:
+        paper = _parse_paper(SAMPLE_RAW_PAPER)
+        assert paper.paper_id == "abc123"
+        assert paper.title == "Attention Is All You Need"
+        assert len(paper.authors) == 2
+        assert "Ashish Vaswani" in paper.authors
+        assert paper.year == 2017
+        assert paper.citation_count == 90000
+        assert paper.external_ids["DOI"] == "10.5555/3295222.3295349"
+
+    def test_parse_minimal_paper(self) -> None:
+        paper = _parse_paper(SAMPLE_RAW_PAPER_MINIMAL)
+        assert paper.paper_id == "def456"
+        assert paper.title == "A Minimal Paper"
+        assert paper.abstract is None
+        assert paper.authors == []
+        assert paper.year is None
+        assert paper.citation_count is None
+        assert paper.external_ids == {}
+
+
+class TestFormatPaper:
+    """Test suite for the _format_paper helper function."""
+
+    def test_format_full_paper(self) -> None:
+        paper = _parse_paper(SAMPLE_RAW_PAPER)
+        formatted = _format_paper(paper)
+        assert "Title: Attention Is All You Need" in formatted
+        assert "Authors: Ashish Vaswani, Noam Shazeer" in formatted
+        assert "Year: 2017" in formatted
+        assert "Citations: 90000" in formatted
+        assert "Abstract:" in formatted
+        assert "URL:" in formatted
+        assert "External IDs:" in formatted
+
+    def test_format_minimal_paper(self) -> None:
+        paper = _parse_paper(SAMPLE_RAW_PAPER_MINIMAL)
+        formatted = _format_paper(paper)
+        assert "Title: A Minimal Paper" in formatted
+        assert "Authors:" not in formatted
+        assert "Year:" not in formatted
+        assert "Abstract:" not in formatted
+
+
+class TestSemanticScholarClient:
+    """Test suite for the SemanticScholarClient class."""
+
+    @patch("autogen.tools.experimental.semantic_scholar.semantic_scholar.requests.get")
+    def test_search_papers_success(self, mock_get: MagicMock) -> None:
+        fake_json = {"data": [SAMPLE_RAW_PAPER]}
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = fake_json
+        mock_get.return_value = mock_response
+
+        client = SemanticScholarClient()
+        results = client.search_papers("attention transformers")
+        assert len(results) == 1
+        assert results[0]["title"] == "Attention Is All You Need"
+
+    @patch("autogen.tools.experimental.semantic_scholar.semantic_scholar.requests.get")
+    def test_search_papers_empty(self, mock_get: MagicMock) -> None:
+        fake_json = {"data": []}
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = fake_json
+        mock_get.return_value = mock_response
+
+        client = SemanticScholarClient()
+        results = client.search_papers("nonexistent query xyz")
+        assert results == []
+
+    @patch("autogen.tools.experimental.semantic_scholar.semantic_scholar.requests.get")
+    def test_search_papers_http_error(self, mock_get: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.HTTPError("HTTP Error")
+        mock_get.return_value = mock_response
+
+        client = SemanticScholarClient()
+        with pytest.raises(requests.HTTPError):
+            client.search_papers("test query")
+
+    @patch("autogen.tools.experimental.semantic_scholar.semantic_scholar.requests.get")
+    def test_get_paper_success(self, mock_get: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = SAMPLE_RAW_PAPER
+        mock_get.return_value = mock_response
+
+        client = SemanticScholarClient()
+        result = client.get_paper("abc123")
+        assert result["title"] == "Attention Is All You Need"
+
+    @patch("autogen.tools.experimental.semantic_scholar.semantic_scholar.requests.get")
+    def test_get_paper_not_found(self, mock_get: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
+        mock_get.return_value = mock_response
+
+        client = SemanticScholarClient()
+        with pytest.raises(requests.HTTPError):
+            client.get_paper("nonexistent_id")
+
+    def test_api_key_header(self) -> None:
+        client = SemanticScholarClient(api_key="test-key-123")
+        assert client.headers["x-api-key"] == "test-key-123"
+
+    def test_no_api_key_header(self) -> None:
+        client = SemanticScholarClient()
+        assert "x-api-key" not in client.headers
+
+
+class TestSemanticScholarSearchTool:
+    """Test suite for the SemanticScholarSearchTool class."""
+
+    @pytest.fixture
+    def tool(self) -> SemanticScholarSearchTool:
+        """Provide a SemanticScholarSearchTool instance for testing.
+
+        Returns:
+            SemanticScholarSearchTool: A configured tool instance with verbose off.
+        """
+        return SemanticScholarSearchTool(verbose=False)
+
+    def test_search_papers_success(self, tool: SemanticScholarSearchTool) -> None:
+        with patch.object(
+            tool.client,
+            "search_papers",
+            return_value=[SAMPLE_RAW_PAPER],
+        ):
+            result = tool.search_papers("attention mechanism")
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert "Attention Is All You Need" in result[0]
+            assert "Ashish Vaswani" in result[0]
+
+    def test_search_papers_no_results(self, tool: SemanticScholarSearchTool) -> None:
+        with patch.object(tool.client, "search_papers", return_value=[]):
+            result = tool.search_papers("completely nonexistent paper xyz123")
+            assert result == "No papers found matching the query on Semantic Scholar"
+
+    def test_search_papers_exception(self, tool: SemanticScholarSearchTool) -> None:
+        with patch.object(tool.client, "search_papers", side_effect=Exception("API timeout")):
+            result = tool.search_papers("test query")
+            assert isinstance(result, str)
+            assert result.startswith("Semantic Scholar search failed:")
+
+    def test_get_paper_success(self, tool: SemanticScholarSearchTool) -> None:
+        with patch.object(
+            tool.client,
+            "get_paper",
+            return_value=SAMPLE_RAW_PAPER,
+        ):
+            result = tool.get_paper("abc123")
+            assert isinstance(result, str)
+            assert "Attention Is All You Need" in result
+
+    def test_get_paper_exception(self, tool: SemanticScholarSearchTool) -> None:
+        with patch.object(tool.client, "get_paper", side_effect=Exception("404 Not Found")):
+            result = tool.get_paper("nonexistent_id")
+            assert isinstance(result, str)
+            assert result.startswith("Semantic Scholar paper lookup failed:")
+
+    def test_tool_name_and_description(self, tool: SemanticScholarSearchTool) -> None:
+        assert tool.name == "semantic-scholar-search"
+        assert "Semantic Scholar" in tool.description
+
+    def test_max_results_capped(self) -> None:
+        tool = SemanticScholarSearchTool(max_results=500)
+        assert tool.max_results == 100
+
+    def test_query_truncation(self, tool: SemanticScholarSearchTool) -> None:
+        long_query = "a" * 500
+        with patch.object(tool.client, "search_papers", return_value=[]) as mock_search:
+            tool.search_papers(long_query)
+            called_query = mock_search.call_args[1]["query"]
+            assert len(called_query) == 300


### PR DESCRIPTION
## Summary
- Add `SemanticScholarSearchTool` under `autogen/tools/experimental/semantic_scholar/` for searching academic papers via the [Semantic Scholar Academic Graph API](https://api.semanticscholar.org/graph/v1/)
- Supports keyword search (`search_papers`) and paper lookup by ID (`get_paper`) with Semantic Scholar IDs, DOIs, ArXiv IDs, and CorpusIds
- Returns structured results including title, authors, abstract, year, citation count, URL, and external identifiers
- No additional dependencies required — uses only `requests` (already in the project) and the free public API

Closes #1760

## Design
Follows the existing Wikipedia tool pattern (`WikipediaQueryRunTool` / `WikipediaPageLoadTool`):
- `SemanticScholarClient` — low-level API client with `search_papers()` and `get_paper()` methods
- `Paper` — Pydantic model for structured paper data
- `SemanticScholarSearchTool(Tool)` — high-level tool class that integrates with AG2 agents
- Optional `api_key` parameter for higher rate limits (public API works without one)
- Configurable `max_results` and `fields` parameters

## Test plan
- [x] Unit tests for `_parse_paper` and `_format_paper` helpers (full and minimal data)
- [x] Unit tests for `SemanticScholarClient` (search success, empty results, HTTP errors, paper lookup, API key handling)
- [x] Unit tests for `SemanticScholarSearchTool` (search success, no results, exceptions, paper lookup, query truncation, max_results capping)
- [x] All 19 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)