### PR TITLE
feat: add ArXiv search tool

### DIFF
--- a/autogen/tools/experimental/__init__.py
+++ b/autogen/tools/experimental/__init__.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from .arxiv import ArxivSearchTool
 from .browser_use import BrowserUseTool
 from .code_execution import PythonCodeExecutionTool
 from .crawl4ai import Crawl4AITool
@@ -28,6 +29,7 @@ from .web_search_preview import WebSearchPreviewTool
 from .wikipedia import WikipediaPageLoadTool, WikipediaQueryRunTool
 
 __all__ = [
+    "ArxivSearchTool",
     "BrowserUseTool",
     "Crawl4AITool",
     "DeepResearchTool",

--- a/autogen/tools/experimental/arxiv/__init__.py
+++ b/autogen/tools/experimental/arxiv/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .arxiv import ArxivSearchTool
+
+__all__ = ["ArxivSearchTool"]

--- a/autogen/tools/experimental/arxiv/arxiv.py
+++ b/autogen/tools/experimental/arxiv/arxiv.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from autogen.import_utils import optional_import_block, require_optional_import
+from autogen.tools import Tool
+
+with optional_import_block():
+    import arxiv
+
+# Maximum allowed length for a query string.
+MAX_QUERY_LENGTH = 300
+# Maximum number of results to retrieve from a search.
+MAX_RESULTS = 50
+# Maximum number of characters to return from a paper summary.
+MAX_SUMMARY_LENGTH = 2000
+
+
+class ArxivArticle(BaseModel):
+    """Pydantic model representing an arXiv article.
+
+    Attributes:
+        title (str): Title of the article.
+        authors (str): Comma-separated list of author names.
+        summary (str): Abstract/summary of the article (possibly truncated).
+        published (str): Publication date in 'YYYY-MM' format.
+        entry_id (str): The arXiv entry URL (e.g., 'http://arxiv.org/abs/2301.00001v1').
+        pdf_url (str): Direct URL to the PDF.
+        doi (str): DOI of the article, if available.
+        primary_category (str): Primary arXiv category (e.g., 'cs.AI').
+    """
+
+    title: str
+    authors: str
+    summary: str
+    published: str
+    entry_id: str
+    pdf_url: str
+    doi: str
+    primary_category: str
+
+
+class ArxivClient:
+    """Client for interacting with the arXiv API.
+
+    Supports searching for papers by query string with configurable
+    sorting and result limits.
+
+    Public methods:
+        search(query: str, max_results: int, sort_by: str) -> list[ArxivArticle]
+
+    Attributes:
+        client (arxiv.Client): Low-level arXiv API client.
+        truncate (int): Maximum number of characters for article summaries.
+    """
+
+    # Mapping of user-friendly sort names to arxiv.SortCriterion values.
+    SORT_CRITERIA = {
+        "relevance": "Relevance",
+        "submittedDate": "SubmittedDate",
+        "lastUpdatedDate": "LastUpdatedDate",
+    }
+
+    def __init__(self, truncate: int = MAX_SUMMARY_LENGTH) -> None:
+        """Initialize the ArxivClient.
+
+        Args:
+            truncate (int): Maximum number of characters for each article summary.
+        """
+        self.client = arxiv.Client()
+        self.truncate = min(truncate, MAX_SUMMARY_LENGTH)
+
+    def search(self, query: str, max_results: int = 5, sort_by: str = "relevance") -> list[ArxivArticle]:
+        """Search arXiv for papers matching a query string.
+
+        Args:
+            query (str): The search keywords or arXiv query expression.
+            max_results (int): Max number of results to return (capped at MAX_RESULTS).
+            sort_by (str): Sorting criterion. One of 'relevance', 'submittedDate',
+                or 'lastUpdatedDate'.
+
+        Returns:
+            list[ArxivArticle]: A list of ArxivArticle objects with paper metadata.
+
+        Raises:
+            ValueError: If sort_by is not a recognized criterion.
+            arxiv.ArxivError: On lower-level API errors.
+        """
+        max_results = min(max_results, MAX_RESULTS)
+
+        criterion_name = self.SORT_CRITERIA.get(sort_by)
+        if criterion_name is None:
+            raise ValueError(
+                f"Invalid sort_by value: '{sort_by}'. "
+                f"Must be one of: {', '.join(self.SORT_CRITERIA.keys())}"
+            )
+        criterion = getattr(arxiv.SortCriterion, criterion_name)
+
+        search = arxiv.Search(query=query, max_results=max_results, sort_by=criterion)
+        results = self.client.results(search)
+
+        articles: list[ArxivArticle] = []
+        for result in results:
+            article = ArxivArticle(
+                title=result.title,
+                authors=", ".join(a.name for a in result.authors),
+                summary=result.summary[: self.truncate],
+                published=result.published.strftime("%Y-%m"),
+                entry_id=result.entry_id,
+                pdf_url=result.pdf_url,
+                doi=result.doi or "",
+                primary_category=result.primary_category,
+            )
+            articles.append(article)
+
+        return articles
+
+
+@require_optional_import(["arxiv"], "arxiv")
+class ArxivSearchTool(Tool):
+    """Tool for searching arXiv and returning structured article metadata.
+
+    This tool uses the `arxiv` Python package to search the arXiv repository
+    and returns up to `max_results` articles with their title, authors,
+    summary, publication date, entry ID, PDF URL, DOI, and primary category.
+
+    Public methods:
+        search(query: str) -> list[ArxivArticle] | str
+
+    Attributes:
+        max_results (int): Max number of articles returned per query (capped at MAX_RESULTS).
+        sort_by (str): Sorting criterion for search results.
+        truncate (int): Max characters for each article summary.
+        verbose (bool): If True, enables debug logging to stdout.
+        arxiv_client (ArxivClient): Internal client for arXiv API calls.
+    """
+
+    def __init__(
+        self,
+        max_results: int = 5,
+        sort_by: str = "relevance",
+        truncate: int = MAX_SUMMARY_LENGTH,
+        verbose: bool = False,
+    ) -> None:
+        """Initialize the ArxivSearchTool.
+
+        Args:
+            max_results (int): Desired number of results (capped at MAX_RESULTS).
+            sort_by (str): Sorting criterion. One of 'relevance', 'submittedDate',
+                or 'lastUpdatedDate'.
+            truncate (int): Maximum number of characters for article summaries
+                (capped at MAX_SUMMARY_LENGTH).
+            verbose (bool): If True, print debug information during searches.
+        """
+        self.max_results = min(max_results, MAX_RESULTS)
+        self.sort_by = sort_by
+        self.truncate = min(truncate, MAX_SUMMARY_LENGTH)
+        self.verbose = verbose
+        self.tool_name = "arxiv-search"
+        self.arxiv_client = ArxivClient(truncate=self.truncate)
+        super().__init__(
+            name=self.tool_name,
+            description=(
+                "Search arXiv for academic papers matching a query. "
+                "Returns a list of articles with title, authors, summary, "
+                "publication date, arXiv entry ID, PDF URL, DOI, and primary category. "
+                "Useful for research, literature review, and finding recent papers."
+            ),
+            func_or_tool=self.search,
+        )
+
+    def search(self, query: str) -> list[ArxivArticle] | str:
+        """Search arXiv and return structured article results.
+
+        Truncates the query to MAX_QUERY_LENGTH before searching.
+
+        Args:
+            query (str): Search term(s) or arXiv query expression to look up.
+
+        Returns:
+            list[ArxivArticle]: Each element contains article metadata.
+            str: Error message if no results are found or on exception.
+
+        Note:
+            Automatically handles API exceptions and returns error strings
+            for robust operation in agent workflows.
+        """
+        try:
+            truncated_query = query[:MAX_QUERY_LENGTH]
+            if self.verbose:
+                print(
+                    f"INFO\t [{self.tool_name}] search query='{truncated_query}' "
+                    f"max_results={self.max_results} sort_by={self.sort_by}"
+                )
+            articles = self.arxiv_client.search(
+                query=truncated_query,
+                max_results=self.max_results,
+                sort_by=self.sort_by,
+            )
+            if not articles:
+                return "No arXiv search results found"
+            return articles
+        except Exception as e:
+            return f"arXiv search failed: {str(e)}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,8 @@ google-search = ["ag2[google-client]"]
 
 wikipedia = ["wikipedia-api>=0.8.1, <1.0"]
 
+arxiv = ["arxiv>=2.1.0, <3.0"]
+
 neo4j = [
     "docx2txt==0.9",
     # Updated llama-index constraints

--- a/test/tools/experimental/arxiv/__init__.py
+++ b/test/tools/experimental/arxiv/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/tools/experimental/arxiv/test_arxiv.py
+++ b/test/tools/experimental/arxiv/test_arxiv.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autogen.import_utils import run_for_optional_imports
+from autogen.tools.experimental.arxiv.arxiv import (
+    ArxivArticle,
+    ArxivClient,
+    ArxivSearchTool,
+)
+
+
+class FakeAuthor:
+    """Simulates an arxiv result author object."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class FakeResult:
+    """Simulates an arxiv.Result object."""
+
+    def __init__(
+        self,
+        title: str = "Test Paper",
+        authors: list[str] | None = None,
+        summary: str = "This is a test summary.",
+        published: datetime | None = None,
+        entry_id: str = "http://arxiv.org/abs/2301.00001v1",
+        pdf_url: str = "http://arxiv.org/pdf/2301.00001v1",
+        doi: str | None = None,
+        primary_category: str = "cs.AI",
+    ) -> None:
+        self.title = title
+        self.authors = [FakeAuthor(name) for name in (authors or ["Author One", "Author Two"])]
+        self.summary = summary
+        self.published = published or datetime(2023, 1, 15)
+        self.entry_id = entry_id
+        self.pdf_url = pdf_url
+        self.doi = doi
+        self.primary_category = primary_category
+
+
+@run_for_optional_imports("arxiv", "arxiv")
+class TestArxivClient:
+    """Test suite for the ArxivClient class."""
+
+    @patch("autogen.tools.experimental.arxiv.arxiv.arxiv")
+    def test_search_success(self, mock_arxiv_module: MagicMock) -> None:
+        """Test that search returns a list of ArxivArticle on success."""
+        fake_result = FakeResult()
+        mock_client_instance = MagicMock()
+        mock_client_instance.results.return_value = [fake_result]
+        mock_arxiv_module.Client.return_value = mock_client_instance
+        mock_arxiv_module.SortCriterion.Relevance = "relevance_criterion"
+        mock_arxiv_module.Search.return_value = MagicMock()
+
+        client = ArxivClient()
+        results = client.search("transformer attention")
+
+        assert len(results) == 1
+        assert isinstance(results[0], ArxivArticle)
+        assert results[0].title == "Test Paper"
+        assert results[0].authors == "Author One, Author Two"
+        assert results[0].published == "2023-01"
+        assert results[0].primary_category == "cs.AI"
+
+    @patch("autogen.tools.experimental.arxiv.arxiv.arxiv")
+    def test_search_empty_results(self, mock_arxiv_module: MagicMock) -> None:
+        """Test that search returns an empty list when no results found."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.results.return_value = []
+        mock_arxiv_module.Client.return_value = mock_client_instance
+        mock_arxiv_module.SortCriterion.Relevance = "relevance_criterion"
+        mock_arxiv_module.Search.return_value = MagicMock()
+
+        client = ArxivClient()
+        results = client.search("some obscure query")
+
+        assert results == []
+
+    @patch("autogen.tools.experimental.arxiv.arxiv.arxiv")
+    def test_search_invalid_sort_by(self, mock_arxiv_module: MagicMock) -> None:
+        """Test that search raises ValueError for invalid sort_by."""
+        mock_arxiv_module.Client.return_value = MagicMock()
+
+        client = ArxivClient()
+        with pytest.raises(ValueError, match="Invalid sort_by value"):
+            client.search("test", sort_by="invalid")
+
+    @patch("autogen.tools.experimental.arxiv.arxiv.arxiv")
+    def test_search_truncates_summary(self, mock_arxiv_module: MagicMock) -> None:
+        """Test that long summaries are truncated."""
+        long_summary = "A" * 5000
+        fake_result = FakeResult(summary=long_summary)
+        mock_client_instance = MagicMock()
+        mock_client_instance.results.return_value = [fake_result]
+        mock_arxiv_module.Client.return_value = mock_client_instance
+        mock_arxiv_module.SortCriterion.Relevance = "relevance_criterion"
+        mock_arxiv_module.Search.return_value = MagicMock()
+
+        client = ArxivClient(truncate=100)
+        results = client.search("test")
+
+        assert len(results[0].summary) == 100
+
+    @patch("autogen.tools.experimental.arxiv.arxiv.arxiv")
+    def test_search_with_sort_by_date(self, mock_arxiv_module: MagicMock) -> None:
+        """Test search with submittedDate sort criterion."""
+        fake_result = FakeResult()
+        mock_client_instance = MagicMock()
+        mock_client_instance.results.return_value = [fake_result]
+        mock_arxiv_module.Client.return_value = mock_client_instance
+        mock_arxiv_module.SortCriterion.SubmittedDate = "submitted_date_criterion"
+        mock_arxiv_module.Search.return_value = MagicMock()
+
+        client = ArxivClient()
+        results = client.search("test", sort_by="submittedDate")
+
+        assert len(results) == 1
+        mock_arxiv_module.Search.assert_called_once()
+
+
+@run_for_optional_imports("arxiv", "arxiv")
+class TestArxivSearchTool:
+    """Test suite for the ArxivSearchTool class."""
+
+    @pytest.fixture
+    def tool(self) -> ArxivSearchTool:
+        """Provide an ArxivSearchTool instance for testing.
+
+        Returns:
+            ArxivSearchTool: A configured tool instance with verbose off.
+        """
+        return ArxivSearchTool(verbose=False)
+
+    def test_search_success(self, tool: ArxivSearchTool) -> None:
+        """Test successful search returns a list of ArxivArticle."""
+        fake_articles = [
+            ArxivArticle(
+                title="Test Paper",
+                authors="Author One, Author Two",
+                summary="Test summary",
+                published="2023-01",
+                entry_id="http://arxiv.org/abs/2301.00001v1",
+                pdf_url="http://arxiv.org/pdf/2301.00001v1",
+                doi="",
+                primary_category="cs.AI",
+            )
+        ]
+        with patch.object(tool.arxiv_client, "search", return_value=fake_articles):
+            result = tool.search("transformer attention")
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert result[0].title == "Test Paper"
+            assert result[0].authors == "Author One, Author Two"
+
+    def test_search_no_results(self, tool: ArxivSearchTool) -> None:
+        """Test search with no results returns an informative message."""
+        with patch.object(tool.arxiv_client, "search", return_value=[]):
+            result = tool.search("some obscure query")
+            assert result == "No arXiv search results found"
+
+    def test_search_exception(self, tool: ArxivSearchTool) -> None:
+        """Test search handles exceptions gracefully."""
+        with patch.object(tool.arxiv_client, "search", side_effect=Exception("connection error")):
+            result = tool.search("test query")
+            assert isinstance(result, str)
+            assert result.startswith("arXiv search failed: ")
+
+    def test_search_truncates_query(self, tool: ArxivSearchTool) -> None:
+        """Test that very long queries are truncated."""
+        long_query = "A" * 500
+        with patch.object(tool.arxiv_client, "search", return_value=[]) as mock_search:
+            tool.search(long_query)
+            called_query = mock_search.call_args[1]["query"]
+            assert len(called_query) == 300
+
+    def test_tool_name_and_description(self, tool: ArxivSearchTool) -> None:
+        """Test tool has correct name and description."""
+        assert tool.name == "arxiv-search"
+        assert "arXiv" in tool.description
+
+    def test_verbose_mode(self) -> None:
+        """Test that verbose mode can be enabled."""
+        tool = ArxivSearchTool(verbose=True)
+        assert tool.verbose is True


### PR DESCRIPTION
## Summary

- Adds a new `ArxivSearchTool` under `autogen/tools/experimental/arxiv/` following the existing Wikipedia tool pattern
- Uses the `arxiv` Python package to search papers and returns structured `ArxivArticle` results with title, authors, summary, published date, entry ID, PDF URL, DOI, and primary category
- Includes configurable `max_results`, `sort_by` (relevance/submittedDate/lastUpdatedDate), `truncate`, and `verbose` options

Closes #1759

## Implementation Details

- **`ArxivArticle`** (Pydantic BaseModel): Structured result with 8 fields (title, authors, summary, published, entry_id, pdf_url, doi, primary_category)
- **`ArxivClient`**: Low-level client wrapping `arxiv.Client` with sort criteria mapping and summary truncation
- **`ArxivSearchTool`** (extends `Tool`): High-level tool class with graceful error handling (returns error strings instead of raising), query truncation, and verbose mode
- **Optional dependency**: `arxiv>=2.1.0, <3.0` added to `pyproject.toml` under `[project.optional-dependencies]`

## Test plan

- [x] 5 `TestArxivClient` tests: search success, empty results, invalid sort_by, summary truncation, sort by date
- [x] 6 `TestArxivSearchTool` tests: search success, no results, exception handling, query truncation, tool name/description, verbose mode
- [x] All 11 tests pass locally with mocked `arxiv` API calls (no network required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)