### PR TITLE
Elva: fix 2 bugs

### DIFF
--- a/website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx
+++ b/website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx
@@ -52,6 +52,9 @@ When `beam_size=1`, ReasoningAgent behaves similarly to Chain-of-Thought (CoT) o
 
 For example:
 ```python
+from autogen import LLMConfig
+from autogen.agents.experimental import ReasoningAgent
+
 llm_config = LLMConfig.from_json(path="OAI_CONFIG_LIST")
 # Create a reasoning agent with beam size 1 (O1-style)
 reason_agent = ReasoningAgent(
@@ -76,6 +79,7 @@ Here's a simple example of using ReasoningAgent:
 import os
 from autogen import (
     AssistantAgent,
+    LLMConfig,
     UserProxyAgent,
 )
 from autogen.agents.experimental import (

--- a/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
+++ b/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
@@ -48,15 +48,13 @@ Below is a simple example of creating a FalkorDB Graph RAG agent in AG2. A data 
 For example:
 ```python
 import os
-import autogen
-
-llm_config = LLMConfig.from_json(path="OAI_CONFIG_LIST)
-os.environ["OPENAI_API_KEY"] = llm_config.config_list[0].api_key # Utilised by the FalkorGraphQueryEngine
-
-from autogen import ConversableAgent, UserProxyAgent
+from autogen import ConversableAgent, LLMConfig, UserProxyAgent
 from autogen.agentchat.contrib.graph_rag.document import Document, DocumentType
 from autogen.agentchat.contrib.graph_rag.falkor_graph_query_engine import FalkorGraphQueryEngine
 from autogen.agentchat.contrib.graph_rag.falkor_graph_rag_capability import FalkorGraphRagCapability
+
+llm_config = LLMConfig.from_json(path="OAI_CONFIG_LIST")
+os.environ["OPENAI_API_KEY"] = llm_config.config_list[0].api_key # Utilised by the FalkorGraphQueryEngine
 
 # Auto generate graph schema from unstructured data
 input_path = "../test/agentchat/contrib/graph_rag/the_matrix.txt"
@@ -131,8 +129,8 @@ This capability provides strict responses, where the LLM provides the data in a 
 This is available when using OpenAI LLMs and is set in the LLM configuration (gpt-3.5-turbo-0613 or gpt-4-0613 and above):
 
 ```python
-import autogen
 import os
+from autogen import AssistantAgent, LLMConfig
 from pydantic import BaseModel
 
 # Here is our model
@@ -145,7 +143,7 @@ class MathReasoning(BaseModel):
     final_answer: str
 
 # response_format is added to our configuration
-llm_config = autogen.LLMConfig(config_list={
+llm_config = LLMConfig(config_list={
     "api_type": "openai",
     "model": "gpt-5-nano",
     "api_key": os.getenv("OPENAI_API_KEY"),
@@ -153,7 +151,7 @@ llm_config = autogen.LLMConfig(config_list={
 })
 
 # This agent's responses will now be based on the MathReasoning model
-assistant = autogen.AssistantAgent(name="Math_solver", llm_config=llm_config)
+assistant = AssistantAgent(name="Math_solver", llm_config=llm_config)
 ```
 
 A sample response to `how can I solve 8x + 7 = -23` would be:


### PR DESCRIPTION
Elva run `a2f9c294-e484-43e3-ac53-5ec90851918e` — automated fix from Sentinel-reported bugs.

## Fixes (2)

- `57a3b4d87ebe` **file-BUG-002** — fix(code_samples): NameError in ReasoningAgent example — LLMConfig not imported
  > The fix correctly resolves the `NameError: name 'LLMConfig' is not defined` bug by adding the missing import statements in both affected code blocks within the blog post.
  > 
  > **What was fixed:**
  > 1. **First code block** (line ~52): Added `from autogen import LLMConfig` and `from autogen.agents.experimental import ReasoningAgent` — both were required but absent, causing the code to be unrunnable as written.
  > 2. **Second code block** (line ~82): Added `LLMConfig` to the existing `from autogen import (...)` block, inserted alphabetically between `AssistantAgent` and `UserProxyAgent` — clean and consistent with surrounding style.
  > 
- `4ff1581ba306` **file-BUG-003** — fix(code_samples): NameError in FalkorDB Structured Output example — autogen not imported
  > The fix correctly addresses all reported bugs in both code blocks of the FalkorDB Structured Output blog post:
  > 
  > **Changes made and verified:**
  > 
  > 1. **First code block (lines ~49–62):** Replaces `import autogen` with explicit named imports (`ConversableAgent`, `LLMConfig`, `UserProxyAgent`, and the graph_rag contrib imports). All imports are consolidated at the top of the block. Also fixes a real syntax bug — a missing closing quote: `path="OAI_CONFIG_LIST)` → `path="OAI_CONFIG_LIST"`.
  > 

## Could not fix (1)

- **file-BUG-001** — The bug (missing comma after `code_execution_config={"work_dir":"coding", "use_docker":False}` in the UserProxyAgent constructor at website/docs/_blogs/2024-01-23-Code-execution-in-docker/index.mdx line 53) is already fixed in the current repo snapshot. The comma is present and validate_fix confirms no errors. The fix was applied upstream in commit b83a7c1e (April 7, 2026). The bug existed at the Sep 2025 commit (d5a8bbc) but is already resolved in the current codebase state.

---
Generated by Elva. Reviewer prime directive: minimize work for the human developer.