### PR TITLE
fix(code_samples): NameError in ReasoningAgent example — LLMConfig not i

### DIFF
--- a/website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx
+++ b/website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx
@@ -52,6 +52,9 @@ When `beam_size=1`, ReasoningAgent behaves similarly to Chain-of-Thought (CoT) o
 
 For example:
 ```python
+from autogen import LLMConfig
+from autogen.agents.experimental import ReasoningAgent
+
 llm_config = LLMConfig.from_json(path="OAI_CONFIG_LIST")
 # Create a reasoning agent with beam size 1 (O1-style)
 reason_agent = ReasoningAgent(
@@ -76,6 +79,7 @@ Here's a simple example of using ReasoningAgent:
 import os
 from autogen import (
     AssistantAgent,
+    LLMConfig,
     UserProxyAgent,
 )
 from autogen.agents.experimental import (


### PR DESCRIPTION
Bug: **file-BUG-002**
Commit: `c752fd367111`

**Files changed:**
- `website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx`

**Reviewer notes:**
> Fix is correct and minimal. The `NameError: name 'LLMConfig' is not defined` is resolved by adding the two missing import statements:
> 
> 1. **First code block (line ~52):** Added `from autogen import LLMConfig` and `from autogen.agents.experimental import ReasoningAgent` before their first use — correct placement and order.
> 2. **Second code block (line ~79):** Added `LLMConfig` alphabetically into the existing `from autogen import (...)` group — follows Python style conventions already present in that block.
> 
> The fix is targeted, introduces no regressions, and matches the surrounding code style. No cross-reference issues. Ready to ship.

---
Generated by [Elva](https://github.com/AG2Platform/workforce-elva).