### PR TITLE
fix(code_samples): NameError in FalkorDB Structured Output example — aut

### DIFF
--- a/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
+++ b/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
@@ -50,7 +50,7 @@ For example:
 import os
 import autogen
 
-llm_config = LLMConfig.from_json(path="OAI_CONFIG_LIST)
+llm_config = autogen.LLMConfig.from_json(path="OAI_CONFIG_LIST")
 os.environ["OPENAI_API_KEY"] = llm_config.config_list[0].api_key # Utilised by the FalkorGraphQueryEngine
 
 from autogen import ConversableAgent, UserProxyAgent


### PR DESCRIPTION
Bug: **file-BUG-003**
Commit: `d3533e294c7e`

**Files changed:**
- `website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx`

**Reviewer notes:**
> Fix is correct and ships as-is.
> 
> **What was fixed (two bugs, one line):**
> 1. **Missing namespace prefix** — `LLMConfig.from_json(...)` → `autogen.LLMConfig.from_json(...)`. The file already has `import autogen` in scope, so the qualified reference is valid and consistent.
> 2. **Unterminated string literal** — `path="OAI_CONFIG_LIST)` (missing closing `"`) → `path="OAI_CONFIG_LIST"` (properly closed).
> 
> **Notes for the PR reviewer:**
> - The fix is minimal and surgical; no other logic is changed.
> - The `from autogen import ConversableAgent, UserProxyAgent` on the next line uses direct imports — `LLMConfig` could alternatively be added there, but `autogen.LLMConfig` is equally correct given `import autogen` is present. No change needed.
> - The target blog page (`/docs/_blogs/2024-12-06-FalkorDB-Structured/`) currently returns 404, but that is a pre-existing routing issue unrelated to this fix.
> - No cross-reference breakage detected.

---
Generated by [Elva](https://github.com/AG2Platform/workforce-elva).