### PR TITLE
NameError in ReasoningAgent example — LLMConfig not imported

### DIFF
--- a/website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx
+++ b/website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx
@@ -52,6 +52,9 @@ When `beam_size=1`, ReasoningAgent behaves similarly to Chain-of-Thought (CoT) o
 
 For example:
 ```python
+from autogen import LLMConfig
+from autogen.agents.experimental import ReasoningAgent
+
 llm_config = LLMConfig.from_json(path="OAI_CONFIG_LIST")
 # Create a reasoning agent with beam size 1 (O1-style)
 reason_agent = ReasoningAgent(
@@ -76,6 +79,7 @@ Here's a simple example of using ReasoningAgent:
 import os
 from autogen import (
     AssistantAgent,
+    LLMConfig,
     UserProxyAgent,
 )
 from autogen.agents.experimental import (


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx`

**What I checked before submitting:**
> Fix correctly resolves the NameError caused by missing imports in two separate code blocks within the ReasoningAgent blog post.
> 
> **What was fixed:**
> 1. **First code block (line ~52):** Added both `from autogen import LLMConfig` and `from autogen.agents.experimental import ReasoningAgent` before their first use — the block was entirely missing its imports.
> 2. **Second code block (line ~82):** Added `LLMConfig` to the existing `from autogen import (...)` group, inserted alphabetically between `AssistantAgent` and `UserProxyAgent` (consistent with Python import sorting conventions).
> 
> **Assessment:**
> - Both fixes are minimal, targeted, and directly address the stated bug.
> - Import paths (`autogen.LLMConfig`, `autogen.agents.experimental.ReasoningAgent`) are consistent with the library's public API as used elsewhere in the file.
> - Documentation-only change; no risk of functional regression.
> - Cross-references: no URL changes, no breakage in other files.
> 
> **Note:** The target URL (`https://docs.ag2.ai/latest/docs/_blogs/2024-12-02-ReasoningAgent2/`) currently returns 404, but this appears to be a pre-existing docs deployment/routing issue unrelated to this fix and not introduced by this change.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).