### PR TITLE
NameError in ReasoningAgent example — LLMConfig not imported

### DIFF
--- a/website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx
+++ b/website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx
@@ -52,6 +52,8 @@ When `beam_size=1`, ReasoningAgent behaves similarly to Chain-of-Thought (CoT) o
 
 For example:
 ```python
+from autogen import LLMConfig
+
 llm_config = LLMConfig.from_json(path="OAI_CONFIG_LIST")
 # Create a reasoning agent with beam size 1 (O1-style)
 reason_agent = ReasoningAgent(
@@ -76,6 +78,7 @@ Here's a simple example of using ReasoningAgent:
 import os
 from autogen import (
     AssistantAgent,
+    LLMConfig,
     UserProxyAgent,
 )
 from autogen.agents.experimental import (


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx`

**What I checked before submitting:**
> Fix is correct and shippable. Two targeted, additive-only changes:
> 
> 1. **Standalone snippet (line ~52):** Adds `from autogen import LLMConfig` as a new top-of-block import before the first usage of `LLMConfig.from_json(...)`. Directly resolves the `NameError`.
> 
> 2. **Grouped import block (line ~78):** Inserts `LLMConfig` alphabetically between `AssistantAgent` and `UserProxyAgent` in the existing `from autogen import (...)` block. Consistent with the file's import style.
> 
> No regressions — the change is purely additive. Style matches the surrounding code. No URL changes; the pre-existing 404 on the target page URL is unrelated to this fix.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).