### PR TITLE
NameError in ReasoningAgent example — LLMConfig not imported

### DIFF
--- a/website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx
+++ b/website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx
@@ -53,6 +53,7 @@ When `beam_size=1`, ReasoningAgent behaves similarly to Chain-of-Thought (CoT) o
 For example:
 ```python
 from autogen import LLMConfig
+from autogen.agents.experimental import ReasoningAgent
 
 llm_config = LLMConfig.from_json(path="OAI_CONFIG_LIST")
 # Create a reasoning agent with beam size 1 (O1-style)


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2024-12-02-ReasoningAgent2/index.mdx`

**What I checked before submitting:**
> The fix correctly adds the missing `from autogen.agents.experimental import ReasoningAgent` import to the code sample, which would cause a `NameError` for anyone copying and running the example.
> 
> **Note on bug description mismatch:** The bug report titles this as "LLMConfig not imported," but `LLMConfig` was already present in the file (it appears as a context line in the diff, not a new addition). The actual omission was `ReasoningAgent` — the fix correctly identifies and resolves this. The bug description was mislabeled, but the code change itself is accurate and beneficial.
> 
> **Minor caveat:** The target URL (https://docs.ag2.ai/latest/docs/_blogs/2024-12-02-ReasoningAgent2/) returns a 404, which suggests the blog page may have moved or been restructured. However, this is unrelated to the correctness of the import fix in the MDX source file. The human reviewer may want to separately verify the import path `autogen.agents.experimental` is correct for the version of autogen being documented.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).