### PR TITLE
NameError in FalkorDB Structured Output example — autogen not imported

### DIFF
--- a/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
+++ b/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
@@ -50,7 +50,7 @@ For example:
 import os
 import autogen
 
-llm_config = LLMConfig.from_json(path="OAI_CONFIG_LIST)
+llm_config = autogen.LLMConfig.from_json(path="OAI_CONFIG_LIST")
 os.environ["OPENAI_API_KEY"] = llm_config.config_list[0].api_key # Utilised by the FalkorGraphQueryEngine
 
 from autogen import ConversableAgent, UserProxyAgent
@@ -145,12 +145,14 @@ class MathReasoning(BaseModel):
     final_answer: str
 
 # response_format is added to our configuration
-llm_config = autogen.LLMConfig(config_list={
-    "api_type": "openai",
-    "model": "gpt-5-nano",
-    "api_key": os.getenv("OPENAI_API_KEY"),
-    "response_format": MathReasoning
-})
+llm_config = autogen.LLMConfig(
+    {
+        "api_type": "openai",
+        "model": "gpt-5-nano",
+        "api_key": os.getenv("OPENAI_API_KEY"),
+    },
+    response_format=MathReasoning,
+)
 
 # This agent's responses will now be based on the MathReasoning model
 assistant = autogen.AssistantAgent(name="Math_solver", llm_config=llm_config)


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx`

**What I checked before submitting:**
> The fix correctly resolves all reported issues in the FalkorDB Structured Output blog code sample:
> 
> 1. **Missing closing quote** (`path="OAI_CONFIG_LIST)` → `path="OAI_CONFIG_LIST"`) — syntax error corrected.
> 2. **Unqualified `LLMConfig`** — properly prefixed as `autogen.LLMConfig` in the `from_json` call.
> 3. **`LLMConfig` constructor** — refactored from passing a mixed dict as `config_list={}` (which also embedded `response_format`) to the correct pattern: positional config dict + `response_format` as a keyword argument.
> 4. **`os` import** — was already present in the file; no regression.
> 5. **Cross-references** — no other files reference the old URL; no breakage.
> 
> **Pre-existing issues (not introduced by this fix, human may want to follow up):**
> - The model name `gpt-5-nano` appears to be a typo (likely `gpt-4o-mini` or similar). This was present before the fix.
> - `config_list` is passed as a `dict` `{}` rather than a `list` `[]`, which may not match autogen's expected API signature. Also pre-existing.
> - The live docs URL returns a 404, which appears to be a publishing/routing issue unrelated to this fix.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).