### PR TITLE
NameError in FalkorDB Structured Output example — autogen not imported

### DIFF
--- a/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
+++ b/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
@@ -50,7 +50,7 @@ For example:
 import os
 import autogen
 
-llm_config = LLMConfig.from_json(path="OAI_CONFIG_LIST)
+llm_config = autogen.LLMConfig.from_json(path="OAI_CONFIG_LIST")
 os.environ["OPENAI_API_KEY"] = llm_config.config_list[0].api_key # Utilised by the FalkorGraphQueryEngine
 
 from autogen import ConversableAgent, UserProxyAgent
@@ -145,12 +145,14 @@ class MathReasoning(BaseModel):
     final_answer: str
 
 # response_format is added to our configuration
-llm_config = autogen.LLMConfig(config_list={
-    "api_type": "openai",
-    "model": "gpt-5-nano",
-    "api_key": os.getenv("OPENAI_API_KEY"),
-    "response_format": MathReasoning
-})
+llm_config = autogen.LLMConfig(
+    {
+        "api_type": "openai",
+        "model": "gpt-5-nano",
+        "api_key": os.getenv("OPENAI_API_KEY"),
+    },
+    response_format=MathReasoning,
+)
 
 # This agent's responses will now be based on the MathReasoning model
 assistant = autogen.AssistantAgent(name="Math_solver", llm_config=llm_config)


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx`

**What I checked before submitting:**
> Fix is correct and addresses all real issues in the code sample:
> 
> 1. **Missing closing quote repaired** — `from_json(path="OAI_CONFIG_LIST)` → `from_json(path="OAI_CONFIG_LIST")`. The original was a syntax error.
> 2. **`LLMConfig` prefixed correctly** — `LLMConfig.from_json(...)` → `autogen.LLMConfig.from_json(...)`. The module `autogen` is imported but `LLMConfig` was used bare, causing a `NameError`.
> 3. **`LLMConfig` constructor call corrected** — `response_format` was incorrectly placed inside the `config_list` dict; it is now passed as a keyword argument at the constructor level, which matches the AG2 API contract.
> 
> **Non-issues (pre-existing, out of scope):**
> - `gpt-5-nano` is not a real OpenAI model name — this was present before the fix and is a separate editorial matter.
> - The `os` import was already present in the file; the bug report's mention of a missing `os` import was inaccurate for this file.
> - The target URL (docs.ag2.ai) returns 404, but this is a docs-hosting/routing concern unrelated to the content fix.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).