### PR TITLE
Broken link to ChromaDB Docker docs

### DIFF
--- a/autogen/agentchat/contrib/rag/chromadb_query_engine.py
+++ b/autogen/agentchat/contrib/rag/chromadb_query_engine.py
@@ -43,7 +43,7 @@ class ChromaDBQueryEngine:
     to natural language queries. Collection can be regarded as an abstraction of group of documents in the database.
 
     It expects a Chromadb server to be running and accessible at the specified host and port.
-    Refer to this [link](https://docs.trychroma.com/production/containers/docker) for running Chromadb in a Docker container.
+    Refer to this [link](https://docs.trychroma.com/guides/deploy/docker) for running Chromadb in a Docker container.
     If the host and port are not provided, the engine will create an in-memory ChromaDB client.
 
 

--- a/notebook/agentchat_LlamaIndex_query_engine.ipynb
+++ b/notebook/agentchat_LlamaIndex_query_engine.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "source": [
     "### In the first example, we build a LLamaIndexQueryEngine instance using ChromaDB. \n",
-    "Refer to this [link](https://docs.trychroma.com/production/containers/docker) for running Chromadb in a Docker container.\n"
+    "Refer to this [link](https://docs.trychroma.com/guides/deploy/docker) for running Chromadb in a Docker container.\n"
    ]
   },
   {

--- a/notebook/agentchat_chromadb_query_engine.ipynb
+++ b/notebook/agentchat_chromadb_query_engine.ipynb
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Refer to this [link](https://docs.trychroma.com/production/containers/docker) for running Chromadb in a Docker container.\n",
+    "Refer to this [link](https://docs.trychroma.com/guides/deploy/docker) for running Chromadb in a Docker container.\n",
     "    If the host and port are not provided, the engine will create an in-memory ChromaDB client.\n"
    ]
   },


### PR DESCRIPTION
**Files changed:**
- `autogen/agentchat/contrib/rag/chromadb_query_engine.py`
- `notebook/agentchat_LlamaIndex_query_engine.ipynb`
- `notebook/agentchat_chromadb_query_engine.ipynb`

**What I checked before submitting:**
> Fix is correct and complete. The broken URL `https://docs.trychroma.com/production/containers/docker` (404) is replaced with `https://docs.trychroma.com/guides/deploy/docker` across all three affected files:
> 
> - `autogen/agentchat/contrib/rag/chromadb_query_engine.py` (docstring)
> - `notebook/agentchat_LlamaIndex_query_engine.ipynb`
> - `notebook/agentchat_chromadb_query_engine.ipynb`
> 
> **URL verification**: The replacement URL returns HTTP 200 with no redirects — confirmed live.
> 
> **Cross-references**: The cross-reference tool flagged the two notebooks as still containing the old URL, but those files are patched within this same diff, so the warning is a false positive.
> 
> No logic changes, pure documentation fix. Safe to merge.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).