### PR TITLE
FalkorDB example missing autogen and os imports

### DIFF
--- a/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
+++ b/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
@@ -50,7 +50,7 @@ For example:
 import os
 import autogen
 
-llm_config = LLMConfig.from_json(path="OAI_CONFIG_LIST)
+llm_config = autogen.LLMConfig.from_json(path="OAI_CONFIG_LIST")
 os.environ["OPENAI_API_KEY"] = llm_config.config_list[0].api_key # Utilised by the FalkorGraphQueryEngine
 
 from autogen import ConversableAgent, UserProxyAgent


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx`

**What I checked before submitting:**
> Fix is correct and minimal. It resolves two bugs on a single broken line:
> 
> 1. **Missing namespace prefix**: `LLMConfig.from_json(...)` → `autogen.LLMConfig.from_json(...)`. The `import autogen` statement was already present, so this is the right qualified form.
> 2. **Unclosed string literal**: `path="OAI_CONFIG_LIST)` → `path="OAI_CONFIG_LIST")`. The missing closing `"` was a syntax error that would have caused the code sample to fail immediately.
> 
> No regressions introduced. Cross-references are clean.
> 
> **Minor follow-up (not blocking):** There is a pre-existing mixed import style in the surrounding code — `autogen.LLMConfig` is used here but `ConversableAgent` and `UserProxyAgent` are imported via `from autogen import ...` below. Could be normalized in a future pass (e.g., add `LLMConfig` to the `from autogen import` line and drop the `import autogen` line if it's unused elsewhere), but that's out of scope for this bug fix.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).