### PR TITLE
feat: add prompt caching support for Anthropic models on Bedrock

### DIFF
--- a/autogen/oai/bedrock.py
+++ b/autogen/oai/bedrock.py
@@ -46,6 +46,7 @@ from ..import_utils import optional_import_block, require_optional_import
 from ..llm_config.entry import LLMConfigEntry, LLMConfigEntryDict
 from .client_utils import validate_parameter
 from .oai_models import ChatCompletion, ChatCompletionMessage, ChatCompletionMessageToolCall, Choice, CompletionUsage
+from .oai_models.completion_usage import PromptTokensDetails
 
 with optional_import_block():
     import boto3
@@ -70,6 +71,8 @@ class BedrockEntryDict(LLMConfigEntryDict, total=False):
     total_max_attempts: int | None
     max_attempts: int | None
     mode: Literal["standard", "adaptive", "legacy"]
+    prompt_caching: bool | Literal["auto"] | None
+    prompt_cache_ttl: Literal["5m", "1h"] | None
 
 
 class BedrockLLMConfigEntry(LLMConfigEntry):
@@ -92,6 +95,8 @@ class BedrockLLMConfigEntry(LLMConfigEntry):
     total_max_attempts: int | None = 5
     max_attempts: int | None = 5
     mode: Literal["standard", "adaptive", "legacy"] = "standard"
+    prompt_caching: bool | Literal["auto"] | None = None
+    prompt_cache_ttl: Literal["5m", "1h"] | None = None
 
     @field_serializer("aws_access_key", "aws_secret_key", "aws_session_token", when_used="unless-none")
     def serialize_aws_secrets(self, v: SecretStr) -> str:
@@ -105,7 +110,15 @@ class BedrockLLMConfigEntry(LLMConfigEntry):
 class BedrockClient:
     """Client for Amazon's Bedrock Converse API."""
 
-    RESPONSE_USAGE_KEYS: list[str] = ["prompt_tokens", "completion_tokens", "total_tokens", "cost", "model"]
+    RESPONSE_USAGE_KEYS: list[str] = [
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "cost",
+        "model",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+    ]
 
     _retries = 5
 
@@ -120,6 +133,8 @@ class BedrockClient:
         self._total_max_attempts = kwargs.get("total_max_attempts", 5)
         self._max_attempts = kwargs.get("max_attempts", 5)
         self._mode = kwargs.get("mode", "standard")
+        self._prompt_caching = kwargs.get("prompt_caching", None)
+        self._prompt_cache_ttl = kwargs.get("prompt_cache_ttl", None)
         self._retry_config = {
             "total_max_attempts": self._total_max_attempts,
             "max_attempts": self._max_attempts,
@@ -360,6 +375,107 @@ class BedrockClient:
         except Exception as e:
             raise ValueError(f"Failed to validate structured output against schema: {e!s}") from e
 
+    # Models that support prompt caching on Bedrock
+    _CACHE_SUPPORTED_MODELS = {
+        "anthropic.claude-opus-4-5",
+        "anthropic.claude-sonnet-4-5",
+        "anthropic.claude-opus-4-1",
+        "anthropic.claude-3-7-sonnet",
+        "anthropic.claude-3-5-haiku",
+        "amazon.nova-micro",
+        "amazon.nova-lite",
+        "amazon.nova-pro",
+        "amazon.nova-premier",
+    }
+
+    # Models that support 1h TTL (others only support 5m)
+    _HOUR_TTL_MODELS = {
+        "anthropic.claude-opus-4-5",
+        "anthropic.claude-sonnet-4-5",
+        "anthropic.claude-3-5-haiku",
+    }
+
+    def _is_cache_supported(self, model_id: str) -> bool:
+        """Check if the model supports prompt caching on Bedrock."""
+        for prefix in self._CACHE_SUPPORTED_MODELS:
+            if model_id.startswith(prefix):
+                return True
+        return False
+
+    def _get_cache_point(self, model_id: str | None = None) -> dict[str, Any]:
+        """Create a cache point marker for the Converse API.
+
+        Returns a cachePoint dict suitable for insertion into system, messages, or tools.
+        """
+        cache_point: dict[str, Any] = {"type": "default"}
+        ttl = self._prompt_cache_ttl
+        if ttl is not None:
+            # Validate 1h TTL is only used with supported models
+            if ttl == "1h" and model_id:
+                is_hour_supported = any(model_id.startswith(p) for p in self._HOUR_TTL_MODELS)
+                if not is_hour_supported:
+                    warnings.warn(
+                        f"Model {model_id} does not support 1h TTL for prompt caching. "
+                        "Falling back to default 5m TTL.",
+                        UserWarning,
+                    )
+                    ttl = "5m"
+            cache_point["ttl"] = ttl
+        return {"cachePoint": cache_point}
+
+    def _inject_cache_points_system(self, system_messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Inject a cache point at the end of system messages."""
+        if not system_messages:
+            return system_messages
+        result = list(system_messages)
+        result.append(self._get_cache_point(self._model_id))
+        return result
+
+    def _inject_cache_points_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Inject cache points into message content blocks.
+
+        Adds a cache point after the last user message's content to mark the
+        conversation prefix for caching.
+        """
+        if not messages:
+            return messages
+
+        result = [msg.copy() for msg in messages]
+
+        # Find the last user message and add a cache point to its content
+        for i in range(len(result) - 1, -1, -1):
+            if result[i].get("role") == "user":
+                content = result[i].get("content", [])
+                if isinstance(content, list):
+                    result[i]["content"] = list(content) + [self._get_cache_point(self._model_id)]
+                break
+
+        return result
+
+    def _inject_cache_points_tools(self, tool_config: dict[str, list]) -> dict[str, list]:
+        """Inject a cache point into tool configuration.
+
+        Adds a cache point marker after the last tool definition.
+        """
+        if not tool_config.get("tools"):
+            return tool_config
+
+        result = {"tools": list(tool_config["tools"])}
+        result["tools"].append(self._get_cache_point(self._model_id))
+        return result
+
+    def _should_use_caching(self) -> bool:
+        """Determine if prompt caching should be used for this request."""
+        if self._prompt_caching is None or self._prompt_caching is False:
+            return False
+
+        if self._prompt_caching == "auto":
+            # Auto mode: enable caching only for supported models
+            return self._is_cache_supported(self._model_id)
+
+        # Explicit True
+        return True
+
     def message_retrieval(self, response):
         """Retrieve the messages from the response."""
         return [choice.message for choice in response.choices]
@@ -414,6 +530,8 @@ class BedrockClient:
             "messages",  # Handled separately
             "tools",  # Handled separately
             "response_format",  # Handled separately in create method
+            "prompt_caching",  # Handled in create method
+            "prompt_cache_ttl",  # Handled in create method
         }
 
         # Here are the possible "base" parameters and their suitable types
@@ -504,6 +622,15 @@ class BedrockClient:
         if len(tool_config["tools"]) > 0:
             request_args["toolConfig"] = tool_config
 
+        # Inject prompt caching markers if enabled
+        if self._should_use_caching():
+            if "system" in request_args:
+                request_args["system"] = self._inject_cache_points_system(request_args["system"])
+            if "messages" in request_args:
+                request_args["messages"] = self._inject_cache_points_messages(request_args["messages"])
+            if "toolConfig" in request_args:
+                request_args["toolConfig"] = self._inject_cache_points_tools(request_args["toolConfig"])
+
         response = self.bedrock_runtime.converse(**request_args)
         if response is None:
             raise RuntimeError(f"Failed to get response from Bedrock after retrying {self._retries} times.")
@@ -536,11 +663,22 @@ class BedrockClient:
         message = ChatCompletionMessage(role="assistant", content=text, tool_calls=tool_calls)
 
         response_usage = response["usage"]
+
+        # Extract prompt caching metrics if present
+        prompt_tokens_details = None
+        cache_read_tokens = response_usage.get("cacheReadInputTokens", 0)
+        cache_write_tokens = response_usage.get("cacheWriteInputTokens", 0)
+        if cache_read_tokens > 0 or cache_write_tokens > 0:
+            prompt_tokens_details = PromptTokensDetails(cached_tokens=cache_read_tokens)
+
         usage = CompletionUsage(
             prompt_tokens=response_usage["inputTokens"],
             completion_tokens=response_usage["outputTokens"],
             total_tokens=response_usage["totalTokens"],
+            prompt_tokens_details=prompt_tokens_details,
         )
+        # Store cache write tokens as an extra attribute for get_usage()
+        usage._cache_creation_input_tokens = cache_write_tokens
 
         return ChatCompletion(
             id=response["ResponseMetadata"]["RequestId"],
@@ -557,14 +695,27 @@ class BedrockClient:
 
     @staticmethod
     def get_usage(response) -> dict:
-        """Get the usage of tokens and their cost information."""
-        return {
+        """Get the usage of tokens and their cost information.
+
+        Includes prompt caching metrics when available:
+        - cache_read_input_tokens: Number of tokens read from cache
+        - cache_creation_input_tokens: Number of tokens written to cache
+        """
+        usage = {
             "prompt_tokens": response.usage.prompt_tokens,
             "completion_tokens": response.usage.completion_tokens,
             "total_tokens": response.usage.total_tokens,
             "cost": response.cost,
             "model": response.model,
         }
+
+        # Include prompt caching metrics if available
+        if response.usage.prompt_tokens_details is not None:
+            usage["cache_read_input_tokens"] = response.usage.prompt_tokens_details.cached_tokens or 0
+        if hasattr(response.usage, "_cache_creation_input_tokens"):
+            usage["cache_creation_input_tokens"] = response.usage._cache_creation_input_tokens
+
+        return usage
 
 
 def extract_system_messages(messages: list[dict[str, Any]]) -> list:

--- a/test/oai/test_bedrock.py
+++ b/test/oai/test_bedrock.py
@@ -2563,3 +2563,363 @@ def test_parsing_params_additional_model_request_fields_with_none_values(bedrock
         except json.JSONDecodeError:
             # If not JSON, verify it contains expected content
             assert "answer" in content.lower() or "x =" in content.lower()
+
+
+# ============================================================================
+# Prompt Caching Tests
+# ============================================================================
+
+
+@pytest.fixture
+def bedrock_client_with_caching():
+    """Create a BedrockClient with prompt caching enabled."""
+    client = BedrockClient(
+        aws_region="us-east-1",
+        prompt_caching=True,
+        prompt_cache_ttl="5m",
+    )
+    client._supports_system_prompts = True
+    return client
+
+
+@pytest.fixture
+def bedrock_client_auto_caching():
+    """Create a BedrockClient with auto prompt caching."""
+    client = BedrockClient(
+        aws_region="us-east-1",
+        prompt_caching="auto",
+    )
+    client._supports_system_prompts = True
+    return client
+
+
+# Test 1: Caching config initialization
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_prompt_caching_initialization():
+    client = BedrockClient(aws_region="us-east-1", prompt_caching=True, prompt_cache_ttl="1h")
+    assert client._prompt_caching is True
+    assert client._prompt_cache_ttl == "1h"
+
+
+# Test 2: Caching disabled by default
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_prompt_caching_disabled_by_default():
+    client = BedrockClient(aws_region="us-east-1")
+    assert client._prompt_caching is None
+    assert client._prompt_cache_ttl is None
+    assert client._should_use_caching() is False
+
+
+# Test 3: Auto caching with supported model
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_prompt_caching_auto_supported_model(bedrock_client_auto_caching: BedrockClient):
+    bedrock_client_auto_caching._model_id = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    assert bedrock_client_auto_caching._should_use_caching() is True
+
+
+# Test 4: Auto caching with unsupported model
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_prompt_caching_auto_unsupported_model(bedrock_client_auto_caching: BedrockClient):
+    bedrock_client_auto_caching._model_id = "meta.llama3-8b-instruct-v1:0"
+    assert bedrock_client_auto_caching._should_use_caching() is False
+
+
+# Test 5: Explicit caching enabled
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_prompt_caching_explicit_true(bedrock_client_with_caching: BedrockClient):
+    bedrock_client_with_caching._model_id = "meta.llama3-8b-instruct-v1:0"
+    assert bedrock_client_with_caching._should_use_caching() is True
+
+
+# Test 6: Model support detection
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_is_cache_supported(bedrock_client_with_caching: BedrockClient):
+    assert bedrock_client_with_caching._is_cache_supported("anthropic.claude-sonnet-4-5-20250929-v1:0") is True
+    assert bedrock_client_with_caching._is_cache_supported("anthropic.claude-opus-4-5-20250929-v1:0") is True
+    assert bedrock_client_with_caching._is_cache_supported("anthropic.claude-3-7-sonnet-20250219-v1:0") is True
+    assert bedrock_client_with_caching._is_cache_supported("anthropic.claude-3-5-haiku-20241022-v1:0") is True
+    assert bedrock_client_with_caching._is_cache_supported("amazon.nova-pro-v1:0") is True
+    assert bedrock_client_with_caching._is_cache_supported("amazon.nova-micro-v1:0") is True
+    assert bedrock_client_with_caching._is_cache_supported("meta.llama3-8b-instruct-v1:0") is False
+    assert bedrock_client_with_caching._is_cache_supported("mistral.mistral-large-2402-v1:0") is False
+
+
+# Test 7: Cache point generation with default TTL
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_get_cache_point_default(bedrock_client_with_caching: BedrockClient):
+    bedrock_client_with_caching._prompt_cache_ttl = None
+    cache_point = bedrock_client_with_caching._get_cache_point()
+    assert cache_point == {"cachePoint": {"type": "default"}}
+
+
+# Test 8: Cache point generation with 5m TTL
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_get_cache_point_5m_ttl(bedrock_client_with_caching: BedrockClient):
+    bedrock_client_with_caching._prompt_cache_ttl = "5m"
+    cache_point = bedrock_client_with_caching._get_cache_point()
+    assert cache_point == {"cachePoint": {"type": "default", "ttl": "5m"}}
+
+
+# Test 9: Cache point generation with 1h TTL
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_get_cache_point_1h_ttl(bedrock_client_with_caching: BedrockClient):
+    bedrock_client_with_caching._prompt_cache_ttl = "1h"
+    cache_point = bedrock_client_with_caching._get_cache_point("anthropic.claude-sonnet-4-5-20250929-v1:0")
+    assert cache_point == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+
+# Test 10: 1h TTL fallback for unsupported model
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_get_cache_point_1h_ttl_fallback(bedrock_client_with_caching: BedrockClient):
+    bedrock_client_with_caching._prompt_cache_ttl = "1h"
+    with pytest.warns(UserWarning, match="does not support 1h TTL"):
+        cache_point = bedrock_client_with_caching._get_cache_point("anthropic.claude-3-7-sonnet-20250219-v1:0")
+    assert cache_point == {"cachePoint": {"type": "default", "ttl": "5m"}}
+
+
+# Test 11: System message cache injection
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_inject_cache_points_system(bedrock_client_with_caching: BedrockClient):
+    bedrock_client_with_caching._model_id = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    bedrock_client_with_caching._prompt_cache_ttl = None
+    system_messages = [{"text": "You are a helpful assistant."}]
+    result = bedrock_client_with_caching._inject_cache_points_system(system_messages)
+    assert len(result) == 2
+    assert result[0] == {"text": "You are a helpful assistant."}
+    assert result[1] == {"cachePoint": {"type": "default"}}
+
+
+# Test 12: Empty system message cache injection
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_inject_cache_points_system_empty(bedrock_client_with_caching: BedrockClient):
+    result = bedrock_client_with_caching._inject_cache_points_system([])
+    assert result == []
+
+
+# Test 13: Message cache injection
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_inject_cache_points_messages(bedrock_client_with_caching: BedrockClient):
+    bedrock_client_with_caching._model_id = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    bedrock_client_with_caching._prompt_cache_ttl = None
+    messages = [
+        {"role": "user", "content": [{"text": "Hello"}]},
+        {"role": "assistant", "content": [{"text": "Hi there!"}]},
+        {"role": "user", "content": [{"text": "Tell me about caching."}]},
+    ]
+    result = bedrock_client_with_caching._inject_cache_points_messages(messages)
+    # Cache point should be added to the last user message
+    assert len(result) == 3
+    assert result[2]["content"][-1] == {"cachePoint": {"type": "default"}}
+    # First user message should not be modified
+    assert len(result[0]["content"]) == 1
+
+
+# Test 14: Tool config cache injection
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_inject_cache_points_tools(bedrock_client_with_caching: BedrockClient):
+    bedrock_client_with_caching._model_id = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    bedrock_client_with_caching._prompt_cache_ttl = None
+    tool_config = {
+        "tools": [
+            {"toolSpec": {"name": "calculator", "description": "A calculator", "inputSchema": {"json": {}}}}
+        ]
+    }
+    result = bedrock_client_with_caching._inject_cache_points_tools(tool_config)
+    assert len(result["tools"]) == 2
+    assert result["tools"][-1] == {"cachePoint": {"type": "default"}}
+
+
+# Test 15: Tool config cache injection with empty tools
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_inject_cache_points_tools_empty(bedrock_client_with_caching: BedrockClient):
+    result = bedrock_client_with_caching._inject_cache_points_tools({"tools": []})
+    assert result == {"tools": []}
+
+
+# Test 16: Full create flow with caching enabled
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+@patch("autogen.oai.bedrock.BedrockClient.__init__", return_value=None)
+def test_create_with_prompt_caching(mock_init):
+    client = BedrockClient.__new__(BedrockClient)
+    client._prompt_caching = True
+    client._prompt_cache_ttl = "5m"
+    client._supports_system_prompts = True
+    client._model_id = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    client._response_format = None
+
+    mock_response = {
+        "stopReason": "end_turn",
+        "output": {"message": {"content": [{"text": "Hello from cache!"}]}},
+        "usage": {
+            "inputTokens": 100,
+            "outputTokens": 50,
+            "totalTokens": 150,
+            "cacheReadInputTokens": 80,
+            "cacheWriteInputTokens": 20,
+        },
+        "ResponseMetadata": {"RequestId": "test-request-id"},
+    }
+
+    client.bedrock_runtime = MagicMock()
+    client.bedrock_runtime.converse.return_value = mock_response
+
+    params = {
+        "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "messages": [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ],
+    }
+
+    response = client.create(params)
+
+    # Verify cache metrics are in usage
+    assert response.usage.prompt_tokens == 100
+    assert response.usage.completion_tokens == 50
+    assert response.usage.prompt_tokens_details is not None
+    assert response.usage.prompt_tokens_details.cached_tokens == 80
+    assert response.usage._cache_creation_input_tokens == 20
+
+    # Verify the converse call included cache points
+    call_args = client.bedrock_runtime.converse.call_args
+    call_kwargs = call_args[1] if call_args[1] else call_args[0]
+
+    # System should have cache point
+    system = call_kwargs.get("system", [])
+    assert any("cachePoint" in item for item in system), "System messages should contain a cachePoint"
+
+    # Messages should have cache point on the last user message
+    messages = call_kwargs.get("messages", [])
+    last_user = None
+    for msg in messages:
+        if msg.get("role") == "user":
+            last_user = msg
+    assert last_user is not None
+    assert any("cachePoint" in item for item in last_user["content"]), (
+        "Last user message should contain a cachePoint"
+    )
+
+
+# Test 17: get_usage includes cache metrics
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_get_usage_with_cache_metrics():
+    from autogen.oai.oai_models.completion_usage import PromptTokensDetails
+
+    mock_response = MagicMock()
+    mock_response.usage.prompt_tokens = 100
+    mock_response.usage.completion_tokens = 50
+    mock_response.usage.total_tokens = 150
+    mock_response.usage.prompt_tokens_details = PromptTokensDetails(cached_tokens=80)
+    mock_response.usage._cache_creation_input_tokens = 20
+    mock_response.cost = 0.01
+    mock_response.model = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+    usage = BedrockClient.get_usage(mock_response)
+    assert usage["prompt_tokens"] == 100
+    assert usage["completion_tokens"] == 50
+    assert usage["cache_read_input_tokens"] == 80
+    assert usage["cache_creation_input_tokens"] == 20
+
+
+# Test 18: get_usage without cache metrics
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_get_usage_without_cache_metrics():
+    mock_response = MagicMock()
+    mock_response.usage.prompt_tokens = 100
+    mock_response.usage.completion_tokens = 50
+    mock_response.usage.total_tokens = 150
+    mock_response.usage.prompt_tokens_details = None
+    mock_response.cost = 0.01
+    mock_response.model = "meta.llama3-8b-instruct-v1:0"
+    # No _cache_creation_input_tokens attribute
+    del mock_response.usage._cache_creation_input_tokens
+
+    usage = BedrockClient.get_usage(mock_response)
+    assert "cache_read_input_tokens" not in usage
+    assert "cache_creation_input_tokens" not in usage
+
+
+# Test 19: LLMConfigEntry with caching params
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_bedrock_llm_config_entry_with_caching():
+    config = BedrockLLMConfigEntry(
+        model="anthropic.claude-sonnet-4-5-20250929-v1:0",
+        aws_region="us-east-1",
+        prompt_caching=True,
+        prompt_cache_ttl="1h",
+    )
+    dumped = config.model_dump()
+    assert dumped["prompt_caching"] is True
+    assert dumped["prompt_cache_ttl"] == "1h"
+
+
+# Test 20: LLMConfigEntry caching defaults
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_bedrock_llm_config_entry_caching_defaults():
+    config = BedrockLLMConfigEntry(
+        model="anthropic.claude-sonnet-4-5-20250929-v1:0",
+        aws_region="us-east-1",
+    )
+    dumped = config.model_dump()
+    assert dumped.get("prompt_caching") is None
+    assert dumped.get("prompt_cache_ttl") is None
+
+
+# Test 21: Create without caching does not inject cache points
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+@patch("autogen.oai.bedrock.BedrockClient.__init__", return_value=None)
+def test_create_without_caching_no_cache_points(mock_init):
+    client = BedrockClient.__new__(BedrockClient)
+    client._prompt_caching = None
+    client._prompt_cache_ttl = None
+    client._supports_system_prompts = True
+    client._model_id = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    client._response_format = None
+
+    mock_response = {
+        "stopReason": "end_turn",
+        "output": {"message": {"content": [{"text": "No cache"}]}},
+        "usage": {"inputTokens": 50, "outputTokens": 25, "totalTokens": 75},
+        "ResponseMetadata": {"RequestId": "test-no-cache"},
+    }
+
+    client.bedrock_runtime = MagicMock()
+    client.bedrock_runtime.converse.return_value = mock_response
+
+    params = {
+        "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "messages": [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ],
+    }
+
+    response = client.create(params)
+
+    call_kwargs = client.bedrock_runtime.converse.call_args[1]
+    system = call_kwargs.get("system", [])
+    messages = call_kwargs.get("messages", [])
+
+    # No cache points should be present
+    for item in system:
+        assert "cachePoint" not in item
+    for msg in messages:
+        if isinstance(msg.get("content"), list):
+            for item in msg["content"]:
+                assert "cachePoint" not in item
+
+
+# Test 22: parse_params excludes caching fields from inference params
+@run_for_optional_imports(["boto3", "botocore"], "bedrock")
+def test_parse_params_excludes_caching_fields(bedrock_client_with_caching: BedrockClient):
+    base_params, additional_params = bedrock_client_with_caching.parse_params({
+        "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "prompt_caching": True,
+        "prompt_cache_ttl": "5m",
+        "temperature": 0.7,
+    })
+    assert "prompt_caching" not in base_params
+    assert "prompt_caching" not in additional_params
+    assert "prompt_cache_ttl" not in base_params
+    assert "prompt_cache_ttl" not in additional_params
+    assert base_params["temperature"] == 0.7


### PR DESCRIPTION
## Summary

- Adds `prompt_caching` configuration parameter (`True`/`False`/`"auto"`) and `prompt_cache_ttl` (`"5m"`/`"1h"`) to `BedrockClient` and `BedrockLLMConfigEntry`
- Injects `cachePoint` markers into system messages, user messages, and tool configurations when caching is enabled via the Converse API
- Extracts and exposes cache metrics (`cache_read_input_tokens`, `cache_creation_input_tokens`) from Bedrock responses, mapping them to `PromptTokensDetails` for compatibility with existing usage tracking
- Validates TTL support per model (1h TTL only for Claude Opus 4.5, Sonnet 4.5, Haiku 3.5) with automatic fallback to 5m
- Adds 22 comprehensive unit tests covering initialization, model detection, cache point injection, full create flow, usage metrics, and config entry validation

### Usage example

```python
config_list = [
    {
        "api_type": "bedrock",
        "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
        "aws_region": "us-west-2",
        "prompt_caching": True,       # or "auto" to enable only for supported models
        "prompt_cache_ttl": "1h",     # optional, defaults to "5m"
    }
]
```

Fixes #2530

## Test plan

- [x] All 22 new prompt caching unit tests pass
- [x] All 33 existing Bedrock unit tests pass (no regressions)
- [ ] Manual testing with actual Bedrock API (requires AWS credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)