### PR TITLE
fix: prevent TerminateTarget from being silently ignored by AutoPattern

### DIFF
--- a/autogen/agentchat/group/group_utils.py
+++ b/autogen/agentchat/group/group_utils.py
@@ -32,6 +32,12 @@ if TYPE_CHECKING:
 # Utility functions for group chat preparation and management
 # These are extracted from multi_agent_chat.py to avoid circular imports
 
+# Sentinel object to distinguish "no after_work matched" from a TerminateTarget
+# returning None (which signals termination). Without this, TerminateTarget's None
+# result is indistinguishable from "no condition matched", causing it to be silently
+# ignored and falling through to the group-level after_work.
+_NO_AFTER_WORK_MATCHED = object()
+
 
 def update_conditional_functions(agent: "ConversableAgent", messages: list[dict[str, Any]]) -> None:
     """Updates the agent's functions based on the OnCondition's available condition.
@@ -94,7 +100,7 @@ def _evaluate_after_works_conditions(
     agent: "ConversableAgent",
     groupchat: GroupChat,
     user_agent: Optional["ConversableAgent"],
-) -> Agent | str | None:
+) -> Agent | str | None | object:
     """Evaluate after_works context conditions for an agent.
 
     Args:
@@ -103,10 +109,11 @@ def _evaluate_after_works_conditions(
         user_agent: Optional user proxy agent
 
     Returns:
-        The resolved speaker selection result if a condition matches, None otherwise
+        The resolved speaker selection result if a condition matches (Agent, str, or
+        None for termination), or _NO_AFTER_WORK_MATCHED sentinel if no condition matched.
     """
     if not hasattr(agent, "handoffs") or not agent.handoffs.after_works:  # type: ignore[attr-defined]
-        return None
+        return _NO_AFTER_WORK_MATCHED
 
     for after_work_condition in agent.handoffs.after_works:  # type: ignore[attr-defined]
         # Check if condition is available
@@ -132,7 +139,7 @@ def _evaluate_after_works_conditions(
 
             return after_works_speaker
 
-    return None
+    return _NO_AFTER_WORK_MATCHED
 
 
 def _run_oncontextconditions(
@@ -521,8 +528,8 @@ def determine_next_agent(
         groupchat,
         user_agent,
     )
-    if after_works_result is not None:
-        return after_works_result
+    if after_works_result is not _NO_AFTER_WORK_MATCHED:
+        return after_works_result  # type: ignore[return-value]
 
     # If no after_works conditions matched, use the group-level after_work
     # Resolve the next agent, termination, or speaker selection method

--- a/test/agentchat/group/test_group_utils.py
+++ b/test/agentchat/group/test_group_utils.py
@@ -16,7 +16,9 @@ from autogen.agentchat.group.context_condition import StringContextCondition
 from autogen.agentchat.group.context_variables import ContextVariables
 from autogen.agentchat.group.group_tool_executor import GroupToolExecutor
 from autogen.agentchat.group.group_utils import (
+    _NO_AFTER_WORK_MATCHED,
     _create_on_condition_handoff_function,
+    _evaluate_after_works_conditions,
     _run_oncontextconditions,
     _validate_handoff_target,
     cleanup_temp_user_messages,
@@ -888,3 +890,231 @@ class TestHelperFunctions:
         ]
 
         assert processed_messages == expected_messages
+
+    # ---- Tests for TerminateTarget / _NO_AFTER_WORK_MATCHED sentinel fix (issue #2575) ----
+
+    def test_evaluate_after_works_returns_sentinel_when_no_handoffs(
+        self, agent1: MagicMock, mock_group_chat: MagicMock, user_proxy: MagicMock
+    ) -> None:
+        """Test that _evaluate_after_works_conditions returns _NO_AFTER_WORK_MATCHED
+        when the agent has no after_works configured."""
+        agent1.handoffs.after_works = []
+        result = _evaluate_after_works_conditions(agent1, mock_group_chat, user_proxy)
+        assert result is _NO_AFTER_WORK_MATCHED
+
+    def test_evaluate_after_works_returns_sentinel_when_no_handoffs_attr(
+        self, mock_group_chat: MagicMock, user_proxy: MagicMock
+    ) -> None:
+        """Test that _evaluate_after_works_conditions returns _NO_AFTER_WORK_MATCHED
+        when the agent has no handoffs attribute at all."""
+        agent_no_handoffs = MagicMock()
+        del agent_no_handoffs.handoffs
+        result = _evaluate_after_works_conditions(agent_no_handoffs, mock_group_chat, user_proxy)
+        assert result is _NO_AFTER_WORK_MATCHED
+
+    def test_evaluate_after_works_returns_none_for_terminate_target(
+        self, agent1: MagicMock, mock_group_chat: MagicMock, user_proxy: MagicMock
+    ) -> None:
+        """Test that _evaluate_after_works_conditions returns None (not sentinel)
+        when a TerminateTarget matches, allowing termination to propagate."""
+        agent1.handoffs.after_works = [OnContextCondition(target=TerminateTarget(), condition=None)]
+        mock_group_chat.agents = [agent1, user_proxy]
+        result = _evaluate_after_works_conditions(agent1, mock_group_chat, user_proxy)
+        # TerminateTarget resolves to None (termination signal), NOT the sentinel
+        assert result is None
+
+    def test_evaluate_after_works_returns_agent_for_agent_target(
+        self, agent1: MagicMock, agent2: MagicMock, mock_group_chat: MagicMock, user_proxy: MagicMock
+    ) -> None:
+        """Test that _evaluate_after_works_conditions returns the agent when
+        an AgentTarget matches."""
+        agent1.handoffs.after_works = [OnContextCondition(target=AgentTarget(agent=agent2), condition=None)]
+        mock_group_chat.agents = [agent1, agent2, user_proxy]
+        result = _evaluate_after_works_conditions(agent1, mock_group_chat, user_proxy)
+        assert result == agent2
+
+    @patch("autogen.agentchat.group.group_utils.get_last_agent_speaker")
+    def test_determine_next_agent_terminate_target_on_agent(
+        self,
+        mock_get_last_agent_speaker: MagicMock,
+        mock_group_chat: MagicMock,
+        agent1: MagicMock,
+        agent2: MagicMock,
+        user_proxy: MagicMock,
+        mock_tool_executor: MagicMock,
+    ) -> None:
+        """Test that TerminateTarget set as agent-level after_work takes precedence
+        over group-level GroupManagerTarget. This is the exact scenario from issue #2575:
+        an agent with set_after_work(TerminateTarget()) should stop the conversation,
+        not be silently overridden by AutoPattern's group_manager after_work."""
+        group_agent_names = ["agent1", "agent2"]
+        mock_group_chat.agents = [agent1, agent2, user_proxy, mock_tool_executor]
+        mock_group_chat.messages = [{"role": "assistant", "name": "agent2", "content": "Goodbye!"}]
+        mock_get_last_agent_speaker.return_value = agent2
+
+        # agent2 has TerminateTarget as after_work (like the issue's reproduction code)
+        agent2.handoffs.after_works = [OnContextCondition(target=TerminateTarget(), condition=None)]
+
+        # group-level after_work is GroupManagerTarget (like AutoPattern sets)
+        group_after_work = GroupManagerTarget()
+
+        next_agent = determine_next_agent(
+            agent2,
+            mock_group_chat,
+            agent1,
+            False,
+            mock_tool_executor,
+            group_agent_names,
+            user_proxy,
+            group_after_work,
+        )
+        # Agent-level TerminateTarget must terminate (return None),
+        # NOT fall through to GroupManagerTarget
+        assert next_agent is None
+
+    @patch("autogen.agentchat.group.group_utils.get_last_agent_speaker")
+    def test_determine_next_agent_no_agent_after_work_falls_through_to_group(
+        self,
+        mock_get_last_agent_speaker: MagicMock,
+        mock_group_chat: MagicMock,
+        agent1: MagicMock,
+        agent2: MagicMock,
+        user_proxy: MagicMock,
+        mock_tool_executor: MagicMock,
+    ) -> None:
+        """Test that when an agent has NO after_work, the group-level after_work
+        is used correctly (e.g., GroupManagerTarget returns 'auto')."""
+        group_agent_names = ["agent1", "agent2"]
+        mock_group_chat.agents = [agent1, agent2, user_proxy, mock_tool_executor]
+        mock_group_chat.messages = [{"role": "assistant", "name": "agent1", "content": "Hello!"}]
+        mock_get_last_agent_speaker.return_value = agent1
+
+        # No agent-level after_work
+        agent1.handoffs.after_works = []
+
+        # Group-level after_work is GroupManagerTarget
+        group_after_work = GroupManagerTarget()
+
+        next_agent = determine_next_agent(
+            agent1,
+            mock_group_chat,
+            agent1,
+            False,
+            mock_tool_executor,
+            group_agent_names,
+            user_proxy,
+            group_after_work,
+        )
+        # Should fall through to group-level GroupManagerTarget -> "auto"
+        assert next_agent == "auto"
+
+    @patch("autogen.agentchat.group.group_utils.get_last_agent_speaker")
+    def test_determine_next_agent_agent_target_takes_precedence_over_group(
+        self,
+        mock_get_last_agent_speaker: MagicMock,
+        mock_group_chat: MagicMock,
+        agent1: MagicMock,
+        agent2: MagicMock,
+        user_proxy: MagicMock,
+        mock_tool_executor: MagicMock,
+    ) -> None:
+        """Test that agent-level AgentTarget after_work takes precedence over
+        group-level after_work."""
+        group_agent_names = ["agent1", "agent2"]
+        mock_group_chat.agents = [agent1, agent2, user_proxy, mock_tool_executor]
+        mock_group_chat.messages = [{"role": "assistant", "name": "agent1", "content": "Hello!"}]
+        mock_get_last_agent_speaker.return_value = agent1
+
+        # agent1 has AgentTarget pointing to agent2
+        agent1.handoffs.after_works = [OnContextCondition(target=AgentTarget(agent=agent2), condition=None)]
+
+        # Group-level after_work is TerminateTarget (should NOT be reached)
+        group_after_work = TerminateTarget()
+
+        next_agent = determine_next_agent(
+            agent1,
+            mock_group_chat,
+            agent1,
+            False,
+            mock_tool_executor,
+            group_agent_names,
+            user_proxy,
+            group_after_work,
+        )
+        # Agent-level AgentTarget should take precedence
+        assert next_agent == agent2
+
+    @patch("autogen.agentchat.group.group_utils.get_last_agent_speaker")
+    def test_determine_next_agent_terminate_with_matching_condition(
+        self,
+        mock_get_last_agent_speaker: MagicMock,
+        mock_group_chat: MagicMock,
+        agent1: MagicMock,
+        agent2: MagicMock,
+        user_proxy: MagicMock,
+        mock_tool_executor: MagicMock,
+    ) -> None:
+        """Test that TerminateTarget with a matching context condition correctly
+        terminates the conversation."""
+        group_agent_names = ["agent1", "agent2"]
+        mock_group_chat.agents = [agent1, agent2, user_proxy, mock_tool_executor]
+        mock_group_chat.messages = [{"role": "assistant", "name": "agent2", "content": "Done!"}]
+        mock_get_last_agent_speaker.return_value = agent2
+
+        # agent2 has TerminateTarget with a condition that evaluates to True
+        # StringContextCondition checks if variable is truthy
+        condition = StringContextCondition(variable_name="should_terminate")
+        agent2.context_variables = ContextVariables(data={"should_terminate": "yes"})
+        agent2.handoffs.after_works = [OnContextCondition(target=TerminateTarget(), condition=condition)]
+
+        group_after_work = GroupManagerTarget()
+
+        next_agent = determine_next_agent(
+            agent2,
+            mock_group_chat,
+            agent1,
+            False,
+            mock_tool_executor,
+            group_agent_names,
+            user_proxy,
+            group_after_work,
+        )
+        assert next_agent is None
+
+    @patch("autogen.agentchat.group.group_utils.get_last_agent_speaker")
+    def test_determine_next_agent_terminate_condition_not_met_falls_through(
+        self,
+        mock_get_last_agent_speaker: MagicMock,
+        mock_group_chat: MagicMock,
+        agent1: MagicMock,
+        agent2: MagicMock,
+        user_proxy: MagicMock,
+        mock_tool_executor: MagicMock,
+    ) -> None:
+        """Test that when TerminateTarget's condition is NOT met, the group-level
+        after_work is used instead."""
+        group_agent_names = ["agent1", "agent2"]
+        mock_group_chat.agents = [agent1, agent2, user_proxy, mock_tool_executor]
+        mock_group_chat.messages = [{"role": "assistant", "name": "agent2", "content": "Continuing..."}]
+        mock_get_last_agent_speaker.return_value = agent2
+
+        # agent2 has TerminateTarget with a condition that evaluates to False
+        # StringContextCondition checks if variable is truthy; empty string is falsy
+        condition = StringContextCondition(variable_name="should_terminate")
+        agent2.context_variables = ContextVariables(data={"should_terminate": ""})
+        agent2.handoffs.after_works = [OnContextCondition(target=TerminateTarget(), condition=condition)]
+
+        group_after_work = GroupManagerTarget()
+
+        next_agent = determine_next_agent(
+            agent2,
+            mock_group_chat,
+            agent1,
+            False,
+            mock_tool_executor,
+            group_agent_names,
+            user_proxy,
+            group_after_work,
+        )
+        # Condition not met, falls through to group-level -> "auto"
+        assert next_agent == "auto"


### PR DESCRIPTION
## Summary

- Fix `TerminateTarget` being silently ignored when set as agent-level `after_work` in `AutoPattern` (or any pattern with group-level `after_work`)
- Introduce a `_NO_AFTER_WORK_MATCHED` sentinel in `_evaluate_after_works_conditions` to distinguish "no condition matched" from `TerminateTarget` returning `None` (termination signal)
- Previously both cases returned `None`, so the termination signal fell through to the group-level `after_work` (e.g., `GroupManagerTarget`), causing the workflow to run to `max_rounds` instead of stopping

Fixes #2575

## Root Cause

In `group_utils.py`, `_evaluate_after_works_conditions()` returned `None` in two distinct cases:
1. No `after_works` configured on the agent (or no conditions matched)
2. A `TerminateTarget` matched and resolved to `None` (the termination signal)

In `determine_next_agent()`, the check `if after_works_result is not None` treated both cases identically -- falling through to the group-level `after_work`. This meant `TerminateTarget` was silently ignored.

## Fix

- Added `_NO_AFTER_WORK_MATCHED = object()` sentinel
- `_evaluate_after_works_conditions` now returns the sentinel instead of `None` when no conditions match
- `determine_next_agent` checks `is not _NO_AFTER_WORK_MATCHED` instead of `is not None`, allowing `None` (terminate) to propagate correctly

## Test plan

- [x] Added test for `_evaluate_after_works_conditions` returning sentinel when no handoffs
- [x] Added test for `_evaluate_after_works_conditions` returning sentinel when no handoffs attribute
- [x] Added test for `_evaluate_after_works_conditions` returning `None` (not sentinel) for `TerminateTarget`
- [x] Added test for `_evaluate_after_works_conditions` returning agent for `AgentTarget`
- [x] Added integration test reproducing exact issue #2575 scenario (agent-level `TerminateTarget` + group-level `GroupManagerTarget`)
- [x] Added test for no agent after_work falling through to group-level
- [x] Added test for `AgentTarget` taking precedence over group-level
- [x] Added test for `TerminateTarget` with matching condition
- [x] Added test for `TerminateTarget` with non-matching condition falling through to group-level
- [x] All 33 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)