### PR TITLE
Broken installing-ag2 link on quickstart page

### DIFF
--- a/website/docs/home/quickstart.mdx
+++ b/website/docs/home/quickstart.mdx
@@ -413,7 +413,7 @@ Explore our collection of [Jupyter Notebooks](/docs/use-cases/notebooks/Notebook
       <Card title="Quick Start" href="../quick-start">
         Build your first agent in 3 minutes with a step-by-step guide.
       </Card>
-      <Card title="Core Concepts" href="../user-guide/basic-concepts/installing-ag2">
+      <Card title="Core Concepts" href="../../user-guide/basic-concepts/installing-ag2">
         Work through the key concepts of AG2 including ConversableAgent, GroupChat, Swarm, and tools.
       </Card>
       <Card title="Use Cases" href="../use-cases/use-cases/customer-service">


### PR DESCRIPTION
**Files changed:**
- `website/docs/home/quickstart.mdx`

*Took me two passes to get this right — first attempt missed the mark.*

**What I checked before submitting:**
> The fix correctly resolves the broken link on the quickstart page.
> 
> **Root cause addressed:** The file lives at `website/docs/home/quickstart.mdx`. The original `../user-guide/basic-concepts/installing-ag2` only went up one level (to `home/`), producing the 404 path `docs/home/user-guide/...`. The corrected `../../user-guide/basic-concepts/installing-ag2` goes up two levels (to `docs/`), landing at the correct `docs/user-guide/basic-concepts/installing-ag2`.
> 
> **Verified:** The target URL `https://docs.ag2.ai/latest/docs/user-guide/basic-concepts/installing-ag2` returns HTTP 200.
> 
> **Style:** Consistent with surrounding `Card` elements which also use relative `href` paths.
> 
> **Note for human reviewer:** Cross-reference scan found 2 other files that contain `../user-guide/basic-concepts/installing-ag2` (`website/mkdocs/_website/generate_mkdocs.py:200` and `notebook/agentchat_nestedchat.ipynb:23`). These references are in different directory contexts, so the relative path may be correct in those locations — but they're worth a quick audit to confirm they don't have the same broken-link issue.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).