### PR TITLE
Broken FSM-GroupChat link in StateFlow blog

### DIFF
--- a/website/docs/_blogs/2024-02-29-StateFlow/index.mdx
+++ b/website/docs/_blogs/2024-02-29-StateFlow/index.mdx
@@ -62,7 +62,7 @@ For both tasks, **StateFlow** achieves the best performance with the lowest cost
 
 
 ## Implement StateFlow With GroupChat
-We illustrate how to build **StateFlow** with GroupChat. Previous blog [FSM Group Chat](/docs/blog/2024-02-11-FSM-GroupChat/index)
+We illustrate how to build **StateFlow** with GroupChat. Previous blog [FSM Group Chat](/docs/blog/2024/02/11/FSM-GroupChat/)
 introduces a new feature of GroupChat that allows us to input a transition graph to constrain agent transitions.
 It requires us to use natural language to describe the transition conditions of the FSM in the agent's `description` parameter, and then use an LLM to take in the description and make decisions for the next agent.
 In this blog, we take advantage of a customized speaker selection function passed to the `speaker_selection_method` of the `GroupChat` object.
@@ -150,5 +150,5 @@ When returning `None`, the group chat will terminate. Note that some of the tran
 * [StateFlow paper](https://arxiv.org/abs/2403.11322)
 * [StateFlow notebook](/docs/use-cases/notebooks/notebooks/agentchat_groupchat_stateflow)
 * [GroupChat with Customized Speaker Selection notebook](/docs/use-cases/notebooks/notebooks/agentchat_groupchat_customized)
-* [FSM Group Chat](/docs/blog/2024-02-11-FSM-GroupChat/index)
+* [FSM Group Chat](/docs/blog/2024/02/11/FSM-GroupChat/)
 * [Documentation about `autogen`](/docs/home/quickstart)


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2024-02-29-StateFlow/index.mdx`

**What I checked before submitting:**
> Fix is correct and verified. The two internal links to the FSM-GroupChat blog were updated from `/docs/blog/2024-02-11-FSM-GroupChat/index` (returns HTTP 404) to `/docs/blog/2024/02/11/FSM-GroupChat/` (returns HTTP 200). Both occurrences in the file (inline reference at line 62 and the references section at line 153) are consistently updated. The new URL format matches the live rendered URL and resolves successfully. No other issues found — the change is minimal, targeted, and correct.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).