### PR TITLE
fix: support async LangChain tools in convert_tool()

### DIFF
--- a/autogen/interop/langchain/langchain_tool.py
+++ b/autogen/interop/langchain/langchain_tool.py
@@ -15,6 +15,36 @@ with optional_import_block():
     from langchain_core.tools import BaseTool as LangchainTool
 
 
+def _langchain_tool_has_async_implementation(langchain_tool: "LangchainTool") -> bool:
+    """Check if a LangChain tool has a real async implementation.
+
+    LangChain's ``BaseTool`` defines a default ``_arun`` that raises
+    ``NotImplementedError``.  We walk the MRO to find the first class that
+    defines ``_arun``.  If that class is the tool's own concrete class (or
+    any intermediate subclass that is *not* ``BaseTool``), we treat it as
+    having a real async implementation.
+
+    Returns:
+        True if the tool overrides ``_arun`` with a custom implementation.
+    """
+    try:
+        from langchain_core.tools import BaseTool as LangchainBaseTool
+    except ImportError:
+        return False
+
+    # Walk the MRO to find the first class that defines ``_arun``.
+    for cls in type(langchain_tool).__mro__:
+        if "_arun" in cls.__dict__:
+            # If the defining class is BaseTool itself, there is no
+            # custom override — it's the default NotImplementedError stub.
+            if cls is LangchainBaseTool:
+                return False
+            # Otherwise a subclass has overridden _arun.
+            return True
+
+    return False
+
+
 @register_interoperable_class("langchain")
 @export_module("autogen.interop")
 class LangChainInteroperability:
@@ -34,6 +64,14 @@ class LangChainInteroperability:
         This method verifies that the provided tool is a valid `LangchainTool`,
         processes the tool's input and description, and returns a standardized
         `Tool` object.
+
+        When the LangChain tool provides a native async implementation
+        (i.e. overrides ``_arun``), the converted tool will be an async
+        function that calls ``ainvoke``, allowing it to be properly awaited
+        inside ``a_initiate_chat`` and other async execution paths.
+
+        For tools without async support, the synchronous ``run`` method is
+        used, preserving backward compatibility.
 
         Args:
             tool (Any): The tool to convert, expected to be an instance of `LangchainTool`.
@@ -55,6 +93,17 @@ class LangChainInteroperability:
         langchain_tool: LangchainTool = tool  # type: ignore[no-any-unimported]
 
         model_type = langchain_tool.get_input_schema()
+
+        if _langchain_tool_has_async_implementation(langchain_tool):
+
+            async def async_func(tool_input: model_type) -> Any:  # type: ignore[valid-type]
+                return await langchain_tool.ainvoke(tool_input.model_dump())  # type: ignore[attr-defined]
+
+            return Tool(
+                name=langchain_tool.name,
+                description=langchain_tool.description,
+                func_or_tool=async_func,
+            )
 
         def func(tool_input: model_type) -> Any:  # type: ignore[valid-type]
             return langchain_tool.run(tool_input.model_dump())  # type: ignore[attr-defined]

--- a/autogen/interop/langchain/langchain_tool.py
+++ b/autogen/interop/langchain/langchain_tool.py
@@ -18,21 +18,39 @@ with optional_import_block():
 def _langchain_tool_has_async_implementation(langchain_tool: "LangchainTool") -> bool:  # type: ignore[no-any-unimported]
     """Check if a LangChain tool has a real async implementation.
 
-    LangChain's ``BaseTool`` defines a default ``_arun`` that raises
-    ``NotImplementedError``.  We walk the MRO to find the first class that
-    defines ``_arun``.  If that class is the tool's own concrete class (or
-    any intermediate subclass that is *not* ``BaseTool``), we treat it as
-    having a real async implementation.
+    Two cases are handled separately because LangChain's class hierarchy
+    forces it:
+
+    1. ``StructuredTool`` / ``Tool`` always overrides ``_arun`` at the
+       class level — internally it delegates to its ``coroutine``
+       attribute, which is set when the wrapped function is async and
+       ``None`` when it is sync. The MRO walk below would therefore
+       misclassify every ``StructuredTool``-wrapped sync function as
+       async-native, so for this path we check ``tool.coroutine`` directly.
+
+    2. Direct ``BaseTool`` subclasses (no ``coroutine`` attribute) may
+       override ``_arun`` themselves; ``BaseTool`` itself only ships a
+       default that raises ``NotImplementedError``. Walk the MRO and
+       treat the tool as async iff the first class that defines
+       ``_arun`` is not ``BaseTool``.
+
+    See review feedback on #2618 — #2790 uses the same two-case split.
 
     Returns:
-        True if the tool overrides ``_arun`` with a custom implementation.
+        True if the tool exposes a real async implementation.
     """
     try:
         from langchain_core.tools import BaseTool as LangchainBaseTool
     except ImportError:
         return False
 
-    # Walk the MRO to find the first class that defines ``_arun``.
+    # Case 1 — StructuredTool / Tool path. ``coroutine`` is the only
+    # reliable signal here; the class always overrides ``_arun`` so the
+    # MRO walk below would misclassify sync wrappers as async.
+    if hasattr(langchain_tool, "coroutine"):
+        return getattr(langchain_tool, "coroutine") is not None
+
+    # Case 2 — BaseTool subclass MRO walk.
     for cls in type(langchain_tool).__mro__:
         if "_arun" in cls.__dict__:
             # If the defining class is BaseTool itself, there is no

--- a/autogen/interop/langchain/langchain_tool.py
+++ b/autogen/interop/langchain/langchain_tool.py
@@ -15,7 +15,7 @@ with optional_import_block():
     from langchain_core.tools import BaseTool as LangchainTool
 
 
-def _langchain_tool_has_async_implementation(langchain_tool: "LangchainTool") -> bool:
+def _langchain_tool_has_async_implementation(langchain_tool: "LangchainTool") -> bool:  # type: ignore[no-any-unimported]
     """Check if a LangChain tool has a real async implementation.
 
     LangChain's ``BaseTool`` defines a default ``_arun`` that raises

--- a/test/interop/langchain/test_langchain_async.py
+++ b/test/interop/langchain/test_langchain_async.py
@@ -213,3 +213,43 @@ class TestLangChainAsyncDetection:
         # The user explicitly defined _arun on their class, so we treat it
         # as having async support regardless of what the body does.
         assert _langchain_tool_has_async_implementation(tool) is True
+
+    def test_structured_tool_sync_wrapped_callable_is_not_async(self) -> None:
+        """Regression for the StructuredTool gap (review feedback on #2618).
+
+        ``StructuredTool`` and ``Tool`` always override ``_arun`` at the
+        class level — internally ``_arun`` delegates to the ``coroutine``
+        attribute, which is ``None`` when the wrapped callable is sync.
+        An MRO-only check therefore misclassifies every sync function wrapped
+        with ``@langchain_core.tools.tool`` as async, routing them through
+        ``arun`` unnecessarily. The helper must instead read ``coroutine``
+        directly for this path.
+        """
+        from autogen.interop.langchain.langchain_tool import _langchain_tool_has_async_implementation
+
+        @langchain_tool  # type: ignore[misc]
+        def sync_wrapped(query: str) -> str:
+            """A sync callable wrapped by the @tool decorator becomes a StructuredTool."""
+            return f"sync:{query}"
+
+        assert hasattr(sync_wrapped, "coroutine"), (
+            "test prerequisite: the @tool decorator should wrap the callable in a "
+            "StructuredTool that exposes `coroutine` — if this assert fails the "
+            "LangChain API has changed and the detection path needs to be re-checked"
+        )
+        assert getattr(sync_wrapped, "coroutine", "<missing>") is None
+        assert _langchain_tool_has_async_implementation(sync_wrapped) is False
+
+    def test_structured_tool_async_wrapped_callable_is_async(self) -> None:
+        """Pair of the above: a StructuredTool whose wrapped callable IS async
+        must be detected as async via the ``coroutine`` attribute (not via the
+        class-level ``_arun`` override)."""
+        from autogen.interop.langchain.langchain_tool import _langchain_tool_has_async_implementation
+
+        @langchain_tool  # type: ignore[misc]
+        async def async_wrapped(query: str) -> str:
+            """An async callable wrapped by @tool stores itself in `coroutine`."""
+            return f"async:{query}"
+
+        assert getattr(async_wrapped, "coroutine", None) is not None
+        assert _langchain_tool_has_async_implementation(async_wrapped) is True

--- a/test/interop/langchain/test_langchain_async.py
+++ b/test/interop/langchain/test_langchain_async.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import inspect
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -30,22 +31,22 @@ class TestLangChainAsyncToolConversion:
     """
 
     @pytest.fixture
-    def sync_tool(self) -> "LangchainBaseTool":
+    def sync_tool(self) -> Any:
         """A LangChain tool with only synchronous implementation."""
         self.sync_mock = MagicMock(return_value="sync result")
 
         class SyncSearchInput(BaseModel):
             query: str = Field(description="search query")
 
-        @langchain_tool("sync-search", args_schema=SyncSearchInput, return_direct=True)
+        @langchain_tool("sync-search", args_schema=SyncSearchInput, return_direct=True)  # type: ignore[misc]
         def sync_search(query: str) -> str:
             """A synchronous search tool."""
-            return self.sync_mock(query)
+            return self.sync_mock(query)  # type: ignore[no-any-return]
 
         return sync_search
 
     @pytest.fixture
-    def async_tool(self) -> "LangchainBaseTool":
+    def async_tool(self) -> Any:
         """A LangChain tool with native async implementation (_arun override)."""
         self.async_mock = AsyncMock(return_value="async result")
         self.sync_fallback_mock = MagicMock(return_value="sync fallback result")
@@ -53,16 +54,16 @@ class TestLangChainAsyncToolConversion:
         class AsyncSearchInput(BaseModel):
             query: str = Field(description="search query")
 
-        class AsyncSearchTool(LangchainBaseTool):
+        class AsyncSearchTool(LangchainBaseTool):  # type: ignore[misc, no-any-unimported]
             name: str = "async-search"
             description: str = "An asynchronous search tool."
             args_schema: type[BaseModel] = AsyncSearchInput
 
             def _run(self, query: str) -> str:
-                return self.sync_fallback_mock(query)
+                return self.sync_fallback_mock(query)  # type: ignore[no-any-return]
 
             async def _arun(self, query: str) -> str:
-                return await self.async_mock(query)
+                return await self.async_mock(query)  # type: ignore[no-any-return]
 
         # Store references for assertion access
         tool_instance = AsyncSearchTool()
@@ -70,7 +71,7 @@ class TestLangChainAsyncToolConversion:
         tool_instance.async_mock = self.async_mock
         return tool_instance
 
-    def test_sync_tool_stays_sync(self, sync_tool: "LangchainBaseTool") -> None:
+    def test_sync_tool_stays_sync(self, sync_tool: Any) -> None:
         """Sync-only LangChain tools should produce a sync converted function."""
         converted = LangChainInteroperability.convert_tool(sync_tool)
 
@@ -79,7 +80,7 @@ class TestLangChainAsyncToolConversion:
         # The converted function should NOT be a coroutine function
         assert not inspect.iscoroutinefunction(converted.func)
 
-    def test_sync_tool_execution(self, sync_tool: "LangchainBaseTool") -> None:
+    def test_sync_tool_execution(self, sync_tool: Any) -> None:
         """Sync converted tool should execute correctly and return expected result."""
         converted = LangChainInteroperability.convert_tool(sync_tool)
 
@@ -90,7 +91,7 @@ class TestLangChainAsyncToolConversion:
         assert result == "sync result"
         self.sync_mock.assert_called_once_with("test query")
 
-    def test_async_tool_produces_async_func(self, async_tool: "LangchainBaseTool") -> None:
+    def test_async_tool_produces_async_func(self, async_tool: Any) -> None:
         """LangChain tools with _arun should produce an async converted function."""
         converted = LangChainInteroperability.convert_tool(async_tool)
 
@@ -100,7 +101,7 @@ class TestLangChainAsyncToolConversion:
         assert inspect.iscoroutinefunction(converted.func)
 
     @pytest.mark.asyncio
-    async def test_async_tool_execution(self, async_tool: "LangchainBaseTool") -> None:
+    async def test_async_tool_execution(self, async_tool: Any) -> None:
         """Async converted tool should be awaitable and call ainvoke internally."""
         converted = LangChainInteroperability.convert_tool(async_tool)
 
@@ -114,7 +115,7 @@ class TestLangChainAsyncToolConversion:
         self.async_mock.assert_called_once_with("async test query")
 
     @pytest.mark.asyncio
-    async def test_async_tool_does_not_block_event_loop(self, async_tool: "LangchainBaseTool") -> None:
+    async def test_async_tool_does_not_block_event_loop(self, async_tool: Any) -> None:
         """Verify that the async tool runs concurrently without blocking.
 
         We run the async tool alongside a fast coroutine. If the tool were
@@ -138,7 +139,7 @@ class TestLangChainAsyncToolConversion:
         assert tool_result == "async result"
         assert "fast_done" in results
 
-    def test_convert_tool_preserves_name_and_description(self, async_tool: "LangchainBaseTool") -> None:
+    def test_convert_tool_preserves_name_and_description(self, async_tool: Any) -> None:
         """Tool metadata should be preserved after conversion."""
         converted = LangChainInteroperability.convert_tool(async_tool)
 
@@ -150,7 +151,7 @@ class TestLangChainAsyncToolConversion:
         with pytest.raises(ValueError, match="Expected an instance of"):
             LangChainInteroperability.convert_tool("not a tool")
 
-    def test_convert_tool_extra_kwargs_raises(self, sync_tool: "LangchainBaseTool") -> None:
+    def test_convert_tool_extra_kwargs_raises(self, sync_tool: Any) -> None:
         """Extra keyword arguments should raise ValueError."""
         with pytest.raises(ValueError, match="does not support any additional arguments"):
             LangChainInteroperability.convert_tool(sync_tool, extra_arg="value")

--- a/test/interop/langchain/test_langchain_async.py
+++ b/test/interop/langchain/test_langchain_async.py
@@ -166,7 +166,7 @@ class TestLangChainAsyncDetection:
         """Tools that override _arun should be detected as async."""
         from autogen.interop.langchain.langchain_tool import _langchain_tool_has_async_implementation
 
-        class AsyncTool(LangchainBaseTool):
+        class AsyncTool(LangchainBaseTool):  # type: ignore[misc, no-any-unimported]
             name: str = "async-tool"
             description: str = "test"
 
@@ -183,7 +183,7 @@ class TestLangChainAsyncDetection:
         """Tools using the @tool decorator (no _arun override) should be detected as sync."""
         from autogen.interop.langchain.langchain_tool import _langchain_tool_has_async_implementation
 
-        @langchain_tool
+        @langchain_tool  # type: ignore[misc]
         def my_sync_tool(query: str) -> str:
             """A sync tool."""
             return "result"
@@ -199,7 +199,7 @@ class TestLangChainAsyncDetection:
         """
         from autogen.interop.langchain.langchain_tool import _langchain_tool_has_async_implementation
 
-        class ToolWithExplicitAsync(LangchainBaseTool):
+        class ToolWithExplicitAsync(LangchainBaseTool):  # type: ignore[misc, no-any-unimported]
             name: str = "explicit-async-tool"
             description: str = "test"
 

--- a/test/interop/langchain/test_langchain_async.py
+++ b/test/interop/langchain/test_langchain_async.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel, Field
+
+from autogen.import_utils import optional_import_block, run_for_optional_imports
+from autogen.interop.langchain import LangChainInteroperability
+
+with optional_import_block():
+    from langchain_core.tools import BaseTool as LangchainBaseTool
+    from langchain_core.tools import tool as langchain_tool
+
+
+@pytest.mark.interop
+@run_for_optional_imports("langchain_core", "interop-langchain")
+class TestLangChainAsyncToolConversion:
+    """Tests for async LangChain tool support in LangChainInteroperability.
+
+    Verifies that:
+    - Tools with native async (_arun) are converted to async functions using ainvoke
+    - Tools without async remain synchronous (backward compatibility)
+    - Async converted tools can be awaited without blocking
+    - Sync converted tools still work as before
+    """
+
+    @pytest.fixture
+    def sync_tool(self) -> "LangchainBaseTool":
+        """A LangChain tool with only synchronous implementation."""
+        self.sync_mock = MagicMock(return_value="sync result")
+
+        class SyncSearchInput(BaseModel):
+            query: str = Field(description="search query")
+
+        @langchain_tool("sync-search", args_schema=SyncSearchInput, return_direct=True)
+        def sync_search(query: str) -> str:
+            """A synchronous search tool."""
+            return self.sync_mock(query)
+
+        return sync_search
+
+    @pytest.fixture
+    def async_tool(self) -> "LangchainBaseTool":
+        """A LangChain tool with native async implementation (_arun override)."""
+        self.async_mock = AsyncMock(return_value="async result")
+        self.sync_fallback_mock = MagicMock(return_value="sync fallback result")
+
+        class AsyncSearchInput(BaseModel):
+            query: str = Field(description="search query")
+
+        class AsyncSearchTool(LangchainBaseTool):
+            name: str = "async-search"
+            description: str = "An asynchronous search tool."
+            args_schema: type[BaseModel] = AsyncSearchInput
+
+            def _run(self, query: str) -> str:
+                return self.sync_fallback_mock(query)
+
+            async def _arun(self, query: str) -> str:
+                return await self.async_mock(query)
+
+        # Store references for assertion access
+        tool_instance = AsyncSearchTool()
+        tool_instance.sync_fallback_mock = self.sync_fallback_mock
+        tool_instance.async_mock = self.async_mock
+        return tool_instance
+
+    def test_sync_tool_stays_sync(self, sync_tool: "LangchainBaseTool") -> None:
+        """Sync-only LangChain tools should produce a sync converted function."""
+        converted = LangChainInteroperability.convert_tool(sync_tool)
+
+        assert converted.name == "sync-search"
+        assert converted.description == "A synchronous search tool."
+        # The converted function should NOT be a coroutine function
+        assert not inspect.iscoroutinefunction(converted.func)
+
+    def test_sync_tool_execution(self, sync_tool: "LangchainBaseTool") -> None:
+        """Sync converted tool should execute correctly and return expected result."""
+        converted = LangChainInteroperability.convert_tool(sync_tool)
+
+        model_type = sync_tool.get_input_schema()
+        tool_input = model_type(query="test query")
+        result = converted.func(tool_input=tool_input)
+
+        assert result == "sync result"
+        self.sync_mock.assert_called_once_with("test query")
+
+    def test_async_tool_produces_async_func(self, async_tool: "LangchainBaseTool") -> None:
+        """LangChain tools with _arun should produce an async converted function."""
+        converted = LangChainInteroperability.convert_tool(async_tool)
+
+        assert converted.name == "async-search"
+        assert converted.description == "An asynchronous search tool."
+        # The converted function MUST be a coroutine function
+        assert inspect.iscoroutinefunction(converted.func)
+
+    @pytest.mark.asyncio
+    async def test_async_tool_execution(self, async_tool: "LangchainBaseTool") -> None:
+        """Async converted tool should be awaitable and call ainvoke internally."""
+        converted = LangChainInteroperability.convert_tool(async_tool)
+
+        model_type = async_tool.get_input_schema()
+        tool_input = model_type(query="async test query")
+
+        # The function should be awaitable
+        result = await converted.func(tool_input=tool_input)
+
+        assert result == "async result"
+        self.async_mock.assert_called_once_with("async test query")
+
+    @pytest.mark.asyncio
+    async def test_async_tool_does_not_block_event_loop(self, async_tool: "LangchainBaseTool") -> None:
+        """Verify that the async tool runs concurrently without blocking.
+
+        We run the async tool alongside a fast coroutine. If the tool were
+        blocking (using sync run()), the fast coroutine would be delayed.
+        """
+        converted = LangChainInteroperability.convert_tool(async_tool)
+        model_type = async_tool.get_input_schema()
+        tool_input = model_type(query="concurrent test")
+
+        results = []
+
+        async def fast_task() -> None:
+            results.append("fast_done")
+
+        # Run both concurrently
+        tool_result, _ = await asyncio.gather(
+            converted.func(tool_input=tool_input),
+            fast_task(),
+        )
+
+        assert tool_result == "async result"
+        assert "fast_done" in results
+
+    def test_convert_tool_preserves_name_and_description(self, async_tool: "LangchainBaseTool") -> None:
+        """Tool metadata should be preserved after conversion."""
+        converted = LangChainInteroperability.convert_tool(async_tool)
+
+        assert converted.name == async_tool.name
+        assert converted.description == async_tool.description
+
+    def test_convert_tool_invalid_type_raises(self) -> None:
+        """Passing a non-LangChain tool should raise ValueError."""
+        with pytest.raises(ValueError, match="Expected an instance of"):
+            LangChainInteroperability.convert_tool("not a tool")
+
+    def test_convert_tool_extra_kwargs_raises(self, sync_tool: "LangchainBaseTool") -> None:
+        """Extra keyword arguments should raise ValueError."""
+        with pytest.raises(ValueError, match="does not support any additional arguments"):
+            LangChainInteroperability.convert_tool(sync_tool, extra_arg="value")
+
+
+@pytest.mark.interop
+@run_for_optional_imports("langchain_core", "interop-langchain")
+class TestLangChainAsyncDetection:
+    """Tests for the _langchain_tool_has_async_implementation helper."""
+
+    def test_detects_async_implementation(self) -> None:
+        """Tools that override _arun should be detected as async."""
+        from autogen.interop.langchain.langchain_tool import _langchain_tool_has_async_implementation
+
+        class AsyncTool(LangchainBaseTool):
+            name: str = "async-tool"
+            description: str = "test"
+
+            def _run(self, query: str) -> str:
+                return "sync"
+
+            async def _arun(self, query: str) -> str:
+                return "async"
+
+        tool = AsyncTool()
+        assert _langchain_tool_has_async_implementation(tool) is True
+
+    def test_detects_sync_only_tool(self) -> None:
+        """Tools using the @tool decorator (no _arun override) should be detected as sync."""
+        from autogen.interop.langchain.langchain_tool import _langchain_tool_has_async_implementation
+
+        @langchain_tool
+        def my_sync_tool(query: str) -> str:
+            """A sync tool."""
+            return "result"
+
+        assert _langchain_tool_has_async_implementation(my_sync_tool) is False
+
+    def test_detects_tool_with_explicit_arun_override(self) -> None:
+        """Tools that explicitly override _arun on a subclass should be detected as async.
+
+        Even if the override raises NotImplementedError, the override is on
+        the concrete class (not BaseTool), so we treat it as async. This is
+        the conservative choice — let LangChain handle error semantics.
+        """
+        from autogen.interop.langchain.langchain_tool import _langchain_tool_has_async_implementation
+
+        class ToolWithExplicitAsync(LangchainBaseTool):
+            name: str = "explicit-async-tool"
+            description: str = "test"
+
+            def _run(self, query: str) -> str:
+                return "sync"
+
+            async def _arun(self, query: str) -> str:
+                raise NotImplementedError("No async support")
+
+        tool = ToolWithExplicitAsync()
+        # The user explicitly defined _arun on their class, so we treat it
+        # as having async support regardless of what the body does.
+        assert _langchain_tool_has_async_implementation(tool) is True


### PR DESCRIPTION
## Summary

Fixes #1402

- **Problem**: `LangChainInteroperability.convert_tool()` always wraps LangChain tools with a synchronous function that calls `langchain_tool.run()`, even when the tool provides native async support via `_arun`. This blocks the event loop when used inside `a_initiate_chat()` and other async execution paths.
- **Solution**: Added async detection via MRO inspection. When a LangChain tool overrides `_arun` (i.e., provides a real async implementation beyond BaseTool's default `NotImplementedError` stub), the converted tool now uses an `async def` function that calls `ainvoke()`. Tools without async support continue to use the synchronous `run()` method, preserving full backward compatibility.
- **How it works with the framework**: AG2's `a_execute_function()` already checks `is_coroutine_callable(func)` and properly awaits async functions. By providing an async function when the LangChain tool supports it, the tool integrates naturally with the existing async execution path.

### Changes

**`autogen/interop/langchain/langchain_tool.py`**:
- Added `_langchain_tool_has_async_implementation()` helper that walks the MRO to detect if the tool's `_arun` is overridden from `BaseTool`'s default
- Modified `convert_tool()` to create an async wrapper using `ainvoke()` when async support is detected
- Sync path remains unchanged for backward compatibility

**`test/interop/langchain/test_langchain_async.py`** (new):
- Tests that sync-only tools remain sync after conversion
- Tests that async tools produce async converted functions
- Tests async tool execution via `await`
- Tests concurrent execution (async tool doesn't block event loop)
- Tests metadata preservation, error handling
- Tests for the `_langchain_tool_has_async_implementation` detection helper

## Test plan

- [ ] `pytest test/interop/langchain/test_langchain_async.py` — new async tests pass
- [ ] `pytest test/interop/langchain/test_langchain.py` — existing sync tests still pass (regression)
- [ ] Verify async detection correctly identifies tools with/without `_arun` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)