### PR TITLE
fix: filter **kwargs and *args from tool call schema generation

### DIFF
--- a/autogen/tools/function_utils.py
+++ b/autogen/tools/function_utils.py
@@ -70,6 +70,7 @@ def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
             annotation=get_typed_annotation(param.annotation, globalns),
         )
         for param in signature.parameters.values()
+        if param.kind not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
     ]
     typed_signature = inspect.Signature(typed_params)
     return typed_signature
@@ -104,7 +105,10 @@ def get_param_annotations(typed_signature: inspect.Signature) -> dict[str, Annot
         A dictionary of the type annotations of the parameters of the function
     """
     return {
-        k: v.annotation for k, v in typed_signature.parameters.items() if v.annotation is not inspect.Signature.empty
+        k: v.annotation
+        for k, v in typed_signature.parameters.items()
+        if v.annotation is not inspect.Signature.empty
+        and v.kind not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
     }
 
 
@@ -173,7 +177,12 @@ def get_required_params(typed_signature: inspect.Signature) -> list[str]:
     Returns:
         A list of the required parameters of the function
     """
-    return [k for k, v in typed_signature.parameters.items() if v.default == inspect.Signature.empty]
+    return [
+        k
+        for k, v in typed_signature.parameters.items()
+        if v.default == inspect.Signature.empty
+        and v.kind not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+    ]
 
 
 def get_default_values(typed_signature: inspect.Signature) -> dict[str, Any]:
@@ -185,7 +194,12 @@ def get_default_values(typed_signature: inspect.Signature) -> dict[str, Any]:
     Returns:
         A dictionary of the default values of the parameters of the function
     """
-    return {k: v.default for k, v in typed_signature.parameters.items() if v.default != inspect.Signature.empty}
+    return {
+        k: v.default
+        for k, v in typed_signature.parameters.items()
+        if v.default != inspect.Signature.empty
+        and v.kind not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+    }
 
 
 def get_parameters(
@@ -225,7 +239,12 @@ def get_missing_annotations(typed_signature: inspect.Signature, required: list[s
     Returns:
         A set of the missing annotations of the function
     """
-    all_missing = {k for k, v in typed_signature.parameters.items() if v.annotation is inspect.Signature.empty}
+    all_missing = {
+        k
+        for k, v in typed_signature.parameters.items()
+        if v.annotation is inspect.Signature.empty
+        and v.kind not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+    }
     missing = all_missing.intersection(set(required))
     unannotated_with_default = all_missing.difference(missing)
     return missing, unannotated_with_default

--- a/test/tools/test_function_utils.py
+++ b/test/tools/test_function_utils.py
@@ -543,7 +543,7 @@ def test_get_param_annotations_excludes_kwargs() -> None:
     def func_with_kwargs(
         a: Annotated[str, AG2Field(description="Param a")],
         b: int = 2,
-        **kwargs: Annotated[Dict, "Extra keyword arguments"],
+        **kwargs: Annotated[Dict[str, Any], "Extra keyword arguments"],
     ) -> str:
         return ""
 
@@ -634,7 +634,7 @@ def test_get_function_schema_with_regular_params_and_kwargs() -> None:
     def hello_world(
         arg1: Annotated[str, AG2Field(description="Case Name")],
         arg2: Annotated[str, AG2Field(description="Clue Name")],
-        **kwargs: Annotated[Dict, "Extra keyword arguments"],
+        **kwargs: Annotated[Dict[str, Any], "Extra keyword arguments"],
     ) -> str:
         return f"{arg1} {arg2}"
 

--- a/test/tools/test_function_utils.py
+++ b/test/tools/test_function_utils.py
@@ -9,7 +9,7 @@ import inspect
 import unittest.mock
 from collections.abc import Callable
 from enum import Enum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Dict, Literal
 
 import pytest
 from pydantic import BaseModel, Field
@@ -491,3 +491,202 @@ def test_serialize_to_str_list_pydantic() -> None:
         serialize_to_str([A(a=1, b=2.3, c="abc"), A(a=4, b=5.6, c="def")])
         == "[{'a': 1, 'b': 2.3, 'c': 'abc'}, {'a': 4, 'b': 5.6, 'c': 'def'}]"
     )
+
+
+# ==================== Tests for **kwargs / *args filtering (GitHub issue #1790) ====================
+
+
+def test_get_typed_signature_filters_var_keyword() -> None:
+    """get_typed_signature should exclude **kwargs parameters."""
+
+    def func_with_kwargs(a: Annotated[str, AG2Field(description="Param a")], **kwargs: Any) -> str:
+        return ""
+
+    sig = get_typed_signature(func_with_kwargs)
+    param_names = list(sig.parameters.keys())
+    assert "kwargs" not in param_names
+    assert "a" in param_names
+
+
+def test_get_typed_signature_filters_var_positional() -> None:
+    """get_typed_signature should exclude *args parameters."""
+
+    def func_with_args(a: Annotated[str, AG2Field(description="Param a")], *args: Any) -> str:
+        return ""
+
+    sig = get_typed_signature(func_with_args)
+    param_names = list(sig.parameters.keys())
+    assert "args" not in param_names
+    assert "a" in param_names
+
+
+def test_get_typed_signature_filters_both_var_positional_and_keyword() -> None:
+    """get_typed_signature should exclude both *args and **kwargs."""
+
+    def func_with_both(
+        a: Annotated[str, AG2Field(description="Param a")],
+        *args: Any,
+        **kwargs: Any,
+    ) -> str:
+        return ""
+
+    sig = get_typed_signature(func_with_both)
+    param_names = list(sig.parameters.keys())
+    assert "args" not in param_names
+    assert "kwargs" not in param_names
+    assert "a" in param_names
+
+
+def test_get_param_annotations_excludes_kwargs() -> None:
+    """get_param_annotations should not include **kwargs in annotations."""
+
+    def func_with_kwargs(
+        a: Annotated[str, AG2Field(description="Param a")],
+        b: int = 2,
+        **kwargs: Annotated[Dict, "Extra keyword arguments"],
+    ) -> str:
+        return ""
+
+    typed_sig = get_typed_signature(func_with_kwargs)
+    annotations = get_param_annotations(typed_sig)
+    assert "kwargs" not in annotations
+    assert "a" in annotations
+
+
+def test_get_required_params_excludes_kwargs() -> None:
+    """get_required_params should not list **kwargs as required."""
+
+    def func_with_kwargs(
+        a: Annotated[str, AG2Field(description="Param a")],
+        **kwargs: Any,
+    ) -> str:
+        return ""
+
+    typed_sig = get_typed_signature(func_with_kwargs)
+    required = get_required_params(typed_sig)
+    assert "kwargs" not in required
+    assert "a" in required
+
+
+def test_get_required_params_excludes_args() -> None:
+    """get_required_params should not list *args as required."""
+
+    def func_with_args(
+        a: Annotated[str, AG2Field(description="Param a")],
+        *args: Any,
+    ) -> str:
+        return ""
+
+    typed_sig = get_typed_signature(func_with_args)
+    required = get_required_params(typed_sig)
+    assert "args" not in required
+    assert "a" in required
+
+
+def test_get_default_values_excludes_kwargs() -> None:
+    """get_default_values should not include **kwargs."""
+
+    def func_with_kwargs(
+        a: Annotated[str, AG2Field(description="Param a")],
+        b: int = 5,
+        **kwargs: Any,
+    ) -> str:
+        return ""
+
+    typed_sig = get_typed_signature(func_with_kwargs)
+    defaults = get_default_values(typed_sig)
+    assert "kwargs" not in defaults
+    assert defaults == {"b": 5}
+
+
+def test_get_missing_annotations_excludes_var_params() -> None:
+    """get_missing_annotations should not flag *args/**kwargs as missing."""
+
+    def func_with_both(a: str, *args, **kwargs) -> str:  # type: ignore[no-untyped-def]
+        return ""
+
+    typed_sig = get_typed_signature(func_with_both)
+    required = get_required_params(typed_sig)
+    missing, unannotated = get_missing_annotations(typed_sig, required)
+    assert "args" not in missing
+    assert "kwargs" not in missing
+    assert "args" not in unannotated
+    assert "kwargs" not in unannotated
+
+
+def test_get_function_schema_with_kwargs_only() -> None:
+    """Schema for a function with only **kwargs should have no properties/required."""
+
+    def func_kwargs_only(**kwargs: Any) -> str:
+        return ""
+
+    schema = get_function_schema(func_kwargs_only, description="kwargs only function")
+    params = schema["function"]["parameters"]
+    assert "kwargs" not in params["properties"]
+    assert "kwargs" not in params["required"]
+    assert params["properties"] == {}
+    assert params["required"] == []
+
+
+def test_get_function_schema_with_regular_params_and_kwargs() -> None:
+    """Schema should include regular params but exclude **kwargs (issue #1790 repro)."""
+
+    def hello_world(
+        arg1: Annotated[str, AG2Field(description="Case Name")],
+        arg2: Annotated[str, AG2Field(description="Clue Name")],
+        **kwargs: Annotated[Dict, "Extra keyword arguments"],
+    ) -> str:
+        return f"{arg1} {arg2}"
+
+    schema = get_function_schema(hello_world, description="Hello world with kwargs")
+    params = schema["function"]["parameters"]
+
+    # kwargs must NOT appear in the schema
+    assert "kwargs" not in params["properties"]
+    assert "kwargs" not in params["required"]
+
+    # Regular params must be present
+    assert "arg1" in params["properties"]
+    assert "arg2" in params["properties"]
+    assert "arg1" in params["required"]
+    assert "arg2" in params["required"]
+
+
+def test_get_function_schema_with_args_and_kwargs() -> None:
+    """Schema should exclude both *args and **kwargs."""
+
+    def func_with_both(
+        name: Annotated[str, AG2Field(description="The name")],
+        *args: Any,
+        **kwargs: Any,
+    ) -> str:
+        return name
+
+    schema = get_function_schema(func_with_both, description="Function with args and kwargs")
+    params = schema["function"]["parameters"]
+
+    assert "args" not in params["properties"]
+    assert "kwargs" not in params["properties"]
+    assert "args" not in params["required"]
+    assert "kwargs" not in params["required"]
+
+    assert "name" in params["properties"]
+    assert "name" in params["required"]
+
+
+def test_get_function_schema_no_kwargs_regression() -> None:
+    """Functions without *args/**kwargs should still work correctly (regression test)."""
+
+    def normal_func(
+        a: Annotated[str, AG2Field(description="Parameter a")],
+        b: Annotated[int, AG2Field(description="Parameter b")] = 10,
+    ) -> str:
+        return a
+
+    schema = get_function_schema(normal_func, description="Normal function")
+    params = schema["function"]["parameters"]
+
+    assert "a" in params["properties"]
+    assert "b" in params["properties"]
+    assert params["required"] == ["a"]
+    assert params["properties"]["b"]["default"] == 10


### PR DESCRIPTION
## Summary
- Filter `VAR_KEYWORD` (`**kwargs`) and `VAR_POSITIONAL` (`*args`) parameter kinds from tool schema generation in `autogen/tools/function_utils.py`
- Fixed all 5 functions that iterate `inspect.Signature.parameters`: `get_typed_signature()`, `get_param_annotations()`, `get_required_params()`, `get_default_values()`, `get_missing_annotations()`
- Added 12 comprehensive tests covering: kwargs-only functions, args+kwargs, regular params with kwargs, and regression tests for functions without variadic params

## Why
When a function has `**kwargs`, AG2's tool schema generation treats `kwargs` as a regular required parameter. The LLM sees it in the schema and nests all arguments inside a `kwargs` field, causing Pydantic validation failure. See the issue for a detailed reproduction.

Fixes #1790

## Test plan
- [x] All 12 new tests pass (`test_get_typed_signature_filters_var_keyword`, `test_get_typed_signature_filters_var_positional`, `test_get_typed_signature_filters_both_var_positional_and_keyword`, `test_get_param_annotations_excludes_kwargs`, `test_get_required_params_excludes_kwargs`, `test_get_required_params_excludes_args`, `test_get_default_values_excludes_kwargs`, `test_get_missing_annotations_excludes_var_params`, `test_get_function_schema_with_kwargs_only`, `test_get_function_schema_with_regular_params_and_kwargs`, `test_get_function_schema_with_args_and_kwargs`, `test_get_function_schema_no_kwargs_regression`)
- [x] All 27 pre-existing tests still pass (1 async test fails due to missing `pytest-asyncio` — pre-existing, unrelated)
- [x] Verified the exact reproduction case from the issue: `hello_world_v3(arg1, arg2, **kwargs)` now generates a schema without `kwargs` in properties or required

🤖 Generated with [Claude Code](https://claude.com/claude-code)