### PR TITLE
fix: preserve parameters_json_schema during context variable injection

### DIFF
--- a/autogen/agentchat/contrib/swarm_agent.py
+++ b/autogen/agentchat/contrib/swarm_agent.py
@@ -358,7 +358,12 @@ def _change_tool_context_variables_to_depends(
         # Recreate the tool without the context_variables parameter
         tool_func = _modify_context_variables_param(current_tool._func, context_variables)
         tool_func = inject_params(tool_func)
-        new_tool = ConversableAgent._create_tool_if_needed(func_or_tool=tool_func, name=name, description=description)
+        new_tool = ConversableAgent._create_tool_if_needed(
+            func_or_tool=tool_func,
+            name=name,
+            description=description,
+            parameters_json_schema=current_tool.parameters_json_schema,
+        )
 
         # Re-register with the agent
         agent.register_for_llm()(new_tool)

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -3924,15 +3924,26 @@ class ConversableAgent(LLMAgent):
         func_or_tool: F | Tool,
         name: str | None,
         description: str | None,
+        parameters_json_schema: dict[str, Any] | None = None,
     ) -> Tool:
         if isinstance(func_or_tool, Tool):
             tool: Tool = func_or_tool
             # create new tool object if name or description is not None
             if name or description:
-                tool = Tool(func_or_tool=tool, name=name, description=description)
+                tool = Tool(
+                    func_or_tool=tool,
+                    name=name,
+                    description=description,
+                    parameters_json_schema=parameters_json_schema,
+                )
         elif inspect.isfunction(func_or_tool):
             function: Callable[..., Any] = func_or_tool
-            tool = Tool(func_or_tool=function, name=name, description=description)
+            tool = Tool(
+                func_or_tool=function,
+                name=name,
+                description=description,
+                parameters_json_schema=parameters_json_schema,
+            )
         else:
             raise TypeError(f"'func_or_tool' must be a function or a Tool object, got '{type(func_or_tool)}' instead.")
         return tool

--- a/autogen/agentchat/group/group_tool_executor.py
+++ b/autogen/agentchat/group/group_tool_executor.py
@@ -143,7 +143,12 @@ class GroupToolExecutor(ConversableAgent):
             # Recreate the tool without the context_variables parameter
             tool_func = self._modify_context_variables_param(tool_func, context_variables)
             tool_func = inject_params(tool_func)
-            return ConversableAgent._create_tool_if_needed(func_or_tool=tool_func, name=name, description=description)
+            return ConversableAgent._create_tool_if_needed(
+                func_or_tool=tool_func,
+                name=name,
+                description=description,
+                parameters_json_schema=current_tool.parameters_json_schema,
+            )
         return None
 
     def _change_tool_context_variables_to_depends(

--- a/autogen/tools/tool.py
+++ b/autogen/tools/tool.py
@@ -61,7 +61,7 @@ class Tool:
                 f"Parameter 'func_or_tool' must be a function, method or a Tool instance, it is '{type(func_or_tool)}' instead."
             )
 
-        self._func_schema = (
+        self._func_schema: dict[str, Any] | None = (
             {
                 "type": "function",
                 "function": {

--- a/autogen/tools/tool.py
+++ b/autogen/tools/tool.py
@@ -86,6 +86,13 @@ class Tool:
     def func(self) -> Callable[..., Any]:
         return self._func
 
+    @property
+    def parameters_json_schema(self) -> dict[str, Any] | None:
+        """Get the custom parameters JSON schema, if one was provided."""
+        if self._func_schema is not None:
+            return self._func_schema["function"].get("parameters")
+        return None
+
     def register_for_llm(self, agent: "ConversableAgent") -> None:
         """Registers the tool for use with a ConversableAgent's language model (LLM).
 

--- a/autogen/tools/tool.py
+++ b/autogen/tools/tool.py
@@ -90,7 +90,7 @@ class Tool:
     def parameters_json_schema(self) -> dict[str, Any] | None:
         """Get the custom parameters JSON schema, if one was provided."""
         if self._func_schema is not None:
-            return self._func_schema["function"].get("parameters")
+            return self._func_schema["function"].get("parameters")  # type: ignore[no-any-return]
         return None
 
     def register_for_llm(self, agent: "ConversableAgent") -> None:

--- a/test/agentchat/group/test_group_tool_executor.py
+++ b/test/agentchat/group/test_group_tool_executor.py
@@ -621,6 +621,198 @@ class TestGroupToolExecutor:
         assert result == str(content)
 
 
+    def test_make_tool_copy_preserves_parameters_json_schema(self, executor: GroupToolExecutor) -> None:
+        """Test that make_tool_copy_with_context_variables preserves parameters_json_schema.
+
+        This is a regression test for https://github.com/ag2ai/ag2/issues/1814.
+        When a Tool uses parameters_json_schema for custom parameter schema AND uses
+        context_variables, the dependency injection process must preserve the custom schema.
+        """
+        custom_schema = {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["start", "stop", "restart"],
+                    "description": "The action to perform",
+                },
+                "target": {
+                    "type": "string",
+                    "description": "The target service",
+                },
+            },
+            "required": ["action", "target"],
+        }
+
+        def my_tool_func(action: str, target: str, context_variables: ContextVariables) -> str:
+            return f"{action} {target}"
+
+        tool = Tool(
+            name="service_control",
+            description="Control a service",
+            func_or_tool=my_tool_func,
+            parameters_json_schema=custom_schema,
+        )
+
+        # Verify the tool has a custom schema before the copy
+        assert tool.parameters_json_schema is not None
+        assert tool.parameters_json_schema == custom_schema
+
+        # Make a copy with context variables injected
+        context_vars = ContextVariables()
+        new_tool = executor.make_tool_copy_with_context_variables(tool, context_vars)
+
+        # The new tool must exist (context_variables was in the schema)
+        assert new_tool is not None
+
+        # The custom parameters_json_schema must be preserved
+        assert new_tool.parameters_json_schema is not None
+        assert new_tool.parameters_json_schema == custom_schema
+
+        # Verify name and description are preserved too
+        assert new_tool.name == "service_control"
+        assert new_tool.description == "Control a service"
+
+    def test_make_tool_copy_without_parameters_json_schema(self, executor: GroupToolExecutor) -> None:
+        """Test that make_tool_copy_with_context_variables works for tools without custom schema.
+
+        This is a regression test to ensure the fix for #1814 does not break
+        tools that use the default auto-generated schema.
+        """
+
+        def my_tool_func(query: str, context_variables: ContextVariables) -> str:
+            return f"searching: {query}"
+
+        tool = Tool(
+            name="search",
+            description="Search for something",
+            func_or_tool=my_tool_func,
+        )
+
+        # Verify the tool does NOT have a custom schema
+        assert tool.parameters_json_schema is None
+
+        # Make a copy with context variables injected
+        context_vars = ContextVariables()
+        new_tool = executor.make_tool_copy_with_context_variables(tool, context_vars)
+
+        # The new tool should exist
+        assert new_tool is not None
+
+        # parameters_json_schema should still be None (no custom schema)
+        assert new_tool.parameters_json_schema is None
+
+        # Verify name and description are preserved
+        assert new_tool.name == "search"
+        assert new_tool.description == "Search for something"
+
+    def test_make_tool_copy_returns_none_without_context_variables_param(self, executor: GroupToolExecutor) -> None:
+        """Test that make_tool_copy_with_context_variables returns None when
+        the tool does not have a context_variables parameter."""
+
+        def simple_func(x: str) -> str:
+            return x
+
+        tool = Tool(
+            name="simple",
+            description="A simple tool",
+            func_or_tool=simple_func,
+        )
+
+        context_vars = ContextVariables()
+        result = executor.make_tool_copy_with_context_variables(tool, context_vars)
+
+        # Should return None because the tool has no context_variables param
+        assert result is None
+
+
+class TestParametersJsonSchemaProperty:
+    """Tests for the Tool.parameters_json_schema property."""
+
+    def test_parameters_json_schema_with_custom_schema(self) -> None:
+        """Test that parameters_json_schema returns the custom schema when provided."""
+        custom_schema = {
+            "type": "object",
+            "properties": {
+                "color": {
+                    "type": "string",
+                    "enum": ["red", "green", "blue"],
+                },
+            },
+            "required": ["color"],
+        }
+
+        def my_func(color: str) -> str:
+            return color
+
+        tool = Tool(
+            name="pick_color",
+            description="Pick a color",
+            func_or_tool=my_func,
+            parameters_json_schema=custom_schema,
+        )
+
+        assert tool.parameters_json_schema == custom_schema
+
+    def test_parameters_json_schema_without_custom_schema(self) -> None:
+        """Test that parameters_json_schema returns None when no custom schema is provided."""
+
+        def my_func(x: str) -> str:
+            return x
+
+        tool = Tool(
+            name="echo",
+            description="Echo input",
+            func_or_tool=my_func,
+        )
+
+        assert tool.parameters_json_schema is None
+
+
+class TestCreateToolIfNeededWithSchema:
+    """Tests for ConversableAgent._create_tool_if_needed with parameters_json_schema."""
+
+    def test_create_tool_from_function_with_schema(self) -> None:
+        """Test that _create_tool_if_needed passes parameters_json_schema when creating from a function."""
+        custom_schema = {
+            "type": "object",
+            "properties": {
+                "mode": {"type": "string", "enum": ["fast", "slow"]},
+            },
+            "required": ["mode"],
+        }
+
+        def my_func(mode: str) -> str:
+            return mode
+
+        tool = ConversableAgent._create_tool_if_needed(
+            func_or_tool=my_func,
+            name="mode_tool",
+            description="Select mode",
+            parameters_json_schema=custom_schema,
+        )
+
+        assert tool.name == "mode_tool"
+        assert tool.description == "Select mode"
+        assert tool.parameters_json_schema == custom_schema
+
+    def test_create_tool_from_function_without_schema(self) -> None:
+        """Test that _create_tool_if_needed works without parameters_json_schema (regression)."""
+
+        def my_func(x: str) -> str:
+            return x
+
+        tool = ConversableAgent._create_tool_if_needed(
+            func_or_tool=my_func,
+            name="echo",
+            description="Echo",
+        )
+
+        assert tool.name == "echo"
+        assert tool.description == "Echo"
+        assert tool.parameters_json_schema is None
+
+
 class TestGroupToolExecutorAsync:
     """Tests for the async _a_generate_group_tool_reply method."""
 


### PR DESCRIPTION
## Summary

Fixes ag2ai/ag2classic#44

- When a `Tool` uses `parameters_json_schema` for custom parameter schema AND uses `context_variables`, the dependency injection process in both `GroupToolExecutor.make_tool_copy_with_context_variables` and `swarm_agent._change_tool_context_variables_to_depends` recreated the Tool via `_create_tool_if_needed()` without passing `parameters_json_schema`, losing the custom schema.
- Added a `parameters_json_schema` property to the `Tool` class to expose the custom schema stored in `_func_schema`
- Updated `ConversableAgent._create_tool_if_needed()` to accept and forward `parameters_json_schema`
- Passed `current_tool.parameters_json_schema` in both `group_tool_executor.py` and `swarm_agent.py` when recreating tools during context variable injection

## Changes

| File | Change |
|------|--------|
| `autogen/tools/tool.py` | Added `parameters_json_schema` property to `Tool` class |
| `autogen/agentchat/conversable_agent.py` | Added `parameters_json_schema` param to `_create_tool_if_needed()` |
| `autogen/agentchat/group/group_tool_executor.py` | Pass `parameters_json_schema` when recreating tool |
| `autogen/agentchat/contrib/swarm_agent.py` | Pass `parameters_json_schema` when recreating tool |
| `test/agentchat/group/test_group_tool_executor.py` | Added comprehensive tests for schema preservation |

## Test plan

- [x] Test Tool with custom `parameters_json_schema` + `context_variables` — schema is preserved after injection
- [x] Test Tool with default schema (no custom `parameters_json_schema`) + `context_variables` — regression test, still works
- [x] Test Tool without `context_variables` param — returns None (no copy needed)
- [x] Test `Tool.parameters_json_schema` property with and without custom schema
- [x] Test `_create_tool_if_needed` with and without `parameters_json_schema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)