### PR TITLE
refactor: rename Context to ConversationContext to avoid naming conflicts

### DIFF
--- a/autogen/beta/annotations.py
+++ b/autogen/beta/annotations.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 
 from fast_depends.library import CustomField
 
-from .context import Context as ContextType
+from .context import ConversationContext
 from .utils import CONTEXT_OPTION_NAME
 
 
@@ -93,6 +93,6 @@ class ContextField(CustomField):
 # `anything: Context`
 # are equal now
 Context = Annotated[
-    ContextType,
+    ConversationContext,
     ContextField(cast=False),
 ]

--- a/autogen/beta/config/anthropic/anthropic_client.py
+++ b/autogen/beta/config/anthropic/anthropic_client.py
@@ -17,7 +17,7 @@ from anthropic.types import (
 )
 
 from autogen.beta.config.client import LLMClient
-from autogen.beta.context import Context
+from autogen.beta.context import ConversationContext
 from autogen.beta.events import (
     BaseEvent,
     ModelMessage,
@@ -79,7 +79,7 @@ class AnthropicClient(LLMClient):
     async def __call__(
         self,
         messages: Sequence[BaseEvent],
-        context: Context,
+        context: "ConversationContext",
         *,
         tools: Iterable[ToolSchema],
         response_schema: ResponseProto | None,
@@ -169,7 +169,7 @@ class AnthropicClient(LLMClient):
     async def _process_response(
         self,
         response: Message,
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         text_parts: list[str] = []
         calls: list[ToolCallEvent] = []
@@ -210,7 +210,7 @@ class AnthropicClient(LLMClient):
     async def _process_stream(
         self,
         stream: Any,
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         full_content: str = ""
         calls: list[ToolCallEvent] = []

--- a/autogen/beta/config/client.py
+++ b/autogen/beta/config/client.py
@@ -5,7 +5,7 @@
 from collections.abc import Iterable, Sequence
 from typing import Protocol, runtime_checkable
 
-from autogen.beta.context import Context
+from autogen.beta.context import ConversationContext
 from autogen.beta.events import BaseEvent, ModelResponse
 from autogen.beta.response import ResponseProto
 from autogen.beta.tools.schemas import ToolSchema
@@ -16,7 +16,7 @@ class LLMClient(Protocol):
     async def __call__(
         self,
         messages: Sequence[BaseEvent],
-        context: Context,
+        context: ConversationContext,
         *,
         tools: Iterable[ToolSchema],
         response_schema: ResponseProto | None,

--- a/autogen/beta/config/dashscope/dashscope_client.py
+++ b/autogen/beta/config/dashscope/dashscope_client.py
@@ -11,7 +11,7 @@ import dashscope
 from dashscope.aigc.generation import AioGeneration
 
 from autogen.beta.config.client import LLMClient
-from autogen.beta.context import Context
+from autogen.beta.context import ConversationContext
 from autogen.beta.events import (
     BaseEvent,
     ModelMessage,
@@ -58,7 +58,7 @@ class DashScopeClient(LLMClient):
     async def __call__(
         self,
         messages: Sequence[BaseEvent],
-        context: Context,
+        context: "ConversationContext",
         *,
         tools: Iterable[ToolSchema],
         response_schema: ResponseProto | None,
@@ -93,7 +93,7 @@ class DashScopeClient(LLMClient):
         self,
         messages: list[dict[str, Any]],
         kwargs: dict[str, Any],
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         response = await AioGeneration.call(
             model=self._model,
@@ -151,7 +151,7 @@ class DashScopeClient(LLMClient):
         self,
         messages: list[dict[str, Any]],
         kwargs: dict[str, Any],
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         responses = await AioGeneration.call(
             model=self._model,

--- a/autogen/beta/config/gemini/gemini_client.py
+++ b/autogen/beta/config/gemini/gemini_client.py
@@ -11,7 +11,7 @@ from google import genai
 from google.genai import types
 
 from autogen.beta.config.client import LLMClient
-from autogen.beta.context import Context
+from autogen.beta.context import ConversationContext
 from autogen.beta.events import (
     BaseEvent,
     ModelMessage,
@@ -57,7 +57,7 @@ class GeminiClient(LLMClient):
     async def __call__(
         self,
         messages: Sequence[BaseEvent],
-        context: Context,
+        context: "ConversationContext",
         *,
         tools: Iterable[ToolSchema],
         response_schema: ResponseProto | None,
@@ -103,7 +103,7 @@ class GeminiClient(LLMClient):
     async def _process_response(
         self,
         response: types.GenerateContentResponse,
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         model_msg: ModelMessage | None = None
         calls: list[ToolCallEvent] = []
@@ -152,7 +152,7 @@ class GeminiClient(LLMClient):
     async def _process_stream(
         self,
         stream: Any,
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         full_content: str = ""
         calls: list[ToolCallEvent] = []

--- a/autogen/beta/config/ollama/ollama_client.py
+++ b/autogen/beta/config/ollama/ollama_client.py
@@ -10,7 +10,7 @@ from typing import Any, TypedDict
 from ollama import AsyncClient
 
 from autogen.beta.config.client import LLMClient
-from autogen.beta.context import Context
+from autogen.beta.context import ConversationContext
 from autogen.beta.events import (
     BaseEvent,
     ModelMessage,
@@ -56,7 +56,7 @@ class OllamaClient(LLMClient):
     async def __call__(
         self,
         messages: Sequence[BaseEvent],
-        context: Context,
+        context: "ConversationContext",
         *,
         tools: Iterable[ToolSchema],
         response_schema: ResponseProto | None,
@@ -87,7 +87,7 @@ class OllamaClient(LLMClient):
         self,
         messages: list[dict[str, Any]],
         kwargs: dict[str, Any],
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         response = await self._client.chat(
             model=self._model,
@@ -135,7 +135,7 @@ class OllamaClient(LLMClient):
         self,
         messages: list[dict[str, Any]],
         kwargs: dict[str, Any],
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         response_stream = await self._client.chat(
             model=self._model,

--- a/autogen/beta/config/openai/openai_client.py
+++ b/autogen/beta/config/openai/openai_client.py
@@ -14,7 +14,7 @@ from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from typing_extensions import Required
 
 from autogen.beta.config.client import LLMClient
-from autogen.beta.context import Context
+from autogen.beta.context import ConversationContext
 from autogen.beta.events import (
     BaseEvent,
     ModelMessage,
@@ -99,7 +99,7 @@ class OpenAIClient(LLMClient):
     async def __call__(
         self,
         messages: Sequence[BaseEvent],
-        context: Context,
+        context: "ConversationContext",
         *,
         tools: Iterable[ToolSchema],
         response_schema: ResponseProto | None,
@@ -134,7 +134,7 @@ class OpenAIClient(LLMClient):
     async def _process_completion(
         self,
         completion: ChatCompletion,
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         for choice in completion.choices or ():
             msg = choice.message
@@ -168,7 +168,7 @@ class OpenAIClient(LLMClient):
     async def _process_stream(
         self,
         response_stream: AsyncStream[ChatCompletionChunk],
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         full_content: str = ""
         usage = Usage()

--- a/autogen/beta/config/openai/openai_responses_client.py
+++ b/autogen/beta/config/openai/openai_responses_client.py
@@ -28,7 +28,7 @@ from openai.types.responses.response_output_item import ImageGenerationCall
 from typing_extensions import Required
 
 from autogen.beta.config.client import LLMClient
-from autogen.beta.context import Context
+from autogen.beta.context import ConversationContext
 from autogen.beta.events import (
     BaseEvent,
     BinaryResult,
@@ -107,7 +107,7 @@ class OpenAIResponsesClient(LLMClient):
     async def __call__(
         self,
         messages: Sequence[BaseEvent],
-        context: Context,
+        context: "ConversationContext",
         *,
         tools: Iterable[ToolSchema],
         response_schema: ResponseProto | None,
@@ -142,7 +142,7 @@ class OpenAIResponsesClient(LLMClient):
     async def _process_response(
         self,
         response: Response,
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         model_msg: ModelMessage | None = None
         calls: list[ToolCallEvent] = []
@@ -222,7 +222,7 @@ class OpenAIResponsesClient(LLMClient):
     async def _process_stream(
         self,
         response_stream: AsyncStream[ResponseStreamEvent],
-        context: Context,
+        context: "ConversationContext",
     ) -> ModelResponse:
         full_content: str = ""
         calls: list[ToolCallEvent] = []

--- a/autogen/beta/context.py
+++ b/autogen/beta/context.py
@@ -24,7 +24,7 @@ SubId: TypeAlias = UUID
 class Stream(Protocol):
     id: StreamId
 
-    async def send(self, event: BaseEvent, context: "Context") -> None: ...
+    async def send(self, event: BaseEvent, context: "ConversationContext") -> None: ...
 
     def where(self, condition: ClassInfo | Condition) -> "Stream": ...
 
@@ -80,7 +80,7 @@ class Stream(Protocol):
 
 
 @dataclass(slots=True)
-class Context:
+class ConversationContext:
     stream: Stream
     dependency_provider: "Provider | None" = None
 

--- a/autogen/beta/observer.py
+++ b/autogen/beta/observer.py
@@ -9,7 +9,7 @@ from typing import Any, Protocol, overload, runtime_checkable
 
 from autogen.beta.types import ClassInfo
 
-from .context import Context
+from .annotations import Context
 from .events.conditions import Condition, TypeCondition
 
 __all__ = ("Observer", "observer")

--- a/autogen/beta/stream.py
+++ b/autogen/beta/stream.py
@@ -12,7 +12,7 @@ from fast_depends.core import CallModel
 
 from autogen.beta.types import ClassInfo
 
-from .context import Context, Stream, StreamId, SubId
+from .context import ConversationContext, Stream, StreamId, SubId
 from .events import BaseEvent
 from .events.conditions import Condition, TypeCondition
 from .history import History, MemoryStorage, Storage
@@ -154,7 +154,7 @@ class MemoryStream(ABCStream):
         self._subscribers.pop(sub_id, None)
         self._interrupters.pop(sub_id, None)
 
-    async def send(self, event: BaseEvent, context: "Context") -> None:
+    async def send(self, event: BaseEvent, context: "ConversationContext") -> None:
         # interrupters should follow registration order
         for condition, interrupter in tuple(self._interrupters.values()):
             if condition and not condition(event):
@@ -254,5 +254,5 @@ class SubStream(ABCStream):
     def unsubscribe(self, sub_id: SubId) -> None:
         return self._parent.unsubscribe(sub_id)
 
-    async def send(self, event: BaseEvent, context: "Context") -> None:
+    async def send(self, event: BaseEvent, context: "ConversationContext") -> None:
         await self._parent.send(event, context)

--- a/autogen/beta/streams/redis/stream.py
+++ b/autogen/beta/streams/redis/stream.py
@@ -8,7 +8,8 @@ from uuid import uuid4
 
 import redis.asyncio as aioredis
 
-from autogen.beta.context import Context, StreamId
+from autogen.beta.annotations import Context
+from autogen.beta.context import StreamId
 from autogen.beta.events import BaseEvent
 from autogen.beta.stream import MemoryStream
 

--- a/autogen/beta/tools/builtin/_resolve.py
+++ b/autogen/beta/tools/builtin/_resolve.py
@@ -5,12 +5,12 @@
 from typing import Any
 
 from autogen.beta.annotations import Variable
-from autogen.beta.context import Context
+from autogen.beta.context import ConversationContext
 
 
 def resolve_variable(
     value: Any,
-    context: Context,
+    context: ConversationContext,
     *,
     param_name: str = "",
 ) -> Any:

--- a/test/beta/config/anthropic/tools/test_code_execution.py
+++ b/test/beta/config/anthropic/tools/test_code_execution.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.anthropic.mappers import tool_to_api
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.code_execution import CodeExecutionTool
 
 

--- a/test/beta/config/anthropic/tools/test_mcp_server.py
+++ b/test/beta/config/anthropic/tools/test_mcp_server.py
@@ -5,8 +5,8 @@
 import pytest
 from dirty_equals import IsPartialDict
 
+from autogen.beta import Context
 from autogen.beta.config.anthropic.mappers import extract_mcp_servers, tool_to_api
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.mcp_server import MCPServerTool
 
 

--- a/test/beta/config/anthropic/tools/test_memory.py
+++ b/test/beta/config/anthropic/tools/test_memory.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.anthropic.mappers import tool_to_api
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.memory import MemoryTool
 
 

--- a/test/beta/config/anthropic/tools/test_shell.py
+++ b/test/beta/config/anthropic/tools/test_shell.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.anthropic.mappers import tool_to_api
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.shell import ContainerAutoEnvironment, ShellTool
 
 

--- a/test/beta/config/anthropic/tools/test_unsupported.py
+++ b/test/beta/config/anthropic/tools/test_unsupported.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.anthropic.mappers import tool_to_api
-from autogen.beta.context import Context
 from autogen.beta.exceptions import UnsupportedToolError
 from autogen.beta.tools.builtin.image_generation import ImageGenerationTool
 

--- a/test/beta/config/anthropic/tools/test_web_fetch.py
+++ b/test/beta/config/anthropic/tools/test_web_fetch.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.anthropic.mappers import tool_to_api
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.web_fetch import WebFetchTool
 
 

--- a/test/beta/config/anthropic/tools/test_web_search.py
+++ b/test/beta/config/anthropic/tools/test_web_search.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.anthropic.mappers import tool_to_api
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.web_search import UserLocation, WebSearchTool
 
 

--- a/test/beta/config/conftest.py
+++ b/test/beta/config/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from autogen.beta.context import Context
+from autogen.beta import Context
 
 
 @pytest.fixture

--- a/test/beta/config/dashscope/tools/test_unsupported.py
+++ b/test/beta/config/dashscope/tools/test_unsupported.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.dashscope.mappers import tool_to_api
-from autogen.beta.context import Context
 from autogen.beta.exceptions import UnsupportedToolError
 from autogen.beta.tools.builtin.code_execution import CodeExecutionTool
 from autogen.beta.tools.builtin.image_generation import ImageGenerationTool

--- a/test/beta/config/gemini/tools/test_code_execution.py
+++ b/test/beta/config/gemini/tools/test_code_execution.py
@@ -5,8 +5,8 @@
 import pytest
 from google.genai import types
 
+from autogen.beta import Context
 from autogen.beta.config.gemini.mappers import build_tools
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.code_execution import CodeExecutionTool
 
 

--- a/test/beta/config/gemini/tools/test_unsupported.py
+++ b/test/beta/config/gemini/tools/test_unsupported.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.gemini.mappers import build_tools
-from autogen.beta.context import Context
 from autogen.beta.exceptions import UnsupportedToolError
 from autogen.beta.tools.builtin.image_generation import ImageGenerationTool
 from autogen.beta.tools.builtin.mcp_server import MCPServerTool

--- a/test/beta/config/gemini/tools/test_web_fetch.py
+++ b/test/beta/config/gemini/tools/test_web_fetch.py
@@ -5,8 +5,8 @@
 import pytest
 from google.genai import types
 
+from autogen.beta import Context
 from autogen.beta.config.gemini.mappers import build_tools
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.web_fetch import WebFetchTool
 
 

--- a/test/beta/config/gemini/tools/test_web_search.py
+++ b/test/beta/config/gemini/tools/test_web_search.py
@@ -5,8 +5,8 @@
 import pytest
 from google.genai import types
 
+from autogen.beta import Context
 from autogen.beta.config.gemini.mappers import build_tools
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.web_search import WebSearchTool
 from test.beta.config._helpers import make_tool
 

--- a/test/beta/config/ollama/tools/test_unsupported.py
+++ b/test/beta/config/ollama/tools/test_unsupported.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.ollama.mappers import tool_to_api
-from autogen.beta.context import Context
 from autogen.beta.exceptions import UnsupportedToolError
 from autogen.beta.tools.builtin.code_execution import CodeExecutionTool
 from autogen.beta.tools.builtin.image_generation import ImageGenerationTool

--- a/test/beta/config/openai/tools/test_code_execution.py
+++ b/test/beta/config/openai/tools/test_code_execution.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.openai.mappers import tool_to_responses_api
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.code_execution import CodeExecutionTool
 
 

--- a/test/beta/config/openai/tools/test_image_generation.py
+++ b/test/beta/config/openai/tools/test_image_generation.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.openai.mappers import tool_to_responses_api
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.image_generation import ImageGenerationTool
 
 

--- a/test/beta/config/openai/tools/test_mcp_server.py
+++ b/test/beta/config/openai/tools/test_mcp_server.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.openai.mappers import tool_to_api, tool_to_responses_api
-from autogen.beta.context import Context
 from autogen.beta.exceptions import UnsupportedToolError
 from autogen.beta.tools.builtin.mcp_server import MCPServerTool
 

--- a/test/beta/config/openai/tools/test_shell.py
+++ b/test/beta/config/openai/tools/test_shell.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.openai.mappers import tool_to_responses_api
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.shell import (
     ContainerAutoEnvironment,
     ContainerReferenceEnvironment,

--- a/test/beta/config/openai/tools/test_unsupported.py
+++ b/test/beta/config/openai/tools/test_unsupported.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.openai.mappers import tool_to_api, tool_to_responses_api
-from autogen.beta.context import Context
 from autogen.beta.exceptions import UnsupportedToolError
 from autogen.beta.tools.builtin.code_execution import CodeExecutionTool
 from autogen.beta.tools.builtin.image_generation import ImageGenerationTool

--- a/test/beta/config/openai/tools/test_web_search.py
+++ b/test/beta/config/openai/tools/test_web_search.py
@@ -4,8 +4,8 @@
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.config.openai.mappers import tool_to_responses_api
-from autogen.beta.context import Context
 from autogen.beta.tools.builtin.web_search import UserLocation, WebSearchTool
 
 

--- a/test/beta/stream/redis/test_redis_stream.py
+++ b/test/beta/stream/redis/test_redis_stream.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import pytest
 import pytest_asyncio
 
-from autogen.beta.context import Context
+from autogen.beta import Context
 from autogen.beta.events import ModelMessage, TextInput, ToolCallEvent
 from autogen.beta.streams.redis.serializer import Serializer
 

--- a/test/beta/test_task.py
+++ b/test/beta/test_task.py
@@ -7,10 +7,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from autogen.beta import Agent, MemoryStream, tool
+from autogen.beta import Agent, Context, MemoryStream, tool
 from autogen.beta.annotations import Context as Ctx
 from autogen.beta.annotations import Variable
-from autogen.beta.context import Context
 from autogen.beta.events import (
     HumanInputRequest,
     HumanMessage,

--- a/test/beta/tools/test_client_tool.py
+++ b/test/beta/tools/test_client_tool.py
@@ -8,8 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from autogen.beta import Agent, MemoryStream, tool
-from autogen.beta.context import Context
+from autogen.beta import Agent, Context, MemoryStream, tool
 from autogen.beta.events import ClientToolCallEvent, ToolCallEvent
 from autogen.beta.middleware import ToolExecution, ToolResultType
 from autogen.beta.testing import TestConfig

--- a/test/beta/tools/test_persistent_stream.py
+++ b/test/beta/tools/test_persistent_stream.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from autogen.beta.context import Context
+from autogen.beta import Context
 from autogen.beta.history import MemoryStorage
 from autogen.beta.stream import MemoryStream
 from autogen.beta.tools.subagents.persistent_stream import persistent_stream

--- a/test/beta/tools/test_resolve.py
+++ b/test/beta/tools/test_resolve.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from autogen.beta import Context
 from autogen.beta.annotations import Variable
-from autogen.beta.context import Context
 from autogen.beta.tools import ImageGenerationTool, UserLocation, WebSearchTool
 from autogen.beta.tools.builtin._resolve import resolve_variable
 from autogen.beta.tools.builtin.image_generation import ImageGenerationToolSchema


### PR DESCRIPTION
## Summary

- Renames the internal `Context` dataclass to `ConversationContext` across `autogen/beta/` to avoid naming conflicts with the public `Context` annotation type
- Updates all references in provider clients, stream implementations, tools, and tests