### PR TITLE
ModuleNotFoundError: opentelemetry.exporter.otlp.proto.grpc not...

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ dashscope = ["dashscope>=1.25.13"]
 
 # public distributions
 redis = ["redis"]
-tracing = ["opentelemetry-sdk>=1.20"]
+tracing = ["opentelemetry-sdk>=1.20", "opentelemetry-exporter-otlp-proto-grpc>=1.20"]
 
 flaml = [
     "flaml",


### PR DESCRIPTION
**Files changed:**
- `pyproject.toml`

**What I checked before submitting:**
> **Fix approved.** The change correctly resolves the `ModuleNotFoundError: No module named 'opentelemetry.exporter.otlp.proto.grpc'` by adding the missing `opentelemetry-exporter-otlp-proto-grpc>=1.20` package to the `[tracing]` optional dependency group in `pyproject.toml`.
> 
> **What looks good:**
> - `opentelemetry-exporter-otlp-proto-grpc` is the correct PyPI package name for the missing module — verified live on PyPI (HTTP 200).
> - Version constraint `>=1.20` is consistent with the existing `opentelemetry-sdk>=1.20` pin, which is appropriate for API compatibility.
> - The change is purely additive to an optional extras group — no regressions possible for users who don't install `[tracing]`.
> - Code style matches surrounding patterns (comma-separated strings, consistent quoting).
> 
> **Minor notes for the human (non-blocking):**
> 1. **gRPC footprint**: `opentelemetry-exporter-otlp-proto-grpc` pulls in gRPC binaries, which are heavier than the HTTP variant (`opentelemetry-exporter-otlp-proto-http`). If the local-setup docs only use the HTTP transport, the lighter package would suffice — but the bug report explicitly names the gRPC module, so this is the right fix for what was reported.
> 2. **Changelog / install docs**: No CHANGELOG entry or installation guide update is visible in the diff. Consider adding a note if there's a "what's included in [tracing]" section in the docs.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).