### PR TITLE
Broken external link: google.github.io/A2A/ returns 404

### DIFF
--- a/website/docs/_blogs/2026-02-08-AG2-OpenTelemetry-Tracing/index.mdx
+++ b/website/docs/_blogs/2026-02-08-AG2-OpenTelemetry-Tracing/index.mdx
@@ -298,7 +298,7 @@ conversation chat_manager                 # run_chat (GroupChatManager)
 
 ## Distributed Tracing with A2A
 
-When agents run as separate services using the [A2A (Agent-to-Agent) protocol](https://google.github.io/A2A/), AG2 propagates [W3C Trace Context](https://www.w3.org/TR/trace-context/) headers across HTTP calls so that client-side and server-side spans share a single trace ID.
+When agents run as separate services using the [A2A (Agent-to-Agent) protocol](https://a2a-protocol.org/), AG2 propagates [W3C Trace Context](https://www.w3.org/TR/trace-context/) headers across HTTP calls so that client-side and server-side spans share a single trace ID.
 
 ![A2A Distributed Trace Diagram](img/a2a-trace-diagram.svg)
 

--- a/website/docs/user-guide/reference-agents/a2uiagent.mdx
+++ b/website/docs/user-guide/reference-agents/a2uiagent.mdx
@@ -5,7 +5,7 @@ sidebarTitle: A2UIAgent
 
 [`A2UIAgent`](/docs/api-reference/autogen/agents/experimental/A2UIAgent) is a specialized AG2 agent that produces rich user interfaces using the [A2UI protocol](https://a2ui.org/){.external-link target="_blank"}. Instead of returning plain text, the agent generates structured JSON that client-side renderers transform into interactive UI components — cards, forms, buttons, images, and more.
 
-A2UIAgent handles the full lifecycle: prompt engineering with schema instructions, response parsing to extract A2UI JSON, optional schema validation with automatic retry, and integration with [A2A (Agent-to-Agent)](https://google.github.io/A2A/){.external-link target="_blank"} for serving UI.
+A2UIAgent handles the full lifecycle: prompt engineering with schema instructions, response parsing to extract A2UI JSON, optional schema validation with automatic retry, and integration with [A2A (Agent-to-Agent)](https://a2a-protocol.org/){.external-link target="_blank"} for serving UI.
 
 ## Architecture
 

--- a/website/docs/user-guide/tracing/remote-agents.mdx
+++ b/website/docs/user-guide/tracing/remote-agents.mdx
@@ -4,7 +4,7 @@ description: "Add distributed tracing across services with AG2's A2A protocol an
 sidebarTitle: Tracing Remote Agents
 ---
 
-When agents run as separate services using the <a href="https://google.github.io/A2A/" className="external-link" target="_blank" rel="noopener noreferrer">A2A (Agent-to-Agent) protocol</a>, a single user request can fan out across multiple processes and machines.
+When agents run as separate services using the <a href="https://a2a-protocol.org/" className="external-link" target="_blank" rel="noopener noreferrer">A2A (Agent-to-Agent) protocol</a>, a single user request can fan out across multiple processes and machines.
 Without distributed tracing, debugging these interactions means correlating logs from each service by hand.
 
 AG2's tracing integration solves this by propagating <a href="https://www.w3.org/TR/trace-context/" className="external-link" target="_blank" rel="noopener noreferrer">W3C Trace Context</a> headers across A2A HTTP calls, so every span -- client-side and server-side -- shares a single trace ID and appears in one unified trace view.


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2026-02-08-AG2-OpenTelemetry-Tracing/index.mdx`
- `website/docs/user-guide/reference-agents/a2uiagent.mdx`
- `website/docs/user-guide/tracing/remote-agents.mdx`

**What I checked before submitting:**
> The fix correctly replaces a confirmed broken link (https://google.github.io/A2A/ → HTTP 404) with https://a2a-protocol.org/ which resolves cleanly with HTTP 200. All 3 occurrences across the 3 documentation files are updated consistently:
> 
> 1. `website/docs/user-guide/tracing/remote-agents.mdx`
> 2. `website/docs/_blogs/2026-02-08-AG2-OpenTelemetry-Tracing/index.mdx`
> 3. `website/docs/user-guide/reference-agents/a2uiagent.mdx`
> 
> Code style is preserved in all three files — no changes to link formatting, attributes, or surrounding content.
> 
> **Note for human reviewer**: If there is a more authoritative canonical URL for the A2A (Agent-to-Agent) protocol specification (e.g., an official Google source or the A2A GitHub repo), consider updating to that URL instead. However, `a2a-protocol.org` is a live, valid target and is a clear improvement over the current 404.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).