### PR TITLE
Broken link: lats_search.ipynb

### DIFF
--- a/website/snippets/components/GalleryPage.mdx
+++ b/website/snippets/components/GalleryPage.mdx
@@ -128,8 +128,9 @@ export const GalleryPage = ({
     if (!item.source) {
       return null;
     }
-    const colab_href = `https://colab.research.google.com/github/ag2ai/ag2/blob/main/${item.source}`;
-    const github_href = `https://github.com/ag2ai/ag2/blob/main/${item.source}`;
+    const source = item.source.replace(/^\//, '');
+    const colab_href = `https://colab.research.google.com/github/ag2ai/ag2/blob/main/${source}`;
+    const github_href = `https://github.com/ag2ai/ag2/blob/main/${source}`;
     return (<span class="badges">
       <a style={{marginRight: '5px'}}href={colab_href} target="_parent"><img noZoom src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
       <a href={github_href} target="_parent"><img noZoom alt="Static Badge" src="https://img.shields.io/badge/Open%20on%20GitHub-grey?logo=github"/></a>


### PR DESCRIPTION
**Files changed:**
- `website/snippets/components/GalleryPage.mdx`

**What I checked before submitting:**
> ## Fix Review: Approved ✅
> 
> **Bug:** Double-slash in GitHub/Colab URLs (`main//notebook/lats_search.ipynb`) caused 404 errors when `item.source` contained a leading `/`.
> 
> **Fix quality: High**
> 
> The change is minimal, correct, and safe:
> - Adds one line: `const source = item.source.replace(/^\//, '');`
> - Applies the stripped value to both the Colab and GitHub URL template literals.
> - When `item.source` has *no* leading slash (the common case), `replace(/^\//, '')` is a no-op — zero regression risk.
> - Code style is consistent with the surrounding JSX/JS: local `const` extraction before template literal use is clean and avoids duplication.
> 
> **Note for maintainers:** The root cause is that some `item.source` values are stored with a leading `/`. It may be worth normalising the data upstream (wherever the gallery data is generated/loaded), but this defensive fix in `GalleryPage.mdx` is a correct and appropriate solution at the rendering layer. A parallel fix in `website/mkdocs/_website/utils.py` (`notebook_src.lstrip("/")`) is handled by a companion PR for the same pattern.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).