### PR TITLE
Broken link: tools_duckduckgo_search.ipynb

### DIFF
--- a/website/snippets/components/GalleryPage.mdx
+++ b/website/snippets/components/GalleryPage.mdx
@@ -128,8 +128,9 @@ export const GalleryPage = ({
     if (!item.source) {
       return null;
     }
-    const colab_href = `https://colab.research.google.com/github/ag2ai/ag2/blob/main/${item.source}`;
-    const github_href = `https://github.com/ag2ai/ag2/blob/main/${item.source}`;
+    const source = item.source.replace(/^\//, '');
+    const colab_href = `https://colab.research.google.com/github/ag2ai/ag2/blob/main/${source}`;
+    const github_href = `https://github.com/ag2ai/ag2/blob/main/${source}`;
     return (<span class="badges">
       <a style={{marginRight: '5px'}}href={colab_href} target="_parent"><img noZoom src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
       <a href={github_href} target="_parent"><img noZoom alt="Static Badge" src="https://img.shields.io/badge/Open%20on%20GitHub-grey?logo=github"/></a>


### PR DESCRIPTION
**Files changed:**
- `website/snippets/components/GalleryPage.mdx`

**What I checked before submitting:**
> The fix correctly addresses the root cause: when `item.source` carries a leading slash (e.g. `/notebook/tools_duckduckgo_search.ipynb`), the template-literal interpolation into `main/${item.source}` produces a double-slash (`main//notebook/...`) that causes HTTP 404s on both GitHub and Colab. Stripping the leading slash with `.replace(/^\//, '')` before building both URLs is idiomatic JS, is a no-op for already-clean paths (no regression), and touches both `colab_href` and `github_href` consistently.
> 
> **Note – partial fix scope:** A sibling bug fix (file-a2f7dd08) addresses the same double-slash problem and also patches `website/mkdocs/_website/utils.py` (the Python-side static site generator path). This fix only touches `GalleryPage.mdx`. If the Python path is live in your deployment, please also apply the `utils.py` strip (`notebook_src = notebook_src.lstrip("/")`) — see the companion PR for that change.
> 
> **Note – notebook existence:** The specific notebook `notebook/tools_duckduckgo_search.ipynb` resolves to 404 even with the correct single-slash path, suggesting the file may have been removed or renamed in the repo. Fixing the double-slash is the right first step; the missing notebook is a separate content issue to investigate.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).