### PR TITLE
NameError: ConversableAgent not defined in code block

### DIFF
--- a/website/docs/_blogs/2025-06-12-ReAct-Loops-in-GroupChat/index.mdx
+++ b/website/docs/_blogs/2025-06-12-ReAct-Loops-in-GroupChat/index.mdx
@@ -57,6 +57,8 @@ Next we will see how to define each agent.
 **Student Agent**
 
 ```python
+from autogen import ConversableAgent, GroupChat, GroupChatManager
+
 system_message = f"""You are an agent representing a student. You have access to the following essay content: {essay}.
 
     Your task is to answer questions about the essay strictly based on information found in the essay content.


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2025-06-12-ReAct-Loops-in-GroupChat/index.mdx`

**What I checked before submitting:**
> The fix correctly resolves the NameError by adding the missing `from autogen import ConversableAgent, GroupChat, GroupChatManager` import statement at the top of the first relevant code block in the blog post. 
> 
> Key points:
> - Import uses the correct package name (`autogen`) and standard import style matching the surrounding code.
> - All three classes (`ConversableAgent`, `GroupChat`, `GroupChatManager`) are contextually appropriate for a GroupChat blog post — including them is correct and harmless.
> - Adding an import cannot introduce regressions.
> - Placement at the start of the first code block that uses these classes is the correct approach for sequential code examples in a blog post.
> 
> No cross-reference issues found. Ready to ship.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).