### PR TITLE
Broken external link: double-slash in GitHub notebook URL

### DIFF
--- a/website/snippets/components/GalleryPage.mdx
+++ b/website/snippets/components/GalleryPage.mdx
@@ -128,8 +128,9 @@ export const GalleryPage = ({
     if (!item.source) {
       return null;
     }
-    const colab_href = `https://colab.research.google.com/github/ag2ai/ag2/blob/main/${item.source}`;
-    const github_href = `https://github.com/ag2ai/ag2/blob/main/${item.source}`;
+    const source = item.source.replace(/^\//, '');
+    const colab_href = `https://colab.research.google.com/github/ag2ai/ag2/blob/main/${source}`;
+    const github_href = `https://github.com/ag2ai/ag2/blob/main/${source}`;
     return (<span class="badges">
       <a style={{marginRight: '5px'}}href={colab_href} target="_parent"><img noZoom src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
       <a href={github_href} target="_parent"><img noZoom alt="Static Badge" src="https://img.shields.io/badge/Open%20on%20GitHub-grey?logo=github"/></a>


### PR DESCRIPTION
**Files changed:**
- `website/snippets/components/GalleryPage.mdx`

**What I checked before submitting:**
> The fix correctly addresses the root cause of the double-slash URL bug in `GalleryPage.mdx`. When `item.source` carries a leading slash (e.g. `/notebook/agentchat_sql_spider.ipynb`), interpolating it directly into the template literal produces `...main//notebook/...`, which GitHub rejects with HTTP 404. The one-liner `.replace(/^\//, '')` strips any leading slash before interpolation — this is a no-op for sources that already lack a leading slash, so all other gallery entries are unaffected. The `if (!item.source)` guard above ensures null/empty sources never reach this code.
> 
> **Note:** The specific notebook `agentchat_sql_spider.ipynb` no longer exists on `main` (confirmed 404 even with the correct single-slash path), so the link will still 404 after this fix. That is a stale-content issue in the gallery data, not a URL-construction bug — it should be addressed separately by removing or updating the entry for `agentchat_sql_spider.ipynb` in the gallery source data. This fix is still correct and valuable for all other notebook entries that were affected by the double-slash pattern.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).