### PR TITLE
Broken external links with double slash in GitHub notebook URLs

### DIFF
--- a/website/snippets/components/GalleryPage.mdx
+++ b/website/snippets/components/GalleryPage.mdx
@@ -128,8 +128,9 @@ export const GalleryPage = ({
     if (!item.source) {
       return null;
     }
-    const colab_href = `https://colab.research.google.com/github/ag2ai/ag2/blob/main/${item.source}`;
-    const github_href = `https://github.com/ag2ai/ag2/blob/main/${item.source}`;
+    const source = item.source.replace(/^\//, '');
+    const colab_href = `https://colab.research.google.com/github/ag2ai/ag2/blob/main/${source}`;
+    const github_href = `https://github.com/ag2ai/ag2/blob/main/${source}`;
     return (<span class="badges">
       <a style={{marginRight: '5px'}}href={colab_href} target="_parent"><img noZoom src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
       <a href={github_href} target="_parent"><img noZoom alt="Static Badge" src="https://img.shields.io/badge/Open%20on%20GitHub-grey?logo=github"/></a>


### PR DESCRIPTION
**Files changed:**
- `website/snippets/components/GalleryPage.mdx`

**What I checked before submitting:**
> The fix correctly addresses the root cause of the double-slash 404s. `item.source` values start with a leading `/`, so interpolating them directly into the URL produced `main//notebook/...` paths. The fix introduces `const source = item.source.replace(/^\//, '')` to strip that leading slash before building both the GitHub and Colab URLs — a minimal, idempotent, and style-consistent change.
> 
> **Verification:** The `/notebook` directory exists on GitHub and individual notebooks like `agentchat_function_call.ipynb` resolve correctly at `main/notebook/...`. The specific notebook `tools_dependency_injection.ipynb` returns 404 even with the corrected URL, which is a separate upstream issue (that notebook may not exist in the repo yet or was renamed) — it is not caused or worsened by this fix.
> 
> **Minor note (non-blocking):** The regex `replace(/^\//, '')` removes only one leading slash. If `item.source` ever starts with `//`, one slash would remain. A slightly more robust form would be `replace(/^\/+/, '')` to strip all leading slashes. This is an edge case unlikely to occur in practice, so no change is required to ship.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).