### PR TITLE
Broken GitHub notebook links on 0.9.6 docs

### DIFF
--- a/website/mkdocs/_website/utils.py
+++ b/website/mkdocs/_website/utils.py
@@ -362,6 +362,7 @@ def render_gallery_html(gallery_file_path: Path) -> str:
             notebook_src = item.get("source", None)
 
             if notebook_src:
+                notebook_src = notebook_src.lstrip("/")
                 colab_href = f"https://colab.research.google.com/github/ag2ai/ag2/blob/main/{notebook_src}"
                 github_href = f"https://github.com/ag2ai/ag2/blob/main/{notebook_src}"
                 badges_html = f"""


### PR DESCRIPTION
**Files changed:**
- `website/mkdocs/_website/utils.py`

**What I checked before submitting:**
> ## Review: Approved ✅
> 
> **Fix:** `website/mkdocs/_website/utils.py` — strip leading slashes from `notebook_src` before URL construction.
> 
> ### What the fix does
> Adds `notebook_src = notebook_src.lstrip("/")` immediately after the `if notebook_src:` guard, before both `colab_href` and `github_href` are built. This prevents double-slash URLs like `main//notebook/...` which were causing HTTP 404s.
> 
> ### Why it's correct
> - **Root cause addressed:** The data source provides `notebook_src` values with a leading `/` (e.g. `/notebook/agentchat_sql_spider.ipynb`). Concatenating that with `main/` in the f-string produces `main//notebook/...`, which GitHub rejects with 404. `lstrip("/")` removes all leading slashes before that interpolation.
> - **No-op for clean data:** If `notebook_src` already lacks a leading slash (the clean case), `lstrip("/")` is harmless.
> - **Guards respected:** The `if notebook_src:` check already prevents `None` or empty strings from reaching this line.
> - **Both URLs fixed in one change:** `colab_href` and `github_href` both benefit from the single sanitization step.
> 
> ### Additional observation (not a fix regression)
> The specific notebook `agentchat_sql_spider.ipynb` returns 404 even with the corrected single-slash URL — it appears to have been deleted from the repo entirely. This is a separate issue (stale gallery data) from the double-slash path bug being fixed here and does not affect the correctness of this change.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).