### PR TITLE
Broken GitHub notebook links on 0.9.7 docs

### DIFF
--- a/website/mkdocs/_website/utils.py
+++ b/website/mkdocs/_website/utils.py
@@ -362,6 +362,7 @@ def render_gallery_html(gallery_file_path: Path) -> str:
             notebook_src = item.get("source", None)
 
             if notebook_src:
+                notebook_src = notebook_src.lstrip("/")
                 colab_href = f"https://colab.research.google.com/github/ag2ai/ag2/blob/main/{notebook_src}"
                 github_href = f"https://github.com/ag2ai/ag2/blob/main/{notebook_src}"
                 badges_html = f"""


### PR DESCRIPTION
**Files changed:**
- `website/mkdocs/_website/utils.py`

**What I checked before submitting:**
> **Fix approved.** The change correctly addresses the root cause of the double-slash URL bug.
> 
> **What the fix does:** Adds `notebook_src = notebook_src.lstrip("/")` immediately before the GitHub and Colab URL constructions in `utils.py`. This strips any leading slashes from the `source` field of notebook data, preventing malformed URLs like `https://github.com/ag2ai/ag2/blob/main//notebook/agentchat_sql_spider.ipynb` (which return HTTP 404).
> 
> **Why it's correct:**
> - `lstrip("/")` is a no-op when `notebook_src` has no leading slash (the normal case), so no regressions.
> - It handles degenerate cases (`//`, `///`, etc.) by stripping all leading slashes — which is the right defensive behaviour.
> - Both the GitHub and Colab URLs share the same variable, so one fix covers both.
> - Code style matches the surrounding Python perfectly.
> 
> **Note:** The specific notebook `agentchat_sql_spider.ipynb` referenced in the bug report appears to have been deleted from the repo entirely (returns 404 even with correct path). That is a separate data/content issue — some notebook entries in the gallery may point to notebooks that no longer exist in the repository. This fix resolves the URL *construction* bug (double slash), but the human may want to audit the gallery source data for stale/removed notebook references as a follow-up.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).