### PR TITLE
Broken external links in Notebooks pages (double slash in path)

### DIFF
--- a/website/mkdocs/_website/utils.py
+++ b/website/mkdocs/_website/utils.py
@@ -362,6 +362,7 @@ def render_gallery_html(gallery_file_path: Path) -> str:
             notebook_src = item.get("source", None)
 
             if notebook_src:
+                notebook_src = notebook_src.lstrip("/")
                 colab_href = f"https://colab.research.google.com/github/ag2ai/ag2/blob/main/{notebook_src}"
                 github_href = f"https://github.com/ag2ai/ag2/blob/main/{notebook_src}"
                 badges_html = f"""


### PR DESCRIPTION
**Files changed:**
- `website/mkdocs/_website/utils.py`

**What I checked before submitting:**
> The fix correctly addresses the root cause of the double-slash URL bug. When a notebook's `source` value begins with `/`, string interpolation in `f"...main/{notebook_src}"` produces `...main//notebook/...`. Adding `notebook_src = notebook_src.lstrip("/")` before both URL constructions cleanly removes one or more leading slashes, and is a no-op for paths that are already correct — so no regressions.
> 
> A few notes for awareness:
> 1. **`reliable_basic_example.ipynb` is itself missing from the repo** — both the old double-slash URL and the corrected single-slash URL return 404. GitHub apparently normalises double slashes for files that *do* exist, but the absence of this particular notebook is a separate content issue that the human may want to track down independently.
> 2. The fix is consistent with the companion change in `GalleryPage.mdx` (fix `b73a7a1d`), which applies the same `lstrip("/")` pattern on the JS side.
> 3. Edge case: if `source` were ever set to `"/"` alone, `lstrip` would produce an empty string, yielding a malformed URL ending in `main/`. Unlikely in practice but worth a note in case the data source is ever extended.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).