### PR TITLE
feat(beta): Add extra_body parameter support to Beta OpenAI client

### DIFF
--- a/autogen/beta/config/openai/config.py
+++ b/autogen/beta/config/openai/config.py
@@ -56,6 +56,7 @@ class OpenAIConfigOverrides(TypedDict, total=False):
     store: bool | None | Omit
     verbosity: str | None | Omit
     web_search_options: dict[str, Any] | Omit
+    extra_body: dict[str, Any] | None
 
 
 @dataclass(slots=True)
@@ -97,6 +98,7 @@ class OpenAIConfig(ModelConfig):
     store: bool | None | Omit = omit
     verbosity: str | None | Omit = omit
     web_search_options: dict[str, Any] | Omit = omit
+    extra_body: dict[str, Any] | None = None
 
     def copy(self, /, **overrides: Unpack[OpenAIConfigOverrides]) -> "OpenAIConfig":
         return replace(self, **overrides)
@@ -131,6 +133,7 @@ class OpenAIConfig(ModelConfig):
             verbosity=self.verbosity,
             web_search_options=self.web_search_options,
             stream_options={"include_usage": True} if self.streaming else omit,
+            extra_body=self.extra_body,
         )
 
         return OpenAIClient(

--- a/autogen/beta/config/openai/openai_client.py
+++ b/autogen/beta/config/openai/openai_client.py
@@ -63,6 +63,7 @@ class CreateOptions(TypedDict, total=False):
     stream: bool
     stream_options: dict[str, Any] | Omit
     reasoning_effort: ReasoningEffort | None | Omit
+    extra_body: dict[str, Any] | None
 
 
 class OpenAIClient(LLMClient):

--- a/test/beta/config/openai/test_openai_config.py
+++ b/test/beta/config/openai/test_openai_config.py
@@ -28,3 +28,28 @@ def test_copy_applies_overrides_without_mutating_original() -> None:
     assert config.temperature == 0.2
     assert config.streaming is False
     assert config.api_key == "key"
+
+
+def test_extra_body_defaults_to_none() -> None:
+    config = OpenAIConfig(model="gpt-5")
+
+    assert config.extra_body is None
+
+
+def test_extra_body_passed_to_create_options() -> None:
+    extra = {"chat_template_kwargs": {"enable_thinking": True}}
+    config = OpenAIConfig(model="test-model", base_url="http://localhost:8000/v1", api_key="EMPTY", extra_body=extra)
+
+    client = config.create()
+
+    assert client._create_options.get("extra_body") == extra
+
+
+def test_copy_with_extra_body() -> None:
+    config = OpenAIConfig(model="gpt-5")
+    extra = {"reasoning_split": True}
+
+    copied = config.copy(extra_body=extra)
+
+    assert copied.extra_body == extra
+    assert config.extra_body is None

--- a/website/docs/beta/model_configuration.mdx
+++ b/website/docs/beta/model_configuration.mdx
@@ -158,6 +158,23 @@ config = OpenAIConfig(
     )
     ```
 
+### Extra Body Parameters
+
+Some OpenAI API-compatible providers require additional, provider-specific parameters in the request body. Use the `extra_body` parameter on `OpenAIConfig` to pass these through directly to the API call.
+
+This is useful for enabling features like extended thinking on self-hosted or third-party models:
+
+```python linenums="1" hl_lines="7"
+from autogen.beta.config import OpenAIConfig
+
+# NVIDIA NIM
+nemotron = OpenAIConfig(
+    model="nvidia/nemotron-3-super-120b-a12b",
+    base_url="https://integrate.api.nvidia.com/v1",
+    extra_body={"chat_template_kwargs": {"thinking": True}},
+)
+```
+
 ## Reusing and Overriding Configurations
 
 Model configurations are **immutable**. If you need to reuse a configuration for multiple agents with slight variations (e.g., changing the model version or adjusting the temperature), use the `.copy()` method. This creates a new updated instance without mutating the original configuration.


### PR DESCRIPTION
## Why are these changes needed?

For developers using OpenAI API-compatible clients, like vLLM, parameters are passed through using an `extra_body` parameter, e.g.: `"extra_body": {"chat_template_kwargs": {"enable_thinking": True}},`

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
