### PR TITLE
feat(beta): Agent Assembly layer (2/3)

### DIFF
--- a/autogen/beta/__init__.py
+++ b/autogen/beta/__init__.py
@@ -5,7 +5,21 @@
 from fast_depends import Depends
 
 from .agent import Agent, AgentReply
+from .aggregate import (
+    AggregateStrategy,
+    AggregateTrigger,
+    ConversationSummaryAggregate,
+    WorkingMemoryAggregate,
+)
 from .annotations import Context, Inject, Variable
+from .assembly import AssemblerMiddleware, AssemblyPolicy
+from .compact import (
+    CompactStrategy,
+    CompactTrigger,
+    CompactionSummary,
+    SummarizeCompact,
+    TailWindowCompact,
+)
 from .events import (
     AudioInput,
     BinaryInput,
@@ -18,6 +32,14 @@ from .events import (
 from .files import FilesAPI
 from .middleware import Middleware
 from .observer import observer
+from .policies import (
+    AlertPolicy,
+    ConversationPolicy,
+    EpisodicMemoryPolicy,
+    SlidingWindowPolicy,
+    TokenBudgetPolicy,
+    WorkingMemoryPolicy,
+)
 from .response import PromptedSchema, ResponseSchema, response_schema
 from .spec import AgentSpec
 from .stream import MemoryStream
@@ -27,12 +49,23 @@ __all__ = (
     "Agent",
     "AgentReply",
     "AgentSpec",
+    "AggregateStrategy",
+    "AggregateTrigger",
+    "AlertPolicy",
+    "AssemblerMiddleware",
+    "AssemblyPolicy",
     "AudioInput",
     "BinaryInput",
+    "CompactStrategy",
+    "CompactTrigger",
+    "CompactionSummary",
     "Context",
+    "ConversationPolicy",
+    "ConversationSummaryAggregate",
     "DataInput",
     "Depends",
     "DocumentInput",
+    "EpisodicMemoryPolicy",
     "FilesAPI",
     "ImageInput",
     "Inject",
@@ -40,11 +73,17 @@ __all__ = (
     "Middleware",
     "PromptedSchema",
     "ResponseSchema",
+    "SlidingWindowPolicy",
+    "SummarizeCompact",
+    "TailWindowCompact",
     "TextInput",
+    "TokenBudgetPolicy",
     "ToolResult",
     "Toolkit",
     "Variable",
     "VideoInput",
+    "WorkingMemoryAggregate",
+    "WorkingMemoryPolicy",
     "observer",
     "response_schema",
     "tool",

--- a/autogen/beta/__init__.py
+++ b/autogen/beta/__init__.py
@@ -5,21 +5,7 @@
 from fast_depends import Depends
 
 from .agent import Agent, AgentReply
-from .aggregate import (
-    AggregateStrategy,
-    AggregateTrigger,
-    ConversationSummaryAggregate,
-    WorkingMemoryAggregate,
-)
 from .annotations import Context, Inject, Variable
-from .assembly import AssemblerMiddleware, AssemblyPolicy
-from .compact import (
-    CompactStrategy,
-    CompactTrigger,
-    CompactionSummary,
-    SummarizeCompact,
-    TailWindowCompact,
-)
 from .events import (
     AudioInput,
     BinaryInput,
@@ -32,14 +18,6 @@ from .events import (
 from .files import FilesAPI
 from .middleware import Middleware
 from .observer import observer
-from .policies import (
-    AlertPolicy,
-    ConversationPolicy,
-    EpisodicMemoryPolicy,
-    SlidingWindowPolicy,
-    TokenBudgetPolicy,
-    WorkingMemoryPolicy,
-)
 from .response import PromptedSchema, ResponseSchema, response_schema
 from .spec import AgentSpec
 from .stream import MemoryStream
@@ -49,23 +27,12 @@ __all__ = (
     "Agent",
     "AgentReply",
     "AgentSpec",
-    "AggregateStrategy",
-    "AggregateTrigger",
-    "AlertPolicy",
-    "AssemblerMiddleware",
-    "AssemblyPolicy",
     "AudioInput",
     "BinaryInput",
-    "CompactStrategy",
-    "CompactTrigger",
-    "CompactionSummary",
     "Context",
-    "ConversationPolicy",
-    "ConversationSummaryAggregate",
     "DataInput",
     "Depends",
     "DocumentInput",
-    "EpisodicMemoryPolicy",
     "FilesAPI",
     "ImageInput",
     "Inject",
@@ -73,17 +40,11 @@ __all__ = (
     "Middleware",
     "PromptedSchema",
     "ResponseSchema",
-    "SlidingWindowPolicy",
-    "SummarizeCompact",
-    "TailWindowCompact",
     "TextInput",
-    "TokenBudgetPolicy",
     "ToolResult",
     "Toolkit",
     "Variable",
     "VideoInput",
-    "WorkingMemoryAggregate",
-    "WorkingMemoryPolicy",
     "observer",
     "response_schema",
     "tool",

--- a/autogen/beta/aggregate.py
+++ b/autogen/beta/aggregate.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from autogen.beta.events import BaseEvent
 
+from .knowledge import CONVERSATIONS_PREFIX, WORKING_MEMORY_PATH
+
 if TYPE_CHECKING:
     from autogen.beta.annotations import Context
     from autogen.beta.config import ModelConfig
@@ -99,7 +101,7 @@ class ConversationSummaryAggregate:
         summary = await self._summarize(events)
         ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
         stream_id = str(context.stream.id)
-        await store.write(f"/memory/conversations/{ts}_{stream_id}.md", summary)
+        await store.write(f"{CONVERSATIONS_PREFIX}{ts}_{stream_id}.md", summary)
 
     async def _summarize(self, events: list[BaseEvent]) -> str:
         from autogen.beta.context import ConversationContext as Ctx
@@ -143,9 +145,9 @@ class WorkingMemoryAggregate:
     ) -> None:
         if not events:
             return
-        existing = await store.read("/memory/working.md") or ""
+        existing = await store.read(WORKING_MEMORY_PATH) or ""
         updated = await self._merge(existing, events)
-        await store.write("/memory/working.md", updated)
+        await store.write(WORKING_MEMORY_PATH, updated)
 
     async def _merge(self, existing: str, events: list[BaseEvent]) -> str:
         from autogen.beta.context import ConversationContext as Ctx

--- a/autogen/beta/aggregate.py
+++ b/autogen/beta/aggregate.py
@@ -43,7 +43,7 @@ class AggregateStrategy(Protocol):
         Args:
             events: Current stream history.
             context: Execution context.
-            store: Actor's knowledge store to write into.
+            store: Agent's knowledge store to write into.
         """
         ...
 

--- a/autogen/beta/aggregate.py
+++ b/autogen/beta/aggregate.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""AggregateStrategy — organizes knowledge for sustained performance.
+
+Aggregation extracts structured knowledge from raw events and writes it
+to the knowledge store. This is the knowledge-organizing operation:
+triggered at deterministic milestones to maintain actor effectiveness.
+
+Unlike compaction (which removes), aggregation creates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from autogen.beta.events import BaseEvent
+
+if TYPE_CHECKING:
+    from autogen.beta.annotations import Context
+    from autogen.beta.config import ModelConfig
+
+    from .knowledge import KnowledgeStore
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class AggregateStrategy(Protocol):
+    """Organizes knowledge for sustained performance.
+
+    Extracts structured knowledge from raw events and writes it to the
+    knowledge store.
+    """
+
+    async def aggregate(
+        self,
+        events: list[BaseEvent],
+        context: Context,
+        store: KnowledgeStore,
+    ) -> None:
+        """Extract and store knowledge.
+
+        Args:
+            events: Current stream history.
+            context: Execution context.
+            store: Actor's knowledge store to write into.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Trigger
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class AggregateTrigger:
+    """Deterministic conditions for triggering aggregation.
+
+    Multiple conditions can be set. Each fires independently.
+    """
+
+    every_n_turns: int = 0  # Aggregate every N LLM turns. 0 = disabled.
+    every_n_events: int = 0  # Aggregate every N new events since last aggregation. 0 = disabled.
+    on_end: bool = True  # Aggregate when conversation ends.
+
+
+# ---------------------------------------------------------------------------
+# Built-in strategies
+# ---------------------------------------------------------------------------
+
+
+class ConversationSummaryAggregate:
+    """Summarize conversation and write to /memory/conversations/.
+
+    Creates a per-conversation summary in the knowledge store.
+    Costs one LLM call per aggregation.
+    """
+
+    def __init__(self, config: ModelConfig) -> None:
+        self._config = config
+        self.last_usage: dict = {}
+
+    async def aggregate(
+        self,
+        events: list[BaseEvent],
+        context: Context,
+        store: KnowledgeStore,
+    ) -> None:
+        if not events:
+            return
+        summary = await self._summarize(events)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        stream_id = str(context.stream.id)
+        await store.write(f"/memory/conversations/{ts}_{stream_id}.md", summary)
+
+    async def _summarize(self, events: list[BaseEvent]) -> str:
+        from autogen.beta.context import ConversationContext as Ctx
+        from autogen.beta.events import ModelRequest
+        from autogen.beta.stream import MemoryStream
+
+        client = self._config.create()
+        prompt_event = ModelRequest.ensure_request([
+            "Summarize this conversation. Include key decisions, "
+            "findings, outcomes, and any unfinished work:\n\n" + "\n".join(str(e) for e in events)
+        ])
+        response = await client(
+            [prompt_event],
+            Ctx(MemoryStream()),
+            tools=[],
+            response_schema=None,
+        )
+        self.last_usage = response.usage if hasattr(response, "usage") and response.usage else {}
+        return response.content or ""
+
+
+class WorkingMemoryAggregate:
+    """Update /memory/working.md with latest context.
+
+    Reads existing working memory, merges with new events, writes
+    updated working memory. The actor starts each new conversation
+    with this as context (via WorkingMemoryPolicy).
+
+    Costs one LLM call per aggregation.
+    """
+
+    def __init__(self, config: ModelConfig) -> None:
+        self._config = config
+        self.last_usage: dict = {}
+
+    async def aggregate(
+        self,
+        events: list[BaseEvent],
+        context: Context,
+        store: KnowledgeStore,
+    ) -> None:
+        if not events:
+            return
+        existing = await store.read("/memory/working.md") or ""
+        updated = await self._merge(existing, events)
+        await store.write("/memory/working.md", updated)
+
+    async def _merge(self, existing: str, events: list[BaseEvent]) -> str:
+        from autogen.beta.context import ConversationContext as Ctx
+        from autogen.beta.events import ModelRequest
+        from autogen.beta.stream import MemoryStream
+
+        client = self._config.create()
+        prompt = (
+            "You maintain an actor's working memory. Update it based on "
+            "the new conversation below. Preserve important existing context. "
+            "Remove outdated information. Keep it concise and actionable.\n\n"
+            f"## Current Working Memory\n{existing or '(empty)'}\n\n"
+            "## New Conversation\n" + "\n".join(str(e) for e in events)
+        )
+        response = await client(
+            [ModelRequest.ensure_request([prompt])],
+            Ctx(MemoryStream()),
+            tools=[],
+            response_schema=None,
+        )
+        self.last_usage = response.usage if hasattr(response, "usage") and response.usage else {}
+        return response.content or existing

--- a/autogen/beta/aggregate.py
+++ b/autogen/beta/aggregate.py
@@ -57,7 +57,7 @@ class AggregateTrigger:
 
     every_n_turns: int = 0  # Aggregate every N LLM turns. 0 = disabled.
     every_n_events: int = 0  # Aggregate every N new events since last aggregation. 0 = disabled.
-    on_end: bool = True  # Aggregate when conversation ends.
+    on_end: bool = False  # Aggregate when conversation ends. Opt-in: each strategy is one LLM call.
 
 
 class ConversationSummaryAggregate:

--- a/autogen/beta/aggregate.py
+++ b/autogen/beta/aggregate.py
@@ -11,26 +11,17 @@ triggered at deterministic milestones to maintain actor effectiveness.
 Unlike compaction (which removes), aggregation creates.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
-from autogen.beta.events import BaseEvent
+from autogen.beta.annotations import Context
+from autogen.beta.config import ModelConfig
+from autogen.beta.context import ConversationContext
+from autogen.beta.events import BaseEvent, ModelRequest
+from autogen.beta.stream import MemoryStream
 
-from .knowledge import CONVERSATIONS_PREFIX, WORKING_MEMORY_PATH
-
-if TYPE_CHECKING:
-    from autogen.beta.annotations import Context
-    from autogen.beta.config import ModelConfig
-
-    from .knowledge import KnowledgeStore
-
-
-# ---------------------------------------------------------------------------
-# Protocol
-# ---------------------------------------------------------------------------
+from .knowledge import CONVERSATIONS_PREFIX, WORKING_MEMORY_PATH, KnowledgeStore
 
 
 @runtime_checkable
@@ -57,11 +48,6 @@ class AggregateStrategy(Protocol):
         ...
 
 
-# ---------------------------------------------------------------------------
-# Trigger
-# ---------------------------------------------------------------------------
-
-
 @dataclass(slots=True)
 class AggregateTrigger:
     """Deterministic conditions for triggering aggregation.
@@ -72,11 +58,6 @@ class AggregateTrigger:
     every_n_turns: int = 0  # Aggregate every N LLM turns. 0 = disabled.
     every_n_events: int = 0  # Aggregate every N new events since last aggregation. 0 = disabled.
     on_end: bool = True  # Aggregate when conversation ends.
-
-
-# ---------------------------------------------------------------------------
-# Built-in strategies
-# ---------------------------------------------------------------------------
 
 
 class ConversationSummaryAggregate:
@@ -104,10 +85,6 @@ class ConversationSummaryAggregate:
         await store.write(f"{CONVERSATIONS_PREFIX}{ts}_{stream_id}.md", summary)
 
     async def _summarize(self, events: list[BaseEvent]) -> str:
-        from autogen.beta.context import ConversationContext as Ctx
-        from autogen.beta.events import ModelRequest
-        from autogen.beta.stream import MemoryStream
-
         client = self._config.create()
         prompt_event = ModelRequest.ensure_request([
             "Summarize this conversation. Include key decisions, "
@@ -115,7 +92,7 @@ class ConversationSummaryAggregate:
         ])
         response = await client(
             [prompt_event],
-            Ctx(MemoryStream()),
+            ConversationContext(MemoryStream()),
             tools=[],
             response_schema=None,
         )
@@ -150,10 +127,6 @@ class WorkingMemoryAggregate:
         await store.write(WORKING_MEMORY_PATH, updated)
 
     async def _merge(self, existing: str, events: list[BaseEvent]) -> str:
-        from autogen.beta.context import ConversationContext as Ctx
-        from autogen.beta.events import ModelRequest
-        from autogen.beta.stream import MemoryStream
-
         client = self._config.create()
         prompt = (
             "You maintain an actor's working memory. Update it based on "
@@ -164,7 +137,7 @@ class WorkingMemoryAggregate:
         )
         response = await client(
             [ModelRequest.ensure_request([prompt])],
-            Ctx(MemoryStream()),
+            ConversationContext(MemoryStream()),
             tools=[],
             response_schema=None,
         )

--- a/autogen/beta/assembly.py
+++ b/autogen/beta/assembly.py
@@ -49,7 +49,7 @@ class AssemblerMiddleware(BaseMiddleware):
     policies in order, transforming (prompts, events) before they
     reach the LLM client.
 
-    Middleware ordering in Actor._execute()::
+    Middleware ordering in Agent._execute()::
 
         1. AssemblerMiddleware(policies)     -- outermost: assembles context
         2. AlertPolicy (in assembly chain)   -- injects observer alerts

--- a/autogen/beta/assembly.py
+++ b/autogen/beta/assembly.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Assembler — composable context assembly for LLM calls.
+
+The assembler composes AssemblyPolicy instances into a middleware that
+transforms (prompts, events) before each LLM call.
+
+Policies compose left-to-right: each sees the output of the previous.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import BaseEvent, ModelResponse
+from autogen.beta.middleware.base import BaseMiddleware, LLMCall
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class AssemblyPolicy(Protocol):
+    """Transforms context before each LLM invocation.
+
+    A policy receives (prompts, events) and returns modified (prompts, events).
+    Policies compose: each sees the output of the previous.
+
+    Policies are pure transforms with one exception: they may read from
+    KnowledgeStore or Hub (via context.dependencies). They must not have
+    side effects on the stream.
+    """
+
+    name: str
+
+    async def apply(
+        self,
+        prompts: list[str],
+        events: list[BaseEvent],
+        context: Context,
+    ) -> tuple[list[str], list[BaseEvent]]:
+        """Transform prompts and events. Return modified copies."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+
+class AssemblerMiddleware(BaseMiddleware):
+    """Runs assembly policies before each LLM call.
+
+    Sits at the outermost position in the middleware chain. Runs all
+    policies in order, transforming (prompts, events) before they
+    reach the LLM client.
+
+    Middleware ordering in Actor._execute()::
+
+        1. AssemblerMiddleware(policies)     -- outermost: assembles context
+        2. AlertPolicy (in assembly chain)   -- injects observer alerts
+        3. CompactionMiddleware              -- triggers compaction after turns
+        4. AggregationMiddleware             -- triggers aggregation after turns
+        5. User-provided middleware           -- logging, retry, etc.
+        6. LLM client call                    -- innermost: sends to model
+    """
+
+    def __init__(
+        self,
+        event: BaseEvent,
+        context: Context,
+        *,
+        policies: list[AssemblyPolicy],
+    ) -> None:
+        super().__init__(event, context)
+        self._policies = policies
+
+    async def on_llm_call(
+        self,
+        call_next: LLMCall,
+        events: Sequence[BaseEvent],
+        context: Context,
+    ) -> ModelResponse:
+        prompts = list(context.prompt)
+        event_list = list(events)
+
+        for policy in self._policies:
+            prompts, event_list = await policy.apply(prompts, event_list, context)
+
+        # Temporarily replace prompts, restore in finally
+        original_prompt = context.prompt
+        context.prompt = prompts
+        try:
+            return await call_next(event_list, context)
+        finally:
+            context.prompt = original_prompt
+
+    @staticmethod
+    def validate_order(policies: list[AssemblyPolicy]) -> list[str]:
+        """Check for known-problematic policy orderings. Returns warnings."""
+        warnings: list[str] = []
+        names = [p.name for p in policies]
+
+        # Reduction policies should come AFTER injection policies
+        # because injections add context that reduction should then trim.
+        reduction = {"sliding_window", "token_budget"}
+        injection = {"episodic_memory", "working_memory", "topic_inbox", "alert"}
+
+        for i, name in enumerate(names):
+            if name in reduction:
+                for j in range(i + 1, len(names)):
+                    if names[j] in injection:
+                        warnings.append(
+                            f"Policy '{name}' (index {i}) runs before '{names[j]}' (index {j}). "
+                            f"Injection policies should generally run before reduction policies "
+                            f"so injected context is included in the reduction budget."
+                        )
+        return warnings

--- a/autogen/beta/assembly.py
+++ b/autogen/beta/assembly.py
@@ -10,18 +10,12 @@ transforms (prompts, events) before each LLM call.
 Policies compose left-to-right: each sees the output of the previous.
 """
 
-from __future__ import annotations
-
 from collections.abc import Sequence
 from typing import Protocol, runtime_checkable
 
 from autogen.beta.context import ConversationContext as Context
 from autogen.beta.events import BaseEvent, ModelResponse
 from autogen.beta.middleware.base import BaseMiddleware, LLMCall
-
-# ---------------------------------------------------------------------------
-# Protocol
-# ---------------------------------------------------------------------------
 
 
 @runtime_checkable
@@ -46,11 +40,6 @@ class AssemblyPolicy(Protocol):
     ) -> tuple[list[str], list[BaseEvent]]:
         """Transform prompts and events. Return modified copies."""
         ...
-
-
-# ---------------------------------------------------------------------------
-# Middleware
-# ---------------------------------------------------------------------------
 
 
 class AssemblerMiddleware(BaseMiddleware):

--- a/autogen/beta/compact.py
+++ b/autogen/beta/compact.py
@@ -12,23 +12,16 @@ stream history.
 Compaction removes. Aggregation creates. They are separate concerns.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
-from autogen.beta.events import BaseEvent
+from autogen.beta.annotations import Context
+from autogen.beta.config import ModelConfig
+from autogen.beta.context import ConversationContext
+from autogen.beta.events import BaseEvent, ModelRequest
+from autogen.beta.stream import MemoryStream
 
-if TYPE_CHECKING:
-    from autogen.beta.annotations import Context
-    from autogen.beta.config import ModelConfig
-
-    from .knowledge import KnowledgeStore
-
-
-# ---------------------------------------------------------------------------
-# Events
-# ---------------------------------------------------------------------------
+from .knowledge import EventLogWriter, KnowledgeStore
 
 
 class CompactionSummary(BaseEvent):
@@ -41,11 +34,6 @@ class CompactionSummary(BaseEvent):
 
     summary: str
     event_count: int  # How many events were summarized
-
-
-# ---------------------------------------------------------------------------
-# Protocol
-# ---------------------------------------------------------------------------
 
 
 @runtime_checkable
@@ -73,11 +61,6 @@ class CompactStrategy(Protocol):
         ...
 
 
-# ---------------------------------------------------------------------------
-# Trigger
-# ---------------------------------------------------------------------------
-
-
 @dataclass(slots=True)
 class CompactTrigger:
     """Deterministic conditions for triggering compaction.
@@ -88,11 +71,6 @@ class CompactTrigger:
     max_events: int = 0  # Compact when event count exceeds this. 0 = disabled.
     max_tokens: int = 0  # Compact when estimated token count exceeds this. 0 = disabled.
     chars_per_token: int = 4  # For token estimation.
-
-
-# ---------------------------------------------------------------------------
-# Built-in strategies
-# ---------------------------------------------------------------------------
 
 
 class TailWindowCompact:
@@ -118,8 +96,6 @@ class TailWindowCompact:
         retained = events[-self._target :]
 
         if store:
-            from .knowledge import EventLogWriter
-
             writer = EventLogWriter(store)
             await writer.persist_dropped(context.stream.id, dropped)
 
@@ -154,8 +130,6 @@ class SummarizeCompact:
 
         # Persist full old events before dropping
         if store:
-            from .knowledge import EventLogWriter
-
             writer = EventLogWriter(store)
             await writer.persist_dropped(context.stream.id, old)
 
@@ -168,19 +142,14 @@ class SummarizeCompact:
         return [summary_event] + recent
 
     async def _summarize(self, events: list[BaseEvent]) -> str:
-        from autogen.beta.events import ModelRequest
-        from autogen.beta.stream import MemoryStream
-
         client = self._config.create()
         prompt_event = ModelRequest.ensure_request([
             "Summarize the following conversation history concisely, "
             "preserving key decisions, findings, and context:\n\n" + "\n".join(str(e) for e in events)
         ])
-        from autogen.beta.context import ConversationContext as Ctx
-
         response = await client(
             [prompt_event],
-            Ctx(MemoryStream()),
+            ConversationContext(MemoryStream()),
             tools=[],
             response_schema=None,
         )

--- a/autogen/beta/compact.py
+++ b/autogen/beta/compact.py
@@ -55,7 +55,7 @@ class CompactStrategy(Protocol):
         Args:
             events: Current stream history.
             context: Execution context.
-            store: Actor's knowledge store (for persisting dropped content).
+            store: Agent's knowledge store (for persisting dropped content).
                    None if not configured.
         """
         ...

--- a/autogen/beta/compact.py
+++ b/autogen/beta/compact.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CompactStrategy — reduces stream history to respect system constraints.
+
+Compaction protects runtime stability. It is the constraint-respecting
+operation: triggered when measurable limits (event count, token count)
+are approached. Returns a reduced event list that replaces the current
+stream history.
+
+Compaction removes. Aggregation creates. They are separate concerns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from autogen.beta.events import BaseEvent
+
+if TYPE_CHECKING:
+    from autogen.beta.annotations import Context
+    from autogen.beta.config import ModelConfig
+
+    from .knowledge import KnowledgeStore
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+class CompactionSummary(BaseEvent):
+    """Synthetic event replacing a sequence of compacted events.
+
+    Created by SummarizeCompact (and similar strategies) to preserve
+    context when old events are dropped. Assembly policies format it
+    for LLM consumption.
+    """
+
+    summary: str
+    event_count: int  # How many events were summarized
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class CompactStrategy(Protocol):
+    """Reduces stream history to respect system constraints.
+
+    Returns a reduced event list that replaces the current stream history.
+    Must preserve causal ordering of retained events.
+    """
+
+    async def compact(
+        self,
+        events: list[BaseEvent],
+        context: Context,
+        store: KnowledgeStore | None,
+    ) -> list[BaseEvent]:
+        """Return compacted event list.
+
+        Args:
+            events: Current stream history.
+            context: Execution context.
+            store: Actor's knowledge store (for persisting dropped content).
+                   None if not configured.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Trigger
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class CompactTrigger:
+    """Deterministic conditions for triggering compaction.
+
+    Compaction fires when ANY condition is exceeded.
+    """
+
+    max_events: int = 0  # Compact when event count exceeds this. 0 = disabled.
+    max_tokens: int = 0  # Compact when estimated token count exceeds this. 0 = disabled.
+    chars_per_token: int = 4  # For token estimation.
+
+
+# ---------------------------------------------------------------------------
+# Built-in strategies
+# ---------------------------------------------------------------------------
+
+
+class TailWindowCompact:
+    """Keep the last N events. Drop the rest.
+
+    Zero LLM cost. Simplest strategy. Suitable when old context
+    has diminishing value and recent events are most relevant.
+    """
+
+    def __init__(self, target: int) -> None:
+        self._target = target
+
+    async def compact(
+        self,
+        events: list[BaseEvent],
+        context: Context,
+        store: KnowledgeStore | None,
+    ) -> list[BaseEvent]:
+        if len(events) <= self._target:
+            return events
+
+        dropped = events[: -self._target]
+        retained = events[-self._target :]
+
+        if store:
+            from .knowledge import EventLogWriter
+
+            writer = EventLogWriter(store)
+            await writer.persist_dropped(context.stream.id, dropped)
+
+        return retained
+
+
+class SummarizeCompact:
+    """Summarize old events into a CompactionSummary event, keep recent.
+
+    Uses an LLM call to create a summary of dropped events. The summary
+    becomes a CompactionSummary event at the head of the history.
+
+    Costs one LLM call per compaction.
+    """
+
+    def __init__(self, target: int, config: ModelConfig) -> None:
+        self._target = target
+        self._config = config
+        self.last_usage: dict = {}
+
+    async def compact(
+        self,
+        events: list[BaseEvent],
+        context: Context,
+        store: KnowledgeStore | None,
+    ) -> list[BaseEvent]:
+        if len(events) <= self._target:
+            return events
+
+        old = events[: -self._target]
+        recent = events[-self._target :]
+
+        # Persist full old events before dropping
+        if store:
+            from .knowledge import EventLogWriter
+
+            writer = EventLogWriter(store)
+            await writer.persist_dropped(context.stream.id, old)
+
+        # Summarize via LLM
+        summary_text = await self._summarize(old)
+        summary_event = CompactionSummary(
+            summary=summary_text,
+            event_count=len(old),
+        )
+        return [summary_event] + recent
+
+    async def _summarize(self, events: list[BaseEvent]) -> str:
+        from autogen.beta.events import ModelRequest
+        from autogen.beta.stream import MemoryStream
+
+        client = self._config.create()
+        prompt_event = ModelRequest.ensure_request([
+            "Summarize the following conversation history concisely, "
+            "preserving key decisions, findings, and context:\n\n" + "\n".join(str(e) for e in events)
+        ])
+        from autogen.beta.context import ConversationContext as Ctx
+
+        response = await client(
+            [prompt_event],
+            Ctx(MemoryStream()),
+            tools=[],
+            response_schema=None,
+        )
+        self.last_usage = response.usage if hasattr(response, "usage") and response.usage else {}
+        return response.content or ""

--- a/autogen/beta/knowledge/__init__.py
+++ b/autogen/beta/knowledge/__init__.py
@@ -23,6 +23,7 @@ from .base import (
     NoopChangeSubscription,
 )
 from .bootstrap import DefaultBootstrap, StoreBootstrap
+from .constants import CONVERSATIONS_PREFIX, LOG_PREFIX, WORKING_MEMORY_PATH
 from .locked import LockedKnowledgeStore
 from .log import EventLogWriter
 from .memory import MemoryKnowledgeStore
@@ -35,16 +36,19 @@ except ImportError as e:
     DiskKnowledgeStore = missing_optional_dependency("DiskKnowledgeStore", "watchdog", e)  # type: ignore[misc]
 
 __all__ = [
+    "CONVERSATIONS_PREFIX",
     "ChangeCallback",
     "ChangeSubscription",
     "DefaultBootstrap",
     "DiskKnowledgeStore",
     "EventLogWriter",
     "KnowledgeStore",
+    "LOG_PREFIX",
     "LockedKnowledgeStore",
     "MemoryKnowledgeStore",
     "NoopChangeSubscription",
     "RedisKnowledgeStore",
     "SqliteKnowledgeStore",
     "StoreBootstrap",
+    "WORKING_MEMORY_PATH",
 ]

--- a/autogen/beta/knowledge/__init__.py
+++ b/autogen/beta/knowledge/__init__.py
@@ -37,18 +37,18 @@ except ImportError as e:
 
 __all__ = [
     "CONVERSATIONS_PREFIX",
+    "LOG_PREFIX",
+    "WORKING_MEMORY_PATH",
     "ChangeCallback",
     "ChangeSubscription",
     "DefaultBootstrap",
     "DiskKnowledgeStore",
     "EventLogWriter",
     "KnowledgeStore",
-    "LOG_PREFIX",
     "LockedKnowledgeStore",
     "MemoryKnowledgeStore",
     "NoopChangeSubscription",
     "RedisKnowledgeStore",
     "SqliteKnowledgeStore",
     "StoreBootstrap",
-    "WORKING_MEMORY_PATH",
 ]

--- a/autogen/beta/knowledge/bootstrap.py
+++ b/autogen/beta/knowledge/bootstrap.py
@@ -5,6 +5,7 @@
 from typing import Protocol, runtime_checkable
 
 from .base import KnowledgeStore
+from .constants import LOG_PREFIX
 
 
 @runtime_checkable
@@ -35,7 +36,7 @@ class DefaultBootstrap:
         )
 
         await store.write(
-            "/log/SKILL.md",
+            f"{LOG_PREFIX}SKILL.md",
             "Conversation logs. Each file is a JSONL record of one conversation's events. "
             "Auto-populated by the framework after each conversation.",
         )

--- a/autogen/beta/knowledge/constants.py
+++ b/autogen/beta/knowledge/constants.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conventional paths shared between aggregation strategies, assembly policies,
+and the event-log writer. Producer/consumer contracts: change one, change the
+matching consumer.
+"""
+
+WORKING_MEMORY_PATH = "/memory/working.md"
+"""Actor's persistent state. Produced by WorkingMemoryAggregate, read by WorkingMemoryPolicy."""
+
+CONVERSATIONS_PREFIX = "/memory/conversations/"
+"""Past-conversation summaries. Produced by ConversationSummaryAggregate, read by EpisodicMemoryPolicy."""
+
+LOG_PREFIX = "/log/"
+"""Stream event logs and dropped-events snapshots (from compaction)."""

--- a/autogen/beta/knowledge/constants.py
+++ b/autogen/beta/knowledge/constants.py
@@ -8,7 +8,7 @@ matching consumer.
 """
 
 WORKING_MEMORY_PATH = "/memory/working.md"
-"""Actor's persistent state. Produced by WorkingMemoryAggregate, read by WorkingMemoryPolicy."""
+"""Agent's persistent state. Produced by WorkingMemoryAggregate, read by WorkingMemoryPolicy."""
 
 CONVERSATIONS_PREFIX = "/memory/conversations/"
 """Past-conversation summaries. Produced by ConversationSummaryAggregate, read by EpisodicMemoryPolicy."""

--- a/autogen/beta/knowledge/log.py
+++ b/autogen/beta/knowledge/log.py
@@ -10,6 +10,7 @@ from autogen.beta.events import BaseEvent, UnknownEvent
 from autogen.beta.events._serialization import import_event_class, qualified_name
 
 from .base import KnowledgeStore
+from .constants import LOG_PREFIX
 
 
 class EventLogWriter:
@@ -26,7 +27,7 @@ class EventLogWriter:
 
     async def persist(self, stream_id: StreamId, events: Iterable[BaseEvent]) -> None:
         """Write final events to /log/{stream_id}.jsonl."""
-        path = f"/log/{stream_id}.jsonl"
+        path = f"{LOG_PREFIX}{stream_id}.jsonl"
         lines = self._serialize_events(events)
         await self._store.write(path, "\n".join(lines))
 
@@ -36,10 +37,10 @@ class EventLogWriter:
         Discovers existing segments in the store to avoid overwriting.
         """
         prefix = f"{stream_id}.dropped-"
-        entries = await self._store.list("/log/")
+        entries = await self._store.list(LOG_PREFIX)
         existing = [e for e in entries if e.startswith(prefix) and e.endswith(".jsonl")]
         n = len(existing) + 1
-        path = f"/log/{stream_id}.dropped-{n}.jsonl"
+        path = f"{LOG_PREFIX}{stream_id}.dropped-{n}.jsonl"
         lines = self._serialize_events(events)
         await self._store.write(path, "\n".join(lines))
 
@@ -50,17 +51,17 @@ class EventLogWriter:
         """
         all_events: list[BaseEvent] = []
 
-        entries = await self._store.list("/log/")
+        entries = await self._store.list(LOG_PREFIX)
         prefix = f"{stream_id}.dropped-"
         segments = sorted(
             [e for e in entries if e.startswith(prefix) and e.endswith(".jsonl")],
             key=lambda e: int(e[len(prefix) : -len(".jsonl")]),
         )
         for segment in segments:
-            events = await self._load_file(f"/log/{segment}")
+            events = await self._load_file(f"{LOG_PREFIX}{segment}")
             all_events.extend(events)
 
-        final = await self._load_file(f"/log/{stream_id}.jsonl")
+        final = await self._load_file(f"{LOG_PREFIX}{stream_id}.jsonl")
         all_events.extend(final)
 
         return all_events

--- a/autogen/beta/policies/__init__.py
+++ b/autogen/beta/policies/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Assembly policies — composable transforms for LLM context."""
+
+from .alert import AlertPolicy
+from .conversation import ConversationPolicy
+from .episodic_memory import EpisodicMemoryPolicy
+from .sliding_window import SlidingWindowPolicy
+from .token_budget import TokenBudgetPolicy
+from .working_memory import WorkingMemoryPolicy
+
+__all__ = (
+    "AlertPolicy",
+    "ConversationPolicy",
+    "EpisodicMemoryPolicy",
+    "SlidingWindowPolicy",
+    "TokenBudgetPolicy",
+    "WorkingMemoryPolicy",
+)

--- a/autogen/beta/policies/alert.py
+++ b/autogen/beta/policies/alert.py
@@ -14,8 +14,6 @@ Key behaviors preserved from the old system:
 - FATAL handling: emits HaltEvent for observers to halt execution
 """
 
-from __future__ import annotations
-
 from autogen.beta.context import ConversationContext as Context
 from autogen.beta.events import BaseEvent
 from autogen.beta.events.alert import HaltEvent, ObserverAlert, Severity

--- a/autogen/beta/policies/alert.py
+++ b/autogen/beta/policies/alert.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""AlertPolicy — delivers observer alerts to the LLM via assembly.
+
+Replaces the old Signal delivery system (SignalPolicy + SignalInjectionMiddleware).
+AlertPolicy reads ObserverAlert events from the event stream and injects them
+into the LLM prompt. FATAL alerts emit a HaltEvent on the stream.
+
+Key behaviors preserved from the old system:
+- Deduplication: each alert is injected once, then marked as delivered
+- Cross-turn accumulation: reads alerts from stream history across LLM calls
+- FATAL handling: emits HaltEvent for observers to halt execution
+"""
+
+from __future__ import annotations
+
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import BaseEvent
+from autogen.beta.events.alert import HaltEvent, ObserverAlert, Severity
+
+
+class AlertPolicy:
+    """Injects observer alerts into the LLM prompt.
+
+    Reads ObserverAlert events from the event list, formats them as
+    prompt text, and tracks which alerts have been delivered to avoid
+    duplicates across LLM calls.
+
+    Deduplication keys on ``(source, severity, message)`` — the semantic
+    content of the alert, not the Python object identity — so dedup
+    survives history replay, compaction (which rewrites history into
+    fresh event objects), and serialization round-trips. Observers that
+    need to re-alert with identical wording can vary the ``data`` dict
+    or the ``message`` string.
+
+    For FATAL alerts, emits a HaltEvent on the stream and adds a halt
+    note to the prompt.
+
+    Ordering: this is an injection policy. Place it after other injection
+    policies (working memory, episodic memory) and before reduction policies
+    (sliding window, token budget).
+    """
+
+    name = "alert"
+
+    def __init__(self) -> None:
+        self._delivered_keys: set[tuple[str, str, str]] = set()
+
+    async def apply(
+        self,
+        prompts: list[str],
+        events: list[BaseEvent],
+        context: Context,
+    ) -> tuple[list[str], list[BaseEvent]]:
+        # Collect undelivered alerts from the event stream
+        new_alerts: list[ObserverAlert] = []
+        for event in events:
+            if isinstance(event, ObserverAlert):
+                key = (event.source, str(event.severity), event.message)
+                if key not in self._delivered_keys:
+                    new_alerts.append(event)
+                    self._delivered_keys.add(key)
+
+        if not new_alerts:
+            return prompts, events
+
+        # Split fatal vs non-fatal
+        fatal = [a for a in new_alerts if a.severity == Severity.FATAL]
+        non_fatal = [a for a in new_alerts if a.severity != Severity.FATAL]
+
+        # Inject non-fatal alerts as prompt text
+        if non_fatal:
+            alert_text = self._format_alerts(non_fatal)
+            prompts = prompts + [alert_text]
+
+        # FATAL: emit HaltEvent on the stream
+        if fatal:
+            await context.send(
+                HaltEvent(
+                    reason=f"FATAL: {fatal[0].message}",
+                    source=fatal[0].source,
+                    alerts=fatal,
+                )
+            )
+            # Add halt note to prompt so LLM sees it if the call isn't short-circuited
+            prompts = prompts + [f"[FATAL ALERT] ({fatal[0].source}): {fatal[0].message}. Execution halting."]
+
+        return prompts, events
+
+    @staticmethod
+    def _format_alerts(alerts: list[ObserverAlert]) -> str:
+        lines = ["[OBSERVER MONITORING ALERTS]"]
+        for a in alerts:
+            level = a.severity.upper() if isinstance(a.severity, str) else str(a.severity)
+            lines.append(f"- [{level}] ({a.source}): {a.message}")
+        return "\n".join(lines)

--- a/autogen/beta/policies/conversation.py
+++ b/autogen/beta/policies/conversation.py
@@ -4,8 +4,6 @@
 
 """ConversationPolicy — only conversation and tool events reach the LLM."""
 
-from __future__ import annotations
-
 from autogen.beta.compact import CompactionSummary
 from autogen.beta.context import ConversationContext as Context
 from autogen.beta.events import BaseEvent, ModelRequest, ModelResponse

--- a/autogen/beta/policies/conversation.py
+++ b/autogen/beta/policies/conversation.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ConversationPolicy — only conversation and tool events reach the LLM."""
+
+from __future__ import annotations
+
+from autogen.beta.compact import CompactionSummary
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import BaseEvent, ModelRequest, ModelResponse
+from autogen.beta.events.tool_events import (
+    ToolCallEvent,
+    ToolCallsEvent,
+    ToolErrorEvent,
+    ToolResultEvent,
+    ToolResultsEvent,
+)
+
+# Event types that are always part of conversation context
+CONVERSATION_TYPES = (
+    ModelRequest,
+    ModelResponse,
+    ToolCallEvent,
+    ToolCallsEvent,
+    ToolResultEvent,
+    ToolResultsEvent,
+    ToolErrorEvent,
+    CompactionSummary,
+)
+
+
+class ConversationPolicy:
+    """Only conversation and tool events reach the LLM.
+
+    Opt-in policy that re-creates plain-loop semantics: only conversation
+    and tool events reach the LLM, everything else is filtered out.
+    CompactionSummary is included so compacted summaries remain visible.
+    """
+
+    name = "conversation"
+
+    async def apply(
+        self,
+        prompts: list[str],
+        events: list[BaseEvent],
+        context: Context,
+    ) -> tuple[list[str], list[BaseEvent]]:
+        filtered = [e for e in events if isinstance(e, CONVERSATION_TYPES)]
+        return prompts, filtered

--- a/autogen/beta/policies/episodic_memory.py
+++ b/autogen/beta/policies/episodic_memory.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""EpisodicMemoryPolicy — injects past conversation summaries."""
+
+from __future__ import annotations
+
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import BaseEvent
+from autogen.beta.knowledge import KnowledgeStore
+
+
+class EpisodicMemoryPolicy:
+    """Injects past conversation summaries from the knowledge store.
+
+    Reads /memory/conversations/ and injects the most recent summaries
+    into the system prompt. This gives the actor context about past episodes.
+    """
+
+    name = "episodic_memory"
+
+    def __init__(self, max_episodes: int = 5, transparent: bool = True) -> None:
+        self._max = max_episodes
+        self._transparent = transparent
+
+    async def apply(
+        self,
+        prompts: list[str],
+        events: list[BaseEvent],
+        context: Context,
+    ) -> tuple[list[str], list[BaseEvent]]:
+        store = context.dependencies.get(KnowledgeStore)
+        if not store:
+            return prompts, events
+
+        entries = await store.list("/memory/conversations/")
+        if not entries:
+            return prompts, events
+
+        # Read most recent summaries
+        recent = entries[-self._max :]
+        summaries: list[str] = []
+        for entry in recent:
+            content = await store.read(f"/memory/conversations/{entry}")
+            if content:
+                summaries.append(content)
+
+        if summaries:
+            block = "## Past Conversations\n\n" + "\n\n---\n\n".join(summaries)
+            prompts = prompts + [block]
+            if self._transparent:
+                prompts = prompts + [f"[{self.name}] Injected {len(summaries)} past conversation summaries."]
+
+        return prompts, events

--- a/autogen/beta/policies/episodic_memory.py
+++ b/autogen/beta/policies/episodic_memory.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from autogen.beta.context import ConversationContext as Context
 from autogen.beta.events import BaseEvent
-from autogen.beta.knowledge import KnowledgeStore
+from autogen.beta.knowledge import CONVERSATIONS_PREFIX, KnowledgeStore
 
 
 class EpisodicMemoryPolicy:
@@ -34,7 +34,7 @@ class EpisodicMemoryPolicy:
         if not store:
             return prompts, events
 
-        entries = await store.list("/memory/conversations/")
+        entries = await store.list(CONVERSATIONS_PREFIX)
         if not entries:
             return prompts, events
 
@@ -42,7 +42,7 @@ class EpisodicMemoryPolicy:
         recent = entries[-self._max :]
         summaries: list[str] = []
         for entry in recent:
-            content = await store.read(f"/memory/conversations/{entry}")
+            content = await store.read(f"{CONVERSATIONS_PREFIX}{entry}")
             if content:
                 summaries.append(content)
 

--- a/autogen/beta/policies/episodic_memory.py
+++ b/autogen/beta/policies/episodic_memory.py
@@ -4,8 +4,6 @@
 
 """EpisodicMemoryPolicy — injects past conversation summaries."""
 
-from __future__ import annotations
-
 from autogen.beta.context import ConversationContext as Context
 from autogen.beta.events import BaseEvent
 from autogen.beta.knowledge import CONVERSATIONS_PREFIX, KnowledgeStore

--- a/autogen/beta/policies/sliding_window.py
+++ b/autogen/beta/policies/sliding_window.py
@@ -4,8 +4,6 @@
 
 """SlidingWindowPolicy — keep the last N events."""
 
-from __future__ import annotations
-
 from autogen.beta.context import ConversationContext as Context
 from autogen.beta.events import BaseEvent, ToolResultsEvent
 

--- a/autogen/beta/policies/sliding_window.py
+++ b/autogen/beta/policies/sliding_window.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SlidingWindowPolicy — keep the last N events."""
+
+from __future__ import annotations
+
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import BaseEvent, ToolResultsEvent
+
+
+class SlidingWindowPolicy:
+    """Keep the last N events. Drop older events.
+
+    Optional transparency: injects a note about how many events were omitted.
+    """
+
+    name = "sliding_window"
+
+    def __init__(self, max_events: int, transparent: bool = False) -> None:
+        self._max = max_events
+        self._transparent = transparent
+
+    async def apply(
+        self,
+        prompts: list[str],
+        events: list[BaseEvent],
+        context: Context,
+    ) -> tuple[list[str], list[BaseEvent]]:
+        total = len(events)
+        if total <= self._max:
+            return prompts, events
+        trimmed = events[-self._max :]
+        # Skip leading ToolResultsEvents whose matching tool_use was trimmed away.
+        while trimmed and isinstance(trimmed[0], ToolResultsEvent):
+            trimmed = trimmed[1:]
+        if self._transparent:
+            prompts = prompts + [f"[{self.name}] Showing last {len(trimmed)} of {total} events."]
+        return prompts, trimmed

--- a/autogen/beta/policies/token_budget.py
+++ b/autogen/beta/policies/token_budget.py
@@ -4,8 +4,6 @@
 
 """TokenBudgetPolicy — keep events within a token budget."""
 
-from __future__ import annotations
-
 from autogen.beta.context import ConversationContext as Context
 from autogen.beta.events import BaseEvent, ToolResultsEvent
 

--- a/autogen/beta/policies/token_budget.py
+++ b/autogen/beta/policies/token_budget.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""TokenBudgetPolicy — keep events within a token budget."""
+
+from __future__ import annotations
+
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import BaseEvent, ToolResultsEvent
+
+
+class TokenBudgetPolicy:
+    """Keep events within a token budget.
+
+    Estimates tokens by character count. Retains most recent events first.
+    """
+
+    name = "token_budget"
+
+    def __init__(self, max_tokens: int, chars_per_token: int = 4, transparent: bool = False) -> None:
+        self._max_chars = max_tokens * chars_per_token
+        self._transparent = transparent
+
+    async def apply(
+        self,
+        prompts: list[str],
+        events: list[BaseEvent],
+        context: Context,
+    ) -> tuple[list[str], list[BaseEvent]]:
+        total_chars = sum(len(str(e)) for e in events)
+        if total_chars <= self._max_chars:
+            return prompts, events
+
+        # Retain from the end, fitting within budget
+        retained: list[BaseEvent] = []
+        budget = self._max_chars
+        for event in reversed(events):
+            cost = len(str(event))
+            if budget - cost < 0 and retained:
+                break
+            retained.append(event)
+            budget -= cost
+        retained.reverse()
+        # Skip leading ToolResultsEvents whose matching tool_use was trimmed away.
+        while retained and isinstance(retained[0], ToolResultsEvent):
+            retained = retained[1:]
+
+        if self._transparent:
+            prompts = prompts + [f"[{self.name}] Showing {len(retained)} of {len(events)} events (token budget)."]
+        return prompts, retained

--- a/autogen/beta/policies/working_memory.py
+++ b/autogen/beta/policies/working_memory.py
@@ -4,8 +4,6 @@
 
 """WorkingMemoryPolicy — injects persistent working memory."""
 
-from __future__ import annotations
-
 from autogen.beta.context import ConversationContext as Context
 from autogen.beta.events import BaseEvent
 from autogen.beta.knowledge import WORKING_MEMORY_PATH, KnowledgeStore

--- a/autogen/beta/policies/working_memory.py
+++ b/autogen/beta/policies/working_memory.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from autogen.beta.context import ConversationContext as Context
 from autogen.beta.events import BaseEvent
-from autogen.beta.knowledge import KnowledgeStore
+from autogen.beta.knowledge import WORKING_MEMORY_PATH, KnowledgeStore
 
 
 class WorkingMemoryPolicy:
@@ -31,7 +31,7 @@ class WorkingMemoryPolicy:
         if not store:
             return prompts, events
 
-        content = await store.read("/memory/working.md")
+        content = await store.read(WORKING_MEMORY_PATH)
         if content:
             prompts = prompts + [f"## Working Memory\n\n{content}"]
 

--- a/autogen/beta/policies/working_memory.py
+++ b/autogen/beta/policies/working_memory.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""WorkingMemoryPolicy — injects persistent working memory."""
+
+from __future__ import annotations
+
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import BaseEvent
+from autogen.beta.knowledge import KnowledgeStore
+
+
+class WorkingMemoryPolicy:
+    """Injects /memory/working.md from the knowledge store.
+
+    Working memory is the actor's persistent state -- updated by
+    AggregateStrategy between conversations. This policy injects
+    it as system prompt context so the actor has continuity.
+    """
+
+    name = "working_memory"
+
+    async def apply(
+        self,
+        prompts: list[str],
+        events: list[BaseEvent],
+        context: Context,
+    ) -> tuple[list[str], list[BaseEvent]]:
+        store = context.dependencies.get(KnowledgeStore)
+        if not store:
+            return prompts, events
+
+        content = await store.read("/memory/working.md")
+        if content:
+            prompts = prompts + [f"## Working Memory\n\n{content}"]
+
+        return prompts, events

--- a/test/beta/framework/test_aggregate.py
+++ b/test/beta/framework/test_aggregate.py
@@ -4,8 +4,6 @@
 
 """Tests for AggregateStrategy, AggregateTrigger, and built-in strategies."""
 
-from __future__ import annotations
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/test/beta/framework/test_aggregate.py
+++ b/test/beta/framework/test_aggregate.py
@@ -24,13 +24,13 @@ class TestAggregateTrigger:
         trigger = AggregateTrigger()
         assert trigger.every_n_turns == 0
         assert trigger.every_n_events == 0
-        assert trigger.on_end is True
+        assert trigger.on_end is False
 
     def test_custom_values(self) -> None:
-        trigger = AggregateTrigger(every_n_turns=5, every_n_events=50, on_end=False)
+        trigger = AggregateTrigger(every_n_turns=5, every_n_events=50, on_end=True)
         assert trigger.every_n_turns == 5
         assert trigger.every_n_events == 50
-        assert trigger.on_end is False
+        assert trigger.on_end is True
 
 
 class TestConversationSummaryAggregate:

--- a/test/beta/framework/test_aggregate.py
+++ b/test/beta/framework/test_aggregate.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for AggregateStrategy, AggregateTrigger, and built-in strategies."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from autogen.beta.aggregate import (
+    AggregateTrigger,
+    ConversationSummaryAggregate,
+    WorkingMemoryAggregate,
+)
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import ModelRequest, TextInput
+from autogen.beta.knowledge import MemoryKnowledgeStore
+from autogen.beta.stream import MemoryStream
+
+
+class TestAggregateTrigger:
+    def test_defaults(self) -> None:
+        trigger = AggregateTrigger()
+        assert trigger.every_n_turns == 0
+        assert trigger.every_n_events == 0
+        assert trigger.on_end is True
+
+    def test_custom_values(self) -> None:
+        trigger = AggregateTrigger(every_n_turns=5, every_n_events=50, on_end=False)
+        assert trigger.every_n_turns == 5
+        assert trigger.every_n_events == 50
+        assert trigger.on_end is False
+
+
+class TestConversationSummaryAggregate:
+    @pytest.mark.asyncio
+    async def test_writes_timestamped_summary(self) -> None:
+        """Summary files should be prefixed with a timestamp for chronological sorting."""
+        mock_response = MagicMock()
+        mock_response.content = "This conversation covered X and Y."
+        mock_response.usage = {"input_tokens": 100, "output_tokens": 50}
+
+        mock_client = AsyncMock(return_value=mock_response)
+        mock_config = MagicMock()
+        mock_config.create.return_value = mock_client
+
+        strategy = ConversationSummaryAggregate(config=mock_config)
+        store = MemoryKnowledgeStore()
+        stream = MemoryStream()
+        ctx = Context(stream=stream)
+        events = [ModelRequest([TextInput("hello")]), ModelRequest([TextInput("world")])]
+
+        await strategy.aggregate(events, ctx, store)
+
+        entries = await store.list("/memory/conversations/")
+        assert len(entries) == 1
+        filename = entries[0]
+        # Filename should start with a timestamp: YYYYMMDDTHHmmss_
+        assert filename[8] == "T"  # ISO date separator
+        assert filename[15] == "_"  # separator before stream ID
+        assert filename.endswith(".md")
+
+    @pytest.mark.asyncio
+    async def test_skips_empty_events(self) -> None:
+        mock_config = MagicMock()
+        strategy = ConversationSummaryAggregate(config=mock_config)
+        store = MemoryKnowledgeStore()
+        ctx = Context(stream=MemoryStream())
+
+        await strategy.aggregate([], ctx, store)
+
+        entries = await store.list("/memory/conversations/")
+        assert len(entries) == 0
+
+    @pytest.mark.asyncio
+    async def test_stores_usage(self) -> None:
+        mock_response = MagicMock()
+        mock_response.content = "Summary"
+        mock_response.usage = {"input_tokens": 200}
+
+        mock_client = AsyncMock(return_value=mock_response)
+        mock_config = MagicMock()
+        mock_config.create.return_value = mock_client
+
+        strategy = ConversationSummaryAggregate(config=mock_config)
+        store = MemoryKnowledgeStore()
+        ctx = Context(stream=MemoryStream())
+
+        await strategy.aggregate([ModelRequest([TextInput("hi")])], ctx, store)
+        assert strategy.last_usage == {"input_tokens": 200}
+
+    @pytest.mark.asyncio
+    async def test_chronological_ordering_of_summaries(self) -> None:
+        """Multiple summaries should sort chronologically by filename."""
+        mock_response = MagicMock()
+        mock_response.content = "Summary"
+        mock_response.usage = {}
+
+        mock_client = AsyncMock(return_value=mock_response)
+        mock_config = MagicMock()
+        mock_config.create.return_value = mock_client
+
+        strategy = ConversationSummaryAggregate(config=mock_config)
+        store = MemoryKnowledgeStore()
+
+        # Write two summaries with different streams
+        stream1 = MemoryStream()
+        ctx1 = Context(stream=stream1)
+        with patch("autogen.beta.aggregate.datetime") as mock_dt:
+            mock_dt.now.return_value.strftime.return_value = "20260101T120000"
+            mock_dt.side_effect = None
+            await strategy.aggregate([ModelRequest([TextInput("first")])], ctx1, store)
+
+        stream2 = MemoryStream()
+        ctx2 = Context(stream=stream2)
+        with patch("autogen.beta.aggregate.datetime") as mock_dt:
+            mock_dt.now.return_value.strftime.return_value = "20260201T120000"
+            mock_dt.side_effect = None
+            await strategy.aggregate([ModelRequest([TextInput("second")])], ctx2, store)
+
+        entries = await store.list("/memory/conversations/")
+        assert len(entries) == 2
+        # Alphabetical sort == chronological sort because of timestamp prefix
+        assert entries[0] < entries[1]
+        assert entries[0].startswith("20260101")
+        assert entries[1].startswith("20260201")
+
+
+class TestWorkingMemoryAggregate:
+    @pytest.mark.asyncio
+    async def test_writes_working_memory(self) -> None:
+        mock_response = MagicMock()
+        mock_response.content = "Updated working memory content."
+        mock_response.usage = {"input_tokens": 100}
+
+        mock_client = AsyncMock(return_value=mock_response)
+        mock_config = MagicMock()
+        mock_config.create.return_value = mock_client
+
+        strategy = WorkingMemoryAggregate(config=mock_config)
+        store = MemoryKnowledgeStore()
+        ctx = Context(stream=MemoryStream())
+
+        await strategy.aggregate([ModelRequest([TextInput("hi")])], ctx, store)
+
+        content = await store.read("/memory/working.md")
+        assert content == "Updated working memory content."
+
+    @pytest.mark.asyncio
+    async def test_merges_with_existing(self) -> None:
+        """Should pass existing working memory to LLM for merging."""
+        mock_response = MagicMock()
+        mock_response.content = "Merged memory."
+        mock_response.usage = {}
+
+        mock_client = AsyncMock(return_value=mock_response)
+        mock_config = MagicMock()
+        mock_config.create.return_value = mock_client
+
+        strategy = WorkingMemoryAggregate(config=mock_config)
+        store = MemoryKnowledgeStore()
+        await store.write("/memory/working.md", "Existing context about project X.")
+        ctx = Context(stream=MemoryStream())
+
+        await strategy.aggregate([ModelRequest([TextInput("update")])], ctx, store)
+
+        # Verify the LLM was called with existing memory in the prompt
+        call_args = mock_client.call_args
+        prompt_event = call_args[0][0][0]
+        assert any(
+            isinstance(inp, TextInput) and "Existing context about project X." in inp.content
+            for inp in prompt_event.inputs
+        )
+
+        content = await store.read("/memory/working.md")
+        assert content == "Merged memory."
+
+    @pytest.mark.asyncio
+    async def test_skips_empty_events(self) -> None:
+        mock_config = MagicMock()
+        strategy = WorkingMemoryAggregate(config=mock_config)
+        store = MemoryKnowledgeStore()
+        ctx = Context(stream=MemoryStream())
+
+        await strategy.aggregate([], ctx, store)
+        assert await store.read("/memory/working.md") is None
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_existing_on_empty_response(self) -> None:
+        mock_response = MagicMock()
+        mock_response.content = ""  # LLM returns empty
+        mock_response.usage = {}
+
+        mock_client = AsyncMock(return_value=mock_response)
+        mock_config = MagicMock()
+        mock_config.create.return_value = mock_client
+
+        strategy = WorkingMemoryAggregate(config=mock_config)
+        store = MemoryKnowledgeStore()
+        await store.write("/memory/working.md", "Existing content.")
+        ctx = Context(stream=MemoryStream())
+
+        await strategy.aggregate([ModelRequest([TextInput("update")])], ctx, store)
+
+        # Should fall back to existing content when LLM returns empty
+        content = await store.read("/memory/working.md")
+        assert content == "Existing content."

--- a/test/beta/framework/test_aggregate.py
+++ b/test/beta/framework/test_aggregate.py
@@ -172,7 +172,7 @@ class TestWorkingMemoryAggregate:
         prompt_event = call_args[0][0][0]
         assert any(
             isinstance(inp, TextInput) and "Existing context about project X." in inp.content
-            for inp in prompt_event.inputs
+            for inp in prompt_event.parts
         )
 
         content = await store.read("/memory/working.md")

--- a/test/beta/framework/test_assembly.py
+++ b/test/beta/framework/test_assembly.py
@@ -72,7 +72,7 @@ class TestSlidingWindowPolicy:
         ctx = Context(stream=MemoryStream())
         _, filtered = await policy.apply([], events, ctx)
         assert len(filtered) == 3
-        assert filtered[0].inputs[0].content == "msg-7"
+        assert filtered[0].parts[0].content == "msg-7"
 
     @pytest.mark.asyncio
     async def test_transparent_adds_note(self) -> None:
@@ -101,7 +101,7 @@ class TestTokenBudgetPolicy:
         _, filtered = await policy.apply([], events, ctx)
         # Should keep at least the last event that fits
         assert len(filtered) >= 1
-        assert filtered[-1].inputs[0].content == "b" * 5
+        assert filtered[-1].parts[0].content == "b" * 5
 
 
 class TestAssemblerMiddleware:

--- a/test/beta/framework/test_assembly.py
+++ b/test/beta/framework/test_assembly.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for assembly policies (replacement for old ContextHarness tests)."""
+
+import pytest
+
+from autogen.beta import AssemblerMiddleware
+from autogen.beta.compact import CompactionSummary
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import ModelMessage, ModelRequest, ModelResponse, TextInput
+from autogen.beta.events.alert import ObserverAlert, Severity
+from autogen.beta.events.tool_events import ToolCallEvent, ToolResultEvent
+from autogen.beta.knowledge import KnowledgeStore, MemoryKnowledgeStore
+from autogen.beta.policies import (
+    ConversationPolicy,
+    EpisodicMemoryPolicy,
+    SlidingWindowPolicy,
+    TokenBudgetPolicy,
+    WorkingMemoryPolicy,
+)
+from autogen.beta.stream import MemoryStream
+
+
+class TestConversationPolicy:
+    @pytest.mark.asyncio
+    async def test_filters_to_conversation_events(self) -> None:
+        policy = ConversationPolicy()
+        events = [
+            ModelRequest([TextInput("hello")]),
+            ModelResponse(message=ModelMessage(content="hi")),
+            ToolCallEvent(name="search", arguments="{}"),
+            ToolResultEvent(id="1", name="search", content="result"),
+            ObserverAlert(source="mon", severity=Severity.WARNING, message="warn"),
+        ]
+        ctx = Context(stream=MemoryStream())
+        prompts, filtered = await policy.apply([], events, ctx)
+        assert len(filtered) == 4
+        assert all(not isinstance(e, ObserverAlert) for e in filtered)
+
+    @pytest.mark.asyncio
+    async def test_includes_compaction_summary(self) -> None:
+        policy = ConversationPolicy()
+        summary = CompactionSummary(summary="Earlier context...", event_count=50)
+        events = [summary, ModelRequest([TextInput("hello")])]
+        ctx = Context(stream=MemoryStream())
+        _, filtered = await policy.apply([], events, ctx)
+        assert summary in filtered
+
+
+# NOTE: TestNetworkPolicy (V2 NetworkPolicy + FormattedEvent wrapping of
+# DelegationResult / SchedulerTriggerFired / TopicMessage) was removed with
+# the V2 rewrite. V3 will reintroduce equivalent assembly glue in Phase 2 /
+# Phase 4 when network Tasks and the multi-participant session types land.
+
+
+class TestSlidingWindowPolicy:
+    @pytest.mark.asyncio
+    async def test_no_trim_below_max(self) -> None:
+        policy = SlidingWindowPolicy(max_events=10)
+        events = [ModelRequest([TextInput(f"msg-{i}")]) for i in range(5)]
+        ctx = Context(stream=MemoryStream())
+        prompts, filtered = await policy.apply([], events, ctx)
+        assert len(filtered) == 5
+        assert prompts == []
+
+    @pytest.mark.asyncio
+    async def test_trims_to_max(self) -> None:
+        policy = SlidingWindowPolicy(max_events=3)
+        events = [ModelRequest([TextInput(f"msg-{i}")]) for i in range(10)]
+        ctx = Context(stream=MemoryStream())
+        _, filtered = await policy.apply([], events, ctx)
+        assert len(filtered) == 3
+        assert filtered[0].inputs[0].content == "msg-7"
+
+    @pytest.mark.asyncio
+    async def test_transparent_adds_note(self) -> None:
+        policy = SlidingWindowPolicy(max_events=3, transparent=True)
+        events = [ModelRequest([TextInput(f"msg-{i}")]) for i in range(10)]
+        ctx = Context(stream=MemoryStream())
+        prompts, _ = await policy.apply([], events, ctx)
+        assert len(prompts) == 1
+        assert "3 of 10" in prompts[0]
+
+
+class TestTokenBudgetPolicy:
+    @pytest.mark.asyncio
+    async def test_no_trim_within_budget(self) -> None:
+        policy = TokenBudgetPolicy(max_tokens=10000)
+        events = [ModelRequest([TextInput("short")])]
+        ctx = Context(stream=MemoryStream())
+        _, filtered = await policy.apply([], events, ctx)
+        assert len(filtered) == 1
+
+    @pytest.mark.asyncio
+    async def test_trims_to_budget(self) -> None:
+        policy = TokenBudgetPolicy(max_tokens=10, chars_per_token=1)
+        events = [ModelRequest([TextInput("a" * 20)]), ModelRequest([TextInput("b" * 5)])]
+        ctx = Context(stream=MemoryStream())
+        _, filtered = await policy.apply([], events, ctx)
+        # Should keep at least the last event that fits
+        assert len(filtered) >= 1
+        assert filtered[-1].inputs[0].content == "b" * 5
+
+
+class TestAssemblerMiddleware:
+    @pytest.mark.asyncio
+    async def test_applies_policies_in_order(self) -> None:
+        stream = MemoryStream()
+        ctx = Context(stream=stream)
+        initial_event = ModelRequest([TextInput("start")])
+
+        policy = ConversationPolicy()
+        mw = AssemblerMiddleware(initial_event, ctx, policies=[policy])
+
+        all_events = [
+            ModelRequest([TextInput("hello")]),
+            ModelResponse(message=ModelMessage(content="hi")),
+            ObserverAlert(source="mon", severity=Severity.WARNING, message="warn"),
+        ]
+
+        received_events = None
+
+        async def mock_llm_call(events, context):
+            nonlocal received_events
+            received_events = list(events)
+            return ModelResponse(message=ModelMessage(content="response"))
+
+        await mw.on_llm_call(mock_llm_call, all_events, ctx)
+
+        assert received_events is not None
+        assert len(received_events) == 2
+        assert all(not isinstance(e, ObserverAlert) for e in received_events)
+
+    @pytest.mark.asyncio
+    async def test_restores_prompts_after_call(self) -> None:
+        stream = MemoryStream()
+        ctx = Context(stream=stream, prompt=["original"])
+        initial_event = ModelRequest([TextInput("start")])
+
+        class _PromptAdder:
+            name = "adder"
+
+            async def apply(self, prompts, events, context):
+                return prompts + ["injected"], events
+
+        mw = AssemblerMiddleware(initial_event, ctx, policies=[_PromptAdder()])
+
+        async def mock_llm_call(events, context):
+            assert "injected" in context.prompt
+            return ModelResponse(message=ModelMessage(content="ok"))
+
+        await mw.on_llm_call(mock_llm_call, [ModelRequest([TextInput("hi")])], ctx)
+        assert ctx.prompt == ["original"]
+
+    def test_validate_order_warns_on_bad_ordering(self) -> None:
+        class _FakePolicy:
+            def __init__(self, n):
+                self.name = n
+
+            async def apply(self, p, e, c):
+                return p, e
+
+        policies = [_FakePolicy("sliding_window"), _FakePolicy("episodic_memory")]
+        warnings = AssemblerMiddleware.validate_order(policies)
+        assert len(warnings) == 1
+        assert "sliding_window" in warnings[0]
+
+    def test_validate_order_no_warnings_for_correct_order(self) -> None:
+        class _FakePolicy:
+            def __init__(self, n):
+                self.name = n
+
+            async def apply(self, p, e, c):
+                return p, e
+
+        policies = [_FakePolicy("episodic_memory"), _FakePolicy("sliding_window")]
+        warnings = AssemblerMiddleware.validate_order(policies)
+        assert len(warnings) == 0
+
+    @pytest.mark.asyncio
+    async def test_restores_prompts_on_exception(self) -> None:
+        stream = MemoryStream()
+        ctx = Context(stream=stream, prompt=["original"])
+        initial_event = ModelRequest([TextInput("start")])
+
+        class _PromptAdder:
+            name = "adder"
+
+            async def apply(self, prompts, events, context):
+                return prompts + ["injected"], events
+
+        mw = AssemblerMiddleware(initial_event, ctx, policies=[_PromptAdder()])
+
+        async def failing_llm_call(events, context):
+            raise RuntimeError("LLM failed")
+
+        with pytest.raises(RuntimeError):
+            await mw.on_llm_call(failing_llm_call, [ModelRequest([TextInput("hi")])], ctx)
+
+        # Prompts must be restored even after exception
+        assert ctx.prompt == ["original"]
+
+
+class TestEpisodicMemoryPolicy:
+    @pytest.mark.asyncio
+    async def test_injects_summaries_from_store(self) -> None:
+        store = MemoryKnowledgeStore()
+        await store.write("/memory/conversations/20260101T120000_abc.md", "Summary of session 1.")
+        await store.write("/memory/conversations/20260102T120000_def.md", "Summary of session 2.")
+
+        policy = EpisodicMemoryPolicy(max_episodes=5)
+        ctx = Context(stream=MemoryStream())
+        ctx.dependencies[KnowledgeStore] = store
+
+        prompts, events = await policy.apply([], [ModelRequest([TextInput("hi")])], ctx)
+        assert any("Past Conversations" in p for p in prompts)
+        assert any("Summary of session 1" in p for p in prompts)
+        assert any("Summary of session 2" in p for p in prompts)
+
+    @pytest.mark.asyncio
+    async def test_limits_to_max_episodes(self) -> None:
+        store = MemoryKnowledgeStore()
+        for i in range(10):
+            await store.write(f"/memory/conversations/2026010{i}T120000_s{i}.md", f"Summary {i}")
+
+        policy = EpisodicMemoryPolicy(max_episodes=3)
+        ctx = Context(stream=MemoryStream())
+        ctx.dependencies[KnowledgeStore] = store
+
+        prompts, _ = await policy.apply([], [ModelRequest([TextInput("hi")])], ctx)
+        # Should have the last 3 (most recent by sorted name)
+        combined = " ".join(prompts)
+        assert "Summary 7" in combined
+        assert "Summary 8" in combined
+        assert "Summary 9" in combined
+        assert "Summary 0" not in combined
+
+    @pytest.mark.asyncio
+    async def test_no_op_without_store(self) -> None:
+        policy = EpisodicMemoryPolicy()
+        ctx = Context(stream=MemoryStream())
+        prompts, events = await policy.apply(["existing"], [ModelRequest([TextInput("hi")])], ctx)
+        assert prompts == ["existing"]
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_no_summaries(self) -> None:
+        store = MemoryKnowledgeStore()
+        policy = EpisodicMemoryPolicy()
+        ctx = Context(stream=MemoryStream())
+        ctx.dependencies[KnowledgeStore] = store
+        prompts, _ = await policy.apply([], [ModelRequest([TextInput("hi")])], ctx)
+        assert prompts == []
+
+
+class TestWorkingMemoryPolicy:
+    @pytest.mark.asyncio
+    async def test_injects_working_memory(self) -> None:
+        store = MemoryKnowledgeStore()
+        await store.write("/memory/working.md", "Current state: working on project X.")
+
+        policy = WorkingMemoryPolicy()
+        ctx = Context(stream=MemoryStream())
+        ctx.dependencies[KnowledgeStore] = store
+
+        prompts, _ = await policy.apply([], [ModelRequest([TextInput("hi")])], ctx)
+        assert any("Working Memory" in p for p in prompts)
+        assert any("project X" in p for p in prompts)
+
+    @pytest.mark.asyncio
+    async def test_no_op_without_store(self) -> None:
+        policy = WorkingMemoryPolicy()
+        ctx = Context(stream=MemoryStream())
+        prompts, _ = await policy.apply([], [ModelRequest([TextInput("hi")])], ctx)
+        assert prompts == []
+
+    @pytest.mark.asyncio
+    async def test_no_op_without_working_memory_file(self) -> None:
+        store = MemoryKnowledgeStore()
+        policy = WorkingMemoryPolicy()
+        ctx = Context(stream=MemoryStream())
+        ctx.dependencies[KnowledgeStore] = store
+        prompts, _ = await policy.apply([], [ModelRequest([TextInput("hi")])], ctx)
+        assert prompts == []
+
+
+# NOTE: TestTopicInboxPolicy removed — TopicInboxPolicy was V2-network-specific.
+# Equivalent SessionInboxPolicy coverage lives with the V3 network tests.

--- a/test/beta/framework/test_assembly.py
+++ b/test/beta/framework/test_assembly.py
@@ -6,7 +6,7 @@
 
 import pytest
 
-from autogen.beta import AssemblerMiddleware
+from autogen.beta.assembly import AssemblerMiddleware
 from autogen.beta.compact import CompactionSummary
 from autogen.beta.context import ConversationContext as Context
 from autogen.beta.events import ModelMessage, ModelRequest, ModelResponse, TextInput

--- a/test/beta/framework/test_compact.py
+++ b/test/beta/framework/test_compact.py
@@ -29,7 +29,7 @@ class TestTailWindowCompact:
         ctx = Context(stream=MemoryStream())
         result = await compact.compact(events, ctx, None)
         assert len(result) == 3
-        assert result[0].inputs[0].content == "msg-7"
+        assert result[0].parts[0].content == "msg-7"
 
     @pytest.mark.asyncio
     async def test_persists_dropped_to_store(self) -> None:

--- a/test/beta/framework/test_compact.py
+++ b/test/beta/framework/test_compact.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for CompactStrategy, CompactTrigger, and built-in strategies."""
+
+import pytest
+
+from autogen.beta.compact import CompactTrigger, CompactionSummary, TailWindowCompact
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import ModelRequest, TextInput
+from autogen.beta.knowledge import MemoryKnowledgeStore
+from autogen.beta.stream import MemoryStream
+
+
+class TestTailWindowCompact:
+    @pytest.mark.asyncio
+    async def test_no_op_below_target(self) -> None:
+        compact = TailWindowCompact(target=10)
+        events = [ModelRequest([TextInput(f"msg-{i}")]) for i in range(5)]
+        ctx = Context(stream=MemoryStream())
+        result = await compact.compact(events, ctx, None)
+        assert len(result) == 5
+
+    @pytest.mark.asyncio
+    async def test_truncates_above_target(self) -> None:
+        compact = TailWindowCompact(target=3)
+        events = [ModelRequest([TextInput(f"msg-{i}")]) for i in range(10)]
+        ctx = Context(stream=MemoryStream())
+        result = await compact.compact(events, ctx, None)
+        assert len(result) == 3
+        assert result[0].inputs[0].content == "msg-7"
+
+    @pytest.mark.asyncio
+    async def test_persists_dropped_to_store(self) -> None:
+        store = MemoryKnowledgeStore()
+        compact = TailWindowCompact(target=3)
+        events = [ModelRequest([TextInput(f"msg-{i}")]) for i in range(10)]
+        stream = MemoryStream()
+        ctx = Context(stream=stream)
+        result = await compact.compact(events, ctx, store)
+        assert len(result) == 3
+
+        # Check that dropped events were persisted
+        entries = await store.list("/log/")
+        dropped = [e for e in entries if "dropped" in e]
+        assert len(dropped) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_persist_without_store(self) -> None:
+        compact = TailWindowCompact(target=3)
+        events = [ModelRequest([TextInput(f"msg-{i}")]) for i in range(10)]
+        ctx = Context(stream=MemoryStream())
+        result = await compact.compact(events, ctx, None)
+        assert len(result) == 3
+
+
+class TestCompactionSummary:
+    def test_is_base_event(self) -> None:
+        summary = CompactionSummary(summary="Earlier work...", event_count=50)
+        assert summary.summary == "Earlier work..."
+        assert summary.event_count == 50
+
+
+class TestCompactTrigger:
+    def test_defaults(self) -> None:
+        trigger = CompactTrigger()
+        assert trigger.max_events == 0
+        assert trigger.max_tokens == 0
+        assert trigger.chars_per_token == 4
+
+    def test_custom_values(self) -> None:
+        trigger = CompactTrigger(max_events=100, max_tokens=50000)
+        assert trigger.max_events == 100
+        assert trigger.max_tokens == 50000

--- a/test/beta/policies/__init__.py
+++ b/test/beta/policies/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/beta/policies/conftest.py
+++ b/test/beta/policies/conftest.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from autogen.beta.context import ConversationContext as Context
+
+
+@pytest.fixture
+def context() -> Context:
+    return Context(stream=MagicMock())

--- a/test/beta/policies/test_sliding_window.py
+++ b/test/beta/policies/test_sliding_window.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from autogen.beta import ToolResult
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import (
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    ToolCallEvent,
+    ToolCallsEvent,
+    ToolResultEvent,
+    ToolResultsEvent,
+)
+from autogen.beta.policies.sliding_window import SlidingWindowPolicy
+
+
+def _tool_response(call_id: str = "tc_1", name: str = "get") -> ModelResponse:
+    return ModelResponse(
+        message=None,
+        tool_calls=ToolCallsEvent(calls=[ToolCallEvent(id=call_id, name=name, arguments="{}")]),
+    )
+
+
+def _tool_results(parent_id: str = "tc_1", name: str = "get") -> ToolResultsEvent:
+    return ToolResultsEvent(
+        results=[ToolResultEvent(parent_id=parent_id, name=name, result=ToolResult(content="ok"))],
+    )
+
+
+class TestNoTrimming:
+    @pytest.mark.asyncio
+    async def test_events_within_limit_are_unchanged(self, context: Context) -> None:
+        events = [ModelRequest([TextInput("a")]), ModelRequest([TextInput("b")])]
+        policy = SlidingWindowPolicy(max_events=5)
+
+        prompts, result = await policy.apply([], events, context)
+
+        assert result == events
+        assert prompts == []
+
+    @pytest.mark.asyncio
+    async def test_events_at_exact_limit(self, context: Context) -> None:
+        events = [ModelRequest([TextInput("a")]), ModelRequest([TextInput("b")])]
+        policy = SlidingWindowPolicy(max_events=2)
+
+        _, result = await policy.apply([], events, context)
+
+        assert result == events
+
+
+class TestTrimming:
+    @pytest.mark.asyncio
+    async def test_keeps_last_n_events(self, context: Context) -> None:
+        events = [ModelRequest([TextInput(str(i))]) for i in range(5)]
+        policy = SlidingWindowPolicy(max_events=2)
+
+        _, result = await policy.apply([], events, context)
+
+        assert len(result) == 2
+        assert result[0].inputs[0].content == "3"
+        assert result[1].inputs[0].content == "4"
+
+    @pytest.mark.asyncio
+    async def test_transparent_adds_prompt(self, context: Context) -> None:
+        events = [ModelRequest([TextInput(str(i))]) for i in range(5)]
+        policy = SlidingWindowPolicy(max_events=2, transparent=True)
+
+        prompts, result = await policy.apply(["existing"], events, context)
+
+        assert len(result) == 2
+        assert len(prompts) == 2
+        assert prompts[0] == "existing"
+        assert "2" in prompts[1] and "5" in prompts[1]
+
+
+class TestOrphanedToolResults:
+    """After trimming, leading ToolResultsEvents without a matching tool_use should be dropped."""
+
+    @pytest.mark.asyncio
+    async def test_leading_orphaned_tool_result_is_skipped(self, context: Context) -> None:
+        events = [
+            _tool_response("tc_1"),  # will be trimmed
+            _tool_results("tc_1"),  # orphaned after trim — should be skipped
+            ModelRequest([TextInput("next")]),
+            ModelRequest([TextInput("final")]),
+        ]
+        policy = SlidingWindowPolicy(max_events=3)
+
+        _, result = await policy.apply([], events, context)
+
+        # The ToolResultsEvent should be dropped, leaving 2 events
+        assert len(result) == 2
+        assert isinstance(result[0], ModelRequest)
+        assert result[0].inputs[0].content == "next"
+
+    @pytest.mark.asyncio
+    async def test_multiple_leading_orphaned_tool_results_are_skipped(self, context: Context) -> None:
+        events = [
+            _tool_response("tc_1"),
+            _tool_response("tc_2"),
+            _tool_results("tc_1"),
+            _tool_results("tc_2"),
+            ModelRequest([TextInput("hello")]),
+        ]
+        policy = SlidingWindowPolicy(max_events=3)
+
+        _, result = await policy.apply([], events, context)
+
+        # Both orphaned ToolResultsEvents should be dropped
+        assert len(result) == 1
+        assert isinstance(result[0], ModelRequest)
+
+    @pytest.mark.asyncio
+    async def test_non_leading_tool_result_is_kept(self, context: Context) -> None:
+        """ToolResultsEvent after a non-ToolResultsEvent should be preserved."""
+        events = [
+            ModelRequest([TextInput("old")]),
+            _tool_response("tc_1"),
+            _tool_results("tc_1"),
+            ModelRequest([TextInput("new")]),
+        ]
+        policy = SlidingWindowPolicy(max_events=3)
+
+        _, result = await policy.apply([], events, context)
+
+        # trim keeps last 3: [tool_response, tool_results, request]
+        assert len(result) == 3
+        assert isinstance(result[0], ModelResponse)
+        assert isinstance(result[1], ToolResultsEvent)
+        assert isinstance(result[2], ModelRequest)
+
+    @pytest.mark.asyncio
+    async def test_transparent_count_reflects_skipped_orphans(self, context: Context) -> None:
+        events = [
+            _tool_response("tc_1"),
+            _tool_results("tc_1"),
+            ModelRequest([TextInput("a")]),
+            ModelRequest([TextInput("b")]),
+        ]
+        policy = SlidingWindowPolicy(max_events=3, transparent=True)
+
+        prompts, result = await policy.apply([], events, context)
+
+        assert len(result) == 2
+        # Prompt should reflect actual count after orphan removal
+        assert "2" in prompts[-1] and "4" in prompts[-1]

--- a/test/beta/policies/test_sliding_window.py
+++ b/test/beta/policies/test_sliding_window.py
@@ -27,7 +27,7 @@ def _tool_response(call_id: str = "tc_1", name: str = "get") -> ModelResponse:
 
 def _tool_results(parent_id: str = "tc_1", name: str = "get") -> ToolResultsEvent:
     return ToolResultsEvent(
-        results=[ToolResultEvent(parent_id=parent_id, name=name, result=ToolResult(content="ok"))],
+        results=[ToolResultEvent(parent_id=parent_id, name=name, result=ToolResult("ok"))],
     )
 
 
@@ -61,8 +61,8 @@ class TestTrimming:
         _, result = await policy.apply([], events, context)
 
         assert len(result) == 2
-        assert result[0].inputs[0].content == "3"
-        assert result[1].inputs[0].content == "4"
+        assert result[0].parts[0].content == "3"
+        assert result[1].parts[0].content == "4"
 
     @pytest.mark.asyncio
     async def test_transparent_adds_prompt(self, context: Context) -> None:
@@ -95,7 +95,7 @@ class TestOrphanedToolResults:
         # The ToolResultsEvent should be dropped, leaving 2 events
         assert len(result) == 2
         assert isinstance(result[0], ModelRequest)
-        assert result[0].inputs[0].content == "next"
+        assert result[0].parts[0].content == "next"
 
     @pytest.mark.asyncio
     async def test_multiple_leading_orphaned_tool_results_are_skipped(self, context: Context) -> None:

--- a/test/beta/policies/test_token_budget.py
+++ b/test/beta/policies/test_token_budget.py
@@ -27,7 +27,7 @@ def _tool_response(call_id: str = "tc_1", name: str = "get") -> ModelResponse:
 
 def _tool_results(parent_id: str = "tc_1", name: str = "get") -> ToolResultsEvent:
     return ToolResultsEvent(
-        results=[ToolResultEvent(parent_id=parent_id, name=name, result=ToolResult(content="ok"))],
+        results=[ToolResultEvent(parent_id=parent_id, name=name, result=ToolResult("ok"))],
     )
 
 
@@ -54,7 +54,7 @@ class TestTrimming:
 
         _, result = await policy.apply([], events, context)
 
-        assert result[-1].inputs[0].content == "z"
+        assert result[-1].parts[0].content == "z"
 
     @pytest.mark.asyncio
     async def test_transparent_adds_prompt(self, context: Context) -> None:

--- a/test/beta/policies/test_token_budget.py
+++ b/test/beta/policies/test_token_budget.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from autogen.beta import ToolResult
+from autogen.beta.context import ConversationContext as Context
+from autogen.beta.events import (
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    ToolCallEvent,
+    ToolCallsEvent,
+    ToolResultEvent,
+    ToolResultsEvent,
+)
+from autogen.beta.policies.token_budget import TokenBudgetPolicy
+
+
+def _tool_response(call_id: str = "tc_1", name: str = "get") -> ModelResponse:
+    return ModelResponse(
+        message=None,
+        tool_calls=ToolCallsEvent(calls=[ToolCallEvent(id=call_id, name=name, arguments="{}")]),
+    )
+
+
+def _tool_results(parent_id: str = "tc_1", name: str = "get") -> ToolResultsEvent:
+    return ToolResultsEvent(
+        results=[ToolResultEvent(parent_id=parent_id, name=name, result=ToolResult(content="ok"))],
+    )
+
+
+class TestNoTrimming:
+    @pytest.mark.asyncio
+    async def test_events_within_budget_are_unchanged(self, context: Context) -> None:
+        events = [ModelRequest([TextInput("hi")])]
+        policy = TokenBudgetPolicy(max_tokens=100_000)
+
+        prompts, result = await policy.apply([], events, context)
+
+        assert result == events
+        assert prompts == []
+
+
+class TestTrimming:
+    @pytest.mark.asyncio
+    async def test_retains_most_recent_events(self, context: Context) -> None:
+        # Use a very tight budget so only the last event fits
+        last = ModelRequest([TextInput("z")])
+        events = [ModelRequest([TextInput("a" * 200)]), last]
+        budget_tokens = (len(str(last)) // 4) + 1
+        policy = TokenBudgetPolicy(max_tokens=budget_tokens)
+
+        _, result = await policy.apply([], events, context)
+
+        assert result[-1].inputs[0].content == "z"
+
+    @pytest.mark.asyncio
+    async def test_transparent_adds_prompt(self, context: Context) -> None:
+        events = [ModelRequest([TextInput("a" * 200)]), ModelRequest([TextInput("b")])]
+        budget_tokens = (len(str(events[-1])) // 4) + 1
+        policy = TokenBudgetPolicy(max_tokens=budget_tokens, transparent=True)
+
+        prompts, _ = await policy.apply(["existing"], events, context)
+
+        assert len(prompts) == 2
+        assert prompts[0] == "existing"
+        assert "token budget" in prompts[1]
+
+
+class TestOrphanedToolResults:
+    """After budget trimming, leading ToolResultsEvents without a matching tool_use should be dropped."""
+
+    @pytest.mark.asyncio
+    async def test_leading_orphaned_tool_result_is_skipped(self, context: Context) -> None:
+        tool_result = _tool_results("tc_1")
+        request = ModelRequest([TextInput("next")])
+        # Budget enough for tool_result + request but NOT for the preceding tool_response
+        events = [
+            ModelRequest([TextInput("a" * 5000)]),
+            _tool_response("tc_1"),
+            tool_result,
+            request,
+        ]
+        # Tight budget: fits tool_result + request but not the big first event and tool_response
+        budget_chars = len(str(tool_result)) + len(str(request)) + 10
+        policy = TokenBudgetPolicy(max_tokens=budget_chars // 4 + 1)
+
+        _, result = await policy.apply([], events, context)
+
+        # The orphaned leading ToolResultsEvent should be dropped
+        for event in result:
+            if isinstance(event, ToolResultsEvent):
+                # If a ToolResultsEvent survived, it must not be the first element
+                assert result[0] is not event
+
+    @pytest.mark.asyncio
+    async def test_multiple_leading_orphaned_tool_results_are_skipped(self, context: Context) -> None:
+        tr1 = _tool_results("tc_1")
+        tr2 = _tool_results("tc_2")
+        request = ModelRequest([TextInput("hello")])
+        events = [
+            ModelRequest([TextInput("a" * 5000)]),
+            _tool_response("tc_1"),
+            _tool_response("tc_2"),
+            tr1,
+            tr2,
+            request,
+        ]
+        budget_chars = len(str(tr1)) + len(str(tr2)) + len(str(request)) + 10
+        policy = TokenBudgetPolicy(max_tokens=budget_chars // 4 + 1)
+
+        _, result = await policy.apply([], events, context)
+
+        # Both orphaned ToolResultsEvents should be dropped
+        assert not isinstance(result[0], ToolResultsEvent)
+
+    @pytest.mark.asyncio
+    async def test_transparent_count_reflects_skipped_orphans(self, context: Context) -> None:
+        tr = _tool_results("tc_1")
+        request = ModelRequest([TextInput("b")])
+        events = [
+            ModelRequest([TextInput("a" * 5000)]),
+            _tool_response("tc_1"),
+            tr,
+            request,
+        ]
+        budget_chars = len(str(tr)) + len(str(request)) + 10
+        policy = TokenBudgetPolicy(max_tokens=budget_chars // 4 + 1, transparent=True)
+
+        prompts, result = await policy.apply([], events, context)
+
+        # The prompt count should reflect that the orphan was removed
+        assert str(len(result)) in prompts[-1]

--- a/website/docs/beta/advanced/aggregation.mdx
+++ b/website/docs/beta/advanced/aggregation.mdx
@@ -1,0 +1,187 @@
+---
+title: Aggregation
+sidebarTitle: Aggregation
+---
+
+**Aggregation** extracts structured knowledge from raw events and writes it to the [KnowledgeStore](/docs/beta/advanced/knowledge_store). It is the knowledge-organizing counterpart to [Compaction](/docs/beta/advanced/compaction).
+
+> Compaction removes. Aggregation creates. They are separate concerns.
+
+Aggregation is how an agent builds up persistent state between conversations — the material that `WorkingMemoryPolicy` and `EpisodicMemoryPolicy` read back in on subsequent runs.
+
+## When to use it
+
+| You want the agent to | Use |
+|---|---|
+| Carry stable facts across conversations (user prefs, role, timezone) | `WorkingMemoryAggregate` + [`WorkingMemoryPolicy`](/docs/beta/advanced/assembly#workingmemorypolicy) |
+| Remember summaries of what happened in past sessions | `ConversationSummaryAggregate` + [`EpisodicMemoryPolicy`](/docs/beta/advanced/assembly#episodicmemorypolicy) |
+| Index artifacts for later retrieval | Write a custom strategy |
+
+Each built-in is one half of a producer/consumer pair: the aggregate writes a file, the assembly policy reads it back on the next turn.
+
+## AggregateStrategy protocol
+
+Every strategy implements the same shape:
+
+```python linenums="1"
+from typing import Protocol
+from autogen.beta import Context
+from autogen.beta.events import BaseEvent
+from autogen.beta.knowledge import KnowledgeStore
+
+
+class AggregateStrategy(Protocol):
+    async def aggregate(
+        self,
+        events: list[BaseEvent],
+        context: Context,
+        store: KnowledgeStore,
+    ) -> None:
+        ...
+```
+
+Aggregation returns nothing — its output lives in the knowledge store. Unlike `CompactStrategy`, the store is required (not optional).
+
+## AggregateTrigger
+
+A dataclass describing when aggregation should fire.
+
+```python linenums="1"
+from autogen.beta.aggregate import AggregateTrigger
+
+trigger = AggregateTrigger(
+    every_n_turns=10,      # aggregate every 10 LLM turns
+    every_n_events=100,    # aggregate every 100 new events
+    on_end=True,           # aggregate when the conversation ends (default)
+)
+```
+
+Each condition is independent. Setting a counter to `0` disables it. `AggregateTrigger()` with no arguments only fires `on_end`.
+
+Like `CompactTrigger`, this is a plain data object — it records when you want aggregation to fire, but does not fire it. Strategies are invoked explicitly via `#!python await strategy.aggregate(...)`.
+
+## Built-in strategies
+
+Both built-ins are importable from `#!python autogen.beta.aggregate` and both take a `#!python ModelConfig` for a summarization LLM call. Use a smaller / cheaper model than the agent's main model.
+
+### ConversationSummaryAggregate
+
+Writes a timestamped summary of the conversation to `/memory/conversations/`. The companion to [`EpisodicMemoryPolicy`](/docs/beta/advanced/assembly#episodicmemorypolicy), which reads from that directory.
+
+```python linenums="1" hl_lines="8-11"
+from autogen.beta.aggregate import ConversationSummaryAggregate
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.knowledge import MemoryKnowledgeStore
+
+store = MemoryKnowledgeStore()
+strategy = ConversationSummaryAggregate(config=OpenAIConfig(model="gpt-5-mini"))
+
+# After the conversation:
+await strategy.aggregate(events, ctx, store)
+
+# Produces a file like:
+# /memory/conversations/20260420T091530_<stream_id>.md
+```
+
+Filenames are `{ISO timestamp}_{stream id}.md`, so lexicographic sort matches chronological sort — which is why `EpisodicMemoryPolicy(max_episodes=N)` can simply take the trailing N entries.
+
+Token usage is recorded on the strategy instance as `#!python strategy.last_usage`.
+
+### WorkingMemoryAggregate
+
+Updates `/memory/working.md` — the actor's single persistent state document. Reads the existing file, merges in context from recent events, writes the updated version back. The companion to [`WorkingMemoryPolicy`](/docs/beta/advanced/assembly#workingmemorypolicy).
+
+```python linenums="1" hl_lines="6 9"
+from autogen.beta.aggregate import WorkingMemoryAggregate
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.knowledge import MemoryKnowledgeStore
+
+store = MemoryKnowledgeStore()
+strategy = WorkingMemoryAggregate(config=OpenAIConfig(model="gpt-5-mini"))
+
+# Refresh working memory at the end of a session:
+await strategy.aggregate(events, ctx, store)
+# /memory/working.md now reflects the latest context.
+```
+
+Unlike `ConversationSummaryAggregate`, this one is destructive toward its own prior output — each call overwrites `/memory/working.md` with the merged version. That is the point: working memory is a rolling single-file state, not an append log.
+
+## Pairing with assembly policies
+
+The intended pattern: aggregate at the end of a conversation (or on a cadence), then read back in on the next turn via the matching assembly policy.
+
+```mermaid
+flowchart LR
+    A[Conversation events] --> B[Aggregate]
+    B --> C[/KnowledgeStore/]
+    C --> D[Policy]
+    D --> E[Next LLM turn]
+```
+
+| Aggregate | File | Policy |
+|---|---|---|
+| `ConversationSummaryAggregate` | `/memory/conversations/{ts}_{id}.md` | [`EpisodicMemoryPolicy`](/docs/beta/advanced/assembly#episodicmemorypolicy) |
+| `WorkingMemoryAggregate` | `/memory/working.md` | [`WorkingMemoryPolicy`](/docs/beta/advanced/assembly#workingmemorypolicy) |
+
+The path constants (`WORKING_MEMORY_PATH`, `CONVERSATIONS_PREFIX`) are defined in `#!python autogen.beta.knowledge`. Both sides of each pair use those constants so the producer/consumer contract is held together by types, not magic strings.
+
+## Driving aggregation
+
+Pattern for invoking a strategy against an `AggregateTrigger`:
+
+```python linenums="1" hl_lines="10-14"
+from autogen.beta.aggregate import AggregateTrigger, ConversationSummaryAggregate
+from autogen.beta.config import OpenAIConfig
+
+trigger = AggregateTrigger(every_n_turns=10, on_end=True)
+strategy = ConversationSummaryAggregate(config=OpenAIConfig(model="gpt-5-mini"))
+
+_turn_count = 0
+
+async def after_turn(events, ctx, store, *, is_end: bool) -> None:
+    global _turn_count
+    _turn_count += 1
+    should = (
+        (trigger.every_n_turns and _turn_count % trigger.every_n_turns == 0)
+        or (is_end and trigger.on_end)
+    )
+    if should:
+        await strategy.aggregate(events, ctx, store)
+```
+
+## Writing a custom strategy
+
+Any object with an `async aggregate(events, ctx, store)` method satisfies the protocol. Use it to extract domain-specific knowledge:
+
+- **Extract facts.** Scan events for entity mentions, write `/memory/facts/{entity}.md`.
+- **Build an index.** On each aggregation, append a row to `/memory/index.jsonl` for later RAG lookup.
+- **Classify and tag.** Read events, ask the LLM for a category, store under `/memory/tags/{tag}/{timestamp}.md`.
+
+```python linenums="1"
+from autogen.beta.events import BaseEvent, ModelResponse
+from autogen.beta.knowledge import KnowledgeStore
+
+
+class ResponseLengthAggregate:
+    """Track the length of each model response for later analysis."""
+
+    async def aggregate(
+        self,
+        events: list[BaseEvent],
+        context,
+        store: KnowledgeStore,
+    ) -> None:
+        lengths = [
+            len(e.message.content)
+            for e in events
+            if isinstance(e, ModelResponse) and e.message
+        ]
+        if not lengths:
+            return
+        stream_id = context.stream.id
+        path = f"/memory/metrics/{stream_id}.txt"
+        await store.write(path, "\n".join(str(n) for n in lengths))
+```
+
+!!! tip
+    Aggregation strategies and assembly policies often come in pairs: the strategy writes a path, the policy reads that same path. If you add a new aggregate, consider also adding the reader policy — otherwise the data sits on disk with no way back into the prompt.

--- a/website/docs/beta/advanced/aggregation.mdx
+++ b/website/docs/beta/advanced/aggregation.mdx
@@ -52,11 +52,11 @@ from autogen.beta.aggregate import AggregateTrigger
 trigger = AggregateTrigger(
     every_n_turns=10,      # aggregate every 10 LLM turns
     every_n_events=100,    # aggregate every 100 new events
-    on_end=True,           # aggregate when the conversation ends (default)
+    on_end=True,           # aggregate when the conversation ends
 )
 ```
 
-Each condition is independent. Setting a counter to `0` disables it. `AggregateTrigger()` with no arguments only fires `on_end`.
+Each condition is independent. Setting a counter to `0` disables it. `AggregateTrigger()` with no arguments fires nothing — every condition is opt-in. `on_end` defaults to `False` because each strategy costs one LLM call per fire, and a typical setup pairs `ConversationSummaryAggregate` with `WorkingMemoryAggregate` (so `on_end=True` doubles the per-conversation cost).
 
 Like `CompactTrigger`, this is a plain data object — it records when you want aggregation to fire, but does not fire it. Strategies are invoked explicitly via `#!python await strategy.aggregate(...)`.
 

--- a/website/docs/beta/advanced/assembly.mdx
+++ b/website/docs/beta/advanced/assembly.mdx
@@ -1,0 +1,245 @@
+---
+title: Assembly
+sidebarTitle: Assembly
+---
+
+**Assembly** is the step that shapes what the LLM actually sees on each turn. An `AssemblerMiddleware` runs an ordered chain of `AssemblyPolicy` instances, each one transforming `(prompts, events)` before they reach the model.
+
+Use it to inject persistent context (working memory, past conversations, observer alerts) and to cap the history footprint (sliding window, token budget) — without touching the event stream itself.
+
+## Why assembly
+
+Everything that happens during an agent's run — model requests/responses, tool calls, observer alerts, lifecycle events — lands on the [Stream](/docs/beta/advanced/stream). But not all of that is useful to send to the next LLM call, and some useful context (e.g. a summary of a prior conversation) lives outside the stream entirely.
+
+Assembly is the seam where you:
+
+- **Inject** information from the [KnowledgeStore](/docs/beta/advanced/knowledge_store) or from [Observer alerts](/docs/beta/advanced/observers) into the prompt.
+- **Filter** the event list down to what the model should see.
+- **Reduce** the history to fit a window or token budget.
+
+Each of those jobs is an `AssemblyPolicy`. The `AssemblerMiddleware` chains them.
+
+## AssemblyPolicy protocol
+
+Every policy implements the same shape:
+
+```python linenums="1"
+from typing import Protocol
+from autogen.beta import Context
+from autogen.beta.events import BaseEvent
+
+class AssemblyPolicy(Protocol):
+    name: str
+
+    async def apply(
+        self,
+        prompts: list[str],
+        events: list[BaseEvent],
+        context: Context,
+    ) -> tuple[list[str], list[BaseEvent]]:
+        ...
+```
+
+A policy receives the current `prompts` and `events`, returns modified copies. Policies compose left-to-right: each one sees the output of the previous. They must be pure — side-effect-free, idempotent where possible, and they must not emit events onto the stream (with one exception: `AlertPolicy` emits `HaltEvent` on FATAL, documented below).
+
+## AssemblerMiddleware
+
+Wire the chain onto an Agent by constructing an `AssemblerMiddleware` with your policy list:
+
+```python linenums="1" hl_lines="11-15"
+from autogen.beta import (
+    Agent,
+    AssemblerMiddleware,
+    AlertPolicy,
+    WorkingMemoryPolicy,
+    SlidingWindowPolicy,
+)
+from autogen.beta.config import OpenAIConfig
+
+agent = Agent(
+    "assistant",
+    config=OpenAIConfig(model="gpt-5"),
+    middleware=[
+        lambda event, ctx: AssemblerMiddleware(
+            event,
+            ctx,
+            policies=[
+                WorkingMemoryPolicy(),
+                AlertPolicy(),
+                SlidingWindowPolicy(max_events=50),
+            ],
+        ),
+    ],
+)
+```
+
+`AssemblerMiddleware` sits at the outermost position in the middleware chain, before any user-provided middleware or the LLM client itself. Inside each turn it:
+
+1. Builds the `prompts` / `events` pair from the current context.
+2. Runs every policy in order, piping the output of each into the next.
+3. Temporarily swaps `context.prompt` for the assembled version while the LLM call runs.
+4. Restores the original prompt afterward.
+
+## Ordering matters
+
+Assembly policies split into two kinds:
+
+| Kind | Purpose | Examples |
+|---|---|---|
+| **Injection** | Add context to `prompts` | `AlertPolicy`, `WorkingMemoryPolicy`, `EpisodicMemoryPolicy` |
+| **Reduction** | Trim `events` | `SlidingWindowPolicy`, `TokenBudgetPolicy`, `ConversationPolicy` |
+
+The rule: **injection before reduction**. If a reducer runs first, the injections it should have included in its budget don't exist yet.
+
+`AssemblerMiddleware.validate_order()` catches known bad orderings and returns a list of warnings:
+
+```python linenums="1" hl_lines="6-9"
+from autogen.beta import AssemblerMiddleware, AlertPolicy, SlidingWindowPolicy
+
+policies = [
+    SlidingWindowPolicy(max_events=20),  # reduction first — wrong
+    AlertPolicy(),
+]
+warnings = AssemblerMiddleware.validate_order(policies)
+for w in warnings:
+    print(w)
+```
+
+## Built-in policies
+
+All six built-ins are importable from `#!python autogen.beta`.
+
+### ConversationPolicy
+
+Keeps only conversation and tool events (`ModelRequest`, `ModelResponse`, `ToolCallEvent`, `ToolResultEvent`, `ToolResultsEvent`, `ToolErrorEvent`, plus `CompactionSummary`). Drops alerts, lifecycle events, observer output — anything the LLM does not need to see.
+
+```python linenums="1"
+from autogen.beta import ConversationPolicy
+
+policy = ConversationPolicy()
+```
+
+Takes no arguments. Effectively an allowlist — add a new event type to the stream and it is filtered out by default.
+
+### SlidingWindowPolicy
+
+Keeps only the last `max_events` events. Skips leading orphaned `ToolResultsEvent` entries so the window never starts on an unmatched tool result.
+
+```python linenums="1"
+from autogen.beta import SlidingWindowPolicy
+
+policy = SlidingWindowPolicy(max_events=50, transparent=True)
+```
+
+Set `transparent=True` to append a prompt note like `"[sliding_window] Showing last 50 of 123 events."` — useful while tuning.
+
+### TokenBudgetPolicy
+
+Keeps the newest events that fit in an estimated token budget. Estimation is `#!python len(str(event)) / chars_per_token` — cheap, not perfectly accurate. Use it as a safety net, not an exact meter.
+
+```python linenums="1"
+from autogen.beta import TokenBudgetPolicy
+
+policy = TokenBudgetPolicy(max_tokens=32_000, chars_per_token=4, transparent=True)
+```
+
+### AlertPolicy
+
+Delivers [ObserverAlerts](/docs/beta/advanced/observers) to the model. Each new alert is formatted into the prompt once (deduplicated on `(source, severity, message)`), and **FATAL** alerts additionally emit a `HaltEvent` onto the stream so the surrounding loop can short-circuit.
+
+```python linenums="1"
+from autogen.beta import AlertPolicy
+
+policy = AlertPolicy()
+```
+
+Takes no arguments. Dedup state lives on the instance — give each Agent its own `AlertPolicy`.
+
+!!! note
+    `AlertPolicy` is what bridges the [Observer](/docs/beta/advanced/observers) system into the LLM. Without it, `ObserverAlert` events sit on the stream but never reach the model. Place it after other injection policies and before reduction policies.
+
+### WorkingMemoryPolicy
+
+Reads `/memory/working.md` from the [KnowledgeStore](/docs/beta/advanced/knowledge_store) and injects it into the prompt. Working memory is the actor's persistent state — written between conversations by an aggregation strategy and read on every turn.
+
+```python linenums="1" hl_lines="7-12"
+from autogen.beta import AssemblerMiddleware, WorkingMemoryPolicy
+from autogen.beta.knowledge import KnowledgeStore, MemoryKnowledgeStore
+
+store = MemoryKnowledgeStore()
+await store.write("/memory/working.md", "- user prefers metric\n- timezone: Australia/Melbourne")
+
+agent = Agent(
+    "assistant",
+    config=config,
+    dependencies={KnowledgeStore: store},
+    middleware=[lambda e, c: AssemblerMiddleware(e, c, policies=[WorkingMemoryPolicy()])],
+)
+```
+
+The policy looks up the store by type (`#!python context.dependencies.get(KnowledgeStore)`) — if no store is registered, it's a no-op.
+
+### EpisodicMemoryPolicy
+
+Reads the most recent summaries under `/memory/conversations/` and injects them. The companion reader for `ConversationSummaryAggregate`, which writes timestamped summary files to that path after each conversation.
+
+```python linenums="1"
+from autogen.beta import EpisodicMemoryPolicy
+
+policy = EpisodicMemoryPolicy(max_episodes=5, transparent=True)
+```
+
+Also requires a `KnowledgeStore` in `#!python context.dependencies`; a no-op otherwise.
+
+## A realistic chain
+
+Typical production ordering — injections first, then `AlertPolicy`, then reduce:
+
+```python linenums="1" hl_lines="8-14"
+from autogen.beta import (
+    AssemblerMiddleware,
+    AlertPolicy,
+    EpisodicMemoryPolicy,
+    SlidingWindowPolicy,
+    WorkingMemoryPolicy,
+)
+
+policies = [
+    WorkingMemoryPolicy(),            # inject persistent state
+    EpisodicMemoryPolicy(max_episodes=3),  # inject past conversations
+    AlertPolicy(),                    # inject observer alerts
+    SlidingWindowPolicy(max_events=80),  # cap turn history
+]
+AssemblerMiddleware.validate_order(policies)  # returns [] — good order
+```
+
+## Writing a custom policy
+
+Any object with a `name` and an `async apply(...)` method satisfies the protocol. Use it for domain-specific injection (project docs, RAG hits, on-call runbooks) or custom filtering:
+
+```python linenums="1" hl_lines="7 9 15"
+from autogen.beta import Context
+from autogen.beta.events import BaseEvent
+
+
+class RunbookPolicy:
+    """Inject the on-call runbook as system context."""
+
+    name = "runbook"
+
+    def __init__(self, runbook: str) -> None:
+        self._runbook = runbook
+
+    async def apply(
+        self,
+        prompts: list[str],
+        events: list[BaseEvent],
+        context: Context,
+    ) -> tuple[list[str], list[BaseEvent]]:
+        return prompts + [f"## On-call Runbook\n\n{self._runbook}"], events
+```
+
+Drop it into the policy list alongside the built-ins.
+
+!!! tip
+    Custom policies are a better fit than [Middleware](/docs/beta/middleware) when you only need to shape the prompt or filter events — not to wrap the LLM call itself. Middleware is for retry, timeout, logging, rate limiting; policies are for context assembly.

--- a/website/docs/beta/advanced/compaction.mdx
+++ b/website/docs/beta/advanced/compaction.mdx
@@ -1,0 +1,172 @@
+---
+title: Compaction
+sidebarTitle: Compaction
+---
+
+**Compaction** reduces a stream's event history to respect runtime constraints — event count or token budget. It is the constraint-respecting counterpart to [Aggregation](/docs/beta/advanced/aggregation).
+
+> Compaction removes. Aggregation creates. They are separate concerns.
+
+## When to use it
+
+Long-running conversations accumulate events faster than the model's context window can absorb. Use compaction to cap the size of history that flows into the next LLM call.
+
+| Symptom | Use |
+|---|---|
+| History getting close to provider token limit | `TailWindowCompact` or `SummarizeCompact` |
+| Need to keep recent events and forget old ones cheaply | `TailWindowCompact` |
+| Want a short summary of old events to preserve context | `SummarizeCompact` |
+
+## CompactStrategy protocol
+
+Every strategy implements the same shape:
+
+```python linenums="1"
+from typing import Protocol
+from autogen.beta import Context
+from autogen.beta.events import BaseEvent
+from autogen.beta.knowledge import KnowledgeStore
+
+
+class CompactStrategy(Protocol):
+    async def compact(
+        self,
+        events: list[BaseEvent],
+        context: Context,
+        store: KnowledgeStore | None,
+    ) -> list[BaseEvent]:
+        ...
+```
+
+Returns a new event list that **replaces** the current history. Strategies must preserve the causal ordering of retained events — no reshuffling.
+
+## CompactTrigger
+
+A dataclass describing when compaction should fire. Any configured threshold that is exceeded triggers compaction.
+
+```python linenums="1"
+from autogen.beta.compact import CompactTrigger
+
+trigger = CompactTrigger(
+    max_events=200,           # fire when history exceeds 200 events
+    max_tokens=32_000,        # fire when estimated tokens exceed 32k
+    chars_per_token=4,        # estimation constant (default 4)
+)
+```
+
+Leaving a field at `0` disables that threshold. `CompactTrigger()` alone does nothing — you must opt into at least one condition.
+
+`CompactTrigger` is a plain data object — it records when you want compaction to fire, but does not fire it. Strategies are invoked explicitly via `#!python await strategy.compact(...)`.
+
+## Built-in strategies
+
+Both built-ins are importable from `#!python autogen.beta.compact`.
+
+### TailWindowCompact
+
+Keeps the last N events, drops the rest. Zero LLM cost. Suitable when old context has diminishing value and recency is what matters.
+
+```python linenums="1" hl_lines="6 9"
+from autogen.beta.compact import TailWindowCompact
+from autogen.beta.knowledge import MemoryKnowledgeStore
+
+store = MemoryKnowledgeStore()
+compact = TailWindowCompact(target=50)
+
+retained = await compact.compact(events, ctx, store)
+# retained is the last 50 events; older ones are dropped
+# (and persisted to /log/{stream_id}.dropped-{n}.jsonl if store is passed)
+```
+
+Passing a `KnowledgeStore` is optional. If provided, dropped events are persisted to `/log/` as a numbered segment — see the [KnowledgeStore docs](/docs/beta/advanced/knowledge_store) — so they can be replayed later via `EventLogWriter.load()`. If omitted, dropped events are discarded.
+
+### SummarizeCompact
+
+Summarizes the dropped portion via one LLM call, inserts a `CompactionSummary` event at the head of retained history. Use when you want to keep some sense of the old conversation instead of just forgetting it.
+
+```python linenums="1" hl_lines="8-12"
+from autogen.beta.compact import SummarizeCompact
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.knowledge import MemoryKnowledgeStore
+
+store = MemoryKnowledgeStore()
+compact = SummarizeCompact(
+    target=50,
+    config=OpenAIConfig(model="gpt-5-mini"),  # cheap model recommended for summaries
+)
+
+retained = await compact.compact(events, ctx, store)
+# retained[0] is a CompactionSummary event; retained[1:] are the last 50 originals
+```
+
+The summarization model is independent from the agent's main model — pick a smaller / cheaper one. Token usage is recorded on the strategy instance as `#!python strategy.last_usage`.
+
+## CompactionSummary
+
+The synthetic event inserted by `SummarizeCompact` at the head of history.
+
+```python linenums="1"
+from autogen.beta.compact import CompactionSummary
+
+summary = CompactionSummary(
+    summary="User asked about gardening and sourdough; decisions made about ...",
+    event_count=42,
+)
+```
+
+`CompactionSummary` is on the allowlist of [`ConversationPolicy`](/docs/beta/advanced/assembly#conversationpolicy), so it passes through the assembly chain and reaches the LLM as context — without requiring special handling elsewhere.
+
+## Driving compaction
+
+Pattern for invoking a strategy against a `CompactTrigger`:
+
+```python linenums="1" hl_lines="11-13"
+from autogen.beta.compact import CompactTrigger, TailWindowCompact
+
+trigger = CompactTrigger(max_events=200)
+compact = TailWindowCompact(target=100)
+
+async def after_turn(events, ctx, store):
+    """Call this after each LLM turn."""
+    should = (
+        trigger.max_events and len(events) > trigger.max_events
+    )
+    if should:
+        events = await compact.compact(events, ctx, store)
+    return events
+```
+
+For the token-based threshold, estimate with `#!python sum(len(str(e)) for e in events) / trigger.chars_per_token`.
+
+## Writing a custom strategy
+
+Any object with an `async compact(events, ctx, store)` method satisfies the protocol. A couple of ideas:
+
+- **Drop tool noise.** Keep `ModelRequest` / `ModelResponse`, drop `ToolCallEvent` / `ToolResultEvent` older than some boundary.
+- **Priority retention.** Score events (e.g. keep every `ModelResponse` but decimate `ToolCallEvent`s).
+- **Segmented summarization.** Run `SummarizeCompact` in chunks to produce multiple `CompactionSummary` events over time rather than one big one.
+
+```python linenums="1"
+from autogen.beta.events import BaseEvent, ToolCallEvent, ToolResultEvent
+from autogen.beta.knowledge import KnowledgeStore
+
+
+class DropOldToolEvents:
+    """Keep conversation events; drop tool events older than the last K."""
+
+    def __init__(self, keep_last_k: int = 20) -> None:
+        self._k = keep_last_k
+
+    async def compact(
+        self,
+        events: list[BaseEvent],
+        context,
+        store: KnowledgeStore | None,
+    ) -> list[BaseEvent]:
+        tool_types = (ToolCallEvent, ToolResultEvent)
+        tool_indices = [i for i, e in enumerate(events) if isinstance(e, tool_types)]
+        if len(tool_indices) <= self._k:
+            return events
+        drop_set = set(tool_indices[: -self._k])
+        return [e for i, e in enumerate(events) if i not in drop_set]
+```

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -408,7 +408,10 @@
             "docs/beta/advanced/stream",
             "docs/beta/advanced/observers",
             "docs/beta/advanced/watches",
-            "docs/beta/advanced/knowledge_store"
+            "docs/beta/advanced/knowledge_store",
+            "docs/beta/advanced/assembly",
+            "docs/beta/advanced/compaction",
+            "docs/beta/advanced/aggregation"
           ]
         },
         {


### PR DESCRIPTION
Part 2 of the assembly/aggregation/compaction split.

## Why are these changes needed?

Adds an assembly layer to beta Agent: a middleware that transforms conversation context before each LLM call via composable policies, paired with strategies for compacting old history and aggregating working/episodic memory into a `KnowledgeStore`.

### Assembly (`autogen.beta.assembly`)

`AssemblerMiddleware` wraps the LLM call and runs an ordered list of `AssemblyPolicy` transforms over the event list. Built-in policies (`autogen.beta.policies`):

- `SlidingWindowPolicy` — keep the most recent N events
- `TokenBudgetPolicy` — trim history to fit a token budget
- `ConversationPolicy` — restructure model/tool events for clean replay
- `EpisodicMemoryPolicy` — surface relevant entries from the `KnowledgeStore` for the current turn
- `WorkingMemoryPolicy` — inject the agent's active working memory from the `KnowledgeStore`
- `AlertPolicy` — deduplicate observer alerts across history

### Compaction (`autogen.beta.compact`)

`CompactStrategy` protocol + `CompactTrigger` for when to compact. Built-ins:

- `TailWindowCompact` — drop oldest events past a window
- `SummarizeCompact` — summarize old events via an LLM, emits `CompactionSummary`

### Aggregation (`autogen.beta.aggregate`)

`AggregateStrategy` protocol + `AggregateTrigger`. Built-ins:

- `ConversationSummaryAggregate` — rolling conversation summary → `KnowledgeStore`
- `WorkingMemoryAggregate` — persist working memory → `KnowledgeStore`

### Knowledge path constants (`autogen.beta.knowledge`)

Adds `CONVERSATIONS_PREFIX`, `WORKING_MEMORY_PATH`, `LOG_PREFIX` to the `knowledge` package as a producer/consumer contract: aggregation strategies, assembly policies, and `EventLogWriter`/`DefaultBootstrap` all reference the same constants instead of duplicating string literals.

## Notes for reviewers

- **No new top-level exports.** Per AGENTS.md, `autogen.beta` is reserved for common APIs; middleware classes, strategy protocols, and individual policies stay in their submodules. Import from `autogen.beta.assembly` / `.compact` / `.aggregate` / `.policies`.
- **`AggregateTrigger` defaults are all opt-in.** `AggregateTrigger()` with no arguments fires nothing. `on_end` defaults to `False` — each strategy is one LLM call per fire, and a typical pairing of `ConversationSummaryAggregate` + `WorkingMemoryAggregate` would otherwise silently double per-conversation cost. Users explicitly enable conditions when they want the behavior.
- **Trigger consumers land in PR3.** `AggregateTrigger` and `CompactTrigger` are config dataclasses — the middleware that interprets them (`AggregationMiddleware`, `CompactionMiddleware`) lands with the Agent merge in #2656. PR2 ships the strategies; users can invoke `strategy.aggregate(...)` / `strategy.compact(...)` directly.

## Related issue number

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
