### PR TITLE
Broken external links in Notebooks pages...

### DIFF
--- a/website/mkdocs/_website/utils.py
+++ b/website/mkdocs/_website/utils.py
@@ -362,6 +362,7 @@ def render_gallery_html(gallery_file_path: Path) -> str:
             notebook_src = item.get("source", None)
 
             if notebook_src:
+                notebook_src = notebook_src.lstrip("/")
                 colab_href = f"https://colab.research.google.com/github/ag2ai/ag2/blob/main/{notebook_src}"
                 github_href = f"https://github.com/ag2ai/ag2/blob/main/{notebook_src}"
                 badges_html = f"""


### PR DESCRIPTION
**Files changed:**
- `website/mkdocs/_website/utils.py`

**What I checked before submitting:**
> **Fix is correct and safe to ship.**
> 
> The root cause is clear: when `item["source"]` begins with a leading `/` (e.g. `"/notebook/reliable_basic_example.ipynb"`), string-interpolating it into `blob/main/{notebook_src}` produces a double-slash path (`blob/main//notebook/...`) that GitHub/Colab reject with 404. Adding `notebook_src.lstrip("/")` before URL construction correctly removes one or more leading slashes, resolving the issue.
> 
> **Why `lstrip` is the right choice:**
> - `lstrip("/")` is a no-op when `notebook_src` has no leading slash (the common/correct case) — zero regression risk.
> - It handles multiple consecutive leading slashes, which is more robust than a simple single-char replace.
> - Unlike `strip("/")`, it does not touch trailing slashes, so paths like `notebook/example/` remain intact.
> 
> **Scope:** This fix covers the Python/MkDocs rendering path (`utils.py`). The companion fix for the frontend JSX rendering path (`GalleryPage.mdx`, bug `file-a2f7dd08`) addresses the same pattern in the React gallery component — both are needed for full coverage.
> 
> **URL verification note:** The specific file `reliable_basic_example.ipynb` returns 404 even with the corrected single-slash URL. This suggests the file may have been moved or renamed in the repo independently of this URL-construction bug. That is a separate concern; fixing the double-slash is still correct and necessary for all other notebooks that _do_ exist.
> 
> **Minor nit (non-blocking):** A brief inline comment explaining _why_ `lstrip` is applied would help future maintainers (e.g., `# strip leading slash to avoid double-slash in constructed URL`). Can be added at merge time.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).