### PR TITLE
Double slash in notebook GitHub links

### DIFF
--- a/website/mkdocs/_website/utils.py
+++ b/website/mkdocs/_website/utils.py
@@ -362,6 +362,7 @@ def render_gallery_html(gallery_file_path: Path) -> str:
             notebook_src = item.get("source", None)
 
             if notebook_src:
+                notebook_src = notebook_src.lstrip("/")
                 colab_href = f"https://colab.research.google.com/github/ag2ai/ag2/blob/main/{notebook_src}"
                 github_href = f"https://github.com/ag2ai/ag2/blob/main/{notebook_src}"
                 badges_html = f"""


### PR DESCRIPTION
**Files changed:**
- `website/mkdocs/_website/utils.py`

**What I checked before submitting:**
> **Approved.** The fix correctly addresses the root cause of double-slash URLs in notebook link generation.
> 
> **What the fix does:** Adds `notebook_src = notebook_src.lstrip("/")` before both `colab_href` and `github_href` are constructed, stripping any leading slashes from the source path so that URLs like `main//notebook/...` become the correct `main/notebook/...`.
> 
> **Why it's correct:**
> - `lstrip("/")` is safe and idiomatic — it's a no-op on paths that don't start with `/`, and handles multiple leading slashes gracefully.
> - Applied once, it covers both URL constructions (Colab and GitHub) consistently.
> - Minimal, well-placed change with no regressions expected.
> 
> **Notes for the human developer:**
> - The fix is a defensive patch at the URL construction site. If leading slashes also exist in the raw config/YAML data files, those could optionally be cleaned up at the source too — but this centralized fix is pragmatic and sufficient.
> - Note: the specific notebook `tools_browser_use_deepseek.ipynb` still returns a 404 even with the corrected URL path — this may indicate a separate issue where the notebook has been renamed or moved in the repo, which is outside the scope of this fix.
> - Consider adding a brief inline comment (e.g., `# strip any accidental leading slashes`) for future maintainability.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).