### PR TITLE
Broken GitHub notebook links with double slash in path

### DIFF
--- a/website/mkdocs/_website/utils.py
+++ b/website/mkdocs/_website/utils.py
@@ -362,6 +362,7 @@ def render_gallery_html(gallery_file_path: Path) -> str:
             notebook_src = item.get("source", None)
 
             if notebook_src:
+                notebook_src = notebook_src.lstrip("/")
                 colab_href = f"https://colab.research.google.com/github/ag2ai/ag2/blob/main/{notebook_src}"
                 github_href = f"https://github.com/ag2ai/ag2/blob/main/{notebook_src}"
                 badges_html = f"""


### PR DESCRIPTION
**Files changed:**
- `website/mkdocs/_website/utils.py`

**What I checked before submitting:**
> ## Fix Review: Broken GitHub notebook links with double slash
> 
> **Verdict: Approved ✅**
> 
> ### What the fix does
> Adds `notebook_src = notebook_src.lstrip("/")` before constructing GitHub/Colab URL strings in `utils.py`. This strips any leading slash(es) from the notebook source path, preventing the `main//notebook/...` double-slash pattern that causes HTTP 404 errors.
> 
> ### Why it's correct
> - The f-string templates already encode `main/` with a trailing slash — if `notebook_src` starts with `/`, the result is `main//notebook/...` which is a 404.
> - `lstrip("/")` is a safe no-op when `notebook_src` has no leading slash (already-correct paths are unaffected).
> - Handles edge cases like multiple leading slashes (`//foo` → `foo`) more robustly than a targeted single-slash replace.
> - Matches surrounding code style perfectly (same indentation, no unnecessary changes).
> - `github_href` and `colab_href` both benefit from the single sanitization.
> 
> ### URL verification
> - `https://github.com/ag2ai/ag2/tree/main/notebook` → **200 OK** (directory exists ✅)
> - `https://github.com/ag2ai/ag2/blob/main/notebook/agentchat_function_call.ipynb` → **200 OK** (similar notebook path pattern works ✅)
> - Note: The specific example notebook `tools_dependency_injection.ipynb` returns 404 even with the fixed path — this appears to be because that particular notebook may have been moved/renamed in the repo, which is a separate issue from the double-slash bug being fixed here.
> 
> ### Minor notes (non-blocking)
> 1. This is a defensive fix at the URL-construction layer rather than fixing the source data. A code comment like `# strip leading slash to avoid double-slash in URL` would help future readers, but not required.
> 2. The root cause (why some `source` values have a leading `/` in the data) is not addressed — worth a follow-up to inspect the gallery data source.
> 3. No tests added, but this is consistent with the existing codebase pattern for this utility.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).