### PR TITLE
Broken external link: google.github.io/A2A/ (404)

### DIFF
--- a/website/docs/_blogs/2026-02-08-AG2-OpenTelemetry-Tracing/index.mdx
+++ b/website/docs/_blogs/2026-02-08-AG2-OpenTelemetry-Tracing/index.mdx
@@ -298,7 +298,7 @@ conversation chat_manager                 # run_chat (GroupChatManager)
 
 ## Distributed Tracing with A2A
 
-When agents run as separate services using the [A2A (Agent-to-Agent) protocol](https://google.github.io/A2A/), AG2 propagates [W3C Trace Context](https://www.w3.org/TR/trace-context/) headers across HTTP calls so that client-side and server-side spans share a single trace ID.
+When agents run as separate services using the [A2A (Agent-to-Agent) protocol](https://a2a-protocol.org/), AG2 propagates [W3C Trace Context](https://www.w3.org/TR/trace-context/) headers across HTTP calls so that client-side and server-side spans share a single trace ID.
 
 ![A2A Distributed Trace Diagram](img/a2a-trace-diagram.svg)
 


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2026-02-08-AG2-OpenTelemetry-Tracing/index.mdx`

**What I checked before submitting:**
> The fix replaces a confirmed 404 URL (`https://google.github.io/A2A/`) with `https://a2a-protocol.org/`, which resolves successfully (HTTP 200, no redirects). The diff is minimal and clean — one line changed, style matches the surrounding content perfectly.
> 
> **One note for the human reviewer**: Please verify that `https://a2a-protocol.org/` is the intended canonical reference for the A2A (Agent-to-Agent) protocol. The original Google-hosted URL (`google.github.io/A2A/`) is currently returning 404, so the fix is strictly better than leaving the broken link. However, if a more authoritative source exists (e.g., `https://github.com/google/A2A` or a new path under `google.github.io`), it may be worth swapping to that URL at merge time. The fix is shippable as-is.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).