### PR TITLE
Broken external link: stackoverflow.com/help/mcve (404)

### DIFF
--- a/website/docs/contributor-guide/file-bug-report.mdx
+++ b/website/docs/contributor-guide/file-bug-report.mdx
@@ -7,7 +7,7 @@ follow these guidelines! This will make it a lot easier to provide you with good
 feedback:
 
 - The ideal bug report contains a short reproducible code snippet. This way
-  anyone can try to reproduce the bug easily (see [this](https://stackoverflow.com/help/mcve) for more details). If your snippet is
+  anyone can try to reproduce the bug easily (see [this](https://stackoverflow.com/help/minimal-reproducible-example) for more details). If your snippet is
   longer than around 50 lines, please link to a [gist](https://gist.github.com) or a GitHub repo.
 
 - If an exception is raised, please **provide the full traceback**.


### PR DESCRIPTION
**Files changed:**
- `website/docs/contributor-guide/file-bug-report.mdx`

**What I checked before submitting:**
> The fix correctly replaces the retired Stack Overflow alias `/help/mcve` with the current canonical path `/help/minimal-reproducible-example`. This is the well-documented canonical URL for Stack Overflow's "How to create a Minimal, Reproducible Example" help article.
> 
> Note: The URL verifier returned 404 for both old and new URLs, but this is a known artifact — Stack Overflow actively blocks automated HTTP requests (even the domain root returns 403), making the verifier unreliable for SO links. The replacement URL is the canonical one documented by Stack Overflow's own meta community.
> 
> The change is minimal, correctly scoped (single line, single file), and does not alter surrounding prose or formatting. No regressions possible from this pure URL substitution.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).