### PR TITLE
Broken GitHub link: simple_workflow.py returns 404

### DIFF
--- a/website/docs/_blogs/2025-05-07-AG2-Copilot-Integration/index.mdx
+++ b/website/docs/_blogs/2025-05-07-AG2-Copilot-Integration/index.mdx
@@ -72,7 +72,7 @@ Before you begin, you’ll need:
 
 ### Backend Setup: AG2 Multi-Agent System
 
-The backend is built with <a href="https://fastagency.ai/" target="_blank">FastAgency</a>, a framework that simplifies creating and deploying AG2 agents. Let’s examine the key components and start with our <a href="https://github.com/ag2ai/ag2-copilotkit-starter/blob/main/agent-py/simple_workflow.py" target='_blank'>simple_workflow.py</a> file:
+The backend is built with <a href="https://fastagency.ai/" target="_blank">FastAgency</a>, a framework that simplifies creating and deploying AG2 agents. Let’s examine the key components and start with our <a href="https://github.com/ag2ai/ag2-copilotkit-starter/blob/main/agent-py/backend.py" target='_blank'>backend.py</a> file:
 
 ```python
 # Initialize the workflowfrom fastagency import UI


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2025-05-07-AG2-Copilot-Integration/index.mdx`

**What I checked before submitting:**
> Fix is correct and verified. The broken link to `simple_workflow.py` (HTTP 404 confirmed) is replaced with `backend.py` (HTTP 200 confirmed). Both the `href` attribute and the visible link text are updated consistently. The change is minimal and stylistically consistent with the surrounding markup.
> 
> **Note (out of scope for this fix):** The code snippet immediately following this link (`# Initialize the workflowfrom fastagency import UI`) has a pre-existing formatting issue — a missing newline/space between the comment and the import statement. Worth addressing in a separate pass.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).