### PR TITLE
Broken localhost link in WebSockets blog post

### DIFF
--- a/website/docs/_blogs/2025-01-10-WebSockets/index.mdx
+++ b/website/docs/_blogs/2025-01-10-WebSockets/index.mdx
@@ -80,7 +80,7 @@ python agentchat-over-websockets/main.py
 ```
 
 ### **Test the App**
-With the server running, open the client application in your browser by navigating to [http://localhost:8001/](http://localhost:8001/). And send a message to the chat and watch the conversation between agents roll out in your browser.
+With the server running, open the client application in your browser by navigating to `http://localhost:8001/`. And send a message to the chat and watch the conversation between agents roll out in your browser.
 
 ## Code review
 


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2025-01-10-WebSockets/index.mdx`

**What I checked before submitting:**
> The fix correctly resolves the broken localhost link by converting `[http://localhost:8001/](http://localhost:8001/)` to inline code `` `http://localhost:8001/` ``. Since `localhost` URLs are development-time addresses that are only meaningful when the user is running the demo locally, they should never appear as clickable hyperlinks in public documentation — they will always be dead links for readers who aren't running the server. Rendering it as inline code preserves the instructional intent (telling the user what URL to open in their browser) while removing the broken link. The change is minimal, targeted, and consistent with standard MDX/Markdown documentation conventions.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).