### PR TITLE
Broken LinkedIn profile link for Stella Xiang returns 999

### DIFF
--- a/website/blogs_and_user_stories_authors.yml
+++ b/website/blogs_and_user_stories_authors.yml
@@ -206,7 +206,7 @@ authors:
   stellaxiang:
     name: Stella Xiang
     description: Developer
-    url: https://www.linkedin.com/in/xingyu-xiang/
+    url: https://github.com/stellaxiang
     avatar: https://github.com/stellaxiang.png
 
   tyler_suard:


### PR DESCRIPTION
**Files changed:**
- `website/blogs_and_user_stories_authors.yml`

**What I checked before submitting:**
> The fix replaces the broken LinkedIn profile URL for Stella Xiang (`https://www.linkedin.com/in/xingyu-xiang/`, HTTP 999) with her GitHub profile URL (`https://github.com/stellaxiang`).
> 
> **Why this is correct:**
> - The new GitHub URL returns HTTP 200 (verified).
> - The replacement is strongly supported by context: the file already uses `https://github.com/stellaxiang.png` as the avatar for this author entry, confirming this is the right GitHub account.
> - YAML formatting and indentation match the surrounding file style exactly.
> - Single-line, minimal-scope change with no regression risk.
> 
> **Note for the human:** LinkedIn's HTTP 999 is sometimes a bot/crawler detection response rather than a truly deleted profile. If Stella Xiang has an active LinkedIn profile she prefers listed, the URL can be restored. However, the GitHub profile is a valid, live alternative that eliminates the broken link.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).