### PR TITLE
Broken GitHub notebook link agenteval_cq_math.ipynb returns 404

### DIFF
--- a/website/docs/_blogs/2023-11-20-AgentEval/index.mdx
+++ b/website/docs/_blogs/2023-11-20-AgentEval/index.mdx
@@ -14,7 +14,7 @@ tags: [Evaluation]
 **TL;DR:**
 * As a developer of an LLM-powered application, how can you assess the utility it brings to end users while helping them with their tasks?
 * To shed light on the question above, we introduce `AgentEval` — the first version of the framework to assess the utility of any LLM-powered application crafted to assist users in specific tasks.  AgentEval aims to simplify the evaluation process by automatically proposing a set of criteria tailored to the unique purpose of your application. This allows for a comprehensive assessment, quantifying the utility of your application against the suggested criteria.
-* We demonstrate how `AgentEval` work using [math problems dataset](https://docs.ag2.ai/latest/docs/blog/2023/06/28/MathChat) as an example in the [following notebook](https://github.com/ag2ai/ag2/blob/main/notebook/agenteval_cq_math.ipynb). Any feedback would be useful for future development. Please contact us on our [Discord](https://discord.gg/pAbnFJrkgZ).
+* We demonstrate how `AgentEval` work using [math problems dataset](https://docs.ag2.ai/latest/docs/blog/2023/06/28/MathChat) as an example. Any feedback would be useful for future development. Please contact us on our [Discord](https://discord.gg/pAbnFJrkgZ).
 
 
 
@@ -56,7 +56,7 @@ critic = autogen.AssistantAgent(
 )
 ```
 
-Next, the critic is given successful and failed examples of the task execution; then, it is able to return a list of criteria (Fig. 1). For reference, use the [following notebook](https://github.com/ag2ai/ag2/blob/main/notebook/agenteval_cq_math.ipynb).
+Next, the critic is given successful and failed examples of the task execution; then, it is able to return a list of criteria (Fig. 1).
 
 * The goal of `QuantifierAgent` is to quantify each of the suggested criteria (Fig. 1), providing us with an idea of the utility of this system for the given task. Here is an example of how it can be defined:
 


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2023-11-20-AgentEval/index.mdx`

*Took me two passes to get this right — first attempt missed the mark.*

**What I checked before submitting:**
> The round-2 fix cleanly addresses both the bug and the round-1 prose feedback.
> 
> **What was fixed:**
> - Both broken links to `https://github.com/ag2ai/ag2/blob/main/notebook/agenteval_cq_math.ipynb` (confirmed HTTP 404) have been removed.
> 
> **Quality of edits:**
> 1. **First occurrence (TL;DR bullet):** The phrase "as an example in the [following notebook](...)" is trimmed to "as an example." — the sentence flows naturally and reads correctly.
> 2. **Second occurrence (body paragraph):** "For reference, use the [following notebook](...)." is removed cleanly, leaving a well-formed sentence ending with "(Fig. 1)."
> 
> No regressions: no link replacements (only deletions of dead links), no YAML frontmatter changes, the valid math problems dataset link is preserved intact.
> 
> This is a correct, minimal, and readable fix — ready to ship.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).