### PR TITLE
Broken internal link on AG2 logging events blog page

### DIFF
--- a/website/docs/_blogs/2025-12-23-Ag2-logging-events/index.mdx
+++ b/website/docs/_blogs/2025-12-23-Ag2-logging-events/index.mdx
@@ -509,11 +509,11 @@ handler.addFilter(EventFilter())  # Only log relevant events
 
 4. **Create and use agents** - events will flow through your configured logger
 
-5. **Review the documentation**: [Event Logging Setup](https://docs.ag2.ai/latest/docs/user-guide/misc/logging_events)
+5. **Review the documentation**: [Event Logging Setup](https://docs.ag2.ai/latest/docs/user-guide/observability/logging_events)
 
 ## Additional Resources
 
-- [AG2 Event Logging Documentation](https://docs.ag2.ai/latest/docs/user-guide/misc/logging_events)
+- [AG2 Event Logging Documentation](https://docs.ag2.ai/latest/docs/user-guide/observability/logging_events)
 - [Python Logging Module Documentation](https://docs.python.org/3/library/logging.html)
 - [Logging Best Practices](https://docs.python.org/3/howto/logging.html)
 


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2025-12-23-Ag2-logging-events/index.mdx`

**What I checked before submitting:**
> Fix is correct and verified. The old URL (`/user-guide/misc/logging_events`) returns HTTP 404; the new URL (`/user-guide/observability/logging_events`) returns HTTP 200. Both occurrences in the file have been updated consistently. The change is minimal and matches the surrounding markdown style.
> 
> **Note for the human reviewer:** The cross-reference check could not be run (repo not available at review time). If other files in the repo reference the old `/user-guide/misc/logging_events` path, they will still be broken after this PR. A quick repo-wide grep for `misc/logging_events` is recommended to catch any additional occurrences.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).