### PR TITLE
Broken internal link on GPT-Researcher blog page

### DIFF
--- a/website/docs/_blogs/2026-03-03-GPT-Researcher-AG2/index.mdx
+++ b/website/docs/_blogs/2026-03-03-GPT-Researcher-AG2/index.mdx
@@ -22,7 +22,7 @@ This post walks through the [build-with-ag2](https://github.com/ag2ai/build-with
 
 ![Research pipeline — eight agents in two rows with HITL feedback loop](img/pipeline.webp)
 
-The example uses AG2's `DefaultPattern` to run eight agents in sequence. Each is a separate `ConversableAgent` with its own system message and dedicated tool function. When a tool returns, it explicitly hands off to the next agent via `AgentNameTarget` -- the same pattern described in AG2's [pipeline cookbook](https://docs.ag2.ai/latest/docs/user-guide/agentchat/group-chat/sequential-chats):
+The example uses AG2's `DefaultPattern` to run eight agents in sequence. Each is a separate `ConversableAgent` with its own system message and dedicated tool function. When a tool returns, it explicitly hands off to the next agent via `AgentNameTarget` -- the same pattern described in AG2's [pipeline cookbook](https://docs.ag2.ai/latest/docs/user-guide/advanced-concepts/pattern-cookbook/pipeline):
 
 1. **Chief Editor** (`init_research`) — receives the query, creates a `GPTResearcher` instance
 2. **Editor** (`plan_sections`) — outlines 3-5 report sections


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2026-03-03-GPT-Researcher-AG2/index.mdx`

**What I checked before submitting:**
> The fix correctly replaces the broken internal link (`/agentchat/group-chat/sequential-chats`, 404) with a verified working URL (`/advanced-concepts/pattern-cookbook/pipeline`, HTTP 200). The new destination is semantically appropriate — the link text "pipeline cookbook" maps well to the pattern-cookbook/pipeline page. The diff is minimal and clean, matching the surrounding MDX style with no unintended side effects. Ready to ship.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).