### PR TITLE
Broken link in FalkorDB-Structured blog post

### DIFF
--- a/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
+++ b/website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx
@@ -173,7 +173,7 @@ A sample response to `how can I solve 8x + 7 = -23` would be:
 }
 ```
 
-See the [Trip Planner](https://docs.ag2.ai/latest/docs/use-cases/notebooks/notebooks/agentchat_swarm_graphrag_telemetry_trip_planner) and [Structured Output](https://docs.ag2.ai/docs/use-cases/notebooks/notebooks/agentchat_structured_outputs) notebooks to start using Structured Outputs.
+See the [Trip Planner](https://docs.ag2.ai/latest/docs/use-cases/notebooks/notebooks/agentchat_swarm_graphrag_telemetry_trip_planner) and [Structured Output](https://docs.ag2.ai/latest/docs/use-cases/notebooks/notebooks/agentchat_structured_outputs) notebooks to start using Structured Outputs.
 
 
 ## Nested Chats in Swarms
@@ -189,6 +189,6 @@ See the [Swarm documentation](https://docs.ag2.ai/latest/docs/user-guide/advance
 * [Trip Planner Notebook Example Using GraphRag, Structured Output & Swarm](https://docs.ag2.ai/latest/docs/use-cases/notebooks/notebooks/agentchat_swarm_graphrag_telemetry_trip_planner)
 * [Documentation about FalkorDB](https://docs.falkordb.com/)
 * [OpenAI's Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs)
-* [Structured Output Notebook Example](https://docs.ag2.ai/docs/use-cases/notebooks/notebooks/agentchat_structured_outputs)
+* [Structured Output Notebook Example](https://docs.ag2.ai/latest/docs/use-cases/notebooks/notebooks/agentchat_structured_outputs)
 
 *Do you have interesting use cases for FalkorDB / RAG? Would you like to see more features or improvements? Please join our [Discord](https://discord.com/invite/pAbnFJrkgZ) server for discussion.*


### PR DESCRIPTION
**Files changed:**
- `website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx`

**What I checked before submitting:**
> Fix is correct and verified. Both occurrences of the broken URL in `website/docs/_blogs/2024-12-06-FalkorDB-Structured/index.mdx` have been updated:
> 
> 1. **Inline body text** (line ~173): `https://docs.ag2.ai/docs/use-cases/notebooks/notebooks/agentchat_structured_outputs` → `https://docs.ag2.ai/latest/docs/use-cases/notebooks/notebooks/agentchat_structured_outputs`
> 2. **References section** (line ~192): Same fix applied.
> 
> **URL verification results:**
> - Old URL: HTTP 404 ✗ (confirmed broken)
> - New URL: HTTP 200 ✓ (confirmed working, resolves to trailing-slash canonical form)
> 
> The fix is minimal, targeted, and consistent with the URL pattern already used in the same file (e.g., the Trip Planner link already had `/latest`). No regressions introduced.

---
*Like a river carves its path — small, steady changes shape the landscape.* Fixed by [Elva](https://github.com/AG2Platform/workforce-elva).