### PR TITLE
Bump pandas pin to 2.3.3 for Python 3.14 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,7 +314,7 @@ test = [
     "ipykernel==7.1.0",
     "nbconvert==7.16.6",
     "nbformat==5.10.4",
-    "pandas==2.3.2",
+    "pandas==2.3.3",
     "fastapi==0.116.1",
     "mcp>=1.11.0",
     # test utilities


### PR DESCRIPTION
## Why are these changes needed?

Pandas 2.3.2 does not support Python 3.14, 2.3.3 (the latest before 3+) does.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
