### PR TITLE
tests: Increase test timeouts for AgentBuilder/TeachableAgent/CaptainAgent

### DIFF
--- a/test/agentchat/contrib/capabilities/test_teachable_agent.py
+++ b/test/agentchat/contrib/capabilities/test_teachable_agent.py
@@ -7,6 +7,8 @@
 # !/usr/bin/env python3 -m pytest
 
 
+import pytest
+
 from autogen import ConversableAgent
 from autogen.agentchat.contrib.capabilities.teachability import Teachability
 from autogen.formatting_utils import colored
@@ -120,6 +122,7 @@ def use_task_advice_pair_phrasing(credentials: Credentials):
     return num_errors, num_tests
 
 
+@pytest.mark.timeout(120)
 @run_for_optional_imports("openai", "openai")
 @run_for_optional_imports(["chromadb"], "teachable")
 @run_for_optional_imports(["openai"], "openai")

--- a/test/agentchat/contrib/test_agent_builder.py
+++ b/test/agentchat/contrib/test_agent_builder.py
@@ -73,6 +73,7 @@ def test_build(builder: AgentBuilder, credentials_all: Credentials):
     assert len(agent_config["agent_configs"]) <= builder.max_agents
 
 
+@pytest.mark.timeout(120)
 @run_for_optional_imports("openai", "openai")
 @run_for_optional_imports(["chromadb", "huggingface_hub"], "autobuild")
 @run_for_optional_imports(["openai"], "openai")

--- a/test/agentchat/contrib/test_captainagent.py
+++ b/test/agentchat/contrib/test_captainagent.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 
+import pytest
+
 from autogen import UserProxyAgent
 from autogen.agentchat.contrib.captainagent.captainagent import CaptainAgent
 from autogen.import_utils import optional_import_block, run_for_optional_imports
@@ -14,6 +16,7 @@ with optional_import_block() as result:
     import huggingface_hub  # noqa: F401
 
 
+@pytest.mark.timeout(120)
 @run_for_optional_imports("openai", "openai")
 def test_captain_agent_from_scratch(credentials_all: Credentials):
     config_list = credentials_all.config_list

--- a/test/agentchat/test_event_streaming.py
+++ b/test/agentchat/test_event_streaming.py
@@ -240,6 +240,7 @@ async def test_group_chat_async(credentials_openai_mini: Credentials):
     assert isinstance(await response.cost, Cost)
 
 
+@pytest.mark.timeout(120)
 @run_for_optional_imports("openai", "openai")
 def test_swarm_sync(credentials_openai_mini: Credentials):
     llm_config = credentials_openai_mini.llm_config
@@ -293,6 +294,7 @@ def test_swarm_sync(credentials_openai_mini: Credentials):
     assert isinstance(response.cost, Cost)
 
 
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 @run_for_optional_imports("openai", "openai")
 async def test_swarm_async(credentials_openai_mini: Credentials):
@@ -426,7 +428,7 @@ def test_sequential_sync(credentials_openai_mini: Credentials):
         assert isinstance(response.cost, Cost)
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 @run_for_optional_imports("openai", "openai")
 async def test_sequential_async(credentials_openai_mini: Credentials):

--- a/test/agentchat/test_groupchat.py
+++ b/test/agentchat/test_groupchat.py
@@ -2330,6 +2330,7 @@ def test_manager_resume_message_assignment():
     assert list(agent_a.chat_messages.values())[0] == prev_messages[:-1]
 
 
+@pytest.mark.timeout(120)
 @pytest.mark.deepseek
 @suppress_json_decoder_error
 @run_for_optional_imports(["openai"], "deepseek")

--- a/test/oai/test_client.py
+++ b/test/oai/test_client.py
@@ -7,6 +7,7 @@
 # !/usr/bin/env python3 -m pytest
 
 import copy
+import importlib.util
 import inspect
 import os
 import shutil
@@ -41,6 +42,11 @@ except ImportError:
 
 
 from test.credentials import Credentials
+
+_SKIP_WITHOUT_DISKCACHE = pytest.mark.skipif(
+    importlib.util.find_spec("diskcache") is None,
+    reason="diskcache package is not installed; Cache.disk falls back to InMemoryCache",
+)
 
 
 class MockModelClient:
@@ -384,6 +390,7 @@ def test_usage_summary(credentials_azure_gpt_4_1_mini: Credentials):
     assert client.total_usage_summary is None, "total_usage_summary should be None"
 
 
+@_SKIP_WITHOUT_DISKCACHE
 @run_for_optional_imports(["openai"], "openai")
 def test_log_cache_seed_value(mock_credentials: Credentials, monkeypatch: pytest.MonkeyPatch):
     chat_completion = ChatCompletion(**{
@@ -440,6 +447,7 @@ def test_log_cache_seed_value(mock_credentials: Credentials, monkeypatch: pytest
     assert actual == expected, f"Expected: {expected}, Actual: {actual}"
 
 
+@_SKIP_WITHOUT_DISKCACHE
 @run_for_optional_imports("openai", "openai")
 @run_for_optional_imports(["openai"], "openai")
 def test_legacy_cache(credentials_openai_mini: Credentials):
@@ -504,6 +512,7 @@ def test_legacy_cache(credentials_openai_mini: Credentials):
     assert os.path.exists(os.path.join(LEGACY_CACHE_DIR, str(21)))
 
 
+@_SKIP_WITHOUT_DISKCACHE
 @run_for_optional_imports(["openai"], "openai")
 def test_no_default_cache(credentials_openai_mini: Credentials):
     # Prompt to use for testing.
@@ -548,6 +557,7 @@ def test_no_default_cache(credentials_openai_mini: Credentials):
     assert os.path.exists(os.path.join(LEGACY_CACHE_DIR, str(LEGACY_DEFAULT_CACHE_SEED)))
 
 
+@_SKIP_WITHOUT_DISKCACHE
 @run_for_optional_imports("openai", "openai")
 @run_for_optional_imports(["openai"], "openai")
 def test_cache(credentials_openai_mini: Credentials):


### PR DESCRIPTION
## Why are these changes needed?

AgentBuilder and TeachableAgent tests were timing out so have increased timeout from global 45s to specific 120s.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
