### PR TITLE
fix(Swarm): remove deprecated ast.Num/Str/NameConstant for Python 3.14 compatibility

### DIFF
--- a/autogen/agentchat/group/context_expression.py
+++ b/autogen/agentchat/group/context_expression.py
@@ -128,15 +128,8 @@ class ContextExpression:
             ast.Load,
             ast.Constant,
             ast.Expression,
-            # Support for basic numeric operations in comparisons
-            ast.Num,
-            ast.NameConstant,
             # Support for negative numbers
             ast.USub,
-            ast.UnaryOp,
-            # Support for string literals
-            ast.Str,
-            ast.Constant,
             # Support for function calls (specifically len())
             ast.Call,
         )


### PR DESCRIPTION
## Why are these changes needed?

ast.Num/Str/NameConstant no longer available in 3.14 (deprecated since 3.8). Have removed.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
