### PR TITLE
fix: Various fixes for optional dependency tests

### DIFF
--- a/.github/workflows/test-with-optional-deps.yml
+++ b/.github/workflows/test-with-optional-deps.yml
@@ -141,7 +141,7 @@ jobs:
             echo "AUTOGEN_USE_DOCKER=False" >> $GITHUB_ENV
           fi
       - name: Install playwright
-        if: matrix.optional-dependencies == 'browser-use' || matrix.optional-dependencies == 'crawl4ai'
+        if: matrix.optional-dependencies == 'crawl4ai'
         shell: bash
         run: |
           python -m playwright install

--- a/autogen/beta/config/gemini/gemini_client.py
+++ b/autogen/beta/config/gemini/gemini_client.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable, Sequence
 from itertools import chain
 from typing import Any, TypedDict
 
-from google import genai
+import google.genai as genai
 from google.genai import types
 
 from autogen.beta.config.client import LLMClient

--- a/test/opentelemetry/__init__.py
+++ b/test/opentelemetry/__init__.py
@@ -1,3 +1,7 @@
 # Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+pytest.importorskip("opentelemetry")

--- a/test/opentelemetry/__init__.py
+++ b/test/opentelemetry/__init__.py
@@ -4,4 +4,4 @@
 
 import pytest
 
-pytest.importorskip("opentelemetry")
+pytest.importorskip("opentelemetry.sdk")

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -80,4 +80,13 @@ def test_list_submodules() -> None:
 # todo: we should always run this
 @pytest.mark.parametrize("module", list_submodules("autogen"))
 def test_submodules(module: str) -> None:
-    importlib.import_module(module)  # nosemgrep
+    try:
+        importlib.import_module(module)  # nosemgrep
+    except ModuleNotFoundError as e:
+        if e.name and e.name.split(".")[0] == "autogen":
+            raise
+        pytest.skip(f"optional dependency missing: {e}")
+    except ImportError as e:
+        if "pip install ag2[" in str(e):
+            pytest.skip(f"optional dependency missing: {e}")
+        raise


### PR DESCRIPTION
## Why are these changes needed?

- **`test_import.py`** skips modules whose optional deps are absent (`ModuleNotFoundError` with a non-autogen name, or `ImportError` hinting `pip install ag2[...]`).
- **Workflow**: drop `browser-use` from the `playwright install` step — `browser-use >=0.9.5` uses `cdp-use`, not playwright.
- **`test/opentelemetry/__init__.py`**: add `pytest.importorskip("opentelemetry.sdk")` so the dir's conftest.py isn't loaded when the SDK is missing (API package can be transitively present without the SDK).
- **`gemini_client.py`**: `from google import genai` → `import google.genai as genai`. The `google` namespace is often partially present; the canonical form raises a clean `ModuleNotFoundError` on missing `google-genai`, which `test_import.py` then skips.

## Out of scope (follow-ups)

- `crawl4ai, win, 3.14`: upstream `crawl4ai<0.9` pins `lxml~=5.3`; no cp314 Windows wheel.
- `rag, *`: unresolvable constraint in `pyproject.toml` `rag` extra (`llama-index-llms-openai<0.6` conflicts with `llama-index>=0.14.13`).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
