### PR TITLE
roadmap: Remove PerplexitySearchTool from deprecations

### DIFF
--- a/autogen/tools/experimental/perplexity/perplexity_search.py
+++ b/autogen/tools/experimental/perplexity/perplexity_search.py
@@ -8,7 +8,6 @@ It defines data models for responses and a tool for executing web and conversati
 
 import json
 import os
-import warnings
 from typing import Any
 
 import requests
@@ -128,12 +127,6 @@ class PerplexitySearchTool(Tool):
             ValueError: If the API key is missing, the model is empty, max_tokens is not positive,
                         or if search_domain_filter is not a list when provided.
         """
-        warnings.warn(
-            "PerplexitySearchTool is deprecated and will be removed in v0.14. "
-            "Use QuickResearchTool or DeepResearchTool instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         self.api_key = api_key or os.getenv("PERPLEXITY_API_KEY")
         self._validate_tool_config(model, self.api_key, max_tokens, search_domain_filter)
         self.url = "https://api.perplexity.ai/chat/completions"

--- a/website/docs/user-guide/release-roadmap.mdx
+++ b/website/docs/user-guide/release-roadmap.mdx
@@ -63,7 +63,6 @@ The beta framework (temporarily `autogen.beta`, with Agent) will, at v1.0, becom
 |------|-------------|
 | `PythonCodeExecutionTool` | `autogen.beta.tools.CodeExecutionTool` |
 | `FirecrawlTool` | `Crawl4AITool` or `BrowserUseTool` |
-| `PerplexitySearchTool` | `QuickResearchTool` or `DeepResearchTool` |
 | `SearxngSearchTool` | `DuckDuckGoSearchTool` or `TavilySearchTool` |
 | `WebSearchPreviewTool` | `autogen.beta.tools.WebSearchTool` |
 


### PR DESCRIPTION
## Why are these changes needed?

Based on community feedback and use of functionality planned for deprecation, this PR will remove items from deprecation.

This will remain open until 0.13.

Restoring:
2026-04-26: PerplexitySearchTool

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
