### PR TITLE
fix: use full path when opening migration scripts in sqlite_logger

### DIFF
--- a/autogen/logger/sqlite_logger.py
+++ b/autogen/logger/sqlite_logger.py
@@ -206,7 +206,7 @@ class SqliteLogger(BaseLogger):
         migrations_to_apply = [m for m in migrations if int(m.split("_")[0]) > current_version]
 
         for script in migrations_to_apply:
-            with open(script) as f:
+            with open(os.path.join(migrations_dir, script)) as f:
                 migration_sql = f.read()
                 self._run_query_script(script=migration_sql)
 


### PR DESCRIPTION
## Why

`_apply_migration()` in `sqlite_logger.py` gets filenames from `os.listdir(migrations_dir)`, which returns **filenames only** (not full paths). It then passes these bare filenames to `open(script)`, which will raise `FileNotFoundError` unless the process's current working directory happens to be `migrations_dir`.

## What

Construct the full path with `os.path.join(migrations_dir, script)` before opening.

## Related

The surrounding code (`os.path.isdir(migrations_dir)` on line 199) already uses `migrations_dir` for path operations, confirming the intent.