### PR TITLE
fix(beta): Streaming usage metadata with VertexAI

### DIFF
--- a/autogen/beta/config/gemini/mappers.py
+++ b/autogen/beta/config/gemini/mappers.py
@@ -249,5 +249,6 @@ def normalize_usage(metadata: Any) -> Usage:
         cache_read_input_tokens=cache_read,
     )
 
+
 def _to_float(value: Any) -> float | None:
     return float(value) if value is not None else None

--- a/autogen/beta/config/gemini/mappers.py
+++ b/autogen/beta/config/gemini/mappers.py
@@ -241,9 +241,6 @@ def convert_messages(
 def normalize_usage(metadata: Any) -> Usage:
     """Build usage from Gemini UsageMetadata, normalizing to standard keys."""
 
-    def _to_float(value: Any) -> float | None:
-        return float(value) if value is not None else None
-
     cache_read = _to_float(metadata.cached_content_token_count) or None
     return Usage(
         prompt_tokens=_to_float(metadata.prompt_token_count),
@@ -251,3 +248,6 @@ def normalize_usage(metadata: Any) -> Usage:
         total_tokens=_to_float(metadata.total_token_count),
         cache_read_input_tokens=cache_read,
     )
+
+def _to_float(value: Any) -> float | None:
+    return float(value) if value is not None else None

--- a/autogen/beta/config/gemini/mappers.py
+++ b/autogen/beta/config/gemini/mappers.py
@@ -240,12 +240,14 @@ def convert_messages(
 
 def normalize_usage(metadata: Any) -> Usage:
     """Build usage from Gemini UsageMetadata, normalizing to standard keys."""
-    cache_read: float | None = None
-    if metadata.cached_content_token_count:
-        cache_read = float(metadata.cached_content_token_count)
+
+    def _to_float(value: Any) -> float | None:
+        return float(value) if value is not None else None
+
+    cache_read = _to_float(metadata.cached_content_token_count) or None
     return Usage(
-        prompt_tokens=float(metadata.prompt_token_count),
-        completion_tokens=float(metadata.candidates_token_count),
-        total_tokens=float(metadata.total_token_count),
+        prompt_tokens=_to_float(metadata.prompt_token_count),
+        completion_tokens=_to_float(metadata.candidates_token_count),
+        total_tokens=_to_float(metadata.total_token_count),
         cache_read_input_tokens=cache_read,
     )

--- a/test/beta/config/gemini/test_gemini_usage.py
+++ b/test/beta/config/gemini/test_gemini_usage.py
@@ -40,3 +40,14 @@ class TestNormalizeUsage:
     def test_no_cache_key_when_zero(self):
         result = normalize_usage(_make_metadata(cached=0))
         assert result.cache_read_input_tokens is None
+
+    def test_handles_none_token_counts_on_streaming_chunks(self):
+        """Vertex streaming emits UsageMetadata with None fields before the
+        final chunk. Those fields must not crash ``float(...)``."""
+        result = normalize_usage(_make_metadata(prompt=None, candidates=None, total=None))
+        assert result == Usage()
+        assert bool(result) is False
+
+    def test_handles_partial_token_counts(self):
+        result = normalize_usage(_make_metadata(prompt=50, candidates=None, total=None))
+        assert result == Usage(prompt_tokens=50)


### PR DESCRIPTION
## Why are these changes needed?

Streaming message chunks with VertexAI didn't contain values for token usage and this was not handled. This is a variation between Gemini direct and VertexAI.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
