### PR TITLE
fix: Tool call thought signature preservation with VertexAI

### DIFF
--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -615,32 +615,33 @@ class GeminiClient:
                 function_name = tool_call["function"]["name"]
                 self.tool_call_function_map[function_id] = function_name
 
-                if self.use_vertexai:
-                    rst.append(
-                        VertexAIPart.from_dict({
-                            "functionCall": {
-                                "name": function_name,
-                                "args": json.loads(tool_call["function"]["arguments"]),
-                            }
-                        })
-                    )
+                # thought_signature preservation
+                thought_sig_raw = tool_call.get("thought_signature")
+                if isinstance(thought_sig_raw, str) and thought_sig_raw:
+                    thought_sig_bytes: bytes | None = base64.b64decode(thought_sig_raw)
+                elif isinstance(thought_sig_raw, bytes) and thought_sig_raw:
+                    thought_sig_bytes = thought_sig_raw
                 else:
-                    # Include thought_signature if available (required for Gemini 3 models)
-                    # Check message-level first (cross-agent), then instance dict (same-agent)
-                    thought_sig_raw = tool_call.get("thought_signature")
-                    if thought_sig_raw and isinstance(thought_sig_raw, str):
-                        thought_sig = base64.b64decode(thought_sig_raw)
-                    elif thought_sig_raw and isinstance(thought_sig_raw, bytes):
-                        thought_sig = thought_sig_raw
-                    else:
-                        thought_sig = self.tool_call_thought_signatures.get(function_id)
+                    thought_sig_bytes = self.tool_call_thought_signatures.get(function_id)
+
+                if self.use_vertexai:
+                    fc_dict: dict[str, Any] = {
+                        "functionCall": {
+                            "name": function_name,
+                            "args": json.loads(tool_call["function"]["arguments"]),
+                        }
+                    }
+                    if thought_sig_bytes:
+                        fc_dict["thoughtSignature"] = base64.b64encode(thought_sig_bytes).decode("ascii")
+                    rst.append(VertexAIPart.from_dict(fc_dict))
+                else:
                     rst.append(
                         Part(
                             function_call=FunctionCall(
                                 name=function_name,
                                 args=json.loads(tool_call["function"]["arguments"]),
                             ),
-                            thought_signature=thought_sig,
+                            thought_signature=thought_sig_bytes,
                         )
                     )
 

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -445,11 +445,22 @@ class GeminiClient:
                     )
 
                     # Embed thought_signature in the tool call so it survives cross-agent routing
-                    # (required for Gemini 3 thinking models in group chat)
-                    # Base64-encode bytes so the dict stays JSON-serializable for other providers
-                    if hasattr(part, "thought_signature") and part.thought_signature:
-                        tool_call_entry.thought_signature = base64.b64encode(part.thought_signature).decode("ascii")
-                        self.tool_call_thought_signatures[tool_call_id] = part.thought_signature
+                    sig_bytes: bytes | None = None
+                    raw_attr = getattr(part, "thought_signature", None)
+                    if isinstance(raw_attr, bytes) and raw_attr:
+                        sig_bytes = raw_attr
+                    elif isinstance(raw_attr, str) and raw_attr:
+                        sig_bytes = base64.b64decode(raw_attr)
+                    elif hasattr(part, "to_dict"):
+                        raw_dict = part.to_dict().get("thought_signature")
+                        if isinstance(raw_dict, bytes) and raw_dict:
+                            sig_bytes = raw_dict
+                        elif isinstance(raw_dict, str) and raw_dict:
+                            sig_bytes = base64.b64decode(raw_dict)
+
+                    if sig_bytes:
+                        tool_call_entry.thought_signature = base64.b64encode(sig_bytes).decode("ascii")
+                        self.tool_call_thought_signatures[tool_call_id] = sig_bytes
 
                     autogen_tool_calls.append(tool_call_entry)
 

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -1505,6 +1505,73 @@ class TestGeminiClient:
         # thought_signature should be None (not set, which is fine for non-Gemini-3 models)
         assert part.thought_signature is None
 
+    def test_thought_signature_replayed_on_vertex_same_agent(self, gemini_client_with_credentials):
+        """Vertex branch must attach thought_signature from the per-instance dict.
+
+        Without this, Gemini 3 thinking models on Vertex reject the replayed
+        function call with `400 INVALID_ARGUMENT ... missing a thought_signature`.
+        """
+        import base64
+
+        client = gemini_client_with_credentials
+        tool_call_id = "vertex_tool_same_agent"
+        test_signature = b"vertex_sig_bytes"
+        client.tool_call_thought_signatures[tool_call_id] = test_signature
+        client.tool_call_function_map[tool_call_id] = "lookup"
+
+        message = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": tool_call_id,
+                    "function": {"name": "lookup", "arguments": '{"q": "widget"}'},
+                    "type": "function",
+                }
+            ],
+        }
+
+        parts, part_type = client._oai_content_to_gemini_content(message)
+
+        assert part_type == "tool_call"
+        assert len(parts) == 1
+        raw = parts[0].to_dict()
+        fc = raw.get("function_call") or raw.get("functionCall")
+        assert fc and fc["name"] == "lookup"
+        sig_b64 = raw.get("thought_signature") or raw.get("thoughtSignature")
+        assert sig_b64 is not None
+        assert base64.b64decode(sig_b64) == test_signature
+
+    def test_thought_signature_replayed_on_vertex_cross_agent(self, gemini_client_with_credentials):
+        """Vertex branch must honour the base64 signature carried on the tool_call dict
+        (cross-agent handoff case — the receiving client has an empty instance dict)."""
+        import base64
+
+        client = gemini_client_with_credentials
+        # Deliberately leave instance dict empty to simulate a different agent's client
+        assert client.tool_call_thought_signatures == {}
+
+        original_bytes = b"cross_agent_sig"
+        message = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "xid",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                    "type": "function",
+                    "thought_signature": base64.b64encode(original_bytes).decode("ascii"),
+                }
+            ],
+        }
+
+        parts, _ = client._oai_content_to_gemini_content(message)
+
+        raw = parts[0].to_dict()
+        sig_b64 = raw.get("thought_signature") or raw.get("thoughtSignature")
+        assert sig_b64 is not None
+        assert base64.b64decode(sig_b64) == original_bytes
+
     @patch("autogen.oai.gemini.genai.Client")
     @patch("autogen.oai.gemini.calculate_gemini_cost")
     def test_thought_signature_embedded_in_tool_call_for_cross_agent(

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -5,6 +5,7 @@
 # Portions derived from https://github.com/microsoft/autogen are under the MIT License.
 # SPDX-License-Identifier: MIT
 
+import base64
 import os
 import warnings
 from typing import Any
@@ -1504,6 +1505,30 @@ class TestGeminiClient:
         assert isinstance(part, Part)
         # thought_signature should be None (not set, which is fine for non-Gemini-3 models)
         assert part.thought_signature is None
+
+    def test_thought_signature_captured_from_vertex_part_via_to_dict(self, gemini_client):
+        """Vertex ``Part`` does not expose ``thought_signature`` as a direct attribute —
+        it is only surfaced via ``part.to_dict()`` as a base64 string."""
+
+        # Fake a Vertex-shaped part: no thought_signature attribute, but to_dict() exposes it.
+        original = b"vertex_sig_value"
+        vertex_part = MagicMock(spec=["function_call", "to_dict"])
+        vertex_part.function_call = MagicMock(name="get_weather", args={"location": "Melbourne"})
+        vertex_part.function_call.name = "get_weather"
+        vertex_part.function_call.args = {"location": "Melbourne"}
+        vertex_part.to_dict.return_value = {
+            "function_call": {"name": "get_weather", "args": {"location": "Melbourne"}},
+            "thought_signature": base64.b64encode(original).decode("ascii"),
+        }
+
+        tool_calls: list = []
+        gemini_client._process_parts([vertex_part], tool_calls)
+
+        assert len(tool_calls) == 1
+        tc = tool_calls[0]
+        assert tc.id in gemini_client.tool_call_thought_signatures
+        assert gemini_client.tool_call_thought_signatures[tc.id] == original
+        assert base64.b64decode(tc.thought_signature) == original
 
     def test_thought_signature_replayed_on_vertex_same_agent(self, gemini_client_with_credentials):
         """Vertex branch must attach thought_signature from the per-instance dict.


### PR DESCRIPTION
## Why are these changes needed?

Thought signatures are not preserved across tool calls when using VertexAI. It is preserved using a non-VertexAI Gemini configuration. This corrects that to be supported in both cases.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
