### PR TITLE
fix: add timeout to HTTP requests across multiple modules

### DIFF
--- a/autogen/agentchat/contrib/captainagent/tools/information_retrieval/get_youtube_caption.py
+++ b/autogen/agentchat/contrib/captainagent/tools/information_retrieval/get_youtube_caption.py
@@ -28,7 +28,7 @@ def get_youtube_caption(video_id: str) -> str:
 
     headers = {"X-RapidAPI-Key": rapid_api_key, "X-RapidAPI-Host": "youtube-transcript3.p.rapidapi.com"}
 
-    response = requests.get(url, headers=headers, params=querystring)
+    response = requests.get(url, headers=headers, params=querystring, timeout=30)
     response = response.json()
     print(response)
     return response["transcript"]

--- a/autogen/agentchat/contrib/captainagent/tools/information_retrieval/perform_web_search.py
+++ b/autogen/agentchat/contrib/captainagent/tools/information_retrieval/perform_web_search.py
@@ -35,7 +35,7 @@ def perform_web_search(query, count=10, offset=0):
     }
 
     # Send the API request
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=30)
     response.raise_for_status()
 
     # Process the search results

--- a/autogen/agentchat/contrib/captainagent/tools/information_retrieval/scrape_wikipedia_tables.py
+++ b/autogen/agentchat/contrib/captainagent/tools/information_retrieval/scrape_wikipedia_tables.py
@@ -15,7 +15,7 @@ def scrape_wikipedia_tables(url: str, header_keyword: str):
     import requests
     from bs4 import BeautifulSoup
 
-    response = requests.get(url)
+    response = requests.get(url, timeout=30)
     response.raise_for_status()
     soup = BeautifulSoup(response.content, "html.parser")
     headers = soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"])

--- a/autogen/agentchat/contrib/captainagent/tools/information_retrieval/youtube_download.py
+++ b/autogen/agentchat/contrib/captainagent/tools/information_retrieval/youtube_download.py
@@ -23,7 +23,7 @@ def youtube_download(url: str):
         "X-RapidAPI-Host": "youtube-mp3-downloader2.p.rapidapi.com",
     }
 
-    response = requests.get(endpoint, headers=headers, params=querystring)
+    response = requests.get(endpoint, headers=headers, params=querystring, timeout=30)
     response = response.json()
 
     if "link" in response:

--- a/autogen/agentchat/contrib/img_utils.py
+++ b/autogen/agentchat/contrib/img_utils.py
@@ -63,7 +63,7 @@ def get_pil_image(image_file: Union[str, "Image.Image"]) -> "Image.Image":
 
     if image_file.startswith("http://") or image_file.startswith("https://"):
         # A URL file
-        response = requests.get(image_file)
+        response = requests.get(image_file, timeout=30)
         content = BytesIO(response.content)
         image = Image.open(content)
     # Match base64-encoded image URIs for supported formats: jpg, jpeg, png, gif, bmp, webp

--- a/autogen/browser_utils.py
+++ b/autogen/browser_utils.py
@@ -172,6 +172,7 @@ class SimpleTextBrowser:
         request_kwargs["stream"] = False
 
         # Make the request
+        request_kwargs.setdefault("timeout", 30)
         response = requests.get(self.bing_base_url, **request_kwargs)
         response.raise_for_status()
         results = response.json()
@@ -214,6 +215,7 @@ class SimpleTextBrowser:
             # Prepare the request parameters
             request_kwargs = self.request_kwargs.copy() if self.request_kwargs is not None else {}
             request_kwargs["stream"] = True
+            request_kwargs.setdefault("timeout", 30)
 
             # Send an HTTP request to the URL
             response = requests.get(url, **request_kwargs)

--- a/autogen/tools/experimental/wikipedia/wikipedia.py
+++ b/autogen/tools/experimental/wikipedia/wikipedia.py
@@ -96,7 +96,7 @@ class WikipediaClient:
             "srprop": "size|wordcount|timestamp",
         }
 
-        response = requests.get(url=self.base_url, params=params, headers=self.headers)
+        response = requests.get(url=self.base_url, params=params, headers=self.headers, timeout=30)
         response.raise_for_status()
         data = response.json()
         search_data = data.get("query", {}).get("search", [])


### PR DESCRIPTION
## Why

Multiple `requests.get()` calls lack a `timeout` parameter. Python's `requests` library defaults to `timeout=None` (infinite wait), so a single unresponsive server can block the calling thread indefinitely — hanging the agent.

## What

Add `timeout=30` to 8 HTTP calls across 7 files:

| File | Context |
|------|---------|
| `browser_utils.py` | Bing search + page fetch (2 calls) |
| `img_utils.py` | Image download |
| `wikipedia.py` | Wikipedia search API |
| `perform_web_search.py` | Bing Web Search API |
| `youtube_download.py` | RapidAPI YouTube download |
| `scrape_wikipedia_tables.py` | Wikipedia page fetch |
| `get_youtube_caption.py` | RapidAPI YouTube caption |

For `browser_utils.py`, `setdefault("timeout", 30)` is used to respect any timeout already configured in `request_kwargs`.