### PR TITLE
fix(beta): Add total_tokens to Usage calculation for Anthropic

### DIFF
--- a/autogen/beta/config/anthropic/mappers.py
+++ b/autogen/beta/config/anthropic/mappers.py
@@ -310,9 +310,12 @@ def normalize_usage(raw: dict[str, Any]) -> Usage:
     """Normalize Anthropic's native usage keys to standard format."""
     cc = raw.get("cache_creation_input_tokens")
     cr = raw.get("cache_read_input_tokens")
+    prompt = float(raw.get("input_tokens", 0))
+    completion = float(raw.get("output_tokens", 0))
     return Usage(
-        prompt_tokens=float(raw.get("input_tokens", 0)),
-        completion_tokens=float(raw.get("output_tokens", 0)),
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=prompt + completion,
         cache_creation_input_tokens=float(cc) if cc else None,
         cache_read_input_tokens=float(cr) if cr else None,
     )

--- a/test/beta/config/anthropic/test_anthropic_usage.py
+++ b/test/beta/config/anthropic/test_anthropic_usage.py
@@ -63,7 +63,7 @@ async def test_process_response_normalizes_usage():
     result = await client._process_response(response, _make_context())
 
     assert isinstance(result, ModelResponse)
-    assert result.usage == Usage(prompt_tokens=100, completion_tokens=25)
+    assert result.usage == Usage(prompt_tokens=100, completion_tokens=25, total_tokens=125)
 
 
 @pytest.mark.asyncio()
@@ -77,6 +77,7 @@ async def test_process_response_includes_cache_creation_tokens():
     assert result.usage == Usage(
         prompt_tokens=3,
         completion_tokens=10,
+        total_tokens=13,
         cache_creation_input_tokens=5058,
     )
     assert result.usage.cache_read_input_tokens is None
@@ -93,6 +94,7 @@ async def test_process_response_includes_cache_read_tokens():
     assert result.usage == Usage(
         prompt_tokens=3,
         completion_tokens=14,
+        total_tokens=17,
         cache_read_input_tokens=5043,
     )
     assert result.usage.cache_creation_input_tokens is None
@@ -106,7 +108,7 @@ async def test_process_response_no_usage():
 
     result = await client._process_response(response, _make_context())
 
-    assert result.usage == Usage(prompt_tokens=0, completion_tokens=0)
+    assert result.usage == Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
 
 
 @pytest.mark.asyncio()
@@ -136,6 +138,7 @@ async def test_process_stream_normalizes_usage():
     assert result.usage == Usage(
         prompt_tokens=50,
         completion_tokens=12,
+        total_tokens=62,
         cache_read_input_tokens=4000,
     )
     assert result.usage.cache_creation_input_tokens is None


### PR DESCRIPTION
## Why are these changes needed?

Anthropic's beta client did not populate the `total_tokens` for `Usage`.

Note: This replaces functionality that was inside PR #2658.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
