### PR TITLE
fix(beta): accept parts= kwarg on ToolResult for JSON roundtrip

### DIFF
--- a/autogen/beta/events/tool_events.py
+++ b/autogen/beta/events/tool_events.py
@@ -22,11 +22,15 @@ class ToolResult:
 
     def __init__(
         self,
-        *parts: SendableMessage | Input,
+        *args: SendableMessage | Input,
+        parts: list[SendableMessage | Input] | None = None,
         final: bool = False,
         metadata: dict[str, Any] | None = None,
     ) -> None:
-        self.parts = [Input.ensure_input(p) for p in parts]
+        inputs: list[SendableMessage | Input] = list(args)
+        if parts:
+            inputs.extend(parts)
+        self.parts = [Input.ensure_input(p) for p in inputs]
         self.final = final
         self.metadata = metadata or {}
 


### PR DESCRIPTION
## Why are these changes needed?

Stream serialisers are failing when trying to rehydrate (MemoryStream excluded as it is an in-process store and doesn't rehydrates via the dataclass constructor). ToolResult, dataclass has a `parts` field but a custom `__init__` that only takes positional varargs. The Redis stream serializer roundtrips events via `cls(**fields_data)`, which includes `parts=` as a keyword — so any `ToolResult` deserialised from Redis history is crashing with "__init__() got an unexpected keyword argument 'parts'".

Updated to accept `parts=` as a keyword in addition to the varargs form. Existing ToolResult(x, y) callers should work as expected and deserialising now works for this case.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
