### PR TITLE
fix(beta): Dispatch RedisStream events locally before publishing

### DIFF
--- a/autogen/beta/streams/redis/stream.py
+++ b/autogen/beta/streams/redis/stream.py
@@ -16,6 +16,10 @@ from autogen.beta.stream import MemoryStream
 from .serializer import Serializer, deserialize, serialize
 from .storage import RedisStorage
 
+# Byte used to separate the origin instance ID from the serialized payload
+# in Redis Pub/Sub messages.  Works for both JSON and pickle payloads.
+_ORIGIN_SEP = b"\x1e"  # ASCII Record Separator
+
 
 class RedisStream(MemoryStream):
     """A full-featured stream with Redis-backed pub/sub and persistent event history.
@@ -24,8 +28,12 @@ class RedisStream(MemoryStream):
     and machines receive every event. History is persisted to Redis.
 
     Event flow:
-        send() → persist to Redis + publish to Pub/Sub channel
-        listener → receives from Pub/Sub → dispatches to local subscribers
+        send() → persist to Redis + dispatch locally + publish to Pub/Sub
+        listener → receives from Pub/Sub → skips self-originated → dispatches
+
+    Local subscribers see events immediately without a Redis roundtrip.
+    Remote listeners receive events via Pub/Sub and dispatch to their own
+    local subscribers using a captured base context for dependency injection.
 
     Args:
         redis_url: Redis connection URL.
@@ -60,6 +68,10 @@ class RedisStream(MemoryStream):
         self._listener_ready = asyncio.Event()
         self._pubsub_redis = aioredis.from_url(redis_url)
         self._publish_redis = aioredis.from_url(redis_url)
+        # Captured from the first send() call so the listener can provide
+        # a context with proper dependency_provider and dependencies to
+        # subscribers processing events from remote instances.
+        self._base_context: Context | None = None
 
     def _ensure_listener(self) -> None:
         """Start the Redis Pub/Sub listener if not already running."""
@@ -76,23 +88,50 @@ class RedisStream(MemoryStream):
             async for message in pubsub.listen():
                 if message["type"] != "message":
                     continue
-                event = deserialize(message["data"], self._serializer)
+                origin, payload = self._split_origin(message["data"])
+                # Skip events published by this instance — they were already
+                # dispatched to local subscribers in send().
+                if origin == self._instance_id:
+                    continue
+                event = deserialize(payload, self._serializer)
                 if isinstance(event, BaseEvent):
-                    await super().send(event, Context(self))
+                    ctx = self._base_context or Context(self)
+                    await super().send(event, ctx)
         except asyncio.CancelledError:
             pass
         finally:
             await pubsub.unsubscribe(self._channel)
             await pubsub.aclose()
 
+    @staticmethod
+    def _split_origin(raw: bytes) -> tuple[str | None, bytes]:
+        """Split an origin-tagged message into (origin_id, payload).
+
+        Messages are framed as ``<instance_id> <RS> <payload>``.
+        If the separator is missing the entire message is treated as payload.
+        """
+        parts = raw.split(_ORIGIN_SEP, 1)
+        if len(parts) == 2:
+            return parts[0].decode(), parts[1]
+        return None, raw
+
     async def send(self, event: BaseEvent, context: Context) -> None:
-        """Persist the event and publish to Redis for all listeners (including self)."""
+        """Persist the event, dispatch locally, and publish to Redis for remote listeners."""
         self._ensure_listener()
         await self._listener_ready.wait()
+        # Capture the first caller's context so the listener can reuse its
+        # dependency_provider and dependencies for remotely-received events.
+        if self._base_context is None:
+            self._base_context = context
         # Persist once — only the sender writes to history
         await self._redis_storage.save_event(event, context)
-        # Publish to Redis — all listeners dispatch to their local subscribers
-        await self._publish_redis.publish(self._channel, serialize(event, self._serializer))
+        # Dispatch to local subscribers immediately, avoiding a Redis roundtrip
+        await super().send(event, context)
+        # Publish to Redis with origin tag — remote listeners dispatch,
+        # local listener skips (already dispatched above).
+        payload = serialize(event, self._serializer)
+        tagged = self._instance_id.encode() + _ORIGIN_SEP + payload
+        await self._publish_redis.publish(self._channel, tagged)
 
     async def close(self) -> None:
         if self._listener_task and not self._listener_task.done():

--- a/autogen/beta/streams/redis/stream.py
+++ b/autogen/beta/streams/redis/stream.py
@@ -68,8 +68,8 @@ class RedisStream(MemoryStream):
         self._listener_ready = asyncio.Event()
         self._pubsub_redis = aioredis.from_url(redis_url)
         self._publish_redis = aioredis.from_url(redis_url)
-        # Captured from the first send() call so the listener can provide
-        # a context with proper dependency_provider and dependencies to
+        # Captured on first send() call so the listener can provide
+        # proper dependency_provider context and dependencies to
         # subscribers processing events from remote instances.
         self._base_context: Context | None = None
 
@@ -119,8 +119,6 @@ class RedisStream(MemoryStream):
         """Persist the event, dispatch locally, and publish to Redis for remote listeners."""
         self._ensure_listener()
         await self._listener_ready.wait()
-        # Capture the first caller's context so the listener can reuse its
-        # dependency_provider and dependencies for remotely-received events.
         if self._base_context is None:
             self._base_context = context
         # Persist once — only the sender writes to history

--- a/test/beta/stream/redis/test_redis_stream.py
+++ b/test/beta/stream/redis/test_redis_stream.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import contextlib
 from collections import defaultdict
 from unittest.mock import patch
 from uuid import uuid4
@@ -365,3 +366,25 @@ class TestRedisStream:
         assert len(received_a) == 1
         assert len(received_b) == 1
         assert len(received_c) == 1
+
+    async def test_local_dispatch_survives_listener_failure(self, redis_stream):
+        """Local subscribers keep receiving events after the pub/sub listener dies."""
+        stream = redis_stream()
+        received = []
+        stream.subscribe(lambda ev: received.append(ev))
+        stream._ensure_listener()
+        await stream._listener_ready.wait()
+
+        stream._listener_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await stream._listener_task
+        dead_task = stream._listener_task
+        # Block auto-restart so the next send() must rely on local dispatch.
+        stream._ensure_listener = lambda: None
+
+        await stream.send(ToolCallEvent(name="post_crash", arguments=""), context=Context(stream))
+        await asyncio.sleep(0.05)
+
+        assert len(received) == 1
+        assert received[0].name == "post_crash"
+        assert stream._listener_task is dead_task and dead_task.done()


### PR DESCRIPTION
## Why are these changes needed?

`RedisStream.send()` currently publishes every event through Redis pub/sub and relies on the listener loop to dispatch back to local subscribers. That couples local delivery to pub/sub health — if the listener task dies (e.g., from a deserialization error like the `ToolResult(parts=...)` bug fixed in #2725), local subscribers silently stop receiving events even while `send()` keeps succeeding. It also pays a Redis round-trip for events that originated in the same process, and has no protection against double-dispatch when multiple instances share a channel.

Now, `send()` dispatches to local subscribers immediately after persisting, then publishes an origin-tagged message (`<instance_id><RS><payload>`) for remote listeners. The listener skips messages whose origin tag matches its own instance, preventing double-dispatch. Remote-received events are dispatched with a `_base_context` captured from the first `send()` call so subscribers processing cross-instance events get the proper `dependency_provider` and `dependencies`.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
