### PR TITLE
feat(interop-langchain): add ChatVertexAI factory for Gemini on Vertex AI

### DIFF
--- a/autogen/interop/langchain/langchain_chat_model_factory.py
+++ b/autogen/interop/langchain/langchain_chat_model_factory.py
@@ -15,6 +15,7 @@ with optional_import_block():
     from langchain_anthropic import ChatAnthropic
     from langchain_core.language_models import BaseChatModel
     from langchain_google_genai import ChatGoogleGenerativeAI
+    from langchain_google_vertexai import ChatVertexAI
     from langchain_ollama import ChatOllama
     from langchain_openai import AzureChatOpenAI, ChatOpenAI
 
@@ -25,7 +26,14 @@ T = TypeVar("T", bound="LangChainChatModelFactory")
 
 
 @require_optional_import(
-    ["langchain_anthropic", "langchain_google_genai", "langchain_ollama", "langchain_openai", "langchain_core"],
+    [
+        "langchain_anthropic",
+        "langchain_google_genai",
+        "langchain_google_vertexai",
+        "langchain_ollama",
+        "langchain_openai",
+        "langchain_core",
+    ],
     "browser-use",
     except_for=["__init__", "register_factory"],
 )
@@ -111,6 +119,15 @@ class ChatAnthropicFactory(LangChainChatModelFactory):
 
 @LangChainChatModelFactory.register_factory()
 class ChatGoogleGenerativeAIFactory(LangChainChatModelFactory):
+    """Route LLMConfig -> langchain_google_genai.ChatGoogleGenerativeAI.
+
+    Targets the AI Studio endpoint (generativelanguage.googleapis.com).
+    Use this api_type when authenticating with a Gemini / AI Studio API
+    key. For Vertex AI (aiplatform.googleapis.com) with ADC / service
+    account auth and project/location, use ``api_type="google_vertex"``
+    instead (see ChatVertexAIFactory).
+    """
+
     @classmethod
     def create(cls, first_llm_config: dict[str, Any]) -> "ChatGoogleGenerativeAI":  # type: ignore [no-any-unimported]
         first_llm_config = cls.prepare_config(first_llm_config)
@@ -120,6 +137,37 @@ class ChatGoogleGenerativeAIFactory(LangChainChatModelFactory):
     @classmethod
     def get_api_type(cls) -> str:
         return "google"
+
+
+@LangChainChatModelFactory.register_factory()
+class ChatVertexAIFactory(LangChainChatModelFactory):
+    """Route LLMConfig -> langchain_google_vertexai.ChatVertexAI.
+
+    Targets the Vertex AI endpoint (aiplatform.googleapis.com) with
+    Google Cloud auth (ADC / service account). Use this api_type when
+    your GCP project authenticates via application default credentials
+    and needs Vertex AI billing + quota — not the AI Studio endpoint
+    that ``api_type="google"`` targets.
+
+    Accepts the usual ChatVertexAI kwargs: ``project``, ``location``,
+    ``credentials``, ``model`` and the temperature / request-options
+    common across langchain chat models. The AG2-typical
+    ``project_id`` field is normalized to ``project`` for convenience.
+    """
+
+    @classmethod
+    def create(cls, first_llm_config: dict[str, Any]) -> "ChatVertexAI":  # type: ignore [no-any-unimported]
+        first_llm_config = cls.prepare_config(first_llm_config)
+        # ChatVertexAI takes `project`, not `project_id`. Normalize so callers
+        # using the AG2-style `project_id` field don't need to learn the
+        # langchain name.
+        if "project_id" in first_llm_config:
+            first_llm_config.setdefault("project", first_llm_config.pop("project_id"))
+        return ChatVertexAI(**first_llm_config)
+
+    @classmethod
+    def get_api_type(cls) -> str:
+        return "google_vertex"
 
 
 @LangChainChatModelFactory.register_factory()

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -106,7 +106,11 @@ logger = logging.getLogger(__name__)
 
 
 class GeminiEntryDict(LLMConfigEntryDict, total=False):
-    api_type: Literal["google"]
+    # "google" targets the AI Studio endpoint; "google_vertex" targets the
+    # Vertex AI endpoint. Both map through the same Gemini config entry —
+    # the langchain factory + any Google-side routing dispatches on the
+    # string value.
+    api_type: Literal["google", "google_vertex"]
 
     project_id: str | None
     location: str | None
@@ -120,7 +124,9 @@ class GeminiEntryDict(LLMConfigEntryDict, total=False):
 
 
 class GeminiLLMConfigEntry(LLMConfigEntry):
-    api_type: Literal["google"] = "google"
+    # "google" = AI Studio (generativelanguage.googleapis.com);
+    # "google_vertex" = Vertex AI (aiplatform.googleapis.com).
+    api_type: Literal["google", "google_vertex"] = "google"
     project_id: str | None = None
     location: str | None = None
     # google_application_credentials points to the path of the JSON Keyfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ quick-research = [
 
 browser-use = [
     "browser-use>=0.3.1,<1.0",
+    "langchain-google-vertexai>=2.0,<3.0",
 ]
 
 google-client = ["google-api-python-client>=2.163.0,<3.0"]

--- a/test/tools/experimental/browser_use/test_langchain_factory.py
+++ b/test/tools/experimental/browser_use/test_langchain_factory.py
@@ -15,14 +15,21 @@ with optional_import_block():
 
 
 @run_for_optional_imports(
-    ["langchain_anthropic", "langchain_google_genai", "langchain_ollama", "langchain_openai", "langchain_core"],
+    [
+        "langchain_anthropic",
+        "langchain_google_genai",
+        "langchain_google_vertexai",
+        "langchain_ollama",
+        "langchain_openai",
+        "langchain_core",
+    ],
     "browser-use",
 )
 class TestLangchainFactory:
     test_api_key = "test"  # pragma: allowlist secret
 
     def test_number_of_factories(self) -> None:
-        assert len(LangChainChatModelFactory._factories) == 6
+        assert len(LangChainChatModelFactory._factories) == 7
 
     @pytest.mark.parametrize(
         ("config_list", "llm_class_name", "base_url"),
@@ -64,6 +71,18 @@ class TestLangchainFactory:
                     {"api_type": "google", "model": "gemini", "api_key": test_api_key},
                 ],
                 "ChatGoogleGenerativeAI",
+                None,
+            ),
+            (
+                [
+                    {
+                        "api_type": "google_vertex",
+                        "model": "gemini-2.5-flash",
+                        "project": "test-project",
+                        "location": "us-central1",
+                    },
+                ],
+                "ChatVertexAI",
                 None,
             ),
             (
@@ -128,7 +147,77 @@ class TestLangchainFactory:
 
 
 @run_for_optional_imports(
-    ["langchain_anthropic", "langchain_google_genai", "langchain_ollama", "langchain_openai", "langchain_core"],
+    [
+        "langchain_anthropic",
+        "langchain_google_genai",
+        "langchain_google_vertexai",
+        "langchain_ollama",
+        "langchain_openai",
+        "langchain_core",
+    ],
+    "browser-use",
+)
+class TestChatVertexAIFactory:
+    """The ChatVertexAIFactory (api_type='google_vertex') is the Vertex AI
+    counterpart of the AI-Studio-oriented ChatGoogleGenerativeAIFactory.
+    It routes to aiplatform.googleapis.com and uses Google Cloud auth."""
+
+    def test_accepts_google_vertex(self) -> None:
+        from autogen.interop.langchain.langchain_chat_model_factory import ChatVertexAIFactory
+
+        assert ChatVertexAIFactory.accepts({"api_type": "google_vertex"}) is True
+        assert ChatVertexAIFactory.accepts({"api_type": "google"}) is False
+        assert ChatVertexAIFactory.accepts({"api_type": "openai"}) is False
+
+    def test_creates_chat_vertex_ai(self) -> None:
+        from langchain_google_vertexai import ChatVertexAI
+
+        llm = LangChainChatModelFactory.create_base_chat_model(
+            llm_config={
+                "config_list": [
+                    {
+                        "api_type": "google_vertex",
+                        "model": "gemini-2.5-flash",
+                        "project": "test-project",
+                        "location": "us-central1",
+                    }
+                ]
+            }
+        )
+        assert isinstance(llm, ChatVertexAI)
+        assert llm.project == "test-project"
+        assert llm.location == "us-central1"
+
+    def test_project_id_is_normalized_to_project(self) -> None:
+        """Callers using the AG2-style ``project_id`` should not need to
+        learn the langchain-internal name ``project``."""
+        from langchain_google_vertexai import ChatVertexAI
+
+        llm = LangChainChatModelFactory.create_base_chat_model(
+            llm_config={
+                "config_list": [
+                    {
+                        "api_type": "google_vertex",
+                        "model": "gemini-2.5-flash",
+                        "project_id": "my-project",
+                        "location": "us-central1",
+                    }
+                ]
+            }
+        )
+        assert isinstance(llm, ChatVertexAI)
+        assert llm.project == "my-project"
+
+
+@run_for_optional_imports(
+    [
+        "langchain_anthropic",
+        "langchain_google_genai",
+        "langchain_google_vertexai",
+        "langchain_ollama",
+        "langchain_openai",
+        "langchain_core",
+    ],
     "browser-use",
 )
 class TestChatOpenAIFactory:


### PR DESCRIPTION
## Summary

- Adds `ChatVertexAIFactory` registered for `api_type="google_vertex"` in `autogen.interop.langchain.langchain_chat_model_factory`, routing AG2 `LLMConfig` to `langchain_google_vertexai.ChatVertexAI` (Vertex AI endpoint, Google Cloud auth).
- Non-breaking: existing `api_type="google"` users keep AI Studio behavior via `ChatGoogleGenerativeAI`.
- Adds `langchain-google-vertexai` to the `browser-use` extra in `pyproject.toml` so the import resolves for users installing `ag2[browser-use]`.
- Adds tests covering the new route, including the AG2-typical `project_id` → ChatVertexAI-style `project` normalization.

## Motivation

AG2's `LangChainChatModelFactory` had no Vertex AI code path. When a caller configured a Gemini model with Google Cloud project and location:

```python
LLMConfig({
    "api_type": "google",
    "model": "gemini-2.5-flash",
    "project_id": "my-project",
    "location": "us-central1",
    "google_application_credentials": "/path/to/sa.json",
})
```

…the factory unconditionally instantiated `ChatGoogleGenerativeAI`, which targets the AI Studio endpoint (`generativelanguage.googleapis.com`) and does not understand `project_id` / `location` / `google_application_credentials`. Those fields were silently dropped or raised as invalid kwargs.

This gap has been latent for most users because many GCP projects historically had both AI Studio and Vertex AI enabled — AG2's misrouting hit AI Studio and AI Studio responded. As Google rolls out its enterprise migration disabling the AI Studio endpoint for Vertex-authorized projects, these users now get `PermissionDenied: 403 ... SERVICE_DISABLED` from an API they never intended to call. Their Vertex credentials sitting in the same `LLMConfig` do nothing.

The fix is to add an explicit Vertex AI route rather than trying to rescue the existing `"google"` factory — keeping the change non-breaking and making caller intent unambiguous.

## Test plan

- [x] `test_number_of_factories` passes at 7
- [x] `api_type="google_vertex"` with `project` + `location` instantiates `ChatVertexAI`
- [x] `project_id` in the config is normalized to `project`
- [x] `accepts()` is disjoint from `"google"` and `"openai"`
- [x] Existing `api_type="google"` tests unchanged and still pass