### PR TITLE
ci: skip Claude Code Review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,8 +18,9 @@ on:
 jobs:
   claude-review:
     if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
-      github.event_name == 'workflow_dispatch'
+      github.actor != 'dependabot[bot]' &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Adds `github.actor != 'dependabot[bot]'` condition to the `claude-review` job
- Dependabot PRs were failing with `Workflow initiated by non-human actor: dependabot (type: Bot)` from `claude-code-action`
- Claude reviewing dependency bump PRs provides no value, so skipping entirely is the right call

## Test plan

- [ ] Verify the next Dependabot PR skips the Claude Code Review job entirely
- [ ] Verify normal PRs still trigger the Claude Code Review job as expected

Closes #2707