### PR TITLE
fix(groupchat): align async speaker selection start_message with sync version

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -938,6 +938,7 @@ class GroupChat:
         if self.select_speaker_prompt_template is not None:
             start_message = {
                 "content": self.select_speaker_prompt(agents),
+                "name": "checking_agent",
                 "override_role": self.role_for_select_speaker_messages,
             }
         else:


### PR DESCRIPTION
## Summary

Sync/async parity fix in \`GroupChat\`'s auto speaker selection.

The synchronous \`_auto_select_speaker\` builds its \`start_message\` dict with a \`\"name\": \"checking_agent\"\` field:

\`\`\`python
# autogen/agentchat/groupchat.py:855-861 (sync)
if self.select_speaker_prompt_template is not None:
    start_message = {
        \"content\": self.select_speaker_prompt(agents),
        \"name\": \"checking_agent\",                        # ← present
        \"override_role\": self.role_for_select_speaker_messages,
    }
\`\`\`

But the async \`a_auto_select_speaker\` was missing \`\"name\"\` when constructing the equivalent dict:

\`\`\`python
# autogen/agentchat/groupchat.py:937-942 (async, before this PR)
if self.select_speaker_prompt_template is not None:
    start_message = {
        \"content\": self.select_speaker_prompt(agents),
        # ← \"name\": \"checking_agent\" was missing
        \"override_role\": self.role_for_select_speaker_messages,
    }
\`\`\`

## Why this matters

Without the \`\"name\"\` field on the kicker message, downstream message handling treats the speaker-selection prompt as nameless. Code paths that filter or attribute messages by sender name (chat-history processing, transcript rendering, transforms keyed off \`name\`) then behave inconsistently between sync and async group chats — same configuration, different observable behavior depending only on whether you used \`run_chat\` vs \`a_run_chat\`.

## Scope

Strict sync/async parity — the rest of the dict (\`content\`, \`override_role\`) and the surrounding flow (\`_create_internal_agents\`, \`max_turns\`, \`silent\`, \`_speaker_selection_transforms\`) are already identical between the two versions. This brings them into full alignment.

## Test plan

- [x] Diffed lines 845-880 (sync) vs lines 927-962 (async) — confirmed the \`name\` field is the only meaningful difference in \`start_message\` construction.
- [x] No new behavior — restoring missing field that the sync path already sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)