### PR TITLE
Add AI policy alignment to PR template and AGENTS.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,3 +15,11 @@
 - [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
 - [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
 - [ ] I've made sure all auto checks have passed.
+
+## AI assistance
+
+<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->
+
+- [ ] I understand the changes in this PR and can explain them in my own words.
+- [ ] I have verified that the PR description accurately reflects the actual diff.
+- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,8 +18,9 @@ on:
 jobs:
   claude-review:
     if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
-      github.event_name == 'workflow_dispatch'
+      github.actor != 'dependabot[bot]' &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # AG2 Beta Development Guidelines
 
+## AI-assisted contribution policy
+
+Before opening a PR, read and follow `.github/AI_POLICY.md`.
+
+- Do not open PRs with unverified AI-generated code or text.
+- Ensure the PR description explains the real problem or use case and accurately reflects the diff.
+- Include validation and testing information in the PR body.
+- Be prepared to explain and revise the contribution in response to reviewer questions.
+
 ## Common rules
 
 - Never use `from __future__ import annotations`.


### PR DESCRIPTION
This PR makes two related contributor workflow improvements, both aimed at improving signal quality without introducing blocking enforcement.

## Changes

### 1. Operationalizes the existing AI policy

- Updated `.github/PULL_REQUEST_TEMPLATE.md`:
  - Added an "AI assistance" section with three checkboxes
  - Reinforces that contributors must understand, validate, and review their changes
  - References `.github/AI_POLICY.md` as the source of truth

- Updated `AGENTS.md`:
  - Added a short section for coding agents (e.g., Claude Code)
  - Instructs agents to read `.github/AI_POLICY.md` before opening PRs
  - Encourages clear use case descriptions, accurate PR bodies, and validation details

### 2. Skips Claude Code Review for Dependabot PRs

- Updated `.github/workflows/claude-code-review.yml`:
  - Adds `github.actor != 'dependabot[bot]'` to the job condition
  - Prevents the Claude review job from running on automated dependency bump PRs, where it adds no value and was previously failing
  - No change to behavior for human-authored or manually triggered PRs

## Notes

- No new policy introduced — both changes reinforce `.github/AI_POLICY.md` as the existing source of truth
- No blocking enforcement added
- Minimal, targeted changes only