### PR TITLE
fix(docs): Code examples documentation tidy

### DIFF
--- a/website/docs/beta/code_examples/01_hello_agent.mdx
+++ b/website/docs/beta/code_examples/01_hello_agent.mdx
@@ -27,7 +27,7 @@ one ``ask()`` call. No tools, no harness primitives, no plugins.
 
 Run::
 
-    .venv-beta/bin/python playground/01_hello_agent.py
+    .venv-beta/bin/python 01_hello_agent.py
 """
 
 import asyncio

--- a/website/docs/beta/code_examples/02_recipe_builder.mdx
+++ b/website/docs/beta/code_examples/02_recipe_builder.mdx
@@ -30,7 +30,7 @@ Shows two core Agent features on top of the bare loop:
 
 Run::
 
-    .venv-beta/bin/python playground/02_recipe_builder.py
+    .venv-beta/bin/python 02_recipe_builder.py
 """
 
 import asyncio

--- a/website/docs/beta/code_examples/03_travel_planner.mdx
+++ b/website/docs/beta/code_examples/03_travel_planner.mdx
@@ -28,7 +28,7 @@ context each time — the stream stays alive across the whole dialogue.
 
 Run::
 
-    .venv-beta/bin/python playground/03_travel_planner.py
+    .venv-beta/bin/python 03_travel_planner.py
 """
 
 import asyncio

--- a/website/docs/beta/code_examples/04_token_watchdog.mdx
+++ b/website/docs/beta/code_examples/04_token_watchdog.mdx
@@ -34,7 +34,7 @@ Demonstrates three observer patterns running against a single Agent:
 
 Run::
 
-    .venv-beta/bin/python playground/04_token_watchdog.py
+    .venv-beta/bin/python 04_token_watchdog.py
 """
 
 import asyncio

--- a/website/docs/beta/code_examples/05_research_squad.mdx
+++ b/website/docs/beta/code_examples/05_research_squad.mdx
@@ -40,7 +40,7 @@ Two patterns for multi-Agent orchestration:
 
 Run::
 
-    .venv-beta/bin/python playground/05_research_squad.py
+    .venv-beta/bin/python 05_research_squad.py
 """
 
 import asyncio

--- a/website/docs/beta/code_examples/06_journal_companion.mdx
+++ b/website/docs/beta/code_examples/06_journal_companion.mdx
@@ -42,7 +42,7 @@ history.
 
 Run::
 
-    .venv-beta/bin/python playground/06_journal_companion.py
+    .venv-beta/bin/python 06_journal_companion.py
 """
 
 import asyncio

--- a/website/docs/beta/code_examples/07_long_doc_chat.mdx
+++ b/website/docs/beta/code_examples/07_long_doc_chat.mdx
@@ -40,7 +40,7 @@ stream history itself (not just the view into it) is kept small.
 
 Run::
 
-    .venv-beta/bin/python playground/07_long_doc_chat.py
+    .venv-beta/bin/python 07_long_doc_chat.py
 """
 
 import asyncio

--- a/website/docs/beta/code_examples/08_safety_guard.mdx
+++ b/website/docs/beta/code_examples/08_safety_guard.mdx
@@ -41,7 +41,7 @@ there is fully wired by the framework:
 
 Run::
 
-    .venv-beta/bin/python playground/08_safety_guard.py
+    .venv-beta/bin/python 08_safety_guard.py
 """
 
 import asyncio

--- a/website/docs/beta/code_examples/code_examples.mdx
+++ b/website/docs/beta/code_examples/code_examples.mdx
@@ -3,7 +3,7 @@ title: "Code Examples"
 sidebarTitle: "Overview"
 ---
 
-End-to-end runnable scripts demonstrating `autogen.beta`. Each example is self-contained, instantiates a `GeminiConfig` directly, and exercises one or two specific harness primitives so you can read it top-to-bottom and copy what you need. The same scripts live in `playground/` at the repo root for quick local hacking.
+End-to-end runnable scripts demonstrating `autogen.beta`. Each example is self-contained, instantiates a `GeminiConfig` directly, and exercises one or two specific harness primitives so you can read it top-to-bottom and copy what you need.
 
 ## Examples
 
@@ -18,16 +18,5 @@ End-to-end runnable scripts demonstrating `autogen.beta`. Each example is self-c
 | 07 | [Long-Doc Chat](/docs/beta/code_examples/07_long_doc_chat) | Composing assembly policies + compaction | `assembly=[...]`, `SlidingWindowPolicy`, `TokenBudgetPolicy`, `TailWindowCompact` |
 | 08 | [Safety Guard](/docs/beta/code_examples/08_safety_guard) | FATAL alert → `AlertPolicy` → `HaltEvent` | `ObserverAlert(FATAL)`, `AlertPolicy`, `HaltEvent` |
 
-## Running locally
-
-The same scripts ship in [`playground/`](https://github.com/ag2ai/ag2/tree/main/playground){.external-link target="_blank"} at the repo root. From a clone:
-
-```bash
-# Install beta extras
-uv sync --extra beta
-
-# Run any example
-.venv-beta/bin/python playground/01_hello_agent.py
-```
 
 Set `GEMINI_API_KEY` (or swap in another provider's `ModelConfig` — `AnthropicConfig`, `OpenAIConfig`, etc.) before running.


### PR DESCRIPTION
## Why are these changes needed?

Code examples don't live as files in the repo as originally planned, so tidied documentation references.

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
