### PR TITLE
feat(beta): expose normalized parts on builtin tool result events

### DIFF
--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -35,10 +35,6 @@ from pydantic import ValidationError
 from typing_extensions import TypeVar as TypeVar313
 
 from autogen.beta.events import BinaryResult
-from autogen.beta.tools.builtin.web_search import (
-    WEB_SEARCH_TOOL_NAME,
-    WebSearchToolSchema,
-)
 
 from .aggregate import AggregateStrategy, AggregateTrigger
 from .annotations import Context
@@ -957,8 +953,8 @@ class Agent(Generic[TResult]):
                 for schema in schemas:
                     if isinstance(schema, FunctionToolSchema):
                         known_tools.add(schema.function.name)
-                    elif isinstance(schema, WebSearchToolSchema):
-                        known_tools.add(WEB_SEARCH_TOOL_NAME)
+                    else:
+                        known_tools.add(schema.type)
 
             middleware_instances: list[BaseMiddleware] = []
             agent_turn: AgentTurn = _execute_turn

--- a/autogen/beta/config/anthropic/events.py
+++ b/autogen/beta/config/anthropic/events.py
@@ -3,18 +3,43 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from typing import TypeAlias
+from base64 import b64decode
+from typing import Any, TypeAlias
 
 from anthropic.types import (
+    Base64PDFSource,
+    BashCodeExecutionResultBlock,
     BashCodeExecutionToolResultBlock,
+    BashCodeExecutionToolResultError,
+    CodeExecutionResultBlock,
     CodeExecutionToolResultBlock,
+    CodeExecutionToolResultError,
+    EncryptedCodeExecutionResultBlock,
+    PlainTextSource,
     ServerToolUseBlock,
+    TextEditorCodeExecutionCreateResultBlock,
+    TextEditorCodeExecutionStrReplaceResultBlock,
     TextEditorCodeExecutionToolResultBlock,
+    TextEditorCodeExecutionToolResultError,
+    TextEditorCodeExecutionViewResultBlock,
+    WebFetchBlock,
     WebFetchToolResultBlock,
+    WebFetchToolResultErrorBlock,
+    WebSearchResultBlock,
     WebSearchToolResultBlock,
+    WebSearchToolResultError,
 )
 
-from autogen.beta.events import BuiltinToolCallEvent, BuiltinToolResultEvent
+from autogen.beta.events import (
+    BinaryInput,
+    BinaryType,
+    BuiltinToolCallEvent,
+    BuiltinToolResultEvent,
+    FileIdInput,
+    Input,
+    TextInput,
+    UrlInput,
+)
 from autogen.beta.events.base import Field
 from autogen.beta.events.tool_events import ToolResult
 from autogen.beta.tools.builtin.code_execution import CODE_EXECUTION_TOOL_NAME
@@ -57,24 +82,103 @@ class AnthropicServerToolResultEvent(BuiltinToolResultEvent):
 
     @classmethod
     def from_block(cls, block: object) -> "AnthropicServerToolResultEvent | None":
+        name: str
+        parts: list[Input] = []
+        metadata: dict[str, Any] = {}
+
         if isinstance(block, WebSearchToolResultBlock):
             name = WEB_SEARCH_TOOL_NAME
+            content = block.content
+            if isinstance(content, WebSearchToolResultError):
+                parts = [TextInput(f"{content.type}: {content.error_code}")]
+                metadata = {"error": True, "error_code": content.error_code, "type": content.type}
+            else:
+                parts = [
+                    UrlInput(
+                        r.url,
+                        kind=BinaryType.BINARY,
+                        metadata={"title": r.title, "page_age": r.page_age},
+                    )
+                    for r in content
+                    if isinstance(r, WebSearchResultBlock)
+                ]
+                metadata = {"count": len(content)}
+
         elif isinstance(block, WebFetchToolResultBlock):
             name = WEB_FETCH_TOOL_NAME
-        elif isinstance(
-            block,
-            (
-                CodeExecutionToolResultBlock,
-                BashCodeExecutionToolResultBlock,
-                TextEditorCodeExecutionToolResultBlock,
-            ),
-        ):
+            content = block.content
+            if isinstance(content, WebFetchToolResultErrorBlock):
+                parts = [TextInput(f"{content.type}: {content.error_code}")]
+                metadata = {"error": True, "error_code": content.error_code, "type": content.type}
+            elif isinstance(content, WebFetchBlock):
+                document = content.content
+                source = document.source
+                parts = [UrlInput(content.url, kind=BinaryType.BINARY)]
+                if isinstance(source, Base64PDFSource):
+                    parts.append(
+                        BinaryInput(b64decode(source.data), media_type="application/pdf", kind=BinaryType.DOCUMENT)
+                    )
+                elif isinstance(source, PlainTextSource):
+                    parts.append(TextInput(source.data))
+                metadata = {"retrieved_at": content.retrieved_at, "title": document.title}
+
+        elif isinstance(block, (CodeExecutionToolResultBlock, BashCodeExecutionToolResultBlock)):
             name = CODE_EXECUTION_TOOL_NAME
+            content = block.content
+            if isinstance(content, (CodeExecutionToolResultError, BashCodeExecutionToolResultError)):
+                parts = [TextInput(f"{content.type}: {content.error_code}")]
+                metadata = {"error": True, "error_code": content.error_code, "type": content.type}
+            elif isinstance(content, EncryptedCodeExecutionResultBlock):
+                parts = [FileIdInput(o.file_id) for o in content.content]
+                metadata = {"return_code": content.return_code, "encrypted": True}
+            elif isinstance(content, (CodeExecutionResultBlock, BashCodeExecutionResultBlock)):
+                if content.stdout:
+                    parts.append(TextInput(content.stdout))
+                if content.stderr:
+                    parts.append(TextInput(content.stderr))
+                parts.extend(FileIdInput(o.file_id) for o in content.content)
+                metadata = {"return_code": content.return_code}
+
+        elif isinstance(block, TextEditorCodeExecutionToolResultBlock):
+            name = CODE_EXECUTION_TOOL_NAME
+            content = block.content
+            if isinstance(content, TextEditorCodeExecutionToolResultError):
+                text = f"{content.type}: {content.error_code}"
+                if content.error_message:
+                    text = f"{text}: {content.error_message}"
+                parts = [TextInput(text)]
+                metadata = {
+                    "error": True,
+                    "error_code": content.error_code,
+                    "error_message": content.error_message,
+                    "type": content.type,
+                }
+            elif isinstance(content, TextEditorCodeExecutionViewResultBlock):
+                parts = [TextInput(content.content)]
+                metadata = {
+                    "file_type": content.file_type,
+                    "num_lines": content.num_lines,
+                    "start_line": content.start_line,
+                    "total_lines": content.total_lines,
+                }
+            elif isinstance(content, TextEditorCodeExecutionCreateResultBlock):
+                metadata = {"is_file_update": content.is_file_update}
+            elif isinstance(content, TextEditorCodeExecutionStrReplaceResultBlock):
+                if content.lines is not None:
+                    parts = [TextInput("\n".join(content.lines))]
+                metadata = {
+                    "new_lines": content.new_lines,
+                    "new_start": content.new_start,
+                    "old_lines": content.old_lines,
+                    "old_start": content.old_start,
+                }
+
         else:
             return None
+
         return cls(
             parent_id=block.tool_use_id,
             name=name,
-            result=ToolResult(),
+            result=ToolResult(parts=parts, metadata=metadata),
             block=block,
         )

--- a/autogen/beta/config/gemini/events.py
+++ b/autogen/beta/config/gemini/events.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from typing import Any
 from uuid import uuid4
 
 from google.genai import types
 
-from autogen.beta.events import BuiltinToolCallEvent, BuiltinToolResultEvent
+from autogen.beta.events import BinaryType, BuiltinToolCallEvent, BuiltinToolResultEvent, Input, TextInput, UrlInput
 from autogen.beta.events.base import Field
 from autogen.beta.events.tool_events import ToolResult
 from autogen.beta.tools.builtin.code_execution import CODE_EXECUTION_TOOL_NAME
@@ -47,20 +48,34 @@ class GeminiServerToolResultEvent(BuiltinToolResultEvent):
 
     @classmethod
     def from_code_execution_result(cls, part: types.Part, *, parent_id: str) -> "GeminiServerToolResultEvent | None":
-        if part.code_execution_result is None:
+        result = part.code_execution_result
+        if result is None:
             return None
+        parts: list[Input] = [TextInput(result.output)] if result.output else []
+        metadata = {"outcome": result.outcome.name if result.outcome is not None else None}
         return cls(
             parent_id=parent_id,
             name=CODE_EXECUTION_TOOL_NAME,
-            result=ToolResult(),
+            result=ToolResult(parts=parts, metadata=metadata),
             part=part,
         )
 
     @classmethod
     def from_grounding(cls, gm: types.GroundingMetadata, *, parent_id: str, name: str) -> "GeminiServerToolResultEvent":
+        chunks = gm.grounding_chunks or []
+        parts: list[Input] = [
+            UrlInput(
+                chunk.web.uri,
+                kind=BinaryType.BINARY,
+                metadata={"title": chunk.web.title, "domain": chunk.web.domain},
+            )
+            for chunk in chunks
+            if chunk.web and chunk.web.uri
+        ]
+        metadata: dict[str, Any] = {"queries": list(gm.web_search_queries or [])} if chunks else {}
         return cls(
             parent_id=parent_id,
             name=name,
-            result=ToolResult(),
+            result=ToolResult(parts=parts, metadata=metadata),
             grounding_metadata=gm,
         )

--- a/autogen/beta/config/openai/events.py
+++ b/autogen/beta/config/openai/events.py
@@ -3,16 +3,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from typing import TypeAlias
+from base64 import b64decode
+from typing import Any, TypeAlias
 
 from openai.types.responses import (
     ResponseCodeInterpreterToolCall,
     ResponseFunctionWebSearch,
     ResponseReasoningItem,
 )
+from openai.types.responses.response_code_interpreter_tool_call import OutputImage, OutputLogs
+from openai.types.responses.response_function_web_search import ActionFind, ActionOpenPage, ActionSearch
 from openai.types.responses.response_output_item import ImageGenerationCall
 
-from autogen.beta.events import BuiltinToolCallEvent, BuiltinToolResultEvent, ModelReasoning
+from autogen.beta.events import (
+    BinaryInput,
+    BinaryType,
+    BuiltinToolCallEvent,
+    BuiltinToolResultEvent,
+    Input,
+    ModelReasoning,
+    TextInput,
+    UrlInput,
+)
 from autogen.beta.events.base import Field
 from autogen.beta.events.tool_events import ToolResult
 from autogen.beta.tools.builtin.code_execution import CODE_EXECUTION_TOOL_NAME
@@ -31,7 +43,11 @@ class OpenAIServerToolCallEvent(BuiltinToolCallEvent):
             return cls(
                 id=item.id,
                 name=WEB_SEARCH_TOOL_NAME,
-                arguments=item.action.model_dump_json(),
+                # warnings=False: pydantic 2.x warns on Action discriminated-union
+                # serialization and on action.sources[].type values that the SDK
+                # has not caught up to (e.g. "api"). The warning is informational —
+                # the dump still produces correct JSON for round-trip.
+                arguments=item.action.model_dump_json(warnings=False),
                 item=item,
             )
         if isinstance(item, ResponseCodeInterpreterToolCall):
@@ -54,13 +70,50 @@ class OpenAIServerToolCallEvent(BuiltinToolCallEvent):
 class OpenAIServerToolResultEvent(BuiltinToolResultEvent):
     @classmethod
     def from_item(cls, item: object, *, parent_id: str) -> "OpenAIServerToolResultEvent | None":
+        name: str
+        parts: list[Input] = []
+        metadata: dict[str, Any] = {}
+
         if isinstance(item, ResponseFunctionWebSearch):
-            return cls(parent_id=parent_id, name=WEB_SEARCH_TOOL_NAME, result=ToolResult())
-        if isinstance(item, ResponseCodeInterpreterToolCall):
-            return cls(parent_id=parent_id, name=CODE_EXECUTION_TOOL_NAME, result=ToolResult())
-        if isinstance(item, ImageGenerationCall) and item.result:
-            return cls(parent_id=parent_id, name=IMAGE_GENERATION_TOOL_NAME, result=ToolResult())
-        return None
+            name = WEB_SEARCH_TOOL_NAME
+            action = item.action
+            metadata = {"action_type": action.type, "status": item.status}
+            if isinstance(action, ActionSearch):
+                # `sources` is populated only when the request asks for it via
+                # include=["web_search_call.action.sources"]. The SDK declares
+                # source.url as `str`, but the API has been observed to return
+                # entries with empty url for synthesised/internal sources —
+                # skip them rather than emit UrlInput(None).
+                for source in action.sources or []:
+                    if source.url:
+                        parts.append(UrlInput(source.url, kind=BinaryType.BINARY))
+                if action.queries:
+                    metadata["queries"] = list(action.queries)
+            elif isinstance(action, ActionOpenPage):
+                if action.url:
+                    parts.append(UrlInput(action.url, kind=BinaryType.BINARY))
+            elif isinstance(action, ActionFind):
+                parts.append(UrlInput(action.url, kind=BinaryType.BINARY))
+                metadata["pattern"] = action.pattern
+
+        elif isinstance(item, ResponseCodeInterpreterToolCall):
+            name = CODE_EXECUTION_TOOL_NAME
+            for output in item.outputs or []:
+                if isinstance(output, OutputLogs):
+                    parts.append(TextInput(output.logs))
+                elif isinstance(output, OutputImage):
+                    parts.append(UrlInput(output.url, kind=BinaryType.IMAGE))
+            metadata = {"container_id": item.container_id, "status": item.status}
+
+        elif isinstance(item, ImageGenerationCall) and item.result:
+            name = IMAGE_GENERATION_TOOL_NAME
+            parts = [BinaryInput(b64decode(item.result), media_type="image/png", kind=BinaryType.IMAGE)]
+            metadata = item.model_dump(exclude={"result", "status", "type"})
+
+        else:
+            return None
+
+        return cls(parent_id=parent_id, name=name, result=ToolResult(parts=parts, metadata=metadata))
 
 
 class OpenAIReasoningEvent(ModelReasoning):

--- a/autogen/beta/config/openai/mappers.py
+++ b/autogen/beta/config/openai/mappers.py
@@ -199,7 +199,10 @@ def events_to_responses_input(
                 result.append(message.item.model_dump(exclude_none=True, mode="json"))
 
         elif isinstance(message, OpenAIServerToolCallEvent):
-            result.append(message.item.model_dump(exclude_none=True, mode="json"))
+            # warnings=False: openai SDK pins ActionSearchSource.type to
+            # Literal["url"] but the API returns other values (e.g. "api"),
+            # which makes pydantic warn on every round-trip serialization.
+            result.append(message.item.model_dump(exclude_none=True, mode="json", warnings=False))
 
         elif isinstance(message, ModelRequest):
             for inp in message.parts:
@@ -460,6 +463,14 @@ def tool_to_responses_api(t: ToolSchema) -> dict[str, Any]:
         raise UnsupportedToolError(t.type, "openai-responses")
 
     raise UnsupportedToolError(t.type, "openai-responses")
+
+
+def responses_api_includes(tools: Iterable[ToolSchema]) -> list[str]:
+    includes: list[str] = []
+    for t in tools:
+        if isinstance(t, WebSearchToolSchema):
+            includes.append("web_search_call.action.sources")
+    return includes
 
 
 def normalize_usage(usage: CompletionUsage) -> Usage:

--- a/autogen/beta/config/openai/openai_responses_client.py
+++ b/autogen/beta/config/openai/openai_responses_client.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import base64
 from collections.abc import Iterable, Sequence
 from itertools import chain
 from typing import Any, TypedDict
@@ -45,6 +44,7 @@ from .mappers import (
     events_to_responses_input,
     normalize_responses_usage,
     response_proto_to_text_config,
+    responses_api_includes,
     tool_to_responses_api,
 )
 
@@ -115,11 +115,15 @@ class OpenAIResponsesClient(LLMClient):
 
         instructions = "\n".join(prompt) or None
 
-        openai_tools = [tool_to_responses_api(t) for t in tools]
+        tools_list = list(tools)
+        openai_tools = [tool_to_responses_api(t) for t in tools_list]
 
         kwargs: dict[str, Any] = {}
         if r := response_proto_to_text_config(response_schema):
             kwargs["text"] = r
+
+        if includes := responses_api_includes(tools_list):
+            kwargs["include"] = includes
 
         response = await self._client.responses.create(
             **self._create_options,
@@ -168,15 +172,12 @@ class OpenAIResponsesClient(LLMClient):
 
             elif call_event := OpenAIServerToolCallEvent.from_item(item):
                 await context.send(call_event)
-                if result_event := OpenAIServerToolResultEvent.from_item(item, parent_id=call_event.id):
+                result_event = OpenAIServerToolResultEvent.from_item(item, parent_id=call_event.id)
+                if result_event:
                     await context.send(result_event)
-                if isinstance(item, ImageGenerationCall) and item.result:
-                    files.append(
-                        BinaryResult(
-                            base64.b64decode(item.result),
-                            metadata=item.model_dump(exclude={"result", "status", "type"}),
-                        )
-                    )
+                    if isinstance(item, ImageGenerationCall) and item.result:
+                        binary = result_event.result.parts[0]
+                        files.append(BinaryResult(binary.data, metadata=result_event.result.metadata))
 
         usage = normalize_responses_usage(response.usage) if response.usage else Usage()
 
@@ -231,15 +232,12 @@ class OpenAIResponsesClient(LLMClient):
 
                 elif call_event := OpenAIServerToolCallEvent.from_item(event.item):
                     await context.send(call_event)
-                    if result_event := OpenAIServerToolResultEvent.from_item(event.item, parent_id=call_event.id):
+                    result_event = OpenAIServerToolResultEvent.from_item(event.item, parent_id=call_event.id)
+                    if result_event:
                         await context.send(result_event)
-                    if isinstance(event.item, ImageGenerationCall) and event.item.result:
-                        files.append(
-                            BinaryResult(
-                                base64.b64decode(event.item.result),
-                                metadata=event.item.model_dump(exclude={"result", "status", "type"}),
-                            )
-                        )
+                        if isinstance(event.item, ImageGenerationCall) and event.item.result:
+                            binary = result_event.result.parts[0]
+                            files.append(BinaryResult(binary.data, metadata=result_event.result.metadata))
 
             elif isinstance(event, ResponseCompletedEvent):
                 # Stream finished

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,7 @@ interop-crewai = [
     "weaviate-client>=4,<5; python_version>='3.10' and python_version<'3.13'",
 ]
 interop-langchain = ["langchain-community>=0.3.12,<1"]
-interop-pydantic-ai = ["pydantic-ai>=1.0.12", "fasta2a"]
+interop-pydantic-ai = ["pydantic-ai>=1.0.12,<1.79", "fasta2a"]
 interop = ["ag2[interop-crewai, interop-langchain, interop-pydantic-ai]"]
 
 autobuild = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ ag-ui = [
 diskcache = ["diskcache"]
 
 # providers
-openai = ["openai>=1.99.3,<2"]
+openai = ["openai>=1.99.3,<2.34"]
 openai-realtime = ["ag2[openai]", "openai[realtime]"]
 
 deepseek = ["ag2[openai]"]

--- a/test/beta/config/anthropic/test_builtin_tool_events.py
+++ b/test/beta/config/anthropic/test_builtin_tool_events.py
@@ -7,23 +7,55 @@ from typing import Any
 
 import pytest
 from anthropic.types import (
+    Base64PDFSource,
+    BashCodeExecutionResultBlock,
     BashCodeExecutionToolResultBlock,
+    CodeExecutionResultBlock,
+    CodeExecutionToolResultBlock,
+    CodeExecutionToolResultError,
+    EncryptedCodeExecutionResultBlock,
     Message,
+    PlainTextSource,
     ServerToolUseBlock,
     TextBlock,
+    TextEditorCodeExecutionCreateResultBlock,
+    TextEditorCodeExecutionStrReplaceResultBlock,
+    TextEditorCodeExecutionToolResultBlock,
+    TextEditorCodeExecutionToolResultError,
+    TextEditorCodeExecutionViewResultBlock,
     ToolUseBlock,
     Usage,
+    WebFetchBlock,
+    WebFetchToolResultBlock,
+    WebFetchToolResultErrorBlock,
+    WebSearchResultBlock,
     WebSearchToolResultBlock,
+    WebSearchToolResultError,
 )
+from anthropic.types.bash_code_execution_output_block import BashCodeExecutionOutputBlock
 from anthropic.types.bash_code_execution_tool_result_error import BashCodeExecutionToolResultError
+from anthropic.types.code_execution_output_block import CodeExecutionOutputBlock
+from anthropic.types.document_block import DocumentBlock
 
 from autogen.beta import MemoryStream
 from autogen.beta.config.anthropic import AnthropicClient
 from autogen.beta.config.anthropic.events import AnthropicServerToolCallEvent, AnthropicServerToolResultEvent
 from autogen.beta.context import ConversationContext
-from autogen.beta.events import BaseEvent, ModelMessage, ModelResponse, ToolCallEvent, ToolCallsEvent
+from autogen.beta.events import (
+    BaseEvent,
+    BinaryInput,
+    BinaryType,
+    FileIdInput,
+    ModelMessage,
+    ModelResponse,
+    TextInput,
+    ToolCallEvent,
+    ToolCallsEvent,
+    UrlInput,
+)
 from autogen.beta.events.tool_events import ToolResult
 from autogen.beta.tools.builtin.code_execution import CODE_EXECUTION_TOOL_NAME
+from autogen.beta.tools.builtin.web_fetch import WEB_FETCH_TOOL_NAME
 from autogen.beta.tools.builtin.web_search import WEB_SEARCH_TOOL_NAME
 
 
@@ -75,12 +107,386 @@ async def test_process_response_routes_all_block_types() -> None:
     assert events == [
         AnthropicServerToolCallEvent(id="w1", name=WEB_SEARCH_TOOL_NAME, arguments='{"q": "x"}', block=web_call),
         AnthropicServerToolResultEvent(
-            parent_id="w1", name=WEB_SEARCH_TOOL_NAME, result=ToolResult(), block=web_result
+            parent_id="w1",
+            name=WEB_SEARCH_TOOL_NAME,
+            result=ToolResult(metadata={"count": 0}),
+            block=web_result,
         ),
         AnthropicServerToolCallEvent(
             id="b1", name=CODE_EXECUTION_TOOL_NAME, arguments='{"cmd": "ls"}', block=bash_call
         ),
         AnthropicServerToolResultEvent(
-            parent_id="b1", name=CODE_EXECUTION_TOOL_NAME, result=ToolResult(), block=bash_result
+            parent_id="b1",
+            name=CODE_EXECUTION_TOOL_NAME,
+            result=ToolResult(
+                TextInput("bash_code_execution_tool_result_error: unavailable"),
+                metadata={
+                    "error": True,
+                    "error_code": "unavailable",
+                    "type": "bash_code_execution_tool_result_error",
+                },
+            ),
+            block=bash_result,
         ),
     ]
+
+
+@pytest.mark.asyncio
+class TestResultParts:
+    async def test_web_search_success_url_inputs(self) -> None:
+        call = ServerToolUseBlock(id="w1", name="web_search", input={}, type="server_tool_use")
+        hits = [
+            WebSearchResultBlock(
+                url="https://a", title="A", encrypted_content="", page_age="1d", type="web_search_result"
+            ),
+            WebSearchResultBlock(
+                url="https://b", title="B", encrypted_content="", page_age=None, type="web_search_result"
+            ),
+        ]
+        result = WebSearchToolResultBlock(tool_use_id="w1", type="web_search_tool_result", content=hits)
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="w1", name=WEB_SEARCH_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="w1",
+                name=WEB_SEARCH_TOOL_NAME,
+                result=ToolResult(
+                    UrlInput("https://a", kind=BinaryType.BINARY, metadata={"title": "A", "page_age": "1d"}),
+                    UrlInput("https://b", kind=BinaryType.BINARY, metadata={"title": "B", "page_age": None}),
+                    metadata={"count": 2},
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_web_search_error_text_input(self) -> None:
+        call = ServerToolUseBlock(id="w1", name="web_search", input={}, type="server_tool_use")
+        err = WebSearchToolResultError(error_code="too_many_requests", type="web_search_tool_result_error")
+        result = WebSearchToolResultBlock(tool_use_id="w1", type="web_search_tool_result", content=err)
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="w1", name=WEB_SEARCH_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="w1",
+                name=WEB_SEARCH_TOOL_NAME,
+                result=ToolResult(
+                    TextInput("web_search_tool_result_error: too_many_requests"),
+                    metadata={
+                        "error": True,
+                        "error_code": "too_many_requests",
+                        "type": "web_search_tool_result_error",
+                    },
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_web_fetch_pdf_binary_input(self) -> None:
+        call = ServerToolUseBlock(id="f1", name="web_fetch", input={}, type="server_tool_use")
+        src = Base64PDFSource(data="YWJj", media_type="application/pdf", type="base64")
+        document = DocumentBlock(source=src, title="Doc", type="document", citations=None)
+        fetch = WebFetchBlock(content=document, retrieved_at="2026-01-01", type="web_fetch_result", url="https://x")
+        result = WebFetchToolResultBlock(tool_use_id="f1", type="web_fetch_tool_result", content=fetch)
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="f1", name=WEB_FETCH_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="f1",
+                name=WEB_FETCH_TOOL_NAME,
+                result=ToolResult(
+                    UrlInput("https://x", kind=BinaryType.BINARY),
+                    BinaryInput(b"abc", media_type="application/pdf", kind=BinaryType.DOCUMENT),
+                    metadata={"retrieved_at": "2026-01-01", "title": "Doc"},
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_web_fetch_plain_text_input(self) -> None:
+        call = ServerToolUseBlock(id="f2", name="web_fetch", input={}, type="server_tool_use")
+        src = PlainTextSource(data="hello world", media_type="text/plain", type="text")
+        document = DocumentBlock(source=src, title="T", type="document", citations=None)
+        fetch = WebFetchBlock(content=document, retrieved_at="2026-01-02", type="web_fetch_result", url="https://y")
+        result = WebFetchToolResultBlock(tool_use_id="f2", type="web_fetch_tool_result", content=fetch)
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="f2", name=WEB_FETCH_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="f2",
+                name=WEB_FETCH_TOOL_NAME,
+                result=ToolResult(
+                    UrlInput("https://y", kind=BinaryType.BINARY),
+                    TextInput("hello world"),
+                    metadata={"retrieved_at": "2026-01-02", "title": "T"},
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_web_fetch_error_text_input(self) -> None:
+        call = ServerToolUseBlock(id="f3", name="web_fetch", input={}, type="server_tool_use")
+        err = WebFetchToolResultErrorBlock(error_code="url_not_accessible", type="web_fetch_tool_result_error")
+        result = WebFetchToolResultBlock(tool_use_id="f3", type="web_fetch_tool_result", content=err)
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="f3", name=WEB_FETCH_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="f3",
+                name=WEB_FETCH_TOOL_NAME,
+                result=ToolResult(
+                    TextInput("web_fetch_tool_result_error: url_not_accessible"),
+                    metadata={
+                        "error": True,
+                        "error_code": "url_not_accessible",
+                        "type": "web_fetch_tool_result_error",
+                    },
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_code_execution_success_emits_stdout_and_files(self) -> None:
+        call = ServerToolUseBlock(id="c1", name="code_execution", input={}, type="server_tool_use")
+        out = CodeExecutionOutputBlock(file_id="file-abc", type="code_execution_output")
+        body = CodeExecutionResultBlock(
+            content=[out], return_code=0, stderr="", stdout="42\n", type="code_execution_result"
+        )
+        result = CodeExecutionToolResultBlock(tool_use_id="c1", type="code_execution_tool_result", content=body)
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="c1", name=CODE_EXECUTION_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="c1",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(
+                    TextInput("42\n"),
+                    FileIdInput("file-abc"),
+                    metadata={"return_code": 0},
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_code_execution_encrypted_emits_files_only(self) -> None:
+        call = ServerToolUseBlock(id="c2", name="code_execution", input={}, type="server_tool_use")
+        out = CodeExecutionOutputBlock(file_id="file-enc", type="code_execution_output")
+        encrypted = EncryptedCodeExecutionResultBlock(
+            content=[out],
+            encrypted_stdout="opaque",
+            return_code=0,
+            stderr="",
+            type="encrypted_code_execution_result",
+        )
+        result = CodeExecutionToolResultBlock(tool_use_id="c2", type="code_execution_tool_result", content=encrypted)
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="c2", name=CODE_EXECUTION_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="c2",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(
+                    FileIdInput("file-enc"),
+                    metadata={"return_code": 0, "encrypted": True},
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_code_execution_error_text_input(self) -> None:
+        call = ServerToolUseBlock(id="c3", name="code_execution", input={}, type="server_tool_use")
+        err = CodeExecutionToolResultError(error_code="unavailable", type="code_execution_tool_result_error")
+        result = CodeExecutionToolResultBlock(tool_use_id="c3", type="code_execution_tool_result", content=err)
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="c3", name=CODE_EXECUTION_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="c3",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(
+                    TextInput("code_execution_tool_result_error: unavailable"),
+                    metadata={
+                        "error": True,
+                        "error_code": "unavailable",
+                        "type": "code_execution_tool_result_error",
+                    },
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_bash_code_execution_success(self) -> None:
+        call = ServerToolUseBlock(id="b1", name="bash_code_execution", input={}, type="server_tool_use")
+        out = BashCodeExecutionOutputBlock(file_id="file-bash", type="bash_code_execution_output")
+        body = BashCodeExecutionResultBlock(
+            content=[out], return_code=0, stderr="warn", stdout="ok\n", type="bash_code_execution_result"
+        )
+        result = BashCodeExecutionToolResultBlock(
+            tool_use_id="b1", type="bash_code_execution_tool_result", content=body
+        )
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="b1", name=CODE_EXECUTION_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="b1",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(
+                    TextInput("ok\n"),
+                    TextInput("warn"),
+                    FileIdInput("file-bash"),
+                    metadata={"return_code": 0},
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_bash_code_execution_error(self) -> None:
+        call = ServerToolUseBlock(id="b2", name="bash_code_execution", input={}, type="server_tool_use")
+        err = BashCodeExecutionToolResultError(error_code="unavailable", type="bash_code_execution_tool_result_error")
+        result = BashCodeExecutionToolResultBlock(tool_use_id="b2", type="bash_code_execution_tool_result", content=err)
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="b2", name=CODE_EXECUTION_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="b2",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(
+                    TextInput("bash_code_execution_tool_result_error: unavailable"),
+                    metadata={
+                        "error": True,
+                        "error_code": "unavailable",
+                        "type": "bash_code_execution_tool_result_error",
+                    },
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_text_editor_view_returns_content_text(self) -> None:
+        call = ServerToolUseBlock(id="t1", name="text_editor_code_execution", input={}, type="server_tool_use")
+        view = TextEditorCodeExecutionViewResultBlock(
+            content="line1\nline2",
+            file_type="text",
+            num_lines=2,
+            start_line=1,
+            total_lines=2,
+            type="text_editor_code_execution_view_result",
+        )
+        result = TextEditorCodeExecutionToolResultBlock(
+            tool_use_id="t1", type="text_editor_code_execution_tool_result", content=view
+        )
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="t1", name=CODE_EXECUTION_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="t1",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(
+                    TextInput("line1\nline2"),
+                    metadata={"file_type": "text", "num_lines": 2, "start_line": 1, "total_lines": 2},
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_text_editor_create_empty_parts(self) -> None:
+        call = ServerToolUseBlock(id="t2", name="text_editor_code_execution", input={}, type="server_tool_use")
+        create = TextEditorCodeExecutionCreateResultBlock(
+            is_file_update=False, type="text_editor_code_execution_create_result"
+        )
+        result = TextEditorCodeExecutionToolResultBlock(
+            tool_use_id="t2", type="text_editor_code_execution_tool_result", content=create
+        )
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="t2", name=CODE_EXECUTION_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="t2",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(metadata={"is_file_update": False}),
+                block=result,
+            ),
+        ]
+
+    async def test_text_editor_str_replace_lines_text(self) -> None:
+        call = ServerToolUseBlock(id="t3", name="text_editor_code_execution", input={}, type="server_tool_use")
+        replace = TextEditorCodeExecutionStrReplaceResultBlock(
+            lines=["a", "b"],
+            new_lines=2,
+            new_start=1,
+            old_lines=2,
+            old_start=1,
+            type="text_editor_code_execution_str_replace_result",
+        )
+        result = TextEditorCodeExecutionToolResultBlock(
+            tool_use_id="t3", type="text_editor_code_execution_tool_result", content=replace
+        )
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="t3", name=CODE_EXECUTION_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="t3",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(
+                    TextInput("a\nb"),
+                    metadata={"new_lines": 2, "new_start": 1, "old_lines": 2, "old_start": 1},
+                ),
+                block=result,
+            ),
+        ]
+
+    async def test_text_editor_error_text_input(self) -> None:
+        call = ServerToolUseBlock(id="t4", name="text_editor_code_execution", input={}, type="server_tool_use")
+        err = TextEditorCodeExecutionToolResultError(
+            error_code="file_not_found",
+            error_message="missing",
+            type="text_editor_code_execution_tool_result_error",
+        )
+        result = TextEditorCodeExecutionToolResultBlock(
+            tool_use_id="t4", type="text_editor_code_execution_tool_result", content=err
+        )
+
+        _, events = await _process([call, result])
+
+        assert events == [
+            AnthropicServerToolCallEvent(id="t4", name=CODE_EXECUTION_TOOL_NAME, arguments="{}", block=call),
+            AnthropicServerToolResultEvent(
+                parent_id="t4",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(
+                    TextInput("text_editor_code_execution_tool_result_error: file_not_found: missing"),
+                    metadata={
+                        "error": True,
+                        "error_code": "file_not_found",
+                        "error_message": "missing",
+                        "type": "text_editor_code_execution_tool_result_error",
+                    },
+                ),
+                block=result,
+            ),
+        ]

--- a/test/beta/config/gemini/test_builtin_tool_events.py
+++ b/test/beta/config/gemini/test_builtin_tool_events.py
@@ -16,6 +16,7 @@ from autogen.beta.config.gemini.events import (
 from autogen.beta.config.gemini.gemini_client import GeminiClient
 from autogen.beta.config.gemini.mappers import grounding_tool_name
 from autogen.beta.context import ConversationContext
+from autogen.beta.events import BinaryType, TextInput, UrlInput
 from autogen.beta.tools.builtin.code_execution import CODE_EXECUTION_TOOL_NAME
 from autogen.beta.tools.builtin.web_fetch import WEB_FETCH_TOOL_NAME
 from autogen.beta.tools.builtin.web_search import WEB_SEARCH_TOOL_NAME
@@ -71,7 +72,7 @@ class TestFactoryFromCodeExecutionResult:
         assert event == GeminiServerToolResultEvent(
             parent_id="call-1",
             name=CODE_EXECUTION_TOOL_NAME,
-            result=ToolResult(),
+            result=ToolResult(TextInput("42"), metadata={"outcome": "OUTCOME_OK"}),
             part=part,
         )
 
@@ -141,7 +142,7 @@ class TestProcessResponseEmitsBuiltinEvents:
             GeminiServerToolResultEvent(
                 parent_id=call_event.id,
                 name=CODE_EXECUTION_TOOL_NAME,
-                result=ToolResult(),
+                result=ToolResult(TextInput("1\n"), metadata={"outcome": "OUTCOME_OK"}),
                 part=result_part,
             ),
         ]
@@ -226,7 +227,7 @@ class TestProcessStreamEmitsBuiltinEvents:
             GeminiServerToolResultEvent(
                 parent_id=call_event.id,
                 name=CODE_EXECUTION_TOOL_NAME,
-                result=ToolResult(),
+                result=ToolResult(TextInput("2\n"), metadata={"outcome": "OUTCOME_OK"}),
                 part=result_part,
             ),
         ]
@@ -255,6 +256,117 @@ class TestProcessStreamEmitsBuiltinEvents:
             GeminiServerToolResultEvent(
                 parent_id=call_event.id,
                 name=WEB_SEARCH_TOOL_NAME,
+                result=ToolResult(),
+                grounding_metadata=gm,
+            ),
+        ]
+
+
+@pytest.mark.asyncio
+class TestResultParts:
+    async def test_code_execution_result_emits_output_text(
+        self, client: GeminiClient, memory_context: tuple[Context, MemoryStream]
+    ) -> None:
+        ctx, stream = memory_context
+        code_part = types.Part(executable_code=types.ExecutableCode(code="print(42)", language="PYTHON"))
+        result_part = types.Part(code_execution_result=types.CodeExecutionResult(outcome="OUTCOME_OK", output="42"))
+
+        await client._process_response(_response([_candidate([code_part, result_part])]), ctx)
+
+        events = list(await stream.history.get_events())
+        [call_event, _] = events
+        assert events == [
+            GeminiServerToolCallEvent(
+                id=call_event.id,
+                name=CODE_EXECUTION_TOOL_NAME,
+                arguments='{"code": "print(42)", "language": "PYTHON"}',
+                part=code_part,
+            ),
+            GeminiServerToolResultEvent(
+                parent_id=call_event.id,
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(TextInput("42"), metadata={"outcome": "OUTCOME_OK"}),
+                part=result_part,
+            ),
+        ]
+
+    async def test_code_execution_result_no_output_empty_parts(
+        self, client: GeminiClient, memory_context: tuple[Context, MemoryStream]
+    ) -> None:
+        ctx, stream = memory_context
+        code_part = types.Part(executable_code=types.ExecutableCode(code="noop()", language="PYTHON"))
+        result_part = types.Part(code_execution_result=types.CodeExecutionResult(outcome="OUTCOME_OK", output=""))
+
+        await client._process_response(_response([_candidate([code_part, result_part])]), ctx)
+
+        events = list(await stream.history.get_events())
+        [call_event, _] = events
+        assert events == [
+            GeminiServerToolCallEvent(
+                id=call_event.id,
+                name=CODE_EXECUTION_TOOL_NAME,
+                arguments='{"code": "noop()", "language": "PYTHON"}',
+                part=code_part,
+            ),
+            GeminiServerToolResultEvent(
+                parent_id=call_event.id,
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(metadata={"outcome": "OUTCOME_OK"}),
+                part=result_part,
+            ),
+        ]
+
+    async def test_grounding_emits_url_inputs_per_chunk(
+        self, client: GeminiClient, memory_context: tuple[Context, MemoryStream]
+    ) -> None:
+        ctx, stream = memory_context
+        chunk = types.GroundingChunk(web=types.GroundingChunkWeb(uri="https://x", title="X", domain="x.com"))
+        gm = types.GroundingMetadata(web_search_queries=["q"], grounding_chunks=[chunk])
+
+        await client._process_response(_response([_candidate([types.Part(text="answer")], grounding_metadata=gm)]), ctx)
+
+        events = list(await stream.history.get_events())
+        [call_event, _] = events
+        assert events == [
+            GeminiServerToolCallEvent(
+                id=call_event.id,
+                name=WEB_SEARCH_TOOL_NAME,
+                arguments='{"queries": ["q"]}',
+                grounding_metadata=gm,
+            ),
+            GeminiServerToolResultEvent(
+                parent_id=call_event.id,
+                name=WEB_SEARCH_TOOL_NAME,
+                result=ToolResult(
+                    UrlInput("https://x", kind=BinaryType.BINARY, metadata={"title": "X", "domain": "x.com"}),
+                    metadata={"queries": ["q"]},
+                ),
+                grounding_metadata=gm,
+            ),
+        ]
+
+    async def test_grounding_url_context_no_chunks_empty_parts(
+        self, client: GeminiClient, memory_context: tuple[Context, MemoryStream]
+    ) -> None:
+        # url_context-only responses arrive without grounding chunks; the provider
+        # does not return the fetched bytes, so parts/metadata stay empty.
+        ctx, stream = memory_context
+        gm = types.GroundingMetadata()
+
+        await client._process_response(_response([_candidate([types.Part(text="answer")], grounding_metadata=gm)]), ctx)
+
+        events = list(await stream.history.get_events())
+        [call_event, _] = events
+        assert events == [
+            GeminiServerToolCallEvent(
+                id=call_event.id,
+                name=WEB_FETCH_TOOL_NAME,
+                arguments='{"queries": []}',
+                grounding_metadata=gm,
+            ),
+            GeminiServerToolResultEvent(
+                parent_id=call_event.id,
+                name=WEB_FETCH_TOOL_NAME,
                 result=ToolResult(),
                 grounding_metadata=gm,
             ),

--- a/test/beta/config/openai/test_builtin_tool_events.py
+++ b/test/beta/config/openai/test_builtin_tool_events.py
@@ -15,7 +15,13 @@ from openai.types.responses import (
     ResponseOutputMessage,
     ResponseReasoningItem,
 )
-from openai.types.responses.response_function_web_search import ActionSearch
+from openai.types.responses.response_code_interpreter_tool_call import OutputImage, OutputLogs
+from openai.types.responses.response_function_web_search import (
+    ActionFind,
+    ActionOpenPage,
+    ActionSearch,
+    ActionSearchSource,
+)
 from openai.types.responses.response_output_item import ImageGenerationCall
 from openai.types.responses.response_output_text import ResponseOutputText
 from openai.types.responses.response_reasoning_item import Summary
@@ -29,7 +35,17 @@ from autogen.beta.config.openai.events import (
 )
 from autogen.beta.config.openai.mappers import events_to_responses_input
 from autogen.beta.context import ConversationContext
-from autogen.beta.events import BaseEvent, ModelMessage, ModelResponse, ToolCallEvent, ToolCallsEvent
+from autogen.beta.events import (
+    BaseEvent,
+    BinaryInput,
+    BinaryType,
+    ModelMessage,
+    ModelResponse,
+    TextInput,
+    ToolCallEvent,
+    ToolCallsEvent,
+    UrlInput,
+)
 from autogen.beta.events.tool_events import ToolResult
 from autogen.beta.tools.builtin.code_execution import CODE_EXECUTION_TOOL_NAME
 from autogen.beta.tools.builtin.image_generation import IMAGE_GENERATION_TOOL_NAME
@@ -101,13 +117,28 @@ async def test_process_response_routes_all_item_types() -> None:
         OpenAIServerToolCallEvent(
             id="ws_1", name=WEB_SEARCH_TOOL_NAME, arguments=web.action.model_dump_json(), item=web
         ),
-        OpenAIServerToolResultEvent(parent_id="ws_1", name=WEB_SEARCH_TOOL_NAME, result=ToolResult()),
+        OpenAIServerToolResultEvent(
+            parent_id="ws_1",
+            name=WEB_SEARCH_TOOL_NAME,
+            result=ToolResult(metadata={"action_type": "search", "status": "completed"}),
+        ),
         OpenAIServerToolCallEvent(
             id="ci_1", name=CODE_EXECUTION_TOOL_NAME, arguments=json.dumps({"code": "print(1)"}), item=code
         ),
-        OpenAIServerToolResultEvent(parent_id="ci_1", name=CODE_EXECUTION_TOOL_NAME, result=ToolResult()),
+        OpenAIServerToolResultEvent(
+            parent_id="ci_1",
+            name=CODE_EXECUTION_TOOL_NAME,
+            result=ToolResult(metadata={"container_id": "c_1", "status": "completed"}),
+        ),
         OpenAIServerToolCallEvent(id="ig_1", name=IMAGE_GENERATION_TOOL_NAME, arguments="", item=image),
-        OpenAIServerToolResultEvent(parent_id="ig_1", name=IMAGE_GENERATION_TOOL_NAME, result=ToolResult()),
+        OpenAIServerToolResultEvent(
+            parent_id="ig_1",
+            name=IMAGE_GENERATION_TOOL_NAME,
+            result=ToolResult(
+                BinaryInput(b"abc", media_type="image/png", kind=BinaryType.IMAGE),
+                metadata=image.model_dump(exclude={"result", "status", "type"}),
+            ),
+        ),
     ]
 
 
@@ -207,3 +238,254 @@ class TestReasoning:
         api_input = events_to_responses_input(events, serializer=None)  # type: ignore[arg-type]
 
         assert api_input == [reasoning_item.model_dump(exclude_none=True, mode="json")]
+
+
+@pytest.mark.asyncio
+class TestResultParts:
+    async def test_web_search_search_action_without_sources_is_metadata_only(self) -> None:
+        # Without include=["web_search_call.action.sources"] the API leaves
+        # `sources` as None, so parts stays empty and only metadata describes
+        # the call.
+        web = ResponseFunctionWebSearch(
+            id="ws_1",
+            action=ActionSearch(type="search", query="bitcoin"),
+            status="completed",
+            type="web_search_call",
+        )
+
+        _, events = await _process([web])
+
+        assert events == [
+            OpenAIServerToolCallEvent(
+                id="ws_1", name=WEB_SEARCH_TOOL_NAME, arguments=web.action.model_dump_json(), item=web
+            ),
+            OpenAIServerToolResultEvent(
+                parent_id="ws_1",
+                name=WEB_SEARCH_TOOL_NAME,
+                result=ToolResult(metadata={"action_type": "search", "status": "completed"}),
+            ),
+        ]
+
+    async def test_web_search_search_action_emits_url_inputs_from_sources(self) -> None:
+        web = ResponseFunctionWebSearch(
+            id="ws_2",
+            action=ActionSearch(
+                type="search",
+                query="bitcoin",
+                queries=["bitcoin price", "btc usd"],
+                sources=[
+                    ActionSearchSource(type="url", url="https://a.example"),
+                    ActionSearchSource(type="url", url="https://b.example"),
+                ],
+            ),
+            status="completed",
+            type="web_search_call",
+        )
+
+        _, events = await _process([web])
+
+        assert events == [
+            OpenAIServerToolCallEvent(
+                id="ws_2", name=WEB_SEARCH_TOOL_NAME, arguments=web.action.model_dump_json(), item=web
+            ),
+            OpenAIServerToolResultEvent(
+                parent_id="ws_2",
+                name=WEB_SEARCH_TOOL_NAME,
+                result=ToolResult(
+                    UrlInput("https://a.example", kind=BinaryType.BINARY),
+                    UrlInput("https://b.example", kind=BinaryType.BINARY),
+                    metadata={
+                        "action_type": "search",
+                        "status": "completed",
+                        "queries": ["bitcoin price", "btc usd"],
+                    },
+                ),
+            ),
+        ]
+
+    async def test_web_search_search_action_skips_sources_with_empty_url(self) -> None:
+        # The API has been observed to return sources with empty url for
+        # synthesised/internal sources; those must not become UrlInput(None).
+        web = ResponseFunctionWebSearch(
+            id="ws_3",
+            action=ActionSearch(
+                type="search",
+                query="bitcoin",
+                sources=[ActionSearchSource.model_construct(type="url", url=None)],
+            ),
+            status="completed",
+            type="web_search_call",
+        )
+
+        _, events = await _process([web])
+
+        assert events == [
+            OpenAIServerToolCallEvent(
+                id="ws_3", name=WEB_SEARCH_TOOL_NAME, arguments=web.action.model_dump_json(), item=web
+            ),
+            OpenAIServerToolResultEvent(
+                parent_id="ws_3",
+                name=WEB_SEARCH_TOOL_NAME,
+                result=ToolResult(metadata={"action_type": "search", "status": "completed"}),
+            ),
+        ]
+
+    async def test_web_search_open_page_emits_url(self) -> None:
+        web = ResponseFunctionWebSearch(
+            id="ws_4",
+            action=ActionOpenPage(type="open_page", url="https://example.com"),
+            status="completed",
+            type="web_search_call",
+        )
+
+        _, events = await _process([web])
+
+        assert events == [
+            OpenAIServerToolCallEvent(
+                id="ws_4", name=WEB_SEARCH_TOOL_NAME, arguments=web.action.model_dump_json(), item=web
+            ),
+            OpenAIServerToolResultEvent(
+                parent_id="ws_4",
+                name=WEB_SEARCH_TOOL_NAME,
+                result=ToolResult(
+                    UrlInput("https://example.com", kind=BinaryType.BINARY),
+                    metadata={"action_type": "open_page", "status": "completed"},
+                ),
+            ),
+        ]
+
+    async def test_web_search_find_in_page_emits_url_and_pattern(self) -> None:
+        web = ResponseFunctionWebSearch(
+            id="ws_5",
+            action=ActionFind(type="find_in_page", url="https://example.com", pattern="needle"),
+            status="completed",
+            type="web_search_call",
+        )
+
+        _, events = await _process([web])
+
+        assert events == [
+            OpenAIServerToolCallEvent(
+                id="ws_5", name=WEB_SEARCH_TOOL_NAME, arguments=web.action.model_dump_json(), item=web
+            ),
+            OpenAIServerToolResultEvent(
+                parent_id="ws_5",
+                name=WEB_SEARCH_TOOL_NAME,
+                result=ToolResult(
+                    UrlInput("https://example.com", kind=BinaryType.BINARY),
+                    metadata={"action_type": "find_in_page", "status": "completed", "pattern": "needle"},
+                ),
+            ),
+        ]
+
+    async def test_code_interpreter_logs_emit_text_input(self) -> None:
+        code = ResponseCodeInterpreterToolCall(
+            id="ci_1",
+            code="print('hi')",
+            container_id="c_1",
+            outputs=[OutputLogs(logs="hi\n", type="logs")],
+            status="completed",
+            type="code_interpreter_call",
+        )
+
+        _, events = await _process([code])
+
+        assert events == [
+            OpenAIServerToolCallEvent(
+                id="ci_1", name=CODE_EXECUTION_TOOL_NAME, arguments=json.dumps({"code": "print('hi')"}), item=code
+            ),
+            OpenAIServerToolResultEvent(
+                parent_id="ci_1",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(TextInput("hi\n"), metadata={"container_id": "c_1", "status": "completed"}),
+            ),
+        ]
+
+    async def test_code_interpreter_image_emits_url_input(self) -> None:
+        code = ResponseCodeInterpreterToolCall(
+            id="ci_2",
+            code="plot()",
+            container_id="c_2",
+            outputs=[OutputImage(type="image", url="https://example.com/x.png")],
+            status="completed",
+            type="code_interpreter_call",
+        )
+
+        _, events = await _process([code])
+
+        assert events == [
+            OpenAIServerToolCallEvent(
+                id="ci_2", name=CODE_EXECUTION_TOOL_NAME, arguments=json.dumps({"code": "plot()"}), item=code
+            ),
+            OpenAIServerToolResultEvent(
+                parent_id="ci_2",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(
+                    UrlInput("https://example.com/x.png", kind=BinaryType.IMAGE),
+                    metadata={"container_id": "c_2", "status": "completed"},
+                ),
+            ),
+        ]
+
+    async def test_code_interpreter_outputs_none_empty_parts(self) -> None:
+        code = ResponseCodeInterpreterToolCall(
+            id="ci_3",
+            code=None,
+            container_id="c_3",
+            outputs=None,
+            status="failed",
+            type="code_interpreter_call",
+        )
+
+        _, events = await _process([code])
+
+        assert events == [
+            OpenAIServerToolCallEvent(id="ci_3", name=CODE_EXECUTION_TOOL_NAME, arguments="{}", item=code),
+            OpenAIServerToolResultEvent(
+                parent_id="ci_3",
+                name=CODE_EXECUTION_TOOL_NAME,
+                result=ToolResult(metadata={"container_id": "c_3", "status": "failed"}),
+            ),
+        ]
+
+    async def test_image_generation_emits_binary_input(self) -> None:
+        image = ImageGenerationCall(
+            id="ig_1",
+            status="completed",
+            type="image_generation_call",
+            result="YWJj",  # base64 "abc"
+            revised_prompt=None,
+            output_format="png",
+        )
+
+        _, events = await _process([image])
+
+        assert events == [
+            OpenAIServerToolCallEvent(id="ig_1", name=IMAGE_GENERATION_TOOL_NAME, arguments="", item=image),
+            OpenAIServerToolResultEvent(
+                parent_id="ig_1",
+                name=IMAGE_GENERATION_TOOL_NAME,
+                result=ToolResult(
+                    BinaryInput(b"abc", media_type="image/png", kind=BinaryType.IMAGE),
+                    metadata=image.model_dump(exclude={"result", "status", "type"}),
+                ),
+            ),
+        ]
+
+    async def test_image_generation_response_files_share_bytes(self) -> None:
+        # Single-decode invariant: response.files reuses the bytes from the event,
+        # so the framework only base64-decodes the image once.
+        image = ImageGenerationCall(
+            id="ig_1",
+            status="completed",
+            type="image_generation_call",
+            result="YWJj",
+            revised_prompt=None,
+            output_format="png",
+        )
+
+        response, events = await _process([image])
+
+        [_, result_event] = events
+        assert isinstance(result_event, OpenAIServerToolResultEvent)
+        assert response.files[0].data is result_event.result.parts[0].data

--- a/test/beta/config/openai/tools/test_web_search.py
+++ b/test/beta/config/openai/tools/test_web_search.py
@@ -5,7 +5,8 @@
 import pytest
 
 from autogen.beta import Context
-from autogen.beta.config.openai.mappers import tool_to_responses_api
+from autogen.beta.config.openai.mappers import responses_api_includes, tool_to_responses_api
+from autogen.beta.tools.builtin.code_execution import CodeExecutionTool
 from autogen.beta.tools.builtin.web_search import UserLocation, WebSearchTool
 
 
@@ -96,3 +97,22 @@ async def test_responses_api_with_allowed_domains(context: Context) -> None:
         "type": "web_search",
         "filters": {"allowed_domains": ["example.com", "docs.example.com"]},
     }
+
+
+@pytest.mark.asyncio
+class TestResponsesApiIncludes:
+    """`responses_api_includes` declares which Responses API include[] entries
+    are required to surface observable payload for the given tools."""
+
+    async def test_web_search_requests_action_sources(self, context: Context) -> None:
+        [schema] = await WebSearchTool().schemas(context)
+
+        assert responses_api_includes([schema]) == ["web_search_call.action.sources"]
+
+    async def test_no_tools_returns_empty(self) -> None:
+        assert responses_api_includes([]) == []
+
+    async def test_unrelated_builtin_returns_empty(self, context: Context) -> None:
+        [schema] = await CodeExecutionTool().schemas(context)
+
+        assert responses_api_includes([schema]) == []


### PR DESCRIPTION
## Why are these changes needed?

Server-side builtin tools (Anthropic `web_search`/`web_fetch`/`code_execution`,
Gemini grounding/`code_execution`, OpenAI Responses `web_search`/
`code_interpreter`/`image_generation`) emit `BuiltinToolCallEvent` /
`BuiltinToolResultEvent` pairs through `autogen.beta`, but the result event
was always constructed with an empty `result=ToolResult()`. The actual payload
(search hits, stdout/stderr, generated images, grounding URLs, …) lived only
inside the provider-specific SDK object attached to the event (`block` /
`part` / `item`).

That meant middleware, observers, watch handlers and UI could not read those
results without:

- knowing the concrete provider event subclass,
- importing provider SDK types (`anthropic.types.WebSearchToolResultBlock`,
  `google.genai.types.GroundingMetadata`,
  `openai.types.responses.*`),
- hand-rolling per-provider `isinstance` ladders.

This PR populates `result.parts` and `result.metadata` with normalized data
extracted from the native objects in the existing
`from_block` / `from_item` / `from_code_execution_result` / `from_grounding`
factories. Round-trip back to providers is unchanged — `convert_messages` and
`events_to_responses_input` still serialize via the native SDK objects
(`block` / `item` / `part`); they never read `result.parts`. The change is a
purely additive observability layer.

## What changed

### `result.parts` / `result.metadata` per provider

**Anthropic** ([`autogen/beta/config/anthropic/events.py`](autogen/beta/config/anthropic/events.py))
— `AnthropicServerToolResultEvent.from_block` parses every documented inner
content variant:

| Block · variant | Parts | Metadata |
|---|---|---|
| `WebSearchToolResultBlock` · hits | `UrlInput(r.url, BINARY, metadata={title, page_age})` per hit | `{count}` |
| `WebSearchToolResultBlock` · error | `TextInput(f"{type}: {error_code}")` | `{error, error_code, type}` |
| `WebFetchToolResultBlock` · `Base64PDFSource` | `[UrlInput, BinaryInput("application/pdf", DOCUMENT)]` | `{retrieved_at, title}` |
| `WebFetchToolResultBlock` · `PlainTextSource` | `[UrlInput, TextInput]` | `{retrieved_at, title}` |
| `CodeExecution` / `BashCodeExecution` · success | `TextInput(stdout)` + `TextInput(stderr)` + `FileIdInput(file_id)` per output | `{return_code}` |
| `CodeExecutionToolResultBlock` · encrypted | `FileIdInput` per output (stdout opaque) | `{return_code, encrypted: True}` |
| `TextEditorCodeExecutionToolResultBlock` · view / create / str_replace / error | content text, str.join lines, etc. | per-variant fields |
| any error block | `TextInput(f"{type}: {error_code}")` | `{error: True, error_code, type}` |

**Gemini** ([`autogen/beta/config/gemini/events.py`](autogen/beta/config/gemini/events.py)):

- `from_code_execution_result` → `TextInput(part.code_execution_result.output)` when
  output is non-empty, plus `metadata={"outcome": Outcome.name}`.
- `from_grounding` → `UrlInput(chunk.web.uri, BINARY, metadata={title, domain})`
  per grounding chunk, plus `metadata={"queries": [...]}`. `url_context`-only
  responses (no chunks) stay empty by design — the provider does not return
  fetched bytes for them.

**OpenAI Responses** ([`autogen/beta/config/openai/events.py`](autogen/beta/config/openai/events.py)):

- `ResponseFunctionWebSearch`:
  - `ActionSearch` → `UrlInput(source.url, BINARY)` per `action.sources`
    (skipping entries with empty url), `metadata={action_type, status,
    queries}`.
  - `ActionOpenPage` / `ActionFind` → `UrlInput(action.url, BINARY)`,
    plus `metadata["pattern"]` for find.
- `ResponseCodeInterpreterToolCall` → `TextInput(o.logs)` per `OutputLogs`,
  `UrlInput(o.url, IMAGE)` per `OutputImage`,
  `metadata={container_id, status}`.
- `ImageGenerationCall` → `BinaryInput(b64decode(item.result), "image/png",
  IMAGE)`, with the **same `bytes` instance** reused by `response.files`
  (single-decode invariant).

### OpenAI: auto-include `web_search_call.action.sources`

`ResponseFunctionWebSearch.action.sources` is only populated by the API when
the request explicitly asks for it via
`include=["web_search_call.action.sources"]`. The new
`mappers.responses_api_includes(tools)` helper computes the required
`include[]` entries from the tool list, and the Responses client adds them
automatically when a `WebSearchToolSchema` is present. Keeps the client thin
and provider-specific knowledge in `mappers.py`.

### Bug fix: `ToolNotFoundEvent` for builtin calls

`Agent` only registered `FunctionToolSchema.function.name` and the hardcoded
`WEB_SEARCH_TOOL_NAME` into `known_tools`, so every other builtin
(`code_execution`, `web_fetch`, `image_generation`, …) tripped the
tool-not-found fallback in `ToolExecutor` and emitted a spurious
`ToolNotFoundEvent` between `BuiltinToolCallEvent` and the result event.

Fix: register `schema.type` for every non-function schema (the field is set
to the tool name on every builtin schema). One-line change in `agent.py`,
plus a regression test in
`test/beta/tools/test_executor_builtin_passthrough.py` covering the builtin
pass-through case.

### Pydantic serializer warnings on round-trip

OpenAI Responses returns `ActionSearchSource.type` values the SDK has not
caught up to (e.g. `"api"` while `openai==2.33.0` still pins
`Literal["url"]`), and pydantic's discriminated-union serializer warns on
every dump. Suppressed locally with `model_dump(... warnings=False)` in two
spots (`OpenAIServerToolCallEvent.from_item` and
`events_to_responses_input`), with comments explaining why. Output JSON is
unchanged.


## AI assistance

- [x] I understand the changes in this PR and can explain them in my own
      words.
- [x] I have verified that the PR description accurately reflects the actual
      diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the
      generated code/text before submitting.

This PR was drafted with AI assistance (Claude Code). All code, tests and
descriptions were reviewed and validated locally — see the Testing section.
