### PR TITLE
feat(beta): disable Agent subtasks by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,10 +162,10 @@ Subagent tools live in `autogen/beta/tools/subagents/` and are imported from `au
 
 ### Auto-injected `run_subtask` / `run_subtasks`
 
-Every `Agent` (unless constructed with `tasks=False`) automatically carries a `run_subtask(task)` and a `run_subtasks(tasks=[...], parallel=True)` tool. Each call spawns a **subtask Agent** that:
+Sub-task delegation is **off by default** (`tasks=False`). Pass `tasks=TaskConfig(...)` to opt in, and the `Agent` gains a `run_subtask(task)` and a `run_subtasks(tasks=[...], parallel=True)` tool. Each call spawns a **subtask Agent** that:
 
 - Inherits the parent's user-supplied tools by default (filterable via `TaskConfig.include_tools` / `exclude_tools`, extendable via `extra_tools`).
-- Is constructed with `tasks=False`, so the subtask itself has **no** `run_subtask` tools — recursive delegation is structurally impossible. No depth limiting required.
+- Is itself constructed with `tasks=False` (the default), so the subtask has **no** `run_subtask` tools — recursive delegation is structurally impossible. No depth limiting required.
 - Runs on its own `MemoryStream`; child events do not leak into the parent's stream beyond `TaskStarted` / `TaskCompleted` / `TaskFailed` lifecycle events.
 
 The LLM is told (via the tool description) that `run_subtask` may be invoked multiple times in parallel within a single response, encouraging the parallel-tool-use pattern Anthropic recommends.

--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -12,7 +12,7 @@ spawning).
 A bare ``Agent(name, config=cfg)`` has zero harness middleware — it behaves
 exactly like a plain LLM loop. Harness features are opt-in: pass ``assembly=``
 for context policies, ``knowledge=KnowledgeConfig(...)`` for a knowledge store,
-or ``tasks=TaskConfig(...)`` for subtask spawning defaults.
+or ``tasks=TaskConfig(...)`` to enable subtask spawning (disabled by default).
 """
 
 import asyncio
@@ -354,10 +354,10 @@ class Agent(Generic[TResult]):
       ``AssemblerMiddleware`` and ``_HaltCheckMiddleware`` are wired in.
     * ``knowledge=KnowledgeConfig(store=...)`` — persistent knowledge store,
       compaction, aggregation.
-    * ``tasks=TaskConfig(...)`` — override the LLM config / prompt /
-      tool-inheritance rules for the auto-injected ``run_subtask`` /
-      ``run_subtasks`` tools. Pass ``tasks=False`` to suppress those tools
-      entirely.
+    * ``tasks=TaskConfig(...)`` — opt in to the auto-injected ``run_subtask``
+      / ``run_subtasks`` tools, and override the LLM config / prompt /
+      tool-inheritance rules for sub-task Agents. Defaults to ``False``
+      (sub-task tools disabled).
     """
 
     @overload
@@ -376,7 +376,7 @@ class Agent(Generic[TResult]):
         response_schema: type[TResult],
         plugins: Iterable["Plugin"] = ...,
         knowledge: KnowledgeConfig | None = ...,
-        tasks: TaskConfig | Literal[False] | None = ...,
+        tasks: TaskConfig | Literal[False] = ...,
         assembly: Iterable[AssemblyPolicy] = ...,
     ) -> None: ...
 
@@ -396,7 +396,7 @@ class Agent(Generic[TResult]):
         response_schema: ResponseProto[TResult],
         plugins: Iterable["Plugin"] = ...,
         knowledge: KnowledgeConfig | None = ...,
-        tasks: TaskConfig | Literal[False] | None = ...,
+        tasks: TaskConfig | Literal[False] = ...,
         assembly: Iterable[AssemblyPolicy] = ...,
     ) -> None: ...
 
@@ -416,7 +416,7 @@ class Agent(Generic[TResult]):
         response_schema: types.UnionType,
         plugins: Iterable["Plugin"] = ...,
         knowledge: KnowledgeConfig | None = ...,
-        tasks: TaskConfig | Literal[False] | None = ...,
+        tasks: TaskConfig | Literal[False] = ...,
         assembly: Iterable[AssemblyPolicy] = ...,
     ) -> None: ...
 
@@ -436,7 +436,7 @@ class Agent(Generic[TResult]):
         response_schema: None = ...,
         plugins: Iterable["Plugin"] = ...,
         knowledge: KnowledgeConfig | None = ...,
-        tasks: TaskConfig | Literal[False] | None = ...,
+        tasks: TaskConfig | Literal[False] = ...,
         assembly: Iterable[AssemblyPolicy] = ...,
     ) -> None: ...
 
@@ -455,7 +455,7 @@ class Agent(Generic[TResult]):
         response_schema: (ResponseProto[TResult] | type[TResult] | types.UnionType | None) = None,
         plugins: Iterable["Plugin"] = (),
         knowledge: KnowledgeConfig | None = None,
-        tasks: TaskConfig | Literal[False] | None = None,
+        tasks: TaskConfig | Literal[False] = False,
         assembly: Iterable[AssemblyPolicy] = (),
     ):
         self.name = name
@@ -497,13 +497,13 @@ class Agent(Generic[TResult]):
         for p in plugins:
             p.register(self)
 
-        # Task spawning. ``tasks=False`` opts out entirely; ``tasks=None`` (the
-        # default) auto-injects ``run_subtask`` / ``run_subtasks`` with
-        # ``TaskConfig()`` defaults.
+        # Task spawning. ``tasks=False`` (the default) means no auto-injected
+        # ``run_subtask`` / ``run_subtasks`` tools. Pass ``tasks=TaskConfig(...)``
+        # to opt in.
         if tasks is False:
             self._task_config: TaskConfig | None = None
         else:
-            self._task_config = tasks if tasks is not None else TaskConfig(config=config)
+            self._task_config = tasks
 
         self._subtask_tools: list[Tool] = _build_subtask_tools(self) if self._task_config is not None else []
 
@@ -799,15 +799,16 @@ class Agent(Generic[TResult]):
 
         The subtask inherits the parent's user-supplied tools (filtered by
         ``TaskConfig.include_tools`` / ``exclude_tools``) plus
-        ``TaskConfig.extra_tools``. It is constructed with ``tasks=False`` so
-        the child has **no** ``run_subtask`` tools — recursive delegation is
-        impossible by construction. ``run_task`` emits the ``TaskStarted`` /
-        ``TaskCompleted`` / ``TaskFailed`` lifecycle events and handles
-        dependency/variable copy and HITL bridging.
+        ``TaskConfig.extra_tools``. It is constructed with ``tasks=False``
+        (the default) so the child has **no** ``run_subtask`` tools —
+        recursive delegation is impossible by construction. ``run_task``
+        emits the ``TaskStarted`` / ``TaskCompleted`` / ``TaskFailed``
+        lifecycle events and handles dependency/variable copy and HITL
+        bridging.
         """
         tc = self._task_config
         if tc is None:
-            return "Error: subtask spawning is disabled on this Agent (tasks=False)."
+            return "Error: subtask spawning is disabled on this Agent (pass tasks=TaskConfig(...) to enable)."
 
         inherited = _filter_subtask_tools(self.tools, tc.include_tools, tc.exclude_tools)
 

--- a/test/beta/providers/agent/test_edge_cases.py
+++ b/test/beta/providers/agent/test_edge_cases.py
@@ -12,7 +12,7 @@ import asyncio
 import pytest
 
 from autogen.beta import Agent
-from autogen.beta.agent import KnowledgeConfig
+from autogen.beta.agent import KnowledgeConfig, TaskConfig
 from autogen.beta.compact import CompactTrigger, TailWindowCompact
 from autogen.beta.events.lifecycle import CompactionCompleted
 from autogen.beta.knowledge import MemoryKnowledgeStore
@@ -102,6 +102,7 @@ async def test_concurrent_tool_calls_via_run_subtasks(provider_config) -> None:
         "parallel",
         prompt=("Use run_subtasks with parallel=True to dispatch independent jobs. Be concise."),
         config=provider_config,
+        tasks=TaskConfig(),
     )
 
     reply = await agent.ask(

--- a/test/beta/providers/agent/test_subtasks.py
+++ b/test/beta/providers/agent/test_subtasks.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_run_subtask_auto_injected(provider_config) -> None:
-    """run_subtask is auto-injected on every Agent; LLM can dispatch it."""
+    """``tasks=TaskConfig()`` injects ``run_subtask``; LLM can dispatch it."""
     task_starts: list[TaskStarted] = []
     task_completions: list[TaskCompleted] = []
 
@@ -37,6 +37,7 @@ async def test_run_subtask_auto_injected(provider_config) -> None:
             "self-contained research questions. Be concise."
         ),
         config=provider_config,
+        tasks=TaskConfig(),
     )
     reply = await agent.ask(
         "Use run_subtask to find out what colour ripe bananas are. Then tell me the answer in one sentence.",
@@ -65,6 +66,7 @@ async def test_run_subtasks_parallel(provider_config) -> None:
             "user asks several unrelated things at once."
         ),
         config=provider_config,
+        tasks=TaskConfig(),
     )
     reply = await agent.ask(
         "Use run_subtasks with parallel=True to answer ALL of these in one tool call: "
@@ -163,6 +165,7 @@ async def test_subtask_cannot_recurse(provider_config) -> None:
             "delegator",
             prompt="Always use run_subtask for any factual lookup. Be concise.",
             config=provider_config,
+            tasks=TaskConfig(),
         )
         await agent.ask("Use run_subtask to look up: what colour is the sky?")
     finally:

--- a/test/beta/tools/test_task.py
+++ b/test/beta/tools/test_task.py
@@ -542,16 +542,23 @@ class TestVariablesPropagation:
 
 @pytest.mark.asyncio
 class TestSubtaskOptOut:
-    async def test_disabled_actor_has_no_subtask_tools(self) -> None:
-        """``tasks=False`` suppresses ``run_subtask`` / ``run_subtasks``."""
+    async def test_default_actor_has_no_subtask_tools(self) -> None:
+        """A bare Agent has no subtask tools by default (``tasks=False``)."""
+        agent = Agent("default")
+
+        names = {t.schema.function.name for t in agent._build_subtask_tools()}
+        assert names == set()
+
+    async def test_explicit_disabled_actor_has_no_subtask_tools(self) -> None:
+        """Explicit ``tasks=False`` also suppresses subtask tools."""
         agent = Agent("disabled", tasks=False)
 
         names = {t.schema.function.name for t in agent._build_subtask_tools()}
         assert names == set()
 
-    async def test_default_actor_has_subtask_tools(self) -> None:
-        """A bare Agent still gets the auto-injected subtask tools by default."""
-        agent = Agent("default")
+    async def test_taskconfig_actor_has_subtask_tools(self) -> None:
+        """Passing ``tasks=TaskConfig(...)`` opts in to the auto-injected subtask tools."""
+        agent = Agent("enabled", tasks=TaskConfig())
 
         names = {t.schema.function.name for t in agent._build_subtask_tools()}
         assert names == {"run_subtask", "run_subtasks"}
@@ -838,7 +845,7 @@ def test_run_subtask_description_advertises_parallel_invocation() -> None:
     This is what teaches Claude/GPT/Gemini to emit multiple ``tool_use``
     blocks in one assistant message rather than serializing them.
     """
-    agent = Agent("any")
+    agent = Agent("any", tasks=TaskConfig())
     [run_subtask, run_subtasks] = agent._build_subtask_tools()
 
     desc = run_subtask.schema.function.description

--- a/website/docs/beta/agent_harness.mdx
+++ b/website/docs/beta/agent_harness.mdx
@@ -108,7 +108,7 @@ The compaction and aggregation middleware are opt-in per field: passing `compact
 
 ## `tasks=` — TaskConfig
 
-Every Agent (unless constructed with `tasks=False`) automatically carries a pair of sub-task tools — `run_subtask` and `run_subtasks` — that let the LLM spawn isolated child Agents to handle self-contained work. `TaskConfig` configures how those children are built.
+Sub-task delegation is **off by default** — a bare Agent has no `run_subtask` / `run_subtasks` tools. Pass `tasks=TaskConfig(...)` to opt in, and the Agent will auto-inject the pair of sub-task tools that let the LLM spawn isolated child Agents to handle self-contained work. `TaskConfig` configures how those children are built.
 
 ```python linenums="1"
 from dataclasses import dataclass
@@ -133,7 +133,7 @@ class TaskConfig:
 | `exclude_tools` | Blocklist of parent-tool names to drop. Applied after `include_tools`. |
 | `extra_tools` | Additional tools given to sub-tasks that the parent does not have. |
 
-By default a sub-task Agent inherits **all** of the parent's user-supplied tools. Sub-tasks are constructed with `tasks=False`, so they themselves have no `run_subtask` / `run_subtasks` tools — recursive delegation is structurally impossible and no depth limit is needed.
+By default a sub-task Agent inherits **all** of the parent's user-supplied tools. Sub-tasks are themselves constructed with `tasks=False` (the Agent default), so they have no `run_subtask` / `run_subtasks` tools — recursive delegation is structurally impossible and no depth limit is needed.
 
 ```python linenums="1" hl_lines="8-12"
 from autogen.beta import Agent, TaskConfig
@@ -150,22 +150,22 @@ agent = Agent(
 )
 ```
 
-### `tasks=False` — opt out
+### `tasks=False` — the default
 
-Pass `tasks=False` to suppress the auto-injected sub-task tools entirely. Use this when an Agent should never spawn children — for example, when it's already running as a sub-task itself, or when delegation isn't appropriate for its role.
+`tasks=False` is the Agent default, so a bare Agent never spawns children. You only need to pass it explicitly to be self-documenting; otherwise just omit `tasks=` entirely.
 
 ```python linenums="1"
 focused = Agent(
     "summarizer",
     prompt="Summarise the input. Do not delegate.",
     config=main_config,
-    tasks=False,
+    # tasks=False is the default — no run_subtask / run_subtasks tools.
 )
 ```
 
 ## `run_subtask` / `run_subtasks` — auto-injected tools
 
-Unless you set `tasks=False`, every Agent exposes two tools to the LLM:
+When you opt in via `tasks=TaskConfig(...)`, the Agent exposes two tools to the LLM:
 
 - `run_subtask(task: str)` — spawn one sub-task Agent. Useful when the LLM has a single self-contained piece of work to delegate.
 - `run_subtasks(tasks: list[str], parallel: bool = True)` — spawn multiple sub-tasks in one tool call. Defaults to running them concurrently with `asyncio.gather`; pass `parallel=False` only when later tasks depend on earlier results.

--- a/website/docs/beta/code_examples/05_research_squad.mdx
+++ b/website/docs/beta/code_examples/05_research_squad.mdx
@@ -3,18 +3,18 @@ title: "Research Squad"
 sidebarTitle: "05 · Research Squad"
 ---
 
-Two complementary multi-Agent patterns in one example. First, a coordinator uses the auto-injected `run_subtasks` tool to fan out three independent factual lookups concurrently in a single tool call. Then a second coordinator delegates arithmetic to a `math_expert` Agent exposed via `Agent.as_tool()`. Together they show "fan out then collect" alongside "named delegate".
+Two complementary multi-Agent patterns in one example. First, a coordinator opts in to the auto-injected `run_subtasks` tool (via `tasks=TaskConfig()`) to fan out three independent factual lookups concurrently in a single tool call. Then a second coordinator delegates arithmetic to a `math_expert` Agent exposed via `Agent.as_tool()`. Together they show "fan out then collect" alongside "named delegate".
 
 ## What it covers
 
-- Auto-injected `run_subtask` / `run_subtasks` — every Agent has them by default; subtasks themselves don't, so recursion is impossible by construction.
+- Opting in to `run_subtask` / `run_subtasks` via `tasks=TaskConfig(...)` — disabled by default; subtasks themselves never get them, so recursion is impossible by construction.
 - Calling `run_subtasks(parallel=True)` to dispatch many sub-questions concurrently from one tool call.
 - Wrapping an Agent with `Agent.as_tool()` to expose it as a named delegate (`task_math-expert`) on a parent's tool list.
 - Subscribing to `TaskStarted` / `TaskCompleted` lifecycle events to observe the fan-out from outside the Agent.
 
 ## Primitives covered
 
-- `Agent` with auto-injected sub-task tools
+- `Agent` with `tasks=TaskConfig(...)` to opt in to sub-task tools
 - `run_subtasks(parallel=True)` for concurrent fan-out
 - `Agent.as_tool(description=...)` for sibling delegation
 - `TaskStarted` / `TaskCompleted` events on the stream
@@ -27,16 +27,17 @@ Two complementary multi-Agent patterns in one example. First, a coordinator uses
 
 Two patterns for multi-Agent orchestration:
 
-1. **Auto-injected subtask tools.** Every Agent automatically carries
-   ``run_subtask`` / ``run_subtasks``. The coordinator uses ``run_subtasks``
-   with ``parallel=True`` to fan out three short investigations
-   concurrently. Spawned subtasks have **no** ``run_subtask`` tools, so
-   recursion is structurally impossible — no depth limiter needed.
+1. **Opt-in subtask tools.** Pass ``tasks=TaskConfig(...)`` and the Agent
+   gains ``run_subtask`` / ``run_subtasks``. The coordinator uses
+   ``run_subtasks`` with ``parallel=True`` to fan out three short
+   investigations concurrently. Spawned subtasks have **no** ``run_subtask``
+   tools (they default to ``tasks=False``), so recursion is structurally
+   impossible — no depth limiter needed.
 
 2. **``Agent.as_tool()``.** A second Agent (``math_expert``) is exposed to
-   the coordinator as a callable tool. Because the wrapped Agent's own
-   ``run_subtask`` tools were stripped at spawn time (in the subtask path)
-   or are simply not used here, recursion is bounded by the call structure.
+   the coordinator as a callable tool. The wrapped Agent has no
+   ``run_subtask`` tools either (default), so recursion is bounded by the
+   call structure.
 
 Run::
 
@@ -47,6 +48,7 @@ import asyncio
 import time
 
 from autogen.beta import Agent
+from autogen.beta.agent import TaskConfig
 from autogen.beta.config import GeminiConfig
 from autogen.beta.events import TaskCompleted, TaskStarted
 from autogen.beta.stream import MemoryStream
@@ -69,6 +71,7 @@ async def main() -> None:
             "packed into the 'tasks' list. Be concise."
         ),
         config=config,
+        tasks=TaskConfig(),  # Opt in to run_subtask / run_subtasks.
     )
 
     # Collect subtask lifecycle events so we can show the fan-out to the user

--- a/website/docs/beta/code_examples/07_long_doc_chat.mdx
+++ b/website/docs/beta/code_examples/07_long_doc_chat.mdx
@@ -86,7 +86,6 @@ async def main() -> None:
             "Answer directly without calling any tools."
         ),
         config=config,
-        tasks=False,  # No subtask tools — keeps the demo focused on assembly + compaction.
         assembly=[
             ConversationPolicy(),
             SlidingWindowPolicy(max_events=6, transparent=True),

--- a/website/docs/beta/task_delegation.mdx
+++ b/website/docs/beta/task_delegation.mdx
@@ -17,7 +17,7 @@ Breaking work across multiple agents gives you:
     When the LLM returns multiple tool calls in a single response, the framework dispatches them concurrently. Each concurrent sub-task gets its own copy of variables, so they don't interfere with each other.
 
 !!! tip
-    For lightweight self-delegation where the parent doesn't need a *named* delegate, every Agent already auto-carries `#!python run_subtask` / `#!python run_subtasks` tools — see [`tasks=` in The Agent Harness](/docs/beta/agent_harness#tasks-taskconfig). Use `Agent.as_tool()` (below) when you want a distinct, purpose-named tool exposed to the LLM.
+    For lightweight self-delegation where the parent doesn't need a *named* delegate, opt in to the auto-injected `#!python run_subtask` / `#!python run_subtasks` tools by passing `#!python tasks=TaskConfig(...)` — see [`tasks=` in The Agent Harness](/docs/beta/agent_harness#tasks-taskconfig). Use `Agent.as_tool()` (below) when you want a distinct, purpose-named tool exposed to the LLM.
 
 ## Subagents API
 


### PR DESCRIPTION
## Why are these changes needed?

By default the Agent subtasks were enabled. However, this can produce unexpected extra LLM calls and costs for agents, which may not require it.

To enable tasks:
```
    coordinator = Agent(
        "coordinator",
        prompt=(
            "..."
        ),
        config=config,
        tasks=TaskConfig(),  # Opt in to run_subtask / run_subtasks.
    )
```

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
