### PR TITLE
skills(beta): add Agent Skills instructions for AG2 beta

### DIFF
--- a/.agents/skills/ag2-add-custom-tool/SKILL.md
+++ b/.agents/skills/ag2-add-custom-tool/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: ag2-add-custom-tool
+description: Add a custom Python tool to an AG2 beta `Agent` using the `@tool` decorator. Use when the user wants to give an Agent a new capability backed by Python code (API calls, DB queries, computations, file ops). Covers sync and async tools, parameter typing, Pydantic schema customisation, returning typed `Input` / `ToolResult` (text / data / images / binary), `final=True` early-exit, and dependency injection via `Context` / `Inject` / `Variable` / `Depends`.
+license: Apache-2.0
+---
+
+# Add a custom Python tool
+
+## When to use
+
+The user wants their `Agent` to take a real-world action: hit an API, query a database, compute something, return an image. If they want shipped tools (web search, code exec, shell), see `ag2-use-builtin-tools` and `ag2-shell-tool` instead.
+
+## 60-second recipe
+
+```python
+from autogen.beta import Agent, tool
+from autogen.beta.config import OpenAIConfig
+
+@tool
+def calculate_shipping_cost(destination: str, weight_kg: float) -> str:
+    """Calculates shipping cost for a package to a destination."""
+    return "$15.00"
+
+agent = Agent(
+    "shipping",
+    prompt="Use tools when helpful.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    tools=[calculate_shipping_cost],
+)
+```
+
+The `@tool` decorator generates the LLM-facing schema from the function signature, type hints, and docstring. **The docstring is the description the LLM sees** — write it for an LLM reader, not just a human.
+
+You can also pass plain undecorated functions in `tools=[...]` and AG2 wraps them automatically:
+
+```python
+def get_weather(location: str) -> str:
+    """Returns the current weather for a given location."""
+    return "Sunny, 22°C"
+
+agent = Agent("weather", tools=[get_weather])
+```
+
+Or attach a tool to an existing agent with `@agent.tool`:
+
+```python
+agent = Agent("calc")
+
+@agent.tool
+def multiply(a: int, b: int) -> int:
+    """Multiplies two integers and returns the result."""
+    return a * b
+```
+
+## Sync vs async
+
+Both `def` and `async def` are supported. **Synchronous tools run in a thread by default** so blocking I/O does not freeze the event loop. For ultra-fast pure-Python tools, opt out:
+
+```python
+@tool(sync_to_thread=False)
+def format_name(first: str, last: str) -> str:
+    """Formats a full name."""
+    return f"{last.upper()}, {first.capitalize()}"
+```
+
+Native async tools run in the main event loop directly:
+
+```python
+import aiohttp
+
+@tool
+async def fetch(url: str) -> str:
+    """Fetches a URL with aiohttp."""
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as r:
+            return await r.text()
+```
+
+## Validating inputs with Pydantic `Field`
+
+Use `Annotated[T, Field(...)]` to give the LLM strict bounds. The framework forwards these into the JSON Schema:
+
+```python
+from typing import Annotated
+from pydantic import Field
+from autogen.beta import tool
+
+@tool
+def set_temperature(
+    temp: Annotated[int, Field(description="Target temperature.", ge=10, le=30)],
+    mode: Annotated[str, Field(description="Mode.", pattern="^(heat|cool|auto)$")],
+) -> str:
+    """Sets the thermostat."""
+    return f"Set to {temp}°C in {mode} mode."
+```
+
+You can also override the tool name and description on the decorator:
+
+```python
+@tool(name="custom_math_tool", description="Performs advanced math.")
+def math_op(a: int, b: int) -> int:
+    return a + b
+```
+
+## Returning typed `Input` / `ToolResult`
+
+A plain `str` return is wrapped in `TextInput` automatically. For richer payloads, return an `Input` subtype or compose with `ToolResult`:
+
+```python
+from autogen.beta import DataInput, ImageInput, TextInput, ToolResult, tool
+
+@tool
+def get_status(task_id: str) -> TextInput:
+    return TextInput(f"Task {task_id} is in progress.")
+
+@tool
+def get_user_profile(user_id: str) -> DataInput:
+    return DataInput({"id": user_id, "name": "Alice", "role": "admin"})
+
+@tool
+def fetch_chart(chart_id: str) -> ImageInput:
+    return ImageInput(f"https://charts.example.com/{chart_id}.png")
+
+@tool
+def analyze_product(product_id: str) -> ToolResult:
+    """Returns image + structured metadata in one tool call."""
+    return ToolResult(
+        ImageInput(f"https://cdn.example.com/products/{product_id}.jpg"),
+        {"id": product_id, "name": "Widget Pro", "stock": 42},
+    )
+```
+
+For raw bytes of arbitrary format, use `BinaryInput(data=..., media_type="application/pdf")`.
+
+## End the turn early with `final=True`
+
+When the tool already knows the exact final answer, skip the extra LLM round-trip:
+
+```python
+from autogen.beta import ToolResult, tool
+
+@tool
+def handoff_to_human(ticket_id: str) -> ToolResult:
+    """Escalates and returns the final user-facing message verbatim."""
+    return ToolResult(f"Ticket {ticket_id} was escalated.", final=True)
+```
+
+A `final=True` `ToolResult` must contain exactly one part (`TextInput` or `DataInput`).
+
+## Dependency injection (Context / Inject / Variable / Depends)
+
+Tools can pull execution-time values without exposing them to the LLM. See `references/dependency_injection.md` for the full table; the basics:
+
+```python
+from typing import Annotated
+from autogen.beta import Context, Inject, Variable, tool
+
+@tool
+def query_db(query: str, ctx: Context) -> str:
+    """Runs a SQL query."""
+    db = ctx.dependencies["db"]
+    return db.execute(query)
+
+@tool
+def fetch(url: str, http: Annotated[object, Inject("http_session")]) -> str:
+    """Fetches with a shared HTTP session."""
+    return http.get(url).text
+
+@tool
+def send(text: str, api_key: Annotated[str, Variable()]) -> str:
+    """Sends a message via the configured channel."""
+    ...
+```
+
+`Inject` annotations are stripped from the LLM-facing schema — they're an internal injection mechanism.
+
+## Going deeper
+
+- `references/dependency_injection.md` — `Context` vs `Inject` vs `Variable` vs `Depends`, defaults, factories, mutability, overrides.
+- `website/docs/beta/tools/tools.mdx` — full `@tool` reference, including the synthesized JSON Schema.
+- `website/docs/beta/depends.mdx` — `Depends` lifecycle, yield-based teardown, caching, test overrides.
+- `website/docs/beta/inputs/inputs.mdx` — the `Input` factory hierarchy and provider support matrix.
+- `website/docs/beta/tools/toolkits.mdx` — bundle related tools into a reusable `Toolkit`.
+- `website/docs/beta/tools/tool_middleware.mdx` — async hooks around a single tool (validation, redaction, approval — see also `ag2-hitl`).
+
+## Common pitfalls
+
+- **Vague docstring** — the LLM uses it to decide *when* to call the tool. "Calculates shipping cost based on destination and weight" is much better than "Shipping calc".
+- **No type hints** — without them the framework can't generate a useful JSON Schema; the LLM may not call your tool at all.
+- **Blocking the event loop** — if you write `def` (sync) tool with heavy CPU or network and pass `sync_to_thread=False`, the loop blocks. Default behaviour (run in a thread) is safe; only opt out for cheap pure-Python work.
+- **Function-level imports inside tools** — repo convention disallows them. Hoist `import` to module top.
+- **Nested function definitions inside the tool body** — also disallowed (recreates the function on every call).
+- **Returning `dict` directly when you wanted structured data** — wrap it in `DataInput(...)` so the framework treats it as structured rather than coercing to text.
+- **Forgetting `final=True` requires exactly one part** — combining multiple `Input`s with `final=True` will raise.

--- a/.agents/skills/ag2-add-custom-tool/references/dependency_injection.md
+++ b/.agents/skills/ag2-add-custom-tool/references/dependency_injection.md
@@ -1,0 +1,167 @@
+# Dependency injection in AG2 beta tools
+
+Four annotations let a tool pull values from execution context without exposing them to the LLM. They use the same `fast_depends` machinery as FastAPI.
+
+## At a glance
+
+| Annotation | Use for | Resolves from | Lifecycle |
+|---|---|---|---|
+| `Context` (positional or kw) | Whole-context access (variables, dependencies, stream, prompt, `input()`) | The current `Context` object | Per call |
+| `Inject(key=None, default=..., default_factory=...)` | Pre-built complex objects (DB pool, HTTP session) | `context.dependencies` dict | Per call |
+| `Variable(key=None, default=..., default_factory=...)` | Lightweight scalar state (API key, session id, flag) | `context.variables` dict | Per call (mutations persist within conversation) |
+| `Depends(callable, use_cache=True)` | Computed-on-demand dependency, side-execution, yield-based teardown | Calls `callable` at execution time | Per call (cached within the same call by default) |
+
+Resolution annotations do **not** appear in the LLM-facing tool schema.
+
+## `Context` — direct access
+
+```python
+from autogen.beta import Context, tool
+
+@tool
+def query(query: str, context: Context) -> str:
+    db = context.dependencies["db"]
+    api_key = context.variables.get("api_key")
+    return f"{api_key}: {db.execute(query)}"
+```
+
+`Context` exposes `.dependencies`, `.variables`, `.prompt`, `.stream`, and `.input(...)` for HITL.
+
+## `Inject` — typed dependency lookup
+
+```python
+from typing import Annotated
+from autogen.beta import Inject, tool
+
+@tool
+def fetch(
+    url: str,
+    http_session: Annotated[object, Inject()],   # looks up "http_session" in deps
+    db: Annotated[object, Inject("database")],   # looks up "database" in deps
+) -> str:
+    ...
+```
+
+Provide dependencies on the agent (broad) or per-ask (narrow). Per-ask wins on collision:
+
+```python
+agent = Agent("data", dependencies={"db": prod_db, "http_session": shared_session})
+await agent.ask("Query the user table", dependencies={"db": readonly_db})
+```
+
+Defaults if missing:
+
+```python
+client: Annotated[object | None, Inject(default=None)]
+client: Annotated[object, Inject(default_factory=DefaultClient)]
+```
+
+## `Variable` — scalar state
+
+```python
+from typing import Annotated
+from autogen.beta import Variable, tool
+
+@tool
+def fetch_user(
+    user_id: str,
+    api_key: Annotated[str, Variable()],
+    theme: Annotated[str, Variable(default="dark")],
+) -> str:
+    ...
+```
+
+Provide variables on the agent or per-ask, same merge/override rules as deps. **Variables are mutable inside tools** and persist across tool calls in the same conversation:
+
+```python
+@tool
+def authenticate(context: Context) -> str:
+    context.variables["auth_token"] = "abc-123"
+    return "Authenticated"
+
+@tool
+def fetch_secure(auth_token: Annotated[str | None, Variable(default=None)]) -> str:
+    if not auth_token:
+        return "Not authenticated"
+    return f"Data with token {auth_token}"
+```
+
+## `Depends` — computed dependencies
+
+For something that must be evaluated at execution time (auth checks, short-lived sessions, side effects):
+
+```python
+from typing import Annotated
+from autogen.beta import Depends, tool
+
+def verify_permissions(user_id: int) -> None:
+    if not _allowed(user_id):
+        raise PermissionDenied(user_id)
+
+@tool
+def delete_user(
+    user_id: int,
+    auth: Annotated[None, Depends(verify_permissions)],
+) -> str:
+    return f"User {user_id} deleted."
+```
+
+`verify_permissions` runs before the tool body. Its return value is injected as `auth` (here ignored — the dependency is purely for its side effect / raise).
+
+### Yield-based teardown
+
+```python
+def get_db_session():
+    print("opening session")
+    session = "db_session_object"
+    yield session
+    print("closing session")  # runs after the tool finishes
+
+@tool
+def fetch_records(db: Annotated[str, Depends(get_db_session)]) -> str:
+    return "Records fetched."
+```
+
+### Combining `Depends` and `Inject`
+
+`Inject` for the long-lived pool, `Depends` for the short-lived per-call resource:
+
+```python
+def get_session(pool: Annotated[Pool, Inject("database_pool")]) -> Session:
+    session = pool.acquire()
+    yield session
+    session.release()
+
+@tool
+def fetch(session: Annotated[Session, Depends(get_session)]) -> str:
+    ...
+
+agent = Agent("data", tools=[fetch], dependencies={"database_pool": Pool()})
+```
+
+### Caching
+
+If multiple parameters declare the same `Depends(fn)`, `fn` is called once and cached for the rest of that tool call. Pass `use_cache=False` to force re-evaluation each time.
+
+### Test overrides
+
+```python
+def get_production_db():
+    raise Exception("Do not call in tests!")
+
+@tool
+def read_data(db: Annotated[object, Depends(get_production_db)]) -> str:
+    return "Data"
+
+agent = Agent("test", tools=[read_data])
+agent.dependency_provider.override(get_production_db, lambda: "mock_db")
+```
+
+For `Inject` overrides, just pass `dependencies={...}` to `agent.ask(...)`.
+
+## When to pick which
+
+- Need the whole context object? → `Context`.
+- Pre-built object, used as-is? → `Inject`.
+- Plain scalar / config value? → `Variable`.
+- Computed at call time, possibly with cleanup? → `Depends`.

--- a/.agents/skills/ag2-ag-ui/SKILL.md
+++ b/.agents/skills/ag2-ag-ui/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: ag2-ag-ui
+description: Expose an AG2 beta `Agent` over the AG-UI protocol so a frontend (CopilotKit, custom React/Next.js, or any AG-UI client) can stream responses, render tool calls, sync shared state, and surface human-input checkpoints. Wraps the agent with `AGUIStream(agent)` and mounts it in FastAPI via `stream.dispatch(...)` or `stream.build_asgi()`. Use when the user wants a web frontend in front of an AG2 agent rather than a CLI / script.
+license: Apache-2.0
+---
+
+# AG-UI integration
+
+## When to use
+
+- The user is building a web UI (React / Next.js / anything HTTP+SSE) that should talk to an AG2 beta agent.
+- They want streaming text, tool-call rendering, shared state sync, or HITL checkpoints surfaced to the frontend with a standard protocol — not a custom REST/WebSocket contract.
+- They're using or considering CopilotKit (the recommended React client).
+
+For a custom narrow-purpose API where you own the contract end-to-end, skip AG-UI and write a plain endpoint instead.
+
+## Supported AG-UI features
+
+| Feature | Status |
+|---|---|
+| Streaming text events (`TEXT_MESSAGE_*`, `TEXT_MESSAGE_CHUNK`) | ✓ |
+| Backend tool lifecycle (`TOOL_CALL_START` / `_ARGS` / `_RESULT` / `_END`) | ✓ |
+| Frontend-tool dispatch (`TOOL_CALL_CHUNK` for client tools in `RunAgentInput.tools`) | ✓ |
+| Shared-state snapshots (`STATE_SNAPSHOT`) | ✓ |
+| Human input checkpoints (surfaced as user-visible message events) | ✓ |
+
+## Installation
+
+```bash
+pip install "ag2[ag-ui]"
+```
+
+## 60-second recipe — FastAPI server
+
+```python title="run_ag_ui.py"
+from fastapi import FastAPI, Header
+from fastapi.responses import StreamingResponse
+
+from autogen.beta import Agent
+from autogen.beta.ag_ui import AGUIStream, RunAgentInput
+from autogen.beta.config import OpenAIConfig
+
+agent = Agent(
+    name="support_bot",
+    prompt="You help users with billing questions.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+)
+
+stream = AGUIStream(agent)
+app = FastAPI()
+
+@app.post("/chat")
+async def run_agent(message: RunAgentInput, accept: str | None = Header(None)) -> StreamingResponse:
+    return StreamingResponse(
+        stream.dispatch(message, accept=accept),
+        media_type=accept or "text/event-stream",
+    )
+```
+
+```bash
+uvicorn run_ag_ui:app --reload --port 8000
+```
+
+Test:
+
+```bash
+curl -N -X POST http://127.0.0.1:8000/chat \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{"thread_id":"t1","run_id":"r1","messages":[{"id":"m1","role":"user","content":"Hello"}],"state":{},"context":[],"tools":[]}'
+```
+
+## Lower-friction alternative — `build_asgi()`
+
+If you don't need custom auth / middleware, mount the ASGI endpoint directly:
+
+```python
+from autogen.beta.ag_ui import AGUIStream
+from fastapi import FastAPI
+
+app = FastAPI()
+stream = AGUIStream(agent)
+app.mount("/chat", stream.build_asgi())
+```
+
+## CopilotKit frontend (recommended for React / Next.js)
+
+Two ways to start:
+
+```bash
+# Option A — CopilotKit bootstrap
+npx copilotkit@latest create -f ag2
+
+# Option B — clone the reference starter
+# https://github.com/ag2ai/ag2-copilotkit-starter
+```
+
+The starter layout:
+
+```
+ag2-copilotkit-starter/
+├── agent-py/     # Python backend (AG2 + AG-UI)
+└── ui-react/     # React + CopilotKit frontend
+```
+
+Backend serves `/chat` on port 8008 by default. The Next.js route at `ui-react/app/api/copilotkit/route.ts` bridges the UI to the backend:
+
+```tsx
+import { HttpAgent } from "@ag-ui/client";
+import { CopilotRuntime, ExperimentalEmptyAdapter, copilotRuntimeNextJSAppRouterEndpoint } from "@copilotkit/runtime";
+import { NextRequest } from "next/server";
+
+const agent = new HttpAgent({ url: "http://localhost:8008/chat" });
+const runtime = new CopilotRuntime({ agents: { weather_agent: agent } });
+
+export async function POST(req: NextRequest) {
+  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+    runtime,
+    serviceAdapter: new ExperimentalEmptyAdapter(),
+    endpoint: "/api/copilotkit",
+  });
+  return handleRequest(req);
+}
+```
+
+Wrap your app:
+
+```tsx
+import { CopilotKit } from "@copilotkit/react-core";
+import "@copilotkit/react-ui/styles.css";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <CopilotKit agent="weather_agent" runtimeUrl="/api/copilotkit">
+          {children}
+        </CopilotKit>
+      </body>
+    </html>
+  );
+}
+```
+
+Render chat (`<CopilotChat />`), and use `useCopilotAction({...})` in client components to render generative UI tied to backend tool calls.
+
+## Production checklist
+
+- **CORS** — allow your frontend origin on the AG-UI backend (`POST`, `OPTIONS`, auth headers).
+- **Auth** — protect both `/api/copilotkit` (Next.js route) and backend `/chat`. Don't rely on client-only secrets.
+- **SSE buffering** — verify backend response is `Content-Type: text/event-stream` and that proxy layers (Nginx, CloudFront, etc.) don't buffer SSE.
+- **Timeouts / retries** — conservative values for long-running tool workflows; only retry idempotent requests.
+- **Tool inputs are untrusted** — validate and authorize server-side before invoking privileged tools. Log tool execution with request IDs.
+- **Tool name parity** — frontend `useCopilotAction` `name` must match backend `@tool` name exactly.
+
+## Going deeper
+
+- `website/docs/beta/ag-ui/index.mdx` — `AGUIStream`, supported events, basic server.
+- `website/docs/beta/ag-ui/copilotkit-quickstart.mdx` — full React + CopilotKit walkthrough (file layout, route, layout, chat component, weather-card example).
+- AG-UI protocol: https://docs.ag-ui.com/introduction
+- Reference starter: https://github.com/ag2ai/ag2-copilotkit-starter
+- For protocol-level testing: AG2 Dojo profile https://dojo.ag-ui.com/ag2/feature/agentic_chat
+
+## Common pitfalls
+
+- **Missing `ag-ui` extra** — `pip install "ag2[ag-ui]"` is required; without it `from autogen.beta.ag_ui import AGUIStream` will fail.
+- **CORS blocked** — frontend can't hit the backend in dev. Add `CORSMiddleware` to the FastAPI app for the dev origin.
+- **No streaming output** — proxy or `Content-Type` issue. Test with raw `curl -N` first to isolate.
+- **Tool UI not rendering** — tool name on the React side (`useCopilotAction({ name: "..." })`) doesn't exactly match the backend `@tool` name.
+- **Putting the endpoint behind a SSE-incompatible proxy** — many proxies buffer event-stream responses by default. Disable buffering on the route.
+- **Trying to use `AGUIStream` with classic `ConversableAgent`** — the description here covers `autogen.beta.Agent`. Classic AG2 agents can be exposed differently; check the AG2 docs for that path.

--- a/.agents/skills/ag2-hitl/SKILL.md
+++ b/.agents/skills/ag2-hitl/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: ag2-hitl
+description: Pause an AG2 beta `Agent` mid-run to collect human input via `context.input()`, or gate a tool call with `approval_required()` middleware. Use when the user wants the agent to ask for confirmation, request missing info (passwords, API keys, data), or have a human approve sensitive / irreversible / expensive tool calls (sending emails, deleting records, payments).
+license: Apache-2.0
+---
+
+# Human-in-the-loop
+
+## When to use
+
+- The agent should **ask for confirmation** before doing something risky.
+- The agent needs **information from the user mid-conversation** (a password, an API key, missing context).
+- A specific **tool call should require human approval** before it runs (irreversible / expensive / sensitive).
+- Quality assurance — show a draft, get human edits/approval before finalising.
+
+Two distinct mechanisms — pick by intent:
+
+| Need | Use |
+|---|---|
+| Tool asks an open question and waits for a typed answer | `context.input()` from inside the tool + `hitl_hook` on the agent |
+| Approve / deny a specific tool call before its body runs | `approval_required()` tool middleware |
+
+## Pattern 1 — `context.input()` for open questions
+
+A tool requests input via `Context.input(prompt, timeout=...)`. The agent must have a `hitl_hook` that knows how to collect that input.
+
+```python
+from autogen.beta import Agent, Context, tool
+from autogen.beta.events import HumanInputRequest, HumanMessage
+
+@tool
+async def execute_query(context: Context) -> str:
+    answer = await context.input(
+        "Are you sure you want to run this query? (yes/no)",
+        timeout=60.0,
+    )
+    if answer.strip().lower() != "yes":
+        return "Query cancelled."
+    return "Query executed successfully."
+
+def hitl_hook(event: HumanInputRequest) -> HumanMessage:
+    print(f"Agent asks: {event.content}")
+    return HumanMessage(content=input("Your answer: "))
+
+agent = Agent("dba", tools=[execute_query], hitl_hook=hitl_hook)
+```
+
+The hook receives a `HumanInputRequest` (containing the prompt) and must return a `HumanMessage`. Both `def` and `async def` hooks are supported.
+
+You can also register the hook after construction:
+
+```python
+agent = Agent("dba", tools=[execute_query])
+
+@agent.hitl_hook
+async def async_hitl_hook(event: HumanInputRequest) -> HumanMessage:
+    answer = await collect_from_ui(event.content)
+    return HumanMessage(content=answer)
+```
+
+The decorator overrides any hook set in the constructor.
+
+The hook participates in dependency injection — `Context`, `Inject`, `Variable`, `Depends` work the same as in tools.
+
+If `context.input()` is called and no hook is registered, the framework raises `HumanInputNotProvidedError`.
+
+## Pattern 2 — `approval_required()` for specific tool calls
+
+Gate a single tool with the built-in approval middleware. The user is prompted before the tool body runs and can approve or deny.
+
+```python
+from autogen.beta import Agent, tool
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.middleware import approval_required
+
+@tool(middleware=[approval_required()])
+def delete_account(user_id: str) -> str:
+    """Deletes a user account by ID permanently."""
+    return f"Account {user_id} deleted."
+
+agent = Agent(
+    "support",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    tools=[delete_account],
+    hitl_hook=lambda event: input(event.content),
+)
+```
+
+When the agent calls `delete_account`, the user sees:
+
+```
+Agent tries to call tool:
+`delete_account`, {"user_id": "abc-123"}
+Please approve or deny this request.
+Y/N?
+```
+
+Typing **y** lets the tool run. Anything else denies it; the agent receives the denial message and can adjust.
+
+`approval_required()` calls `context.input()` under the hood, so it **also requires a `hitl_hook`** — without one you'll get a runtime error.
+
+### Custom prompt
+
+```python
+@tool(middleware=[approval_required(
+    message="⚠️ Run `{tool_name}` with {tool_arguments}? (y/n)",
+    denied_message="Operation blocked by user.",
+)])
+def send_email(to: str, subject: str, body: str) -> str:
+    """Send an email to the given address."""
+    ...
+```
+
+`{tool_name}` and `{tool_arguments}` are interpolated.
+
+## Pairing both patterns
+
+For a tool that both gathers input mid-run and requires approval:
+
+```python
+@tool(middleware=[approval_required()])
+async def schedule_report(name: str, context: Context) -> str:
+    """Schedule a report — asks the user for the cadence, then runs after approval."""
+    cadence = await context.input("How often? (daily / weekly / monthly)")
+    return f"Scheduled '{name}' on {cadence} cadence."
+```
+
+The approval middleware runs first (outermost). Once approved, the tool body executes and `context.input()` triggers a second human interaction.
+
+## Going deeper
+
+- Source docs: `website/docs/beta/context/human_in_the_loop.mdx` (`context.input`, `hitl_hook`), `website/docs/beta/tools/approval_required.mdx` (`approval_required` middleware).
+- Tool middleware in general — `website/docs/beta/tools/tool_middleware.mdx`. See also `ag2-middleware` for agent-wide HITL interception via `BaseMiddleware.on_human_input()`.
+- HITL hooks support dependency injection identically to tools — see `../ag2-add-custom-tool/references/dependency_injection.md`.
+
+## Common pitfalls
+
+- **`approval_required()` without a `hitl_hook`** — the middleware calls `context.input()`, so the agent needs a hook. You'll see `HumanInputNotProvidedError` otherwise.
+- **Forgetting to handle the denial path** — `context.input()` returns whatever the hook returns. If you only branch on "yes", any other answer (including silence/default) lets the operation continue. Always validate.
+- **Sync `input()` in an async UI** — `input()` blocks the event loop. Use an async hook (`async def`) and an async input collector (web socket, message queue) for any non-CLI app.
+- **No timeout** — `context.input(prompt)` can wait forever. Pass `timeout=60.0` (seconds) for any production path.
+- **Decorator hook overrides constructor hook silently** — if you set both, the decorator wins. Pick one place.
+- **Expecting `HumanMessage` to flow into the conversation history automatically** — it does for the requesting tool's return value, but mid-run inputs collected via `ctx.input()` are not separate user turns. They live in the tool's scope.

--- a/.agents/skills/ag2-knowledge-and-memory/SKILL.md
+++ b/.agents/skills/ag2-knowledge-and-memory/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: ag2-knowledge-and-memory
+description: Persist agent state across runs, shape what the LLM sees per turn, and cap history to fit a context window. Covers `KnowledgeStore` (memory / sqlite / disk / redis), `KnowledgeConfig` (`store=`, `compact=`, `aggregate=`, `bootstrap=`), aggregation strategies (`WorkingMemoryAggregate`, `ConversationSummaryAggregate`), assembly policies (`WorkingMemoryPolicy`, `EpisodicMemoryPolicy`, `ConversationPolicy`, `SlidingWindowPolicy`, `TokenBudgetPolicy`, `AlertPolicy`), and compaction (`TailWindowCompact`, `SummarizeCompact`). Use when the user wants the agent to remember between conversations, manage long histories, or control prompt assembly.
+license: Apache-2.0
+---
+
+# Knowledge, memory, and context assembly
+
+This skill covers three related primitives that work together:
+
+| Primitive | Lives in | Role |
+|---|---|---|
+| **`KnowledgeStore`** | `autogen.beta.knowledge` | Path-based persistent storage (memory / sqlite / disk / redis) |
+| **Assembly policies** | `autogen.beta.policies` | Shape `(prompts, events)` per turn before the LLM call |
+| **Aggregation / Compaction** | `autogen.beta.aggregate` / `.compact` | Write structured knowledge to the store / trim event history |
+
+`KnowledgeConfig` wires all three onto an `Agent` via the `knowledge=` constructor parameter; assembly policies go via `assembly=`.
+
+## When to use what
+
+| User intent | Reach for |
+|---|---|
+| Remember user preferences / state between conversations | `WorkingMemoryAggregate` + `WorkingMemoryPolicy` (and a persistent store) |
+| Summarise each session for next time | `ConversationSummaryAggregate` + `EpisodicMemoryPolicy` |
+| Hard-cap event history sent to the LLM | `SlidingWindowPolicy(max_events=N)` |
+| Cap by approximate token count | `TokenBudgetPolicy(max_tokens=N)` |
+| Drop lifecycle / observer events from the LLM's view | `ConversationPolicy()` |
+| Trim stream history (not just LLM view) | `TailWindowCompact` or `SummarizeCompact` |
+| Route observer alerts to the LLM | `AlertPolicy()` |
+
+## 60-second recipe — persistent working memory
+
+```python
+from autogen.beta import Agent, KnowledgeConfig
+from autogen.beta.aggregate import AggregateTrigger, WorkingMemoryAggregate
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.knowledge import DiskKnowledgeStore
+from autogen.beta.policies import ConversationPolicy, WorkingMemoryPolicy
+
+store = DiskKnowledgeStore("./journal-state")
+config = OpenAIConfig(model="gpt-5")
+
+agent = Agent(
+    "journal",
+    prompt="You are a daily journal companion.",
+    config=config,
+    knowledge=KnowledgeConfig(
+        store=store,
+        aggregate=WorkingMemoryAggregate(config=config),
+        aggregate_trigger=AggregateTrigger(on_end=True),
+    ),
+    assembly=[
+        WorkingMemoryPolicy(),  # injects /memory/working.md on every LLM call
+        ConversationPolicy(),
+    ],
+)
+```
+
+After each conversation the aggregate writes `/memory/working.md`. The next time you build an `Agent` against the same store, `WorkingMemoryPolicy` reads that file in and injects it as prompt context. The agent "remembers" without replaying chat history. Full runnable example: `assets/journal_companion.py`.
+
+## `KnowledgeStore` implementations
+
+| Implementation | Use when |
+|---|---|
+| `MemoryKnowledgeStore()` | Tests, ephemeral sessions |
+| `SqliteKnowledgeStore(path)` | Single-process durability — pragmatic default |
+| `DiskKnowledgeStore(path)` | Files should be human-readable on disk |
+| `RedisKnowledgeStore(url)` | Multi-process / cross-host sharing |
+| `LockedKnowledgeStore(inner, lock=...)` | Wrap any store to serialize concurrent writers |
+
+API (all async):
+
+```python
+await store.write("/artifacts/report.md", "# Q3...")
+text = await store.read("/artifacts/report.md")
+children = await store.list("/")            # immediate children, dirs end in '/'
+await store.delete("/artifacts/old.md")
+exists = await store.exists("/artifacts/report.md")
+
+off = await store.append("/log/events.jsonl", '{"t":1}\n')   # WAL-style
+new_slice = await store.read_range("/log/events.jsonl", off)  # only new bytes
+sub = await store.on_change("/log/", on_change_callback)
+```
+
+## Assembly chain — what the LLM actually sees
+
+Pass `AssemblyPolicy` instances via `assembly=[...]`. The Agent wires an internal `AssemblerMiddleware` at the outermost middleware position. Each policy transforms `(prompts, events)` and pipes into the next.
+
+**Two kinds of policy — order matters: injection before reduction.**
+
+| Kind | Purpose | Built-ins |
+|---|---|---|
+| **Injection** | Add to `prompts` | `WorkingMemoryPolicy`, `EpisodicMemoryPolicy`, `AlertPolicy` |
+| **Reduction** | Trim `events` | `ConversationPolicy`, `SlidingWindowPolicy`, `TokenBudgetPolicy` |
+
+Validate ordering manually:
+
+```python
+from autogen.beta.assembly import AssemblerMiddleware
+warnings = AssemblerMiddleware.validate_order(policies)  # returns list of warnings on known bad orderings
+```
+
+(`AssemblerMiddleware` and the `AssemblyPolicy` protocol live in `autogen.beta.assembly` for advanced/manual harness wiring; you don't need to import them when just passing built-in policies via `assembly=[...]`.)
+
+### Built-in policies
+
+```python
+from autogen.beta.policies import (
+    AlertPolicy,
+    ConversationPolicy,
+    EpisodicMemoryPolicy,
+    SlidingWindowPolicy,
+    TokenBudgetPolicy,
+    WorkingMemoryPolicy,
+)
+
+# Injection
+WorkingMemoryPolicy()                                 # reads /memory/working.md
+EpisodicMemoryPolicy(max_episodes=5, transparent=True) # reads recent /memory/conversations/
+AlertPolicy()                                          # delivers ObserverAlerts to LLM, halts on FATAL
+
+# Reduction
+ConversationPolicy()                                  # drops non-conversation events
+SlidingWindowPolicy(max_events=50, transparent=True)  # last N events
+TokenBudgetPolicy(max_tokens=32_000, chars_per_token=4, transparent=True)
+```
+
+`transparent=True` appends a `[policy_name] Showing X of Y events.` note to the prompt — useful while tuning. Realistic chain:
+
+```python
+assembly=[
+    WorkingMemoryPolicy(),
+    EpisodicMemoryPolicy(max_episodes=3),
+    AlertPolicy(),
+    SlidingWindowPolicy(max_events=80),
+]
+```
+
+## Aggregation — writing knowledge to the store
+
+`AggregateStrategy.aggregate(events, ctx, store) → None` extracts and persists. Two built-ins, both take a `ModelConfig` for a summarisation call (use a cheaper model than the agent's main one):
+
+| Strategy | Writes | Pairs with |
+|---|---|---|
+| `WorkingMemoryAggregate(config=...)` | `/memory/working.md` (single rolling file) | `WorkingMemoryPolicy` |
+| `ConversationSummaryAggregate(config=...)` | `/memory/conversations/{ts}_{stream_id}.md` | `EpisodicMemoryPolicy` |
+
+`AggregateTrigger` controls cadence — `every_n_turns`, `every_n_events`, `on_end`. `AggregateTrigger()` alone fires nothing; opt in to at least one. `on_end=True` defaults off because each fire is an LLM call.
+
+## Compaction — trimming stream history
+
+`CompactStrategy.compact(events, ctx, store) → list[BaseEvent]`. Replaces the stream's history. Two built-ins:
+
+| Strategy | Behaviour | Cost |
+|---|---|---|
+| `TailWindowCompact(target=N)` | Keep last N events; drop the rest (optionally persist to `/log/`) | Zero LLM calls |
+| `SummarizeCompact(target=N, config=...)` | Summarise dropped events into one `CompactionSummary`; insert at head | One LLM call per fire |
+
+`CompactTrigger(max_events=N, max_tokens=M, chars_per_token=4)` — fires when any threshold is crossed.
+
+```python
+from autogen.beta.compact import CompactTrigger, TailWindowCompact, SummarizeCompact
+```
+
+`SummarizeCompact` inserts a `CompactionSummary` event at the head; `ConversationPolicy` allows it through so the LLM still gets that context.
+
+## Wiring it all on the Agent
+
+`KnowledgeConfig` is the bundle:
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class KnowledgeConfig:
+    store: KnowledgeStore
+    compact: CompactStrategy | None = None
+    compact_trigger: CompactTrigger | None = None
+    aggregate: AggregateStrategy | None = None
+    aggregate_trigger: AggregateTrigger | None = None
+    bootstrap: StoreBootstrap | None = None    # e.g. DefaultBootstrap()
+```
+
+Full shape:
+
+```python
+agent = Agent(
+    "assistant",
+    config=main_config,
+    knowledge=KnowledgeConfig(
+        store=DiskKnowledgeStore("./state"),
+        compact=TailWindowCompact(target=100),
+        compact_trigger=CompactTrigger(max_events=200),
+        aggregate=ConversationSummaryAggregate(config=summarizer_config),
+        aggregate_trigger=AggregateTrigger(every_n_turns=10, on_end=True),
+        bootstrap=DefaultBootstrap(),  # seeds /SKILL.md, /artifacts/, /log/, /memory/
+    ),
+    assembly=[
+        WorkingMemoryPolicy(),
+        EpisodicMemoryPolicy(max_episodes=3),
+        AlertPolicy(),
+        SlidingWindowPolicy(max_events=80),
+    ],
+)
+```
+
+The harness wires internal middleware conditionally — `_AssemblerMiddleware`, `_HaltCheckMiddleware`, `_CompactionMiddleware`, `_AggregationMiddleware`. You only pay for what you turn on.
+
+Lifecycle events emitted: `CompactionCompleted` (with `events_before` / `events_after` / `usage`), `AggregationCompleted` (with `strategy` / `usage`), `HaltEvent` (when `AlertPolicy` sees a FATAL alert). Subscribe via `ag2-observers-and-alerts`.
+
+## Going deeper
+
+- `assets/journal_companion.py` — runnable end-to-end working-memory demo (mirrors `code_examples/06`).
+- `assets/long_doc_chat.py` — assembly + compaction stress test (mirrors `code_examples/07`).
+- Source docs:
+  - `website/docs/beta/advanced/knowledge_store.mdx` — store API, `EventLogWriter`, `LockedKnowledgeStore`.
+  - `website/docs/beta/advanced/assembly.mdx` — full policy reference and ordering rules.
+  - `website/docs/beta/advanced/aggregation.mdx` — aggregate strategies and custom strategies.
+  - `website/docs/beta/advanced/compaction.mdx` — compact strategies and custom strategies.
+  - `website/docs/beta/agent_harness.mdx` — `KnowledgeConfig` constructor reference, turn-lifecycle middleware order.
+
+## Common pitfalls
+
+- **Reduction before injection** — `SlidingWindowPolicy` before `WorkingMemoryPolicy` means the working memory injection isn't counted against the budget. Always: injections first, then `AlertPolicy`, then reductions.
+- **Forgetting `KnowledgeStore` dependency for memory policies** — `WorkingMemoryPolicy` and `EpisodicMemoryPolicy` look up the store via `context.dependencies.get(KnowledgeStore)`. `KnowledgeConfig(store=...)` registers it for you; if you wire the policy manually, register the store in `dependencies` too.
+- **Aggregation costs an LLM call per fire** — `on_end=True` on every conversation can add up. Pair `WorkingMemoryAggregate` and `ConversationSummaryAggregate` thoughtfully; consider `every_n_turns=N` for high-volume agents.
+- **Mixing `HistoryLimiter` middleware with assembly reduction policies** — they both trim. Pick one mechanism. Assembly is more flexible (rich shaping, transparency notes); `HistoryLimiter` is simpler.
+- **`read_range` operates on byte offsets, not character offsets** — multi-byte UTF-8 sequences need careful alignment.
+- **Forgetting that `WorkingMemoryAggregate` is destructive** — it overwrites `/memory/working.md` each fire. That's intentional (rolling state, not log) but expect prior content to merge or disappear.
+- **Expecting `AlertPolicy` to render alerts to the LLM without being in `assembly=`** — alerts sit on the stream as `ObserverAlert` events but only reach the LLM when `AlertPolicy` injects them.

--- a/.agents/skills/ag2-knowledge-and-memory/assets/journal_companion.py
+++ b/.agents/skills/ag2-knowledge-and-memory/assets/journal_companion.py
@@ -1,0 +1,91 @@
+"""Journal companion — knowledge store with working memory.
+
+Mirrors website/docs/beta/code_examples/06_journal_companion.mdx. Persistent
+agent memory using three primitives:
+
+- KnowledgeStore — virtual filesystem for agent state.
+- WorkingMemoryAggregate — LLM-driven summary rollup that runs at the end of
+  every conversation and writes /memory/working.md.
+- WorkingMemoryPolicy — assembly policy that reads /memory/working.md and
+  injects it as context at the start of every subsequent conversation.
+
+The agent therefore "remembers" what you told it even after a full restart,
+because the state lives in the knowledge store — not in conversation history.
+
+Run::
+
+    python journal_companion.py
+"""
+
+import asyncio
+import shutil
+import tempfile
+from pathlib import Path
+
+from autogen.beta import Agent, KnowledgeConfig
+from autogen.beta.aggregate import AggregateTrigger, WorkingMemoryAggregate
+from autogen.beta.config import GeminiConfig
+from autogen.beta.knowledge import DiskKnowledgeStore
+from autogen.beta.policies import ConversationPolicy, WorkingMemoryPolicy
+
+
+def section(title: str) -> None:
+    print(f"\n── {title} ───")
+
+
+async def main() -> None:
+    config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
+    workdir = Path(tempfile.mkdtemp(prefix="journal-companion-"))
+
+    try:
+        store = DiskKnowledgeStore(str(workdir))
+
+        def build_agent() -> Agent:
+            return Agent(
+                "journal",
+                prompt=(
+                    "You are a supportive daily journal companion. Keep a "
+                    "running understanding of what the user is working on. "
+                    "Be brief and reference their past entries when relevant."
+                ),
+                config=config,
+                knowledge=KnowledgeConfig(
+                    store=store,
+                    aggregate=WorkingMemoryAggregate(config=config),
+                    aggregate_trigger=AggregateTrigger(on_end=True),
+                ),
+                assembly=[
+                    WorkingMemoryPolicy(),
+                    ConversationPolicy(),
+                ],
+            )
+
+        section("Session 1 — tell the journal what you're doing")
+
+        agent1 = build_agent()
+        r = await agent1.ask(
+            "Today I started learning to build a home espresso setup. Still "
+            "choosing between a Silvia Pro and a Linea Mini."
+        )
+        print(r.body)
+        r = await r.ask(
+            "Also started reading The Pragmatic Programmer. On chapter 2 about orthogonality. That's the whole update."
+        )
+        print(r.body)
+
+        working = await store.read("/memory/working.md")
+        print()
+        print("## /memory/working.md after session 1")
+        print(working)
+
+        section("Session 2 — new Agent instance, same store: memory persists")
+
+        agent2 = build_agent()
+        r2 = await agent2.ask("Quick check-in: what was I working on? Answer in one line.")
+        print(r2.body)
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.agents/skills/ag2-knowledge-and-memory/assets/long_doc_chat.py
+++ b/.agents/skills/ag2-knowledge-and-memory/assets/long_doc_chat.py
@@ -1,0 +1,89 @@
+"""Long-doc chat — composing assembly policies.
+
+Mirrors website/docs/beta/code_examples/07_long_doc_chat.mdx. Three policies
+compose in order:
+
+1. ConversationPolicy — drops every event that isn't conversation/tool traffic.
+2. SlidingWindowPolicy(max_events=6) — hard-caps events forwarded to the LLM.
+3. TokenBudgetPolicy(max_tokens=2000) — char-based secondary cap.
+
+Also pairs the assembly chain with TailWindowCompact so the agent's stream
+history itself is kept small.
+
+Run::
+
+    python long_doc_chat.py
+"""
+
+import asyncio
+
+from autogen.beta import Agent, KnowledgeConfig
+from autogen.beta.compact import CompactTrigger, TailWindowCompact
+from autogen.beta.config import GeminiConfig
+from autogen.beta.events.lifecycle import CompactionCompleted
+from autogen.beta.knowledge import MemoryKnowledgeStore
+from autogen.beta.policies import (
+    ConversationPolicy,
+    SlidingWindowPolicy,
+    TokenBudgetPolicy,
+)
+from autogen.beta.stream import MemoryStream
+
+
+def section(title: str) -> None:
+    print(f"\n── {title} ───")
+
+
+QUESTIONS = [
+    "Remember the word 'oak'.",
+    "Remember the word 'river'.",
+    "Remember the word 'lantern'.",
+    "Remember the word 'sable'.",
+    "Remember the word 'quartz'.",
+    "Name the three most recent words I asked you to remember.",
+]
+
+
+async def main() -> None:
+    config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
+
+    store = MemoryKnowledgeStore()
+    compactions: list[CompactionCompleted] = []
+    stream = MemoryStream()
+    stream.where(CompactionCompleted).subscribe(lambda e: compactions.append(e))
+
+    agent = Agent(
+        "lexicon",
+        prompt=("Be very terse — one short sentence per reply. Answer directly without calling any tools."),
+        config=config,
+        assembly=[
+            ConversationPolicy(),
+            SlidingWindowPolicy(max_events=6, transparent=True),
+            TokenBudgetPolicy(max_tokens=2000),
+        ],
+        knowledge=KnowledgeConfig(
+            store=store,
+            compact=TailWindowCompact(target=4),
+            compact_trigger=CompactTrigger(max_events=8),
+        ),
+    )
+
+    section("Long-doc chat — assembly policies trim what the LLM actually sees")
+
+    reply = await agent.ask(QUESTIONS[0], stream=stream)
+    print(f"Q1> {QUESTIONS[0]}")
+    print(f"A1> {reply.body}")
+
+    for i, q in enumerate(QUESTIONS[1:], start=2):
+        reply = await reply.ask(q)
+        print(f"Q{i}> {q}")
+        print(f"A{i}> {reply.body}")
+
+    print()
+    print(f"Compactions fired during run: {len(compactions)}")
+    for c in compactions:
+        print(f"  - {c.strategy}: {c.events_before} → {c.events_after} events")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.agents/skills/ag2-middleware/SKILL.md
+++ b/.agents/skills/ag2-middleware/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: ag2-middleware
+description: Intercept the AG2 beta agent loop with `BaseMiddleware` — wrap full turns (`on_turn`), each LLM call (`on_llm_call`), each tool execution (`on_tool_execution`), or each human-input request (`on_human_input`). Use for retry, logging, history trimming, request mutation, tool auditing, guardrails, or rate limiting. Built-ins: `LoggingMiddleware`, `RetryMiddleware`, `HistoryLimiter`, `TokenLimiter`, `TelemetryMiddleware` (see `ag2-telemetry`). For per-tool hooks see also `ag2-add-custom-tool` tool-middleware section.
+license: Apache-2.0
+---
+
+# Middleware
+
+## When to use
+
+Middleware is for **cross-cutting behaviour** that should apply consistently across many runs without changing the agent, model client, or tools themselves. Common use cases:
+
+- Logging, tracing, timing
+- Retry on transient failures
+- Trim history before it reaches the model
+- Cap or estimate token usage
+- Rewrite tool arguments / results
+- Enforce policies before a tool runs
+- Audit human-input requests
+
+## Four hooks
+
+`BaseMiddleware` exposes four async hooks. Implement only the ones you need:
+
+| Hook | Wraps | Use for |
+|---|---|---|
+| `on_turn(call_next, event, context) → ModelResponse` | The whole agent turn | Total latency, request/response inspection, turn-level policies |
+| `on_llm_call(call_next, events, context) → ModelResponse` | Each LLM API call | Retry, logging, history trim, request mutation, caching |
+| `on_tool_execution(call_next, event, context) → ToolResultType` | Each tool invocation | Validate args, redact results, fallback on failure, access control |
+| `on_human_input(call_next, event, context) → HumanMessage` | Each `context.input()` | Audit, rewrite prompts, automated short-circuit, rate limit |
+
+Each instance is created **once per turn** and can hold per-turn state on `self`. The same instance can implement multiple hooks.
+
+## Built-in middleware
+
+Importable from `autogen.beta.middleware`:
+
+| Middleware | Purpose | Constructor |
+|---|---|---|
+| `LoggingMiddleware` | Logs turn start/end, each LLM call, each tool execution | no args |
+| `RetryMiddleware` | Retries failed LLM calls | `max_retries=N`, `retry_on=ExceptionClass` |
+| `HistoryLimiter` | Cap event count before LLM call | `max_events=N` |
+| `TokenLimiter` | Char-based token-budget cap before LLM call | `max_tokens=N`, `chars_per_token=4` |
+| `TelemetryMiddleware` | OpenTelemetry GenAI spans (see `ag2-telemetry`) | see telemetry skill |
+
+## Registration — agent-level
+
+Apply to every turn:
+
+```python
+from autogen.beta import Agent
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.middleware import LoggingMiddleware, RetryMiddleware
+
+agent = Agent(
+    "assistant",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    middleware=[
+        LoggingMiddleware(),
+        RetryMiddleware(max_retries=2),
+    ],
+)
+```
+
+## Registration — call-level
+
+Add temporary middleware for one turn. Both `agent.ask(...)` and `reply.ask(...)` accept it:
+
+```python
+from autogen.beta.middleware import TokenLimiter
+
+reply = await agent.ask("Summarise the latest messages.", middleware=[LoggingMiddleware()])
+next_turn = await reply.ask("Now answer in one paragraph.", middleware=[TokenLimiter(max_tokens=4000)])
+```
+
+Call-level middleware is **appended after** the agent's middleware list.
+
+## Ordering
+
+Middleware runs in registration order, like nested `with` blocks. Registering `[A, B, C]` enters `A → B → C` and unwinds `C → B → A`:
+
+```
+enter A
+  enter B
+    enter C
+      <LLM call>
+    exit C
+  exit B
+exit A
+```
+
+This matters when you mix logging, mutation, retry. If `RetryMiddleware` should retry mutated requests, mutation goes **inside** retry; if you want each retry attempt logged separately, logging goes **inside** retry.
+
+## Writing your own
+
+Subclass `BaseMiddleware`, implement the hooks you need:
+
+```python
+import logging
+from collections.abc import Sequence
+from autogen.beta import Agent, Context
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.events import BaseEvent, ModelResponse, ToolCallEvent
+from autogen.beta.middleware import BaseMiddleware, LLMCall, Middleware, ToolExecution
+
+class AuditMiddleware(BaseMiddleware):
+    def __init__(self, event: BaseEvent, context: Context, logger: logging.Logger) -> None:
+        super().__init__(event, context)
+        self.logger = logger
+
+    async def on_llm_call(self, call_next: LLMCall, events: Sequence[BaseEvent], context: Context) -> ModelResponse:
+        self.logger.info("Calling model with %d events", len(events))
+        response = await call_next(events, context)
+        self.logger.info("Model returned: %s", response)
+        return response
+
+    async def on_tool_execution(self, call_next: ToolExecution, event: ToolCallEvent, context: Context):
+        self.logger.info("Executing tool: %s", event.name)
+        return await call_next(event, context)
+
+agent = Agent(
+    "assistant",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    middleware=[
+        Middleware(AuditMiddleware, logger=logging.getLogger("ag2.audit")),
+    ],
+)
+```
+
+If your middleware needs constructor args beyond `event` and `context`, **wrap with `Middleware(YourClass, ...)`** when registering. Zero-config middleware can be passed bare (`middleware=[LoggingMiddleware()]`).
+
+## Tool-scoped vs agent-scoped
+
+For behaviour that applies to **one tool only** (validation, redaction for that tool's output, approval gates), use **tool middleware** instead — `middleware=[hook]` on `@tool`, `@agent.tool`, or `Toolkit`. See `ag2-add-custom-tool` for the syntax. The `approval_required()` built-in (see `ag2-hitl`) is a tool middleware.
+
+Agent middleware runs **outside** tool middleware: `BaseMiddleware.on_tool_execution()` sees the full execution including tool-scoped hooks.
+
+## Picking the right hook
+
+- `on_turn` → behaviour about the whole request/response lifecycle.
+- `on_llm_call` → behaviour about what goes into / comes out of the model.
+- `on_tool_execution` → tool safety / auditing / result shaping across many tools.
+- Tool-scoped middleware (not `BaseMiddleware`) → behaviour for a single tool's definition.
+- `on_human_input` → intercept HITL requests/responses.
+
+## Going deeper
+
+- `references/builtin_middleware.md` — every built-in's params, common-case recipes, when each fits.
+- `website/docs/beta/middleware.mdx` — full reference, ordering examples, custom-middleware guidelines.
+- `website/docs/beta/tools/tool_middleware.mdx` — per-tool hooks (different mental model — plain async callables, not `BaseMiddleware`).
+- For OpenTelemetry instrumentation specifically, see `ag2-telemetry`.
+
+## Common pitfalls
+
+- **Forgetting `Middleware(...)` for constructor args** — `middleware=[AuditMiddleware]` (no wrapper) only works if the class needs only `event` and `context`. Otherwise wrap: `middleware=[Middleware(AuditMiddleware, logger=...)]`.
+- **Mutation order surprises** — middleware runs in registration order. If middleware A trims history and middleware B logs it, register `[A, B]` so B sees the trimmed view.
+- **Per-call middleware doesn't replace agent middleware** — it's appended. Agent middleware still runs.
+- **One big middleware doing five things** — keep hooks focused. Logging + retry + mutation + policy in one class is hard to reason about and order. Split into multiple instances.
+- **`on_tool_execution` branching on `event.name` for a single tool** — that's a smell; use tool-scoped middleware for one-tool behaviour and reserve `on_tool_execution` for cross-cutting policies.
+- **Putting OpenTelemetry instrumentation in custom code** — there's a `TelemetryMiddleware` for that; see `ag2-telemetry`.

--- a/.agents/skills/ag2-middleware/references/builtin_middleware.md
+++ b/.agents/skills/ag2-middleware/references/builtin_middleware.md
@@ -1,0 +1,114 @@
+# Built-in middleware reference
+
+All importable from `autogen.beta.middleware` (and `autogen.beta.middleware.builtin` for `TelemetryMiddleware`).
+
+## `LoggingMiddleware`
+
+```python
+from autogen.beta.middleware import LoggingMiddleware
+
+agent = Agent(..., middleware=[LoggingMiddleware()])
+```
+
+Logs:
+- when a turn starts and finishes
+- each LLM call and its response time
+- each tool execution and its result
+
+Use for quick debugging or application-level observability. For production-grade traces use `TelemetryMiddleware` (`ag2-telemetry`) instead.
+
+No constructor args.
+
+## `RetryMiddleware`
+
+```python
+from autogen.beta.middleware import RetryMiddleware
+
+agent = Agent(..., middleware=[RetryMiddleware(max_retries=2)])
+```
+
+Retries failed LLM calls up to `max_retries` times. Defaults to retrying any `Exception`; narrow with `retry_on=`:
+
+```python
+RetryMiddleware(max_retries=3, retry_on=httpx.HTTPError)
+```
+
+Use for transient provider failures, network blips, occasional rate-limit responses.
+
+## `HistoryLimiter`
+
+```python
+from autogen.beta.middleware import HistoryLimiter
+
+agent = Agent(..., middleware=[HistoryLimiter(max_events=100)])
+```
+
+Trims event history to `max_events` before each LLM call. Preserves the first `ModelRequest` when possible and avoids leaving leading orphaned `ToolResultsEvent` entries.
+
+Use when you want a simple, deterministic, **count-based** cap on context. For richer history shaping (token-budget, working-memory injection, sliding window with summary) use **assembly policies** instead — see `ag2-knowledge-and-memory`.
+
+## `TokenLimiter`
+
+```python
+from autogen.beta.middleware import TokenLimiter
+
+agent = Agent(..., middleware=[TokenLimiter(max_tokens=1000, chars_per_token=4)])
+```
+
+Char-based estimate (`len(str(event)) / chars_per_token`) — cheap, not perfectly accurate. Trims to fit the budget.
+
+Use as a **safety net** alongside other history shaping, not as an exact meter. For accurate token counting use a model-specific tokenizer in a custom middleware.
+
+## `TelemetryMiddleware`
+
+OpenTelemetry instrumentation following the GenAI semantic conventions.
+
+```python
+from autogen.beta.middleware.builtin import TelemetryMiddleware
+
+agent = Agent(
+    "assistant",
+    config=...,
+    middleware=[
+        TelemetryMiddleware(
+            tracer_provider=tracer_provider,
+            agent_name="assistant",
+            capture_content=True,   # default; False for privacy-sensitive contexts
+        ),
+    ],
+)
+```
+
+Full setup, span attributes, content-capture controls — see the `ag2-telemetry` skill.
+
+## Choosing between built-ins
+
+| Want to | Reach for |
+|---|---|
+| See what's happening at runtime | `LoggingMiddleware` |
+| Survive flaky providers | `RetryMiddleware` |
+| Hard cap on history length | `HistoryLimiter` |
+| Hard cap on history size in tokens (rough) | `TokenLimiter` |
+| Production-grade traces, GenAI semconv | `TelemetryMiddleware` |
+| Trim history but keep a summary of dropped events | `SummarizeCompact` (see `ag2-knowledge-and-memory`) |
+| Inject working memory before LLM call | `WorkingMemoryPolicy` (see `ag2-knowledge-and-memory`) |
+| Approve a single tool call | `approval_required()` (see `ag2-hitl`) |
+
+## Stacking pattern (typical)
+
+```python
+agent = Agent(
+    "assistant",
+    config=config,
+    middleware=[
+        TelemetryMiddleware(tracer_provider=tracer, agent_name="assistant"),
+        LoggingMiddleware(),
+        RetryMiddleware(max_retries=2),
+        HistoryLimiter(max_events=200),  # last line of defence
+    ],
+)
+```
+
+Order: tracing on the outside (sees retries as separate spans), logging next (logs each retry), retry inner (so trim doesn't undo a successful retry), history limit closest to the LLM call (operates on what would actually be sent).
+
+For richer history strategies (summarisation, sliding window, token-budget assembly, working memory) prefer the **assembly + compaction** pipeline documented in `ag2-knowledge-and-memory` over `HistoryLimiter` / `TokenLimiter`.

--- a/.agents/skills/ag2-multimodal-input/SKILL.md
+++ b/.agents/skills/ag2-multimodal-input/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: ag2-multimodal-input
+description: Send images, audio, video, or documents into an AG2 beta `Agent` alongside text. Pass `ImageInput`, `AudioInput`, `VideoInput`, or `DocumentInput` as positional args to `agent.ask(...)`. Use when the user wants the agent to process non-text input — describe a photo, transcribe audio, summarise a PDF, analyse a video. Covers per-provider support matrix, the four ways to source data (URL / path / bytes / file_id), Gemini-specific YouTube + media-resolution + clipping, OpenAI image-detail, Anthropic prompt-caching on attachments, and `FilesAPI` for upload lifecycle.
+license: Apache-2.0
+---
+
+# Multimodal inputs
+
+## When to use
+
+The user wants the agent to process non-text input: an image to describe, audio to transcribe, video to summarise, or a PDF / document to extract from. The same factory pattern works across providers; per-provider support varies.
+
+## 60-second recipe
+
+```python
+from autogen.beta import Agent
+from autogen.beta.config import GeminiConfig
+from autogen.beta.events import ImageInput
+
+agent = Agent(
+    "vision",
+    "You describe images.",
+    config=GeminiConfig(model="gemini-3-flash-preview"),
+)
+
+image = ImageInput("https://example.com/photo.jpg")
+reply = await agent.ask("Describe this image in detail.", image)
+print(reply.body)
+```
+
+Multiple inputs in one ask are fine:
+
+```python
+reply = await agent.ask(
+    "Compare these two images.",
+    ImageInput("https://example.com/before.jpg"),
+    ImageInput("https://example.com/after.jpg"),
+)
+```
+
+## Input factories
+
+| Factory | Formats |
+|---|---|
+| `ImageInput(...)` | JPEG, PNG, GIF, WebP |
+| `AudioInput(...)` | WAV, MP3, OGG, FLAC, AAC |
+| `VideoInput(...)` | MP4, WebM, MOV, MKV, MPEG |
+| `DocumentInput(...)` | PDF, TXT, HTML, Markdown, CSV, JSON, Office formats |
+
+Each accepts the same four data sources:
+
+```python
+from autogen.beta.events import ImageInput
+
+ImageInput("https://example.com/photo.jpg")     # URL
+ImageInput(path="photo.jpg")                    # local file
+ImageInput(data=raw_bytes, media_type="image/png")  # bytes
+ImageInput(file_id="file-abc123")               # provider-uploaded
+```
+
+## Provider matrix
+
+| Input type | OpenAI | OpenAI Responses | Gemini | Anthropic |
+|---|:---:|:---:|:---:|:---:|
+| Text | ✓ | ✓ | ✓ | ✓ |
+| Image (URL) | ✓ | ✓ | ✓ | ✓ |
+| Image (binary) | ✓ | ✓ | ✓ | ✓ |
+| Audio (URL) | – | – | ✓ | – |
+| Audio (binary) | ✓ | – | ✓ | – |
+| Video (URL) | – | – | ✓ | – |
+| Video (binary) | – | – | ✓ | – |
+| Document (URL) | – | ✓ | ✓ | ✓ |
+| Document (binary) | – | – | ✓ | ✓ |
+| File ID | – | ✓ | – | ✓ |
+
+Unsupported combinations raise `UnsupportedInputError` with a clear message.
+
+**Gemini has the broadest multimodal support.** If you don't know which provider to pick for a multimodal task, start there.
+
+## Provider-specific niceties
+
+### Gemini — YouTube URLs work directly
+
+```python
+from autogen.beta.events import VideoInput
+
+video = VideoInput("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+reply = await agent.ask("Summarize this video.", video)
+```
+
+### Gemini — large files (> 20MB) via Google Files API
+
+```python
+from google import genai
+from autogen.beta.events import VideoInput
+import time
+
+client = genai.Client()
+uploaded = client.files.upload(file="large_video.mp4")
+while uploaded.state.name == "PROCESSING":
+    time.sleep(2)
+    uploaded = client.files.get(name=uploaded.name)
+
+video = VideoInput(uploaded.uri)
+```
+
+### Gemini — `vendor_metadata`
+
+| Key | Purpose |
+|---|---|
+| `media_resolution` | `MEDIA_RESOLUTION_LOW/MEDIUM/HIGH/ULTRA_HIGH` — token vs cost |
+| `video_metadata` | Clipping (`start_offset`, `end_offset`) and `fps` |
+| `display_name` | Display name for the file |
+
+```python
+ImageInput(data=raw, media_type="image/jpeg", vendor_metadata={"media_resolution": "MEDIA_RESOLUTION_LOW"})
+
+VideoInput(path="lecture.mp4", vendor_metadata={
+    "video_metadata": {"start_offset": "60s", "end_offset": "120s", "fps": 0.5},
+})
+```
+
+### OpenAI — image detail
+
+```python
+ImageInput(data=raw, media_type="image/png", vendor_metadata={"detail": "low"})  # "low" | "high" | "auto"
+```
+
+### Anthropic — File ID + prompt caching
+
+```python
+import anthropic
+from autogen.beta.events import ImageInput, DocumentInput
+
+client = anthropic.Anthropic()
+uploaded = client.beta.files.upload(file=("photo.jpg", open("photo.jpg", "rb"), "image/jpeg"))
+
+# filename determines block type (image vs document)
+image = ImageInput(file_id=uploaded.id, filename="photo.jpg")
+
+# Cache an attachment so subsequent turns skip re-uploading
+doc = DocumentInput(path="report.pdf", vendor_metadata={"cache_control": {"type": "ephemeral"}})
+```
+
+## `FilesAPI` — upload lifecycle, provider-agnostic
+
+For any provider that has a file API (`OpenAIConfig`, `OpenAIResponsesConfig`, `AnthropicConfig`, `GeminiConfig`):
+
+```python
+from autogen.beta import FilesAPI
+from autogen.beta.config import OpenAIResponsesConfig
+
+files = FilesAPI(OpenAIResponsesConfig(model="gpt-5-mini"))
+
+uploaded = await files.upload(path="report.pdf", purpose="assistants")
+print(uploaded.file_id)
+
+# Or from bytes (filename required)
+uploaded = await files.upload(data=b"...", filename="hello.txt", purpose="assistants")
+
+# List, read, delete
+all_files = await files.list()
+data = await files.read(uploaded.file_id)        # NotImplementedError on Gemini
+await files.delete(uploaded.file_id)
+```
+
+Pass the `file_id` to `DocumentInput`, `ImageInput`, etc.:
+
+```python
+from autogen.beta.events import DocumentInput
+
+doc = DocumentInput(file_id=uploaded.file_id)
+reply = await agent.ask("Summarize this report.", doc)
+```
+
+## Going deeper
+
+- `website/docs/beta/inputs/inputs.mdx` — full provider matrix and `vendor_metadata` reference.
+- `website/docs/beta/advanced/files.mdx` — `FilesAPI` reference (upload / list / read / delete).
+- For tools that **return** images / binary back to the LLM, see `ag2-add-custom-tool` (`ImageInput`, `BinaryInput`, `ToolResult`).
+
+## Common pitfalls
+
+- **Picking a provider that doesn't support your input type** — silently you'll get `UnsupportedInputError`. Check the matrix; Gemini is broadest.
+- **`FilesAPI.read()` on Gemini** — raises `NotImplementedError`. Gemini doesn't expose download.
+- **Calling `files.upload(data=...)` without `filename=`** — raises `ValueError`. Filename is required for in-memory uploads.
+- **Providing `path=` and `data=` to the same factory** — pick one source. Same for `file_id=`.
+- **Anthropic `ImageInput(file_id=...)` without `filename=`** — Anthropic decides block type (image vs document) by filename extension. Pass it.
+- **Gemini `vendor_metadata` keys are nested** — `video_metadata` itself takes a dict. Check the doc table for shape.
+- **Forgetting to wait for Gemini file processing** — large uploads have a `PROCESSING` state. Poll `client.files.get(name=...)` until ready before referencing the URI.

--- a/.agents/skills/ag2-observers-and-alerts/SKILL.md
+++ b/.agents/skills/ag2-observers-and-alerts/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: ag2-observers-and-alerts
+description: Monitor an AG2 beta agent's stream — log events, detect repeated tool calls, track token spend, build trigger-driven observers, route observer alerts to the model, and halt on FATAL conditions. Covers `@observer(...)` (stateless), `BaseObserver` (stateful), built-ins (`TokenMonitor`, `LoopDetector`), `Watch` primitives (`EventWatch`, `CadenceWatch`, `DelayWatch`, `IntervalWatch`, `CronWatch`, `AllOf`, `AnyOf`, `Sequence`), `ObserverAlert` (`Severity.INFO/WARNING/CRITICAL/FATAL`), `AlertPolicy`, and `HaltEvent`. Use when the user wants observability, runtime safety guards, alerts, or batch/time-based reactive logic.
+license: Apache-2.0
+---
+
+# Observers, watches, and alerts
+
+## When to use
+
+- **Observability** — log model responses, tool calls, token usage.
+- **Runtime safety** — block dangerous tool arguments, halt the agent.
+- **Reactive metrics** — fire on every Nth response, or every M seconds.
+- **Loop / repetition detection** — catch infinite tool-call loops.
+- **Stateful monitoring** — anything that needs to remember prior events to decide what to do next.
+
+## Two observer shapes
+
+| Shape | When | Use |
+|---|---|---|
+| Stateless function | One-off event hook (logging, metrics) | `@observer(EventType)` |
+| Stateful class | Counters / windows / thresholds / composed triggers | Subclass `BaseObserver` |
+
+Both are stream subscribers under the hood — registered on the agent rather than directly on the stream.
+
+## 60-second recipe — `@observer`
+
+```python
+from autogen.beta import Agent, observer
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.events import ModelResponse
+
+@observer(ModelResponse)
+async def log_response(event: ModelResponse) -> None:
+    print(f"Model said: {event.content}")
+
+agent = Agent(
+    "assistant",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    observers=[log_response],
+)
+```
+
+Or attach after construction with `@agent.observer(...)`. Per-call observers also supported (`agent.ask("...", observers=[...])`).
+
+Observer callbacks support full dependency injection (`Context`, `Inject`, `Variable`, `Depends`). Filter by event type, multiple types (`ModelRequest | ModelResponse`), or field value (`ToolCallEvent.name == "search"`). Use `interrupt=True` to modify or suppress events before regular subscribers see them.
+
+## Built-in stateful observers
+
+```python
+from autogen.beta import Agent
+from autogen.beta.observer import LoopDetector, TokenMonitor
+
+agent = Agent(
+    "assistant",
+    config=config,
+    observers=[
+        TokenMonitor(warn_threshold=50_000, alert_threshold=100_000),
+        LoopDetector(window_size=10, repeat_threshold=3),
+    ],
+)
+```
+
+- **`TokenMonitor`** — tracks cumulative tokens across `ModelResponse` and `TaskCompleted`. Emits `WARNING` / `CRITICAL` `ObserverAlert`s as thresholds are crossed. Read state via `monitor.total_tokens`.
+- **`LoopDetector`** — sliding window of recent tool calls. Emits a `WARNING` alert when `repeat_threshold` consecutive identical calls are seen.
+
+## Custom `BaseObserver`
+
+A `BaseObserver` pairs a `Watch` (when to fire) with a `process()` method (what to do):
+
+```python
+from autogen.beta import Context
+from autogen.beta.observer import BaseObserver
+from autogen.beta.watch import CadenceWatch
+from autogen.beta.events import BaseEvent, ModelResponse
+from autogen.beta.events.alert import ObserverAlert, Severity
+
+class AvgCompletionObserver(BaseObserver):
+    """Every N responses, emit an INFO alert with avg completion-token count."""
+
+    def __init__(self, window: int = 5) -> None:
+        super().__init__("avg-completion", watch=CadenceWatch(n=window, condition=ModelResponse))
+        self._window = window
+
+    async def process(self, events: list[BaseEvent], ctx: Context) -> ObserverAlert | None:
+        tokens = [e.usage.completion_tokens for e in events if isinstance(e, ModelResponse) and e.usage]
+        if not tokens:
+            return None
+        return ObserverAlert(
+            source=self.name,
+            severity=Severity.INFO,
+            message=f"Avg completion tokens over last {self._window}: {sum(tokens) / len(tokens):.0f}",
+        )
+```
+
+If `process()` returns an `ObserverAlert`, the base class emits it onto the stream. You can also send events manually via `await ctx.send(...)`.
+
+## Watch primitives — picking *when* to fire
+
+| You need | Use |
+|---|---|
+| Every matching event | `EventWatch(EventType)` or just `stream.subscribe(fn, condition=...)` |
+| Every N matching events | `CadenceWatch(n=N, condition=EventType)` |
+| Every T seconds (buffered events) | `CadenceWatch(max_wait=T, condition=EventType)` |
+| Either threshold | `CadenceWatch(n=N, max_wait=T, condition=EventType)` |
+| Once after delay | `DelayWatch(seconds)` |
+| Periodic timer | `IntervalWatch(seconds)` |
+| Cron schedule | `CronWatch("0 9 * * MON")` |
+| All sub-watches must fire | `AllOf(w1, w2)` |
+| Any sub-watch fires | `AnyOf(w1, w2)` |
+| In order | `Sequence(w1, w2)` |
+
+All importable from `autogen.beta.watch`. Callback signature is uniform: `async def cb(events: list[BaseEvent], ctx: Context) -> None`. Time-driven watches pass `events=[]`.
+
+## `ObserverAlert` — the alert type
+
+```python
+from autogen.beta.events.alert import ObserverAlert, Severity
+
+ObserverAlert(
+    source="my-observer",
+    severity=Severity.WARNING,    # INFO, WARNING, CRITICAL, FATAL
+    message="What happened",
+)
+```
+
+**Important:** `ObserverAlert` is on the stream and persisted in history, but the default provider mappers **do not render it back to the LLM**. To make the agent see alerts, add `AlertPolicy()` to `assembly=[...]`:
+
+```python
+from autogen.beta.policies import AlertPolicy
+agent = Agent("assistant", config=config, assembly=[AlertPolicy()])
+```
+
+## FATAL alerts → `HaltEvent` → short-circuit
+
+`AlertPolicy` does two things on `Severity.FATAL`:
+
+1. Emits a `HaltEvent` on the stream.
+2. Appends a halt notice to the system prompt.
+
+When `assembly=[...]` is non-empty, the harness automatically wires `_HaltCheckMiddleware` which sees the `HaltEvent` and short-circuits the next LLM call with a synthetic `HALTED: ...` response.
+
+```python
+from autogen.beta import Context
+from autogen.beta.observer import BaseObserver
+from autogen.beta.events import BaseEvent, ToolCallEvent
+from autogen.beta.events.alert import HaltEvent, ObserverAlert, Severity
+from autogen.beta.policies import AlertPolicy
+from autogen.beta.watch import EventWatch
+
+class PathGuardian(BaseObserver):
+    def __init__(self) -> None:
+        super().__init__("path-guardian", watch=EventWatch(ToolCallEvent))
+
+    async def process(self, events: list[BaseEvent], ctx: Context) -> ObserverAlert | None:
+        for event in events:
+            if not isinstance(event, ToolCallEvent) or event.name != "write_file":
+                continue
+            if "/etc/" in event.arguments or "/usr/" in event.arguments:
+                return ObserverAlert(
+                    source=self.name,
+                    severity=Severity.FATAL,
+                    message=f"blocked dangerous write: {event.arguments}",
+                )
+        return None
+
+agent = Agent(
+    "safe-shell",
+    prompt="...",
+    config=config,
+    tools=[write_file],
+    observers=[PathGuardian()],
+    assembly=[AlertPolicy()],   # routes FATAL → HaltEvent
+)
+```
+
+The first dangerous tool call triggers FATAL → halt; the agent's next ask is short-circuited. Full runnable demo: `assets/safety_guard.py`.
+
+## Subscribing to alerts and halts from outside
+
+```python
+from autogen.beta import MemoryStream
+from autogen.beta.events.alert import HaltEvent, ObserverAlert
+
+stream = MemoryStream()
+stream.where(ObserverAlert).subscribe(lambda e: print(f"[{e.severity}] {e.source}: {e.message}"))
+stream.where(HaltEvent).subscribe(lambda e: print(f"HALT: {e.reason}"))
+await agent.ask("...", stream=stream)
+```
+
+## Observers vs Middleware vs Stream subscribers
+
+| Feature | Observer | Middleware | Stream subscriber |
+|---|---|---|---|
+| Registered on | Agent | Agent | Stream |
+| Lifecycle | Scoped to execution | Scoped to execution | Manual |
+| Boilerplate | Function (or `BaseObserver`) | `BaseMiddleware` class | Function |
+| Can modify events | `interrupt=True` | Yes (wraps execution) | `interrupt=True` |
+| DI support | Yes | Yes | Yes |
+| Use case | Monitoring, metrics, alerts | Cross-cutting (retry, auth, rate limit) | Low-level event wiring |
+
+## Going deeper
+
+- `assets/token_watchdog.py` — three observers (`TokenMonitor`, `LoopDetector`, custom `AlertConsole`) on one agent. Mirrors `code_examples/04`.
+- `assets/safety_guard.py` — `PathGuardian` → FATAL → `AlertPolicy` → `HaltEvent` → short-circuit. Mirrors `code_examples/08`.
+- Source docs:
+  - `website/docs/beta/advanced/observers.mdx` — `@observer`, `BaseObserver`, registration, built-ins, `ObserverAlert`.
+  - `website/docs/beta/advanced/watches.mdx` — every Watch primitive, composition rules.
+  - `website/docs/beta/advanced/stream.mdx` — Stream API, `where`, `subscribe`, interrupters, `RedisStream`.
+  - `website/docs/beta/advanced/assembly.mdx` — `AlertPolicy` ordering and dedup.
+
+## Common pitfalls
+
+- **Alerts not reaching the model** — `ObserverAlert` events are on the stream but invisible to the LLM by default. Add `AlertPolicy()` to `assembly=[...]`.
+- **FATAL not halting** — `AlertPolicy` is what creates `HaltEvent`. Without `assembly=[..., AlertPolicy(), ...]` (or any non-empty assembly chain enabling `_HaltCheckMiddleware`), nothing halts.
+- **Sharing one `AlertPolicy()` across agents** — dedup state lives on the instance. Give each agent its own.
+- **Watch callback assumes `events` is non-empty** — for time-driven watches (`DelayWatch`, `IntervalWatch`, `CronWatch`), `events` is always `[]`.
+- **Forgetting `process()` is async** — `BaseObserver.process` must be `async def`.
+- **Subscribing with `subscribe(fn)` when you wanted `subscribe()` decorator** — both work; the bare-call form is `stream.subscribe(fn)`, the decorator form is `@stream.subscribe()` (with parens).
+- **`CadenceWatch` with no `n` and no `max_wait`** — invalid; at least one is required.

--- a/.agents/skills/ag2-observers-and-alerts/assets/safety_guard.py
+++ b/.agents/skills/ag2-observers-and-alerts/assets/safety_guard.py
@@ -1,0 +1,110 @@
+"""Safety guard — FATAL alert halts the Agent.
+
+Mirrors website/docs/beta/code_examples/08_safety_guard.mdx. A hand-rolled
+BaseObserver watches every tool call and flags anything that looks
+dangerous (here: a write_file tool asked to touch /etc/). It emits a
+Severity.FATAL ObserverAlert. The flow from there is fully wired by the
+framework:
+
+1. Alert lands on the agent's stream.
+2. AlertPolicy (assembly) picks it up before the next LLM call, emits a
+   HaltEvent on the stream, and appends a halt notice to the system prompt.
+3. _HaltCheckMiddleware (auto-wired when assembly is non-empty) sees the
+   HaltEvent and short-circuits the LLM call with a synthetic "HALTED:"
+   response.
+
+Run::
+
+    python safety_guard.py
+"""
+
+import asyncio
+
+from autogen.beta import Agent
+from autogen.beta.annotations import Context
+from autogen.beta.config import GeminiConfig
+from autogen.beta.events import BaseEvent, ToolCallEvent
+from autogen.beta.events.alert import HaltEvent, ObserverAlert, Severity
+from autogen.beta.observer import BaseObserver
+from autogen.beta.policies import AlertPolicy
+from autogen.beta.stream import MemoryStream
+from autogen.beta.watch import EventWatch
+
+
+def section(title: str) -> None:
+    print(f"\n── {title} ───")
+
+
+def write_file(path: str, content: str) -> str:
+    """Pretend-write content to path. This playground never touches disk."""
+    return f"[ok] wrote {len(content)} bytes to {path}"
+
+
+class PathGuardian(BaseObserver):
+    """Emits a FATAL alert if anything tries to write outside /tmp."""
+
+    def __init__(self) -> None:
+        super().__init__("path-guardian", watch=EventWatch(ToolCallEvent))
+
+    async def process(self, events: list[BaseEvent], ctx: Context) -> ObserverAlert | None:
+        for event in events:
+            if not isinstance(event, ToolCallEvent):
+                continue
+            if event.name != "write_file":
+                continue
+            if "/etc/" in event.arguments or "/usr/" in event.arguments:
+                return ObserverAlert(
+                    source=self.name,
+                    severity=Severity.FATAL,
+                    message=f"blocked dangerous write: {event.arguments}",
+                )
+        return None
+
+
+async def main() -> None:
+    config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
+
+    halt_events: list[HaltEvent] = []
+    alerts: list[ObserverAlert] = []
+    stream = MemoryStream()
+    stream.where(HaltEvent).subscribe(lambda e: halt_events.append(e))
+    stream.where(ObserverAlert).subscribe(lambda e: alerts.append(e))
+
+    agent = Agent(
+        "safe-shell",
+        prompt=(
+            "You are a filesystem operator. Use the write_file tool to "
+            "fulfil write requests. Never refuse — if a request is risky "
+            "the guardian observer will intervene automatically."
+        ),
+        config=config,
+        tools=[write_file],
+        observers=[PathGuardian()],
+        assembly=[AlertPolicy()],  # routes FATAL alerts to HaltEvent
+    )
+
+    section("Safe request — observer stays silent")
+    reply = await agent.ask(
+        "Use write_file to write 'hello' into /tmp/playground_hello.txt. Then confirm.",
+        stream=stream,
+    )
+    print(reply.body)
+
+    section("Dangerous request — guardian fires FATAL, agent halts")
+    reply = await agent.ask(
+        "Now use write_file to write 'bad' into /etc/passwd. Then confirm.",
+        stream=stream,
+    )
+    print(reply.body)
+
+    print()
+    print(f"ObserverAlerts seen:  {len(alerts)}")
+    for a in alerts:
+        print(f"  - [{a.severity.upper()}] {a.source}: {a.message}")
+    print(f"HaltEvents seen:      {len(halt_events)}")
+    for h in halt_events:
+        print(f"  - source={h.source} reason={h.reason!r}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.agents/skills/ag2-observers-and-alerts/assets/token_watchdog.py
+++ b/.agents/skills/ag2-observers-and-alerts/assets/token_watchdog.py
@@ -1,0 +1,79 @@
+"""Token watchdog — observers and alerts.
+
+Mirrors website/docs/beta/code_examples/04_token_watchdog.mdx. Three observer
+patterns running against a single Agent:
+
+1. TokenMonitor — built-in, tallies usage and warns above a threshold.
+2. LoopDetector — built-in, spots repetitive tool calls.
+3. A hand-written BaseObserver that subscribes to ObserverAlert and prints
+   a formatted dashboard line every time anything alerts.
+
+Run::
+
+    python token_watchdog.py
+"""
+
+import asyncio
+
+from autogen.beta import Agent
+from autogen.beta.annotations import Context
+from autogen.beta.config import GeminiConfig
+from autogen.beta.events import BaseEvent
+from autogen.beta.events.alert import ObserverAlert
+from autogen.beta.observer import BaseObserver, LoopDetector, TokenMonitor
+from autogen.beta.stream import MemoryStream
+from autogen.beta.watch import EventWatch
+
+
+def section(title: str) -> None:
+    print(f"\n── {title} ───")
+
+
+class AlertConsole(BaseObserver):
+    """Watches the stream for ObserverAlerts and prints them to stdout."""
+
+    def __init__(self) -> None:
+        super().__init__("alert-console", watch=EventWatch(ObserverAlert))
+        self.seen: list[ObserverAlert] = []
+
+    async def process(self, events: list[BaseEvent], ctx: Context) -> None:
+        for event in events:
+            if isinstance(event, ObserverAlert):
+                self.seen.append(event)
+                print(f"    [{event.severity.upper():<8}] {event.source}: {event.message}")
+        return None
+
+
+async def main() -> None:
+    config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
+
+    section("Watchdog — low thresholds so observers trip on a single ask")
+
+    token_monitor = TokenMonitor(warn_threshold=50, alert_threshold=5_000)
+    loop_detector = LoopDetector(window_size=5, repeat_threshold=2)
+    console = AlertConsole()
+
+    stream = MemoryStream()
+
+    agent = Agent(
+        "writer",
+        prompt=("Write prose the user asks for. Favour variety — never repeat the same sentence twice."),
+        config=config,
+        observers=[token_monitor, loop_detector, console],
+    )
+
+    reply = await agent.ask(
+        "Write three distinct 30-word paragraphs about springtime in Kyoto.",
+        stream=stream,
+    )
+
+    print()
+    print("Final reply (truncated):")
+    print("   ", (reply.body or "")[:240], "...")
+    print()
+    print(f"Total tokens tracked by TokenMonitor: {token_monitor.total_tokens}")
+    print(f"Alerts emitted this run:              {len(console.seen)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.agents/skills/ag2-overview/SKILL.md
+++ b/.agents/skills/ag2-overview/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: ag2-overview
+description: Map of AG2 beta capabilities and which sibling skill to reach for. Load first when the user mentions building with AG2 beta (autogen.beta) but the specific feature isn't yet clear — agents, tools, model config, delegation, memory, observers, structured output, HITL, AG-UI, telemetry, or testing.
+license: Apache-2.0
+---
+
+# AG2 Beta — capability map
+
+AG2 beta (`autogen.beta`) is an async, protocol-driven agent framework. The full reference docs live under `website/docs/beta/`. This skill is the index of sibling skills that cover the common build paths.
+
+## When to use
+
+Read this file first when a request mentions "AG2 beta", "autogen.beta", or building agents in this repo and you don't yet know which feature is needed. Use the table below to pick the right specialised skill, then load that skill's `SKILL.md` for the recipe.
+
+## Pick the right skill
+
+| User intent | Skill | What it covers |
+|---|---|---|
+| Build an `Agent` from scratch, pick a model | `ag2-quickstart` | `Agent`, `ModelConfig`, `ask()` / `reply.ask()` chaining, providers, env vars |
+| Give the Agent a custom Python tool | `ag2-add-custom-tool` | `@tool`, sync/async, `ToolResult`, `Context`, `Inject`, `Variable`, `Depends` |
+| Use shipped tools (web search, code exec, MCP, etc.) | `ag2-use-builtin-tools` | `WebSearchTool`, `WebFetchTool`, `CodeExecutionTool`, `MCPServerTool`, `ImageGenerationTool`, `MemoryTool`, `FilesystemToolkit`, `DuckDuckSearchTool`, `ExaToolkit`, `TavilySearchTool` |
+| Run shell commands from an agent | `ag2-shell-tool` | `LocalShellTool` (any provider), provider-side `ShellTool`, sandboxing (`allowed`/`blocked`/`ignore`/`readonly`) |
+| Get typed Pydantic / dataclass output | `ag2-structured-output` | `response_schema=`, `ResponseSchema`, `@response_schema`, `PromptedSchema`, `reply.content()`, retries |
+| Multi-agent: parallel subtasks or named delegates | `ag2-subagent-delegation` | `tasks=TaskConfig()`, `run_subtasks(parallel=True)`, `Agent.as_tool()`, `persistent_stream` |
+| Pause for human input or gate a tool with approval | `ag2-hitl` | `context.input()`, `hitl_hook`, `approval_required()` middleware |
+| Logging, retry, history-trim, custom interception | `ag2-middleware` | `BaseMiddleware`, `LoggingMiddleware`, `RetryMiddleware`, `HistoryLimiter`, `TokenLimiter`, tool middleware |
+| Test agents and tools | `ag2-testing` | `TestConfig`, mocking LLM responses, simulating `ToolCallEvent` |
+| Persistent memory across runs, history compaction, assembly | `ag2-knowledge-and-memory` | `KnowledgeStore`, `KnowledgeConfig`, `WorkingMemoryAggregate`, `AssemblyPolicy`, `SlidingWindowPolicy`, `TokenBudgetPolicy`, `TailWindowCompact`, `SummarizeCompact` |
+| Observability, alerts, halts | `ag2-observers-and-alerts` | `BaseObserver`, `TokenMonitor`, `LoopDetector`, `EventWatch`, `CadenceWatch`, `AlertPolicy`, `HaltEvent` |
+| Send images / audio / video / PDFs in | `ag2-multimodal-input` | `ImageInput`, `AudioInput`, `VideoInput`, `DocumentInput`, `FilesAPI` |
+| Web frontend via the AG-UI protocol | `ag2-ag-ui` | `AGUIStream`, FastAPI mount, CopilotKit |
+| OpenTelemetry traces / metrics | `ag2-telemetry` | `TelemetryMiddleware`, GenAI semconv attributes, content capture |
+
+## Project conventions for any skill that writes code into the AG2 repo
+
+These are repo-wide rules from `CLAUDE.md`. Apply them whenever generating code that lands in `autogen/beta/`:
+
+- Do **not** use `from __future__ import annotations`.
+- All top-level imports — no function-level imports unless explicitly allowed.
+- No nested functions in runtime execution paths (decorator factories are fine).
+- No side effects in `__init__` — apply them at runtime.
+- Internal filesystem paths use `pathlib.Path`; public signatures accept `str | os.PathLike[str]`.
+- Common reusable APIs come from the `autogen.beta` top-level (e.g. `from autogen.beta import Agent, tool, Context`); advanced/specialised APIs come from sub-modules (`autogen.beta.middleware`, `autogen.beta.config`, etc.).
+
+## Beta-doc cross-reference
+
+If a skill's recipe is incomplete for the case at hand, the source docs are at `website/docs/beta/`. Each sibling skill points to its primary `.mdx` files in its own "Going deeper" section.

--- a/.agents/skills/ag2-quickstart/SKILL.md
+++ b/.agents/skills/ag2-quickstart/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: ag2-quickstart
+description: Build a minimal AG2 beta `Agent` end to end — pick a model provider, set a prompt, call `agent.ask()`, then continue the conversation with `reply.ask()` (multi-turn). Use when the user is starting a new AG2 beta project, has no working `Agent` yet, or needs the multi-turn chaining pattern. Covers `OpenAIConfig`, `AnthropicConfig`, `GeminiConfig`, `OllamaConfig` etc., and env-var fallback for API keys.
+license: Apache-2.0
+---
+
+# Quickstart: build your first AG2 beta Agent
+
+## When to use
+
+- The user is starting from a blank file and wants a working AG2 beta agent.
+- The user is unsure which provider config to use.
+- The user wants to chain follow-up turns without losing conversation context.
+- A larger task needs the basic Agent setup as its skeleton — start here, then layer the relevant feature skill on top.
+
+## 60-second recipe
+
+```python
+import asyncio
+from autogen.beta import Agent
+from autogen.beta.config import OpenAIConfig
+
+async def main() -> None:
+    agent = Agent(
+        "assistant",
+        prompt="You are a helpful assistant. Reply in one sentence.",
+        config=OpenAIConfig(model="gpt-4o-mini"),
+    )
+
+    # First turn
+    reply = await agent.ask("What is the capital of France?")
+    print(reply.body)
+
+    # Continue the same conversation — context is preserved
+    reply = await reply.ask("And of Germany?")
+    print(reply.body)
+
+asyncio.run(main())
+```
+
+`Agent.ask(...)` starts a new turn and returns an `AgentReply`. `AgentReply.ask(...)` continues the same conversation, preserving its context and history. The reply text is in `reply.body`; for typed output see the `ag2-structured-output` skill (`reply.content()`).
+
+## Picking a provider
+
+Each provider has its own config class in `autogen.beta.config`. All accept `model=`, optional `api_key=`, and (where supported) `streaming=True`. **Streaming is recommended** — AG2 beta is async- and streaming-first.
+
+```python
+from autogen.beta.config import OpenAIConfig          # gpt-4o, gpt-5-*, o-series, etc.
+from autogen.beta.config import OpenAIResponsesConfig # OpenAI Responses API (image gen, file_id support)
+from autogen.beta.config import AnthropicConfig       # claude-sonnet-4-6, claude-opus-4-7, etc.
+from autogen.beta.config import GeminiConfig          # Gemini Developer API (api_key)
+from autogen.beta.config import VertexAIConfig        # Gemini on Google Vertex AI (project + location)
+from autogen.beta.config import OllamaConfig          # local Ollama
+from autogen.beta.config import DashScopeConfig       # Alibaba Qwen
+
+config = AnthropicConfig(model="claude-sonnet-4-6", streaming=True)
+```
+
+If `api_key=` is omitted, the config reads the standard env var — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` (or `GOOGLE_API_KEY`), etc.
+
+For **OpenAI-compatible endpoints** (vLLM, LM Studio, Together, NVIDIA NIM, etc.) use `OpenAIConfig` with `base_url=` set:
+
+```python
+config = OpenAIConfig(
+    model="qwen-3",
+    base_url="http://localhost:8000/v1",
+    api_key="NotRequired",
+)
+```
+
+## Multi-turn — chain `reply.ask()`
+
+```python
+agent = Agent("planner", prompt="...", config=config)
+reply = await agent.ask("Plan a 5-day Japan trip in late April.")
+reply = await reply.ask("Budget is $2500 per person, two travellers.")
+reply = await reply.ask("Prefer trains. Day-by-day itinerary.")
+print(reply.body)
+```
+
+`reply.ask()` keeps the prior turns in scope so the LLM remembers the constraints. Calling `agent.ask(...)` again instead would start a fresh conversation. See `assets/multi_turn.py` for the full travel-planner example.
+
+## Reusing model configs
+
+Configs are immutable. Use `.copy(...)` to fork one with overrides:
+
+```python
+base = OpenAIConfig(model="gpt-5")
+hot = base.copy(temperature=0.8)
+cheap = base.copy(model="gpt-5-mini")
+```
+
+You can also override the model **per ask** — useful when the user brings their own API key per request:
+
+```python
+agent = Agent("assistant", prompt="Help.")
+reply = await agent.ask("Hello!", config=OpenAIConfig(model="gpt-5", api_key="sk-..."))
+```
+
+The per-ask config completely replaces the agent's config for that turn.
+
+## Going deeper
+
+- Working starter (single-turn): `assets/hello_agent.py` (mirrors `code_examples/01`).
+- Multi-turn starter: `assets/multi_turn.py` (mirrors `code_examples/03`).
+- Full provider reference, including `VertexAIConfig` auth, `extra_body`, custom `httpx` client, env-var fallback table: `website/docs/beta/model_configuration.mdx`.
+- Agent communication API surface (events, observing, HITL): `website/docs/beta/agents.mdx`.
+- Static, dynamic, per-turn prompts: `website/docs/beta/system_prompts.mdx`.
+
+## Common pitfalls
+
+- **Forgetting to `await`** — every method on `Agent` / `AgentReply` is async. Wrap in `asyncio.run(main())` for scripts.
+- **Calling `agent.ask()` twice expecting context to carry** — it doesn't; use `reply.ask()` instead.
+- **Hardcoding API keys** — prefer env-var fallback (`OPENAI_API_KEY`, etc.) so configs commit cleanly.
+- **Skipping `streaming=True`** — AG2 beta is streaming-first; you'll get a worse user experience without it on supported providers.
+- **Per-ask `config=` is total override**, not a partial merge — be deliberate about which knobs you set.

--- a/.agents/skills/ag2-quickstart/SKILL.md
+++ b/.agents/skills/ag2-quickstart/SKILL.md
@@ -64,7 +64,7 @@ For **OpenAI-compatible endpoints** (vLLM, LM Studio, Together, NVIDIA NIM, etc.
 config = OpenAIConfig(
     model="qwen-3",
     base_url="http://localhost:8000/v1",
-    api_key="NotRequired",
+    api_key="NotRequired",  # pragma: allowlist secret
 )
 ```
 
@@ -94,7 +94,7 @@ You can also override the model **per ask** — useful when the user brings thei
 
 ```python
 agent = Agent("assistant", prompt="Help.")
-reply = await agent.ask("Hello!", config=OpenAIConfig(model="gpt-5", api_key="sk-..."))
+reply = await agent.ask("Hello!", config=OpenAIConfig(model="gpt-5", api_key="sk-..."))  # pragma: allowlist secret
 ```
 
 The per-ask config completely replaces the agent's config for that turn.

--- a/.agents/skills/ag2-quickstart/assets/hello_agent.py
+++ b/.agents/skills/ag2-quickstart/assets/hello_agent.py
@@ -1,0 +1,43 @@
+"""Hello Agent — minimal AG2 beta example.
+
+Mirrors website/docs/beta/code_examples/01_hello_agent.mdx. The smallest
+possible end-to-end: instantiate an Agent with one model config, call ask(),
+print the reply, then reuse the same Agent for a second turn.
+
+Run::
+
+    python hello_agent.py
+"""
+
+import asyncio
+
+from autogen.beta import Agent
+from autogen.beta.config import GeminiConfig
+
+
+def section(title: str) -> None:
+    print(f"\n── {title} ───")
+
+
+async def main() -> None:
+    config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
+
+    section("Bare Agent — ask and print")
+
+    agent = Agent(
+        "greeter",
+        prompt="You are a friendly but concise assistant. Reply in one sentence.",
+        config=config,
+    )
+
+    reply = await agent.ask("Give me a single tip for learning to play chess.")
+    print(reply.body)
+
+    section("Reuse the Agent for another ask")
+
+    reply2 = await agent.ask("And a tip for learning poker, in one sentence.")
+    print(reply2.body)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.agents/skills/ag2-quickstart/assets/multi_turn.py
+++ b/.agents/skills/ag2-quickstart/assets/multi_turn.py
@@ -1,0 +1,55 @@
+"""Travel planner — multi-turn conversation via reply.ask() chaining.
+
+Mirrors website/docs/beta/code_examples/03_travel_planner.mdx. Chained
+``reply.ask()`` builds on the same conversation history. The planner remembers
+constraints from earlier turns without the caller re-supplying context.
+
+Run::
+
+    python multi_turn.py
+"""
+
+import asyncio
+
+from autogen.beta import Agent
+from autogen.beta.config import GeminiConfig
+
+
+def section(title: str) -> None:
+    print(f"\n── {title} ───")
+
+
+TURNS = [
+    "I want to plan a 5-day trip to Japan in late April. Just cherry-blossom season.",
+    "Budget is around $2500 per person, two travellers. Optimise for sightseeing, not luxury.",
+    "We prefer trains to flights once we're in Japan. Draft a day-by-day itinerary.",
+    "Looks great. For day 3, swap the shopping stop for something outdoorsy in or near Kyoto.",
+    "Summarize the final itinerary in a single bullet list, one line per day.",
+]
+
+
+async def main() -> None:
+    config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
+
+    agent = Agent(
+        "travel-planner",
+        prompt=(
+            "You are a detail-oriented travel planner. When the user adds "
+            "constraints, update the plan rather than starting over. Be "
+            "concrete and concise."
+        ),
+        config=config,
+    )
+
+    section("Turn 1 — kick off")
+    reply = await agent.ask(TURNS[0])
+    print(reply.body)
+
+    for i, question in enumerate(TURNS[1:], start=2):
+        section(f"Turn {i} — {question}")
+        reply = await reply.ask(question)
+        print(reply.body)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.agents/skills/ag2-shell-tool/SKILL.md
+++ b/.agents/skills/ag2-shell-tool/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: ag2-shell-tool
+description: Give an AG2 beta `Agent` the ability to run shell commands. Covers `LocalShellTool` (client-side `subprocess`, works with any provider) and the provider-native `ShellTool` (Anthropic / OpenAI execution). Use when the user wants the Agent to execute commands, build/test code, manage files, or operate on a workspace. Always pair with sandboxing — `allowed`, `blocked`, `ignore`, or `readonly`.
+license: Apache-2.0
+---
+
+# Shell tools
+
+## When to use
+
+Two distinct tools, both named "shell" — pick deliberately:
+
+| Need | Use | Why |
+|---|---|---|
+| Works with any model provider; full control over what runs and where | `LocalShellTool` | Client-side `subprocess`. You own the sandbox. |
+| Provider-managed sandbox (container, network policy) on Anthropic / OpenAI | `ShellTool` | Server-side execution. No local subprocess. |
+
+**`LocalShellTool` is the workhorse**. Reach for it unless you specifically need provider-managed isolation and you're on Anthropic or OpenAI.
+
+## 60-second recipe — `LocalShellTool`
+
+```python
+from autogen.beta import Agent
+from autogen.beta.config import AnthropicConfig
+from autogen.beta.tools import LocalShellTool
+
+agent = Agent(
+    "coder",
+    "You write and run Python code.",
+    config=AnthropicConfig(model="claude-sonnet-4-6"),
+    tools=[LocalShellTool()],
+)
+
+reply = await agent.ask("Write a hello world script and run it.")
+print(await reply.content())
+```
+
+With no arguments, `LocalShellTool` creates a temporary working directory (prefixed `ag2_shell_`) and cleans it up when the process exits. Pass a path to use a specific directory:
+
+```python
+from pathlib import Path
+LocalShellTool("/tmp/my_project")
+LocalShellTool(Path("/tmp/my_project"))
+```
+
+When a path is given, the directory is created if it does not exist and is **not** deleted on exit. Inspect the resolved working directory via `tool.workdir`.
+
+## Sandboxing (`LocalShellEnvironment`)
+
+For anything beyond a throwaway demo, use `LocalShellEnvironment` and lock down what the agent can do. Filtering is applied in this order on every call:
+
+1. `allowed` — if set, the command must match at least one prefix.
+2. `blocked` — if set, the command must not match any prefix.
+3. `ignore` — literal path tokens in the command are checked against gitignore-style patterns; matches return `"Access denied: <path>"`.
+4. Execute via `subprocess.run`.
+
+```python
+from autogen.beta.tools import LocalShellTool
+from autogen.beta.tools.shell import LocalShellEnvironment
+
+sh = LocalShellTool(
+    LocalShellEnvironment(
+        path="/tmp/my_project",
+        allowed=["python", "uv run", "git"],
+        blocked=["rm -rf", "curl", "wget"],
+        ignore=["**/.env", "*.key", "secrets/**"],
+        timeout=30,
+        max_output=50_000,
+    )
+)
+```
+
+### Read-only mode
+
+For inspection-only access (`cat`, `head`, `tail`, `ls`, `grep`, `find`, `git log`, `git diff`, `git status`, …):
+
+```python
+from autogen.beta.tools import LocalShellTool
+from autogen.beta.tools.shell import LocalShellEnvironment
+
+sh = LocalShellTool(LocalShellEnvironment(path="/my/codebase", readonly=True))
+```
+
+Pass an explicit `allowed=[...]` to override the built-in read-only allowlist.
+
+### `LocalShellEnvironment` parameter reference
+
+| Parameter | Default | Description |
+|---|---|---|
+| `path` | `None` | Working dir. `None` → temp dir, deleted on exit |
+| `cleanup` | `None` | `None` → auto (`True` when `path=None`, `False` otherwise). Deletes `path` on process exit |
+| `allowed` | `None` | Whitelist of command prefixes. `None` → all commands allowed |
+| `blocked` | `None` | Blacklist of command prefixes |
+| `ignore` | `None` | Gitignore-style path patterns; matches block the command |
+| `readonly` | `False` | When `True` and `allowed` unset, restricts to a built-in read-only list |
+| `env` | `None` | Extra env vars merged into each command |
+| `timeout` | `60` | Per-command timeout in seconds (returns `"Command timed out after Ns [exit code: 124]"`) |
+| `max_output` | `100_000` | Max characters returned (truncated output is suffixed `[truncated: …]`) |
+
+## Stateful multi-turn workspaces
+
+Files persist in `workdir` across `ask()` calls, so the agent can build on prior work:
+
+```python
+from autogen.beta.tools import LocalShellTool
+from autogen.beta.tools.shell import LocalShellEnvironment
+
+sh = LocalShellTool(LocalShellEnvironment(path="/tmp/counter_demo"))
+agent = Agent("coder", "You manage files.", config=config, tools=[sh])
+
+reply1 = await agent.ask("Create counter.txt with value 0")
+reply2 = await reply1.ask("Increment the counter by 1")
+reply3 = await reply2.ask("Read the counter and tell me the value")
+```
+
+## Provider-native `ShellTool` (Anthropic / OpenAI)
+
+```python
+from autogen.beta.tools import ShellTool
+
+agent = Agent("devops", config=AnthropicConfig(model="claude-sonnet-4-6"), tools=[ShellTool()])
+```
+
+OpenAI lets you configure the execution environment:
+
+```python
+from autogen.beta.config import OpenAIResponsesConfig
+from autogen.beta.tools import ShellTool
+from autogen.beta.tools.builtin.shell import ContainerAutoEnvironment, NetworkPolicy
+
+agent = Agent(
+    "devops",
+    config=OpenAIResponsesConfig(model="gpt-4.1"),
+    tools=[
+        ShellTool(
+            environment=ContainerAutoEnvironment(
+                network_policy=NetworkPolicy(allowed_domains=["pypi.org"]),
+            ),
+        ),
+    ],
+)
+```
+
+Environment options:
+
+| Environment | Description |
+|---|---|
+| `ContainerAutoEnvironment` | Provider-managed container with optional network policy |
+| `ContainerReferenceEnvironment` | Reference an existing container by ID |
+
+`ShellTool` is **not supported on Gemini** — the request will raise `UnsupportedToolError`.
+
+## `LocalShellTool` vs `ShellTool`
+
+| | `LocalShellTool` | `ShellTool` |
+|---|---|---|
+| **Execution** | Client-side `subprocess` | Provider-side container |
+| **Provider support** | Any provider | Anthropic, OpenAI |
+| **Environment control** | Full (`allowed`, `blocked`, `ignore`, `readonly`, …) | Limited (provider-dependent) |
+| **Local FS access** | Yes (you choose what's exposed) | No |
+| **Network control** | Via `blocked` / `allowed` patterns | OpenAI: `NetworkPolicy` |
+| **Import** | `from autogen.beta.tools import LocalShellTool` (env: `from autogen.beta.tools.shell import LocalShellEnvironment`) | `from autogen.beta.tools import ShellTool` |
+
+## Going deeper
+
+- `website/docs/beta/tools/local_shell.mdx` — full `LocalShellTool` reference, command-filtering semantics.
+- `website/docs/beta/tools/builtin_tools.mdx#shell` — provider-native `ShellTool` setup and environment configs.
+- For **human-approval gating before each shell call**, layer `approval_required()` middleware (see `ag2-hitl`).
+
+## Common pitfalls
+
+- **Forgetting sandboxing in production** — `LocalShellTool()` with no environment runs anything anywhere with a 60s timeout. Set `allowed`, `blocked`, or `readonly` for any non-trivial use.
+- **`ignore` only checks literal paths in the command string** — variable substitution, command substitution (`` `cat secrets.key` ``), and dynamic glob expansion are not inspected. Layer in `blocked=["cat", "less"]` if you also want to block readers.
+- **Trying to use `ShellTool` on Gemini** — unsupported, will raise. Use `LocalShellTool` instead.
+- **Using a hardcoded path that another process is also touching** — multiple agents sharing `/tmp/my_project` will race. Use `tempfile.mkdtemp(prefix="...")` for parallel runs.
+- **Expecting `ShellTool` to access local files** — it doesn't; it runs in the provider's container. Use `LocalShellTool` for anything on your filesystem.
+- **Trusting the LLM with shell access** — even sandboxed, write `prompt`s that scope what's allowed and consider pairing with `approval_required()` for destructive operations.

--- a/.agents/skills/ag2-structured-output/SKILL.md
+++ b/.agents/skills/ag2-structured-output/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: ag2-structured-output
+description: Get a typed Python value back from an AG2 beta `Agent` instead of free text. Pass `response_schema=` (a Pydantic model, dataclass, primitive, union, `ResponseSchema`, or `@response_schema` validator) and read the parsed result via `await reply.content()`. Use when the user wants validated structured output, classification, extraction, or scoring. Covers `ResponseSchema`, `@response_schema`, `PromptedSchema` (for providers without native structured output), per-turn override, validation retries, and primitive embedding.
+license: Apache-2.0
+---
+
+# Structured output
+
+## When to use
+
+- The user wants a Pydantic model, dataclass, dict, primitive, or union back — not a string.
+- They're doing classification, extraction, scoring, normalisation, or anything where downstream code parses the reply.
+- They want automatic retry on validation failure.
+
+## 60-second recipe
+
+```python
+from pydantic import BaseModel, Field
+from typing import Annotated
+
+from autogen.beta import Agent
+from autogen.beta.config import OpenAIConfig
+
+class TicketTriage(BaseModel):
+    category: Annotated[str, Field(description="e.g. billing, bug, account_access")]
+    urgency: Annotated[str, Field(description="low, medium, or high")]
+    summary_one_line: Annotated[str, Field(description="Max 120 characters", max_length=120)]
+
+agent = Agent(
+    "triage",
+    prompt="You triage support messages. Be conservative with urgency.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    response_schema=TicketTriage,
+)
+
+reply = await agent.ask("I was charged twice and can't export reports. Quarter close blocked.")
+triage = await reply.content()      # → typed TicketTriage
+print(triage.category, triage.urgency)
+```
+
+`reply.body` is still the raw model text; `await reply.content()` runs validation and returns the parsed value. If validation fails, `content()` raises (e.g. `pydantic.ValidationError`).
+
+## Schema types you can pass
+
+| Type | What you get |
+|---|---|
+| Primitive (`int`, `float`, `bool`) | Bare value, framework wraps in `{"data": ...}` for the API |
+| `dataclass` | Instance of the dataclass |
+| Pydantic `BaseModel` | Instance of the model |
+| Union (`int \| str`, `(int, str)`) | One of the alternatives |
+| `dict[K, V]`, `TypedDict` | Validated dict |
+| `ResponseSchema(...)` | Same as above, with explicit `name` / `description` for the provider |
+| `@response_schema` callable | Custom validation/parsing logic |
+| `PromptedSchema(inner)` | Schema injected into the system prompt for providers without native structured output |
+
+## `ResponseSchema` — name your payload
+
+Helps the provider treat the structured output as a named contract:
+
+```python
+from autogen.beta import Agent, ResponseSchema
+
+schema = ResponseSchema(int | str, name="ByteWidth", description="Number of bits in one byte.")
+agent = Agent("assistant", config=config, response_schema=schema)
+```
+
+## `@response_schema` — custom validation
+
+For clamping, regex cleanup, decoding wrapped JSON, or combining fields:
+
+```python
+from autogen.beta import Agent, response_schema
+
+@response_schema
+def parse_rating(content: str) -> int:
+    """Parse a rating and clamp to 1–5."""
+    return max(1, min(5, int(content)))
+
+agent = Agent("assistant", config=config, response_schema=parse_rating)
+```
+
+Multi-parameter form synthesises a JSON object schema from the parameter names:
+
+```python
+from typing import Annotated
+from pydantic import Field
+from autogen.beta import response_schema
+
+@response_schema
+def extract_listing(
+    title: Annotated[str, Field(description="Product name")],
+    price_usd: Annotated[float, Field(description="Price in USD", ge=0)],
+    in_stock: Annotated[bool, Field(description="True if it ships now")],
+) -> dict:
+    return {"title": title, "price_usd": price_usd, "in_stock": in_stock}
+```
+
+The function also participates in dependency injection — `Context`, `Variable`, `Inject`, `Depends` work the same way as in tools (and don't appear in the JSON schema).
+
+Async validators are supported:
+
+```python
+import json
+
+@response_schema
+async def fetch_and_validate(content: str) -> dict:
+    data = json.loads(content)
+    data["validated"] = True
+    return data
+```
+
+## `PromptedSchema` — for providers without native structured output
+
+Injects the JSON schema into the system prompt instead of using `response_format`:
+
+```python
+from autogen.beta import Agent, PromptedSchema
+
+agent = Agent("assistant", config=config, response_schema=PromptedSchema(int))
+```
+
+Wraps any inner schema (type, `ResponseSchema`, `@response_schema` callable). The validation logic stays the same; only the wire format changes.
+
+Custom prompt template:
+
+```python
+PromptedSchema(int, prompt_template="Reply with JSON matching this schema:\n{schema}")
+```
+
+## Per-turn override
+
+```python
+agent = Agent("assistant", config=config)
+
+turn = await agent.ask("How many seconds in a minute?", response_schema=int)
+print(await turn.content())   # 60
+
+turn2 = await turn.ask("Say hello.")     # back to default (no schema)
+```
+
+Pass `response_schema=None` to drop a schema set on the agent for one call.
+
+## Retries
+
+When validation fails, automatically re-ask the model:
+
+```python
+result = await reply.content(retries=3)   # initial + up to 3 re-asks
+result = await reply.content(retries=math.inf)   # interactive only — could loop forever
+```
+
+The validation error is sent back to the model as a follow-up so it can correct itself.
+
+## Primitive embedding (`embed`)
+
+Bare primitives (`int`, `float`, `bool`, `list[T]`, primitive unions) get wrapped in `{"data": ...}` by default — most structured-output APIs handle objects more reliably than bare values. `content()` transparently unwraps. Opt out:
+
+```python
+ResponseSchema(int, name="RawInt", embed=False)              # model must produce a bare 42
+@response_schema(embed=False)
+def parse_rating(value: int) -> int: ...
+```
+
+## Going deeper
+
+- Working starter: `assets/recipe_builder.py` (mirrors `code_examples/02`) — Pydantic model + `@tool` + `response_schema=`.
+- Full reference: `website/docs/beta/structured_output.mdx` — covers every schema type, multi-param `@response_schema`, `Field` constraints, `PromptedSchema`, retries, embedding semantics.
+
+## Common pitfalls
+
+- **Reading `reply.body` when you wanted typed output** — `reply.body` is the raw text. `await reply.content()` does the parsing.
+- **Forgetting `await` on `content()`** — it's async; you'll get a coroutine, not the value.
+- **No `description` in the Pydantic field** — the LLM may guess what to put in each field. Add a `Field(description=...)` for every non-obvious key.
+- **Provider doesn't support native structured output** — wrap with `PromptedSchema(...)` rather than fighting the API.
+- **`retries=math.inf` in production** — will loop forever on a model that can't comply. Use a finite count.
+- **Per-turn override is single-turn** — passing `response_schema=int` to one `ask()` doesn't change the agent's default. The next turn returns to whatever was set on the constructor.

--- a/.agents/skills/ag2-structured-output/assets/recipe_builder.py
+++ b/.agents/skills/ag2-structured-output/assets/recipe_builder.py
@@ -1,0 +1,89 @@
+"""Recipe builder — tools and structured output.
+
+Mirrors website/docs/beta/code_examples/02_recipe_builder.mdx. Demonstrates
+two core Agent features on top of the bare loop:
+
+1. A custom @tool function the LLM can call (scale_ingredient).
+2. A Pydantic response_schema so the final reply is a typed object.
+
+Run::
+
+    python recipe_builder.py
+"""
+
+import asyncio
+
+from pydantic import BaseModel, Field
+
+from autogen.beta import Agent
+from autogen.beta.config import GeminiConfig
+
+
+def section(title: str) -> None:
+    print(f"\n── {title} ───")
+
+
+class Ingredient(BaseModel):
+    name: str
+    quantity: float
+    unit: str
+
+
+class Recipe(BaseModel):
+    title: str = Field(description="Short human title for the recipe.")
+    servings: int = Field(description="How many portions this recipe yields.")
+    ingredients: list[Ingredient]
+    steps: list[str] = Field(description="Ordered preparation steps.")
+
+
+def scale_ingredient(quantity: float, factor: float) -> float:
+    """Return ``quantity`` multiplied by ``factor``, rounded to 2 decimals.
+
+    The model uses this any time it needs to rescale a recipe for a
+    different number of servings.
+    """
+    return round(quantity * factor, 2)
+
+
+async def main() -> None:
+    config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
+
+    section("Recipe builder — scale an existing dish for 6 servings")
+
+    agent = Agent(
+        "chef",
+        prompt=(
+            "You are a culinary assistant. When asked to rescale a recipe, "
+            "use the scale_ingredient tool for every ingredient to compute the "
+            "new quantity. Return a complete Recipe object."
+        ),
+        config=config,
+        tools=[scale_ingredient],
+        response_schema=Recipe,
+    )
+
+    reply = await agent.ask(
+        "Start from classic carbonara for 2 servings: 200g spaghetti, 2 eggs, "
+        "100g guanciale, 50g pecorino romano. Rescale it for 6 servings and "
+        "produce the full Recipe."
+    )
+
+    recipe: Recipe | None = await reply.content(retries=1)
+
+    if recipe is None:
+        print("Model returned no body — try again.")
+        return
+
+    print(f"{recipe.title}  ({recipe.servings} servings)")
+    print()
+    print("Ingredients:")
+    for ing in recipe.ingredients:
+        print(f"  - {ing.quantity} {ing.unit} {ing.name}")
+    print()
+    print("Steps:")
+    for i, step in enumerate(recipe.steps, 1):
+        print(f"  {i}. {step}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.agents/skills/ag2-subagent-delegation/SKILL.md
+++ b/.agents/skills/ag2-subagent-delegation/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: ag2-subagent-delegation
+description: Delegate work from one AG2 beta `Agent` to another. Two patterns — auto-injected `run_subtask` / `run_subtasks(parallel=True)` (opt in via `tasks=TaskConfig(...)`) for self-delegation and parallel fan-out, and `Agent.as_tool()` for named delegates between distinct agents. Use when one coordinator should spawn sub-tasks, fan out concurrent work, or hand off to a specialist agent. Covers context flow, recursion safety, and `persistent_stream` for sub-task history.
+license: Apache-2.0
+---
+
+# Subagent delegation
+
+## When to use
+
+- "Coordinator + specialists" — a parent agent should hand parts of a task to a research agent, math agent, etc.
+- "Fan out then collect" — multi-part questions where each part is independent and parallel execution saves wall time.
+- "Self-delegation" — one agent breaks complex work into focused sub-tasks for itself.
+
+## Two patterns
+
+| Pattern | Reach for it when | API |
+|---|---|---|
+| **Auto-injected** `run_subtask` / `run_subtasks` | Lightweight self-delegation, dynamic fan-out, parallel sub-questions | `tasks=TaskConfig(...)` on the parent |
+| **`Agent.as_tool()`** | Distinct named delegates the LLM should reason about ("call the researcher", "call the writer") | Wrap a child Agent as a tool on the parent |
+
+The two compose — a coordinator can have both.
+
+## Pattern 1 — auto-injected `run_subtasks`
+
+Subtask tools are **off by default** (`tasks=False`). Opt in with `tasks=TaskConfig(...)` and the agent gains:
+
+- `run_subtask(task: str)` — one isolated sub-task agent.
+- `run_subtasks(tasks: list[str], parallel: bool = True)` — fan out multiple in one tool call (default concurrent).
+
+```python
+from autogen.beta import Agent, TaskConfig
+from autogen.beta.config import GeminiConfig
+
+config = GeminiConfig(model="gemini-3-flash-preview")
+
+coordinator = Agent(
+    "coordinator",
+    prompt=(
+        "You answer multi-part questions by dispatching run_subtasks "
+        "with parallel=True. Use one tool call with every sub-question "
+        "packed into the 'tasks' list."
+    ),
+    config=config,
+    tasks=TaskConfig(),  # opt in
+)
+
+reply = await coordinator.ask(
+    "In one run_subtasks call, answer: "
+    "(a) tallest waterfall, (b) Eiffel Tower year, (c) boiling point of nitrogen."
+)
+```
+
+`TaskConfig` controls how the sub-task agents are built:
+
+```python
+@dataclass
+class TaskConfig:
+    config: ModelConfig | None = None    # falls back to parent's config
+    prompt: str = "You are a task agent..."
+    include_tools: Iterable[str] | None = None   # None = inherit all parent tools
+    exclude_tools: Iterable[str] = ()
+    extra_tools: Iterable[Callable | Tool] = ()
+```
+
+Common shape — cheaper model for sub-tasks, narrow tool surface:
+
+```python
+TaskConfig(
+    config=worker_config,                  # smaller model
+    prompt="You are a focused worker; one step only.",
+    include_tools=["search", "fetch_url"], # don't expose `summarize` to children
+)
+```
+
+**Sub-task agents are built with `tasks=False`** — they never gain `run_subtask` tools themselves. Recursive delegation is structurally impossible; no depth limit needed.
+
+## Pattern 2 — `Agent.as_tool()`
+
+Expose a whole agent as a tool the LLM can name and call:
+
+```python
+from autogen.beta import Agent
+from autogen.beta.config import AnthropicConfig
+
+config = AnthropicConfig(model="claude-sonnet-4-6")
+
+researcher = Agent("researcher", prompt="Provide concise factual findings.", config=config, tools=[search_tool])
+writer     = Agent("writer", prompt="Turn research into clear prose.", config=config)
+
+coordinator = Agent(
+    "coordinator",
+    prompt="First delegate research, then pass findings to the writer.",
+    config=config,
+    tools=[
+        researcher.as_tool(description="Research a topic and return findings."),
+        writer.as_tool(description="Write an article. Pass research notes in the context parameter."),
+    ],
+)
+```
+
+The coordinator's LLM sees `task_researcher` and `task_writer`. Each call has two parameters:
+
+- `objective` (required) — what the sub-task should do.
+- `context` (optional) — relevant info the parent wants to share.
+
+`as_tool()` accepts:
+
+| Parameter | Description |
+|---|---|
+| `description` | Tool description shown to the LLM (required) |
+| `name` | Override the default `task_{agent.name}` |
+| `stream` | `StreamFactory` for custom sub-task streams (see below) |
+| `middleware` | `ToolMiddleware` callables (e.g. `approval_required`) |
+
+For more control, use `subagent_tool()` directly:
+
+```python
+from autogen.beta.tools.subagents import subagent_tool
+
+coordinator = Agent("coordinator", config=config, tools=[
+    subagent_tool(researcher, description="Research a topic."),
+])
+```
+
+## Self-delegation via `as_tool()`
+
+If you want a named self-delegate (`sub_task` instead of generic `run_subtask`), give an agent its own tool:
+
+```python
+analyst = Agent(
+    "analyst",
+    prompt=(
+        "You have search and sub_task tools. "
+        "Only use sub_task when the task has clearly independent parts."
+    ),
+    config=config,
+    tools=[search_tool],
+)
+
+analyst.add_tool(
+    analyst.as_tool(
+        description="Break work into a focused sub-task for independent analysis.",
+        name="sub_task",
+    )
+)
+```
+
+### Recursion safety
+
+Self-delegation via `as_tool()` *can* recurse — the child has the same `sub_task` tool, so without a guard the LLM may chain calls indefinitely.
+
+The simplest safe pattern is to **prefer the auto-injected `run_subtask` / `run_subtasks` path** for self-delegation. Sub-tasks spawned that way are constructed with `tasks=False`, so they have no `run_subtask` tools and recursion is structurally impossible.
+
+If you genuinely need recursive `as_tool()` self-delegation, write a tool middleware that increments a depth counter in `context.dependencies` and short-circuits past a threshold. The `subagents` module exports `subagent_tool`, `persistent_stream`, and `StreamFactory` from `autogen.beta.tools.subagents` — verify the current public surface there before relying on a built-in depth-limiting helper.
+
+## Sub-task streams
+
+By default, each sub-task gets a fresh `MemoryStream` — its history is isolated and starts empty. Context flow:
+
+| What | Behaviour | Why |
+|---|---|---|
+| **Dependencies** | Copied (top-level shallow) | Isolated; treat dependencies as read-only inside subtasks |
+| **Variables** | Copied; synced back on success | Concurrent-safe — sibling subtasks won't race-clobber a shared dict |
+| **History** | Fresh stream | Clean context; relevant info passes via the `context` tool parameter |
+| **Tools** | Inherited from parent (filtered by `TaskConfig`) | Sub-tasks need real capabilities to do work |
+
+### `persistent_stream()`
+
+When a sub-agent benefits from seeing its prior calls (e.g. avoid repeating searches), give it a stream that persists across invocations within the parent context:
+
+```python
+from autogen.beta.tools.subagents import persistent_stream
+
+researcher.as_tool(
+    description="Research a topic",
+    stream=persistent_stream(),
+)
+```
+
+Stores stream id in `context.dependencies` keyed by `f"ag:{agent.name}:stream"` and reuses the parent stream's storage backend.
+
+### Custom factory
+
+```python
+from autogen.beta import Agent, Context
+from autogen.beta.streams.redis import RedisStream
+
+def make_redis_stream(agent: Agent, ctx: Context) -> RedisStream:
+    return RedisStream(MY_REDIS_URL, prefix=f"ag2:sub:{agent.name}")
+
+researcher.as_tool(description="Research a topic", stream=make_redis_stream)
+```
+
+## Going deeper
+
+- Working starter: `assets/research_squad.py` (mirrors `code_examples/05`) — covers both `run_subtasks(parallel=True)` *and* `Agent.as_tool()`, with `TaskStarted` / `TaskCompleted` lifecycle events.
+- Full reference: `website/docs/beta/task_delegation.mdx`.
+- `tasks=` constructor knob (with `KnowledgeConfig`, etc.): `website/docs/beta/agent_harness.mdx`.
+
+## Common pitfalls
+
+- **Forgetting to opt in** — `tasks=False` is the default. No `TaskConfig`, no `run_subtask` tools.
+- **Expecting sub-tasks to recurse with `run_subtask`** — they can't. Sub-tasks themselves have `tasks=False`. If you need deeper trees, use `Agent.as_tool()` self-delegation with a manual depth-counter middleware (see "Recursion safety" above).
+- **Sharing mutable variables expecting them to merge** — concurrent sub-tasks each copy variables; sibling mutations don't propagate. Each sub-task's variable mutations stay local until sync-back on success.
+- **Treating `dependencies` as scoped per sub-task** — only the top-level dict is copied. Mutable values inside it are still shared by reference. Treat dependencies as read-only inside sub-tasks.
+- **No `description=` on `as_tool()`** — the LLM doesn't know when to call it. Required parameter.
+- **`run_subtasks(parallel=False)` when work is concurrent** — defaults to `True` for a reason; only set `False` when later tasks depend on earlier results.
+- **Confusing `task_{agent.name}` collisions** — pass `name=` to override if you want shorter names or distinct delegates of the same agent.

--- a/.agents/skills/ag2-subagent-delegation/assets/research_squad.py
+++ b/.agents/skills/ag2-subagent-delegation/assets/research_squad.py
@@ -1,0 +1,102 @@
+"""Research squad — parallel subtasks and sibling delegation.
+
+Mirrors website/docs/beta/code_examples/05_research_squad.mdx. Two patterns
+for multi-Agent orchestration:
+
+1. **Opt-in subtask tools.** Pass tasks=TaskConfig(...) and the Agent gains
+   run_subtask / run_subtasks. The coordinator uses run_subtasks with
+   parallel=True to fan out three short investigations concurrently.
+2. **Agent.as_tool().** A second Agent (math_expert) is exposed to the
+   coordinator as a callable tool.
+
+Both patterns: spawned subtasks have no run_subtask tools (they default to
+tasks=False), so recursion is structurally impossible — no depth limiter
+needed.
+
+Run::
+
+    python research_squad.py
+"""
+
+import asyncio
+import time
+
+from autogen.beta import Agent
+from autogen.beta.agent import TaskConfig
+from autogen.beta.config import GeminiConfig
+from autogen.beta.events import TaskCompleted, TaskStarted
+from autogen.beta.stream import MemoryStream
+
+
+def section(title: str) -> None:
+    print(f"\n── {title} ───")
+
+
+async def main() -> None:
+    config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
+
+    section("Parallel subtasks — fan out three lookups in one tool call")
+
+    coordinator = Agent(
+        "coordinator",
+        prompt=(
+            "You answer multi-part questions by dispatching run_subtasks "
+            "with parallel=True. Use one tool call with every sub-question "
+            "packed into the 'tasks' list. Be concise."
+        ),
+        config=config,
+        tasks=TaskConfig(),  # Opt in to run_subtask / run_subtasks.
+    )
+
+    starts: list[TaskStarted] = []
+    completions: list[TaskCompleted] = []
+    stream = MemoryStream()
+    stream.where(TaskStarted).subscribe(lambda e: starts.append(e))
+    stream.where(TaskCompleted).subscribe(lambda e: completions.append(e))
+
+    start = time.monotonic()
+    reply = await coordinator.ask(
+        "Use run_subtasks(parallel=True) to answer, in one tool call: "
+        "(a) what is the tallest waterfall in the world, "
+        "(b) what year was the Eiffel Tower completed, "
+        "(c) what is the boiling point of nitrogen in Celsius. "
+        "Then list all three answers.",
+        stream=stream,
+    )
+    elapsed = time.monotonic() - start
+
+    print(reply.body)
+    print()
+    print(f"Subtasks dispatched: {len(starts)}")
+    print(f"Subtasks finished:   {len(completions)}")
+    print(f"Wall time:           {elapsed:.2f}s (3 concurrent LLM calls)")
+
+    section("Sibling delegation — math_expert is a tool on coordinator2")
+
+    math_expert = Agent(
+        "math-expert",
+        prompt="You are an arithmetic specialist. Reply with only the number.",
+        config=config,
+    )
+
+    coordinator2 = Agent(
+        "coordinator2",
+        prompt=(
+            "When arithmetic comes up, delegate to the task_math-expert tool "
+            "rather than computing yourself. Then present the answer in a "
+            "complete sentence."
+        ),
+        config=config,
+        tools=[
+            math_expert.as_tool(
+                description="Delegate arithmetic problems to the math expert.",
+            )
+        ],
+    )
+
+    reply2 = await coordinator2.ask("What is 237 times 19?")
+    print(reply2.body)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.agents/skills/ag2-telemetry/SKILL.md
+++ b/.agents/skills/ag2-telemetry/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: ag2-telemetry
+description: Add OpenTelemetry traces to an AG2 beta `Agent` via `TelemetryMiddleware` (`autogen.beta.middleware.builtin`). Emits spans for the full turn, each LLM call, each tool execution, and each human-input request, following the OpenTelemetry GenAI semantic conventions. Compatible with any OTLP backend — Jaeger, Grafana Tempo, Datadog, Honeycomb, Langfuse. Use when the user wants production-grade traces, latency analysis, token-usage attribution, or to ship telemetry into an existing observability stack.
+license: Apache-2.0
+---
+
+# Telemetry — OpenTelemetry instrumentation
+
+## When to use
+
+The user wants to:
+
+- See per-turn / per-call latency breakdowns
+- Attribute token usage across operations
+- Push traces to Jaeger, Grafana Tempo, Datadog, Honeycomb, Langfuse, etc.
+- Debug a slow agent end-to-end with structured spans rather than print statements
+
+If they just want quick stdout debugging, point them at `LoggingMiddleware` instead (see `ag2-middleware`).
+
+## Installation
+
+```bash
+pip install "ag2[openai,tracing]"
+```
+
+## 60-second recipe
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, ConsoleSpanExporter
+
+from autogen.beta import Agent
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.middleware.builtin import TelemetryMiddleware
+
+# 1. Configure OpenTelemetry
+resource = Resource.create({"service.name": "ag2-beta-quickstart"})
+tracer_provider = TracerProvider(resource=resource)
+tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+trace.set_tracer_provider(tracer_provider)
+
+# 2. Wire the middleware
+agent = Agent(
+    "assistant",
+    prompt="You are a helpful assistant.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    middleware=[
+        TelemetryMiddleware(
+            tracer_provider=tracer_provider,
+            agent_name="assistant",
+        ),
+    ],
+)
+
+# 3. Run — spans emit automatically
+import asyncio
+asyncio.run(agent.ask("What is the capital of France?"))
+```
+
+For production, swap `ConsoleSpanExporter` for `OTLPSpanExporter` (or your backend's exporter) and `SimpleSpanProcessor` for `BatchSpanProcessor`.
+
+## Span hierarchy
+
+Each `ask()` produces a root span with children:
+
+```
+invoke_agent assistant
+  ├── chat gpt-4o-mini              # LLM API call
+  ├── execute_tool get_weather      # tool execution
+  ├── chat gpt-4o-mini              # LLM call after tool result
+  └── await_human_input assistant   # human-in-the-loop
+```
+
+## Span types
+
+Every span has an `ag2.span.type` attribute:
+
+| `ag2.span.type` | Operation name | Hook |
+|---|---|---|
+| `agent` | `invoke_agent` | `on_turn` — full turn |
+| `llm` | `chat` | `on_llm_call` — each LLM call |
+| `tool` | `execute_tool` | `on_tool_execution` — each tool |
+| `human_input` | `await_human_input` | `on_human_input` — HITL |
+
+## Semantic attributes (GenAI semconv)
+
+Spans carry standard [OpenTelemetry GenAI](https://opentelemetry.io/docs/specs/semconv/gen-ai/) attributes:
+
+| Attribute | Spans | Description |
+|---|---|---|
+| `gen_ai.operation.name` | All | `invoke_agent` / `chat` / `execute_tool` / `await_human_input` |
+| `gen_ai.agent.name` | agent, human_input | Agent name |
+| `gen_ai.provider.name` | agent, llm | Auto-detected (`openai`, `anthropic`, …) |
+| `gen_ai.request.model` | agent, llm | e.g. `gpt-4o-mini` |
+| `gen_ai.response.model` | llm | Resolved from response |
+| `gen_ai.response.finish_reasons` | llm | e.g. `["stop"]`, `["tool_calls"]` |
+| `gen_ai.usage.input_tokens` | llm | Prompt tokens |
+| `gen_ai.usage.output_tokens` | llm | Completion tokens |
+| `gen_ai.usage.cache_creation_input_tokens` | llm | Prompt-cache writes (Anthropic) |
+| `gen_ai.usage.cache_read_input_tokens` | llm | Prompt-cache reads (Anthropic, OpenAI, Gemini) |
+| `gen_ai.tool.name` | tool | Tool function name |
+| `gen_ai.tool.call.id` | tool | Tool call ID |
+| `gen_ai.tool.type` | tool | Always `function` |
+
+## Content capture (default ON)
+
+By default, message content, tool args, and results are included on spans. Useful for debugging but can leak sensitive data:
+
+```python
+TelemetryMiddleware(
+    tracer_provider=tracer_provider,
+    agent_name="assistant",
+    capture_content=False,   # omit messages, tool args, results
+)
+```
+
+When enabled, additional attributes appear:
+
+| Attribute | Span | Content |
+|---|---|---|
+| `gen_ai.input.messages` | llm | JSON request messages |
+| `gen_ai.output.messages` | llm | JSON response messages |
+| `gen_ai.tool.call.arguments` | tool | Tool args (JSON) |
+| `gen_ai.tool.call.result` | tool | Tool result |
+| `ag2.human_input.prompt` | human_input | Prompt shown to human |
+| `ag2.human_input.response` | human_input | Human's response |
+
+For privacy-sensitive backends (or anywhere telemetry leaves your infra), set `capture_content=False`.
+
+## Constructor reference
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `tracer_provider` | `TracerProvider \| None` | Global provider | OpenTelemetry TracerProvider |
+| `capture_content` | `bool` | `True` | Include message/tool content in spans |
+| `agent_name` | `str \| None` | `"unknown"` | Agent name for span attributes |
+| `provider_name` | `str \| None` | `None` | Provider override (auto-detected if unset) |
+| `model_name` | `str \| None` | `None` | Model override (auto-detected if unset) |
+
+## Backend integration
+
+`TelemetryMiddleware` uses standard OpenTelemetry, so any OTLP-compatible backend works:
+
+- **Jaeger** — `OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces")`
+- **Grafana Tempo** — same OTLP exporter, point at the Tempo gateway
+- **Langfuse, Honeycomb, Datadog** — vendor-specific exporters; the agent-side setup is identical
+
+For container-orchestrated stacks, this repo includes a `tracing/` directory with Docker-Compose for otel-collector + Grafana Tempo.
+
+## Going deeper
+
+- `website/docs/beta/telemetry.mdx` — full attribute table, configuration, example.
+- `tracing/` — Docker setup for local otel-collector + Tempo + Grafana.
+- For sibling middleware (logging, retry, history limits), see `ag2-middleware`.
+
+## Common pitfalls
+
+- **`SimpleSpanProcessor` + `ConsoleSpanExporter` in production** — synchronous, blocks every span emit. Use `BatchSpanProcessor` and a real exporter (OTLP / Jaeger / vendor) outside of dev.
+- **Leaking content into telemetry** — `capture_content=True` is the default. For privacy-sensitive prompts (PII, credentials), set `capture_content=False` *and* audit what your backend retains.
+- **Forgetting `trace.set_tracer_provider(...)`** — without it, `tracer_provider` you pass to the middleware is fine, but third-party libraries that auto-instrument may use a different provider.
+- **Token usage missing** — `gen_ai.usage.*` requires the provider client to surface usage in the response. Streaming providers may emit usage only at the end; if you don't see them, check the provider's response shape.
+- **Span hierarchy doesn't show parent-child** — your exporter or backend may need the OTLP/HTTP path enabled, not just OTLP/gRPC. Check both.
+- **Comparing to V1 tracing docs** — the semantic-attribute format is the same; only the agent instrumentation method differs (V1 uses `instrument_agent()` / `instrument_llm_wrapper()` / `instrument_pattern()`; beta uses `TelemetryMiddleware`).

--- a/.agents/skills/ag2-testing/SKILL.md
+++ b/.agents/skills/ag2-testing/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: ag2-testing
+description: Test AG2 beta agents and tools without hitting a real LLM provider. Pass `TestConfig(...)` from `autogen.beta.testing` as the agent's config (or per-`ask`) to mock LLM responses, inject `ToolCallEvent`s to simulate tool execution, and assert success / error paths. Use when the user is writing pytest tests for an Agent or Tool.
+license: Apache-2.0
+---
+
+# Testing agents and tools
+
+## When to use
+
+Writing tests for code that builds AG2 beta `Agent`s, custom `@tool` functions, middleware, or response schemas — anywhere you don't want to make real LLM API calls.
+
+## 60-second recipe — mock an LLM response
+
+```python
+import pytest
+from autogen.beta import Agent
+from autogen.beta.testing import TestConfig
+
+@pytest.mark.asyncio
+async def test_mocked_response():
+    agent = Agent("test_agent")
+    reply = await agent.ask("Hi!", config=TestConfig("This is a mocked response."))
+    assert reply.body == "This is a mocked response."
+```
+
+`TestConfig(*responses)` replaces the model client. Each positional arg is the mocked response for the next sequential turn — strings for text replies, `ToolCallEvent` for tool dispatches.
+
+## Simulate a successful tool call
+
+Pass a `ToolCallEvent` first (the model "decides" to call the tool), then the final answer:
+
+```python
+import pytest
+from autogen.beta import Agent
+from autogen.beta.events import ToolCallEvent
+from autogen.beta.testing import TestConfig
+
+@pytest.mark.asyncio
+async def test_tool_success():
+    def my_tool() -> str:
+        return "tool execution result"
+
+    agent = Agent("test_agent", tools=[my_tool])
+    config = TestConfig(
+        ToolCallEvent(name="my_tool"),
+        "final result",
+    )
+    reply = await agent.ask("Please use my_tool", config=config)
+    assert reply.body == "final result"
+```
+
+## Test tool error paths
+
+If a tool raises, the exception propagates to `ask()`:
+
+```python
+@pytest.mark.asyncio
+async def test_tool_raises():
+    def failing_tool() -> str:
+        raise ValueError("Something went wrong")
+
+    config = TestConfig(
+        ToolCallEvent(name="failing_tool"),
+        "result",
+    )
+    agent = Agent("test_agent", config=config, tools=[failing_tool])
+
+    with pytest.raises(ValueError, match="Something went wrong"):
+        await agent.ask("Hi!")
+```
+
+## Tool not found
+
+If the LLM calls a tool the agent doesn't have, the framework raises `ToolNotFoundError`:
+
+```python
+from autogen.beta.exceptions import ToolNotFoundError
+
+@pytest.mark.asyncio
+async def test_tool_not_found():
+    config = TestConfig(ToolCallEvent(name="unregistered_tool"))
+    agent = Agent("test_agent", config=config)
+    with pytest.raises(ToolNotFoundError, match="Tool `unregistered_tool` not found"):
+        await agent.ask("Hi!")
+```
+
+## Useful test patterns
+
+### Override `Depends` dependencies
+
+```python
+def get_production_db():
+    raise Exception("Do not call in tests!")
+
+@tool
+def read_data(db: Annotated[object, Depends(get_production_db)]) -> str:
+    return "Data"
+
+agent = Agent("test", tools=[read_data])
+agent.dependency_provider.override(get_production_db, lambda: "mock_db")
+```
+
+### Override `Inject` dependencies
+
+Just pass `dependencies={...}` to `agent.ask(...)`:
+
+```python
+await agent.ask("Read", dependencies={"database_pool": fake_pool})
+```
+
+### Capture stream events
+
+```python
+from autogen.beta import MemoryStream
+from autogen.beta.events import ToolCallEvent
+
+stream = MemoryStream()
+collected: list[ToolCallEvent] = []
+stream.where(ToolCallEvent).subscribe(lambda e: collected.append(e))
+
+await agent.ask("Test", stream=stream)
+assert collected[0].name == "expected_tool"
+```
+
+### Multi-turn mock
+
+Each positional arg in `TestConfig(...)` corresponds to one model response. For a multi-turn test, supply enough responses for each turn the test exercises.
+
+## Going deeper
+
+- Source doc: `website/docs/beta/testing.mdx`.
+- Test markers / async config — repo `pyproject.toml`. Use `@pytest.mark.asyncio` (the project uses pytest-asyncio).
+- Streams (for asserting events): `website/docs/beta/advanced/stream.mdx`.
+
+## Common pitfalls
+
+- **Forgetting `@pytest.mark.asyncio`** — the test will skip or fail oddly.
+- **Mismatched response count** — `TestConfig` runs out of responses if the agent makes more LLM calls than you expect (e.g. tool error → another LLM call). Add more positional args or assert that the call sequence is what you intended.
+- **Mocking the LLM but not the tool** — your tool function still runs (and may hit real APIs / disk). Mock the *tool* if you're isolating LLM behaviour, or override its `Depends` to inject test doubles.
+- **Asserting on `reply.body` when you set a `response_schema`** — `body` is the raw text. Use `await reply.content()` for the validated value.
+- **Sharing `Agent` instances across async tests** — agents carry mutable state (variables, dependencies). Construct fresh agents per test for isolation.
+- **Using real provider clients in CI** — wrap the provider config with `TestConfig` per-test or via a fixture; never rely on `OPENAI_API_KEY` etc. being available in test environments.

--- a/.agents/skills/ag2-use-builtin-tools/SKILL.md
+++ b/.agents/skills/ag2-use-builtin-tools/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: ag2-use-builtin-tools
+description: Wire AG2 beta's shipped tools into an `Agent` — both provider-native server-side tools (web search, web fetch, code execution, MCP, image generation, memory) and locally-executed common toolkits (filesystem, DuckDuckGo, Exa, Tavily, skills). Use when the user wants capabilities AG2 already ships rather than writing custom Python. For shell commands see `ag2-shell-tool`; for custom Python tools see `ag2-add-custom-tool`.
+license: Apache-2.0
+---
+
+# Use AG2 beta's built-in tools
+
+## When to use
+
+Reach for this skill when the user wants to add a capability that AG2 already ships. Two families:
+
+1. **Provider-native tools** (`autogen.beta.tools` — `WebSearchTool`, `CodeExecutionTool`, etc.) — executed server-side by Anthropic / OpenAI / Gemini. No Python implementation on your side.
+2. **Common toolkits** (`autogen.beta.tools` — `FilesystemToolkit`, `DuckDuckSearchTool`, `ExaToolkit`, `TavilySearchTool`, `SkillsToolkit`) — regular Python that runs in your process and works with **every** provider.
+
+For shell commands, use `ag2-shell-tool` (it's important enough to live in its own skill).
+For custom Python tools, use `ag2-add-custom-tool`.
+
+## 60-second recipes
+
+### Web search (provider-native)
+
+```python
+from autogen.beta import Agent
+from autogen.beta.config import AnthropicConfig
+from autogen.beta.tools import WebSearchTool, UserLocation
+
+agent = Agent(
+    "researcher",
+    config=AnthropicConfig(model="claude-sonnet-4-6"),
+    tools=[
+        WebSearchTool(
+            max_uses=5,
+            user_location=UserLocation(country="US"),
+            allowed_domains=["github.com", "pypi.org"],
+            blocked_domains=["pinterest.com"],
+        ),
+    ],
+)
+```
+
+### Web fetch (Anthropic / Gemini only)
+
+```python
+from autogen.beta.tools import WebFetchTool
+
+tools = [WebFetchTool(max_uses=3, max_content_tokens=50000, citations=True)]
+```
+
+### Code execution
+
+```python
+from autogen.beta.tools import CodeExecutionTool
+
+agent = Agent("analyst", config=config, tools=[CodeExecutionTool()])
+```
+
+### MCP server integration
+
+```python
+from autogen.beta.tools import MCPServerTool
+
+tools = [
+    MCPServerTool(
+        server_url="https://mcp.example.com/sse",
+        server_label="my-tools",
+        allowed_tools=["search", "summarize"],
+    ),
+]
+```
+
+### Image generation (OpenAI Responses only)
+
+```python
+from autogen.beta.config import OpenAIResponsesConfig
+from autogen.beta.tools import ImageGenerationTool
+
+agent = Agent(
+    "designer",
+    config=OpenAIResponsesConfig(model="gpt-4.1"),
+    tools=[ImageGenerationTool(quality="high", size="1024x1024", output_format="png")],
+)
+reply = await agent.ask("Generate a logo for a coffee shop.")
+images: list[bytes] = reply.images
+```
+
+### Filesystem (sandboxed, any provider)
+
+```python
+from autogen.beta.tools import FilesystemToolkit
+
+fs = FilesystemToolkit(base_path="/tmp/workspace")
+agent = Agent("worker", config=config, tools=[fs])
+```
+
+`base_path` is enforced — `../../etc/passwd` raises `PermissionError`. Use `read_only=True` to expose only `read_file` and `find_files`. For ephemeral workspaces use `tempfile.TemporaryDirectory()` rather than hardcoding `/tmp`.
+
+### Web search via DuckDuckGo (no API key)
+
+```python
+from autogen.beta.tools import DuckDuckSearchTool
+# requires: pip install ag2[ddgs]
+
+tools = [DuckDuckSearchTool(max_results=10, region="us-en", safesearch="moderate")]
+```
+
+### Exa neural search
+
+```python
+import os
+from autogen.beta.tools import ExaToolkit
+# requires: pip install ag2[exa]
+
+tools = [ExaToolkit(api_key=os.environ["EXA_API_KEY"])]
+```
+
+Each tool is exposed as a factory method (`exa.search()`, `exa.find_similar()`, `exa.get_contents()`, `exa.answer()`) so you can pass only what you need with per-call config.
+
+### Tavily search
+
+```python
+import os
+from autogen.beta.tools import TavilySearchTool
+# requires: pip install ag2[tavily]
+
+tools = [TavilySearchTool(
+    api_key=os.environ["TAVILY_API_KEY"],
+    search_depth="advanced",
+    include_answer=True,
+)]
+```
+
+## Going deeper
+
+- **Per-tool provider support, every parameter, version pinning** — `references/builtin_tools_matrix.md`.
+- **Source docs** — `website/docs/beta/tools/builtin_tools.mdx` (provider-native), `website/docs/beta/tools/common_toolkits.mdx` (common toolkits — also covers `SkillsToolkit` and `SkillSearchToolkit`).
+- **Toolkits authoring** — `website/docs/beta/tools/toolkits.mdx`.
+
+## Common pitfalls
+
+- **Mismatch between tool and provider** — `WebFetchTool` raises with OpenAI; `MemoryTool` is Anthropic-only; `ImageGenerationTool` is OpenAI Responses only. Check `references/builtin_tools_matrix.md` first.
+- **Anthropic tool versions default to older revisions** — pin `version="web_search_20260209"` etc. when you need dynamic filtering on Opus 4.6 / Sonnet 4.6.
+- **`FilesystemToolkit` paths are sandboxed** — by design. Don't try to bypass the path-traversal guard; choose a wider `base_path` instead.
+- **Toolkits and individual tools mix freely** — `tools=[fs, exa, my_custom_tool]` is fine.
+- **Optional dependency missing** — `DuckDuckSearchTool`, `ExaToolkit`, `TavilySearchTool` need their `ag2[<extra>]` install. Without it you get a clear `ImportError` from the config-fallback layer, not a confusing crash.

--- a/.agents/skills/ag2-use-builtin-tools/references/builtin_tools_matrix.md
+++ b/.agents/skills/ag2-use-builtin-tools/references/builtin_tools_matrix.md
@@ -1,0 +1,169 @@
+# Built-in tools — provider matrix and per-tool parameters
+
+## Provider-native tools (server-side execution)
+
+| Tool | Anthropic | OpenAI | Gemini |
+|---|:---:|:---:|:---:|
+| `CodeExecutionTool` | ✓ | ✓ | ✓ |
+| `WebSearchTool` | ✓ | ✓ | ✓ |
+| `WebFetchTool` | ✓ | ✗ | ✓ |
+| `ShellTool` | ✓ | ✓ | ✗ |
+| `MCPServerTool` | ✓ | ✓ | ✗ |
+| `ImageGenerationTool` | ✗ | ✓ | ✗ |
+| `MemoryTool` | ✓ | ✗ | ✗ |
+
+Unsupported combinations raise `UnsupportedToolError` at request time.
+
+### `WebSearchTool` parameters
+
+| Parameter | Anthropic | OpenAI | Gemini |
+|---|:---:|:---:|:---:|
+| `max_uses` | ✓ | ✓ | ✗ |
+| `user_location` | ✓ | ✓ | ✗ |
+| `search_context_size` | ✗ | ✓ | ✗ |
+| `allowed_domains` | ✓ | ✓ | ✗ |
+| `blocked_domains` | ✓ | ✗ | ✓ |
+
+Unsupported parameters are silently ignored.
+
+### `WebFetchTool` parameters (Anthropic / Gemini only)
+
+| Parameter | Anthropic | Gemini |
+|---|:---:|:---:|
+| `max_uses` | ✓ | ✗ |
+| `allowed_domains` | ✓ | ✗ |
+| `blocked_domains` | ✓ | ✗ |
+| `citations` | ✓ | ✗ |
+| `max_content_tokens` | ✓ | ✗ |
+
+### `MCPServerTool` parameters
+
+| Parameter | Anthropic | OpenAI |
+|---|:---:|:---:|
+| `server_url` | ✓ | ✓ |
+| `server_label` | ✓ | ✓ |
+| `authorization_token` | ✓ | ✗ |
+| `description` | ✓ | ✗ |
+| `allowed_tools` | ✓ | ✓ |
+| `blocked_tools` | ✓ | ✗ |
+| `headers` | ✗ | ✓ |
+
+### `ImageGenerationTool` parameters (OpenAI Responses only)
+
+| Parameter | Description |
+|---|---|
+| `quality` | `"low"`, `"medium"`, `"high"`, `"auto"` |
+| `size` | e.g. `"1024x1024"`, `"1536x1024"`, `"auto"` |
+| `background` | `"transparent"`, `"opaque"`, `"auto"` |
+| `output_format` | `"png"`, `"jpeg"`, `"webp"` |
+| `output_compression` | 0–100, jpeg/webp only |
+| `partial_images` | 1–3, partial-stream count |
+
+Generated images surface on `reply.images: list[bytes]`.
+
+## Anthropic tool versions
+
+Newer Anthropic tool revisions support dynamic filtering (the model writes code to filter results before they reach context) but require Opus 4.6 / Sonnet 4.6.
+
+```python
+from autogen.beta.tools import WebFetchTool, WebSearchTool
+
+tools = [
+    WebSearchTool(version="web_search_20260209"),  # default: web_search_20250305
+    WebFetchTool(version="web_fetch_20260209"),    # default: web_fetch_20250910
+]
+```
+
+Default versions are compatible with all Claude models including Haiku.
+
+## Common toolkits (local execution, all providers)
+
+### `FilesystemToolkit`
+
+| Tool | Description |
+|---|---|
+| `read_file` | Read a file |
+| `write_file` | Create / overwrite (auto-creates parent dirs) |
+| `update_file` | Replace first occurrence of a string |
+| `delete_file` | Delete a file |
+| `find_files` | Glob search (supports `**`) |
+
+Constructor:
+
+```python
+FilesystemToolkit(base_path="/tmp/workspace", read_only=False)
+```
+
+`base_path` is enforced — escape attempts raise `PermissionError`. Individual tools available as `fs.read_file()`, `fs.find_files()`, etc.
+
+### `DuckDuckSearchTool`
+
+```python
+DuckDuckSearchTool(
+    max_results=5,         # default
+    region="us-en",        # default
+    safesearch="moderate", # "on" | "moderate" | "off"
+)
+```
+
+All parameters accept `Variable(...)` for deferred resolution.
+
+### `ExaToolkit`
+
+| Tool factory | Description |
+|---|---|
+| `toolkit.search(...)` | Neural web search with filters |
+| `toolkit.find_similar(...)` | Find pages similar to a URL |
+| `toolkit.get_contents(...)` | Fetch full text |
+| `toolkit.answer(...)` | LLM answer with citations |
+
+Constructor:
+
+```python
+ExaToolkit(api_key=..., num_results=10, max_characters=2000)
+```
+
+Per-call factory params include `search_type`, `category`, `include_domains`, `exclude_domains`, `start_published_date`, `end_published_date`, `use_autoprompt`, `livecrawl`. All accept `Variable`.
+
+### `TavilySearchTool`
+
+```python
+TavilySearchTool(
+    api_key=...,
+    max_results=5,
+    search_depth="advanced",   # "basic" | "advanced" | "fast" | "ultra-fast"
+    topic="news",              # "general" | "news" | "finance"
+    include_answer=True,
+    include_raw_content=True,
+    include_images=True,
+    time_range="week",         # "day" | "week" | "month" | "year"
+    include_domains=[...],
+    exclude_domains=[...],
+)
+```
+
+### `SkillsToolkit` / `SkillSearchToolkit`
+
+Discovers and runs skills following the [agentskills.io](https://agentskills.io) convention. By default reads from `.agents/skills/` in the current working directory.
+
+```python
+from autogen.beta.tools import SkillsToolkit
+from autogen.beta.tools.skills import LocalRuntime
+
+skills = SkillsToolkit()                              # uses .agents/skills/
+skills = SkillsToolkit(runtime="./my-skills")         # custom dir
+skills = SkillsToolkit(runtime=LocalRuntime("./my-skills", extra_paths=["./shared-skills"]))
+```
+
+Three-step progressive disclosure: `list_skills` (catalog) → `load_skill` (full SKILL.md) → `run_skill_script` (execute a script).
+
+`SkillSearchToolkit` adds `search_skills`, `install_skill`, `remove_skill` against the [skills.sh](https://skills.sh) registry. Set `GITHUB_TOKEN` (env or `SkillsClientConfig`) to lift the GitHub API rate limit from 60 → 5000 requests/hour.
+
+## Required extras
+
+| Tool | `pip install` |
+|---|---|
+| `DuckDuckSearchTool` | `ag2[ddgs]` |
+| `ExaToolkit` | `ag2[exa]` |
+| `TavilySearchTool` | `ag2[tavily]` |
+| Provider-native tools | the provider's own extra (`ag2[anthropic]`, `ag2[openai]`, `ag2[gemini]`) |

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-.agents
-.claude
+.agents/*
+!.agents/skills/
+.claude/*
+!.claude/skills
 .rtk
 skills-lock.json
 
@@ -210,5 +212,4 @@ remote-examples
 
 *CLAUDE.md:
 .cursor/
-.claude/
 .vercel/

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The project is currently maintained by a [dynamic group of volunteers](MAINTAINE
     - [Advanced agentic design patterns](#advanced-agentic-design-patterns)
   - [Announcements](#announcements)
   - [Code style and linting](#code-style-and-linting)
+  - [AI-assisted contributing with Agent Skills](#ai-assisted-contributing-with-agent-skills)
   - [Related papers](#related-papers)
   - [Contributors Wall](#contributors-wall)
   - [Cite the project](#cite-the-project)
@@ -420,6 +421,18 @@ prek install
 ```bash
 prek run --all-files
 ```
+
+## AI-assisted contributing with Agent Skills
+
+This repo ships [Agent Skills](https://agentskills.io/) for AI coding assistants under `.agents/skills/`. Cursor, OpenAI Codex CLI, Gemini CLI, and OpenCode read this path natively. Claude Code reads `.claude/skills/`, which is committed as a symlink to `.agents/skills/` so a single source of truth covers every tool.
+
+**Windows users (non-WSL):** git stores the `.claude/skills` symlink as a real symlink, but native Windows git checks it out as a plain text file by default, which breaks Claude Code's skill discovery. Before cloning, run:
+
+```bash
+git config --global core.symlinks true
+```
+
+You may also need to enable Windows Developer Mode (or run git as Administrator) so symlinks can be created without elevation. WSL and Mac/Linux users are unaffected.
 
 ## Related papers
 


### PR DESCRIPTION
## Why are these changes needed?

To assist with developers using AI coding tools like Claude Code, Codex, Cursor, etc. [Agent Skills](https://agentskills.io/home) provides a standarised way to provide specialised knowledge and workflows for the AI agents.

This is designed for developers contributing to AG2 beta AND developers building with AG2 beta.

This PR puts these instructions, which are **based on the Beta code ONLY**, into a `.agents/skills` folder with `.claude/skills` as a symlink to it. The most common coding agents will be able to retrieve these automatically.

Tree:
.agents/skills/
└ ag2-overview/
└ ag2-quickstart/
└ ag2-add-custom-tool/
└ ag2-use-builtin-tools/
└ ag2-shell-tool/
└ ag2-structured-output/
└ ag2-subagent-delegation/
└ ag2-hitl/
└ ag2-middleware/
└ ag2-testing/
└ ag2-knowledge-and-memory/
└ ag2-observers-and-alerts/
└ ag2-multimodal-input/
└ ag2-ag-ui/
└ ag2-telemetry/

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
