### PR TITLE
fix(beta): drain CadenceWatch buffer when callback outlasts max_wait

### DIFF
--- a/autogen/beta/watch.py
+++ b/autogen/beta/watch.py
@@ -157,13 +157,18 @@ class CadenceWatch(_BaseWatch):
 
     async def _wait_and_fire(self, stream: Stream) -> None:
         assert self._max_wait is not None
-        try:
-            await asyncio.sleep(self._max_wait)
-        except asyncio.CancelledError:
-            return
-        if self._buffer and self._callback is not None:
-            ctx = ContextType(stream=stream)
+        ctx = ContextType(stream=stream)
+        # Loop ensures draining of events that arrive while slow callbacks await.
+        while True:
+            try:
+                await asyncio.sleep(self._max_wait)
+            except asyncio.CancelledError:
+                return
+            if not (self._buffer and self._callback is not None):
+                return
             await self._fire(ctx)
+            if not self._buffer:
+                return
 
     async def _fire(self, ctx: Context) -> None:
         if not self._buffer or self._callback is None:

--- a/test/beta/test_watch.py
+++ b/test/beta/test_watch.py
@@ -258,6 +258,43 @@ class TestCadenceWatch:
         assert len(batches[1]) == 1
 
     @pytest.mark.asyncio
+    async def test_events_during_slow_callback_are_not_stranded(self) -> None:
+        stream = MemoryStream()
+        ctx = Context(stream=stream)
+        delivered: list[str] = []
+        callback_sleep = 0.15
+        max_wait = 0.05
+
+        async def slow_callback(events, _ctx):
+            await asyncio.sleep(callback_sleep)
+            delivered.extend(e.content for e in events)
+
+        watch = CadenceWatch(n=5, max_wait=max_wait)
+        watch.arm(stream, slow_callback)
+
+        # Wave 1: count-trigger fires batch 1 (callback now awaiting).
+        for i in range(1, 6):
+            await stream.send(ModelMessage(content=f"m{i}"), ctx)
+
+        # Wave 2: while batch 1's callback is in flight, queue 3 events.
+        # max_wait elapses, _wait_and_fire fires batch 2 (also slow).
+        await asyncio.sleep(0.01)
+        for i in range(6, 9):
+            await stream.send(ModelMessage(content=f"m{i}"), ctx)
+        await asyncio.sleep(max_wait + 0.02)
+
+        # Wave 3: lands while batch 2's callback is awaiting. Pre-fix, the
+        # max_wait timer task is alive (in callback) so no fresh timer is
+        # scheduled and these events sit in the buffer forever.
+        for i in range(9, 12):
+            await stream.send(ModelMessage(content=f"m{i}"), ctx)
+
+        # Wait for all in-flight callbacks plus one more max_wait cycle.
+        await asyncio.sleep(2 * callback_sleep + max_wait + 0.1)
+
+        assert set(delivered) == {f"m{i}" for i in range(1, 12)}
+
+    @pytest.mark.asyncio
     async def test_count_fires_after_timer_flush(self) -> None:
         stream = MemoryStream()
         ctx = Context(stream=stream)


### PR DESCRIPTION
## Why are these changes needed?

`CadenceWatch` silently dropped events when a user callback's runtime exceeded `max_wait` and new events arrived during the callback's await.

The cause was that `_timer_task` represents both the sleep phase and the firing phase, so once `_wait_and_fire` entered `await self._fire(ctx)` the task was still alive but no longer sleeping - and `_handle_cadence_event`'s check (`_timer_task is None or _timer_task.done()`) would not schedule a fresh timer for newly arriving events. When the callback eventually returned and the task finished, no further events were arriving to wake `_handle_cadence_event`, so the buffered events sat in `_buffer` indefinitely. 

Fixed by reshaping `_wait_and_fire` as a loop that re-checks the buffer after each fire and sleeps again to drain anything that accumulated during the callback. Adds a regression test (`test_events_during_slow_callback_are_not_stranded`) that reproduces the three-wave timing — count-trigger, max_wait-trigger during slow callback, late wave during second slow callback — and asserts every sent event is delivered.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
