### PR TITLE
fix(beta): Move serialisation for Redis to event serialiser

### DIFF
--- a/autogen/beta/events/_serialization.py
+++ b/autogen/beta/events/_serialization.py
@@ -2,17 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Event serialization utilities.
-
-Shared by BaseEvent.to_dict/from_dict and Envelope wire format.
-Placed in the events package to avoid circular imports between
-Layer 1 (events) and Layer 2 (network primitives).
-"""
+"""Event serialization utilities."""
 
 import base64
 import importlib
+from dataclasses import fields, is_dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from .base import BaseEvent
@@ -64,6 +63,18 @@ def serialize_value(value: Any) -> Any:
         return [serialize_value(v) for v in value]
     if isinstance(value, (bytes, bytearray)):
         return {"__bytes__": base64.b64encode(value).decode("ascii")}
+    if isinstance(value, UUID):
+        return {"__uuid__": str(value)}
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            "__dataclass__": qualified_name_from_class(type(value)),
+            "data": {f.name: serialize_value(getattr(value, f.name)) for f in fields(value)},
+        }
+    if isinstance(value, BaseModel):
+        return {
+            "__pydantic__": qualified_name_from_class(type(value)),
+            "data": serialize_value(value.model_dump(mode="python")),
+        }
     # Primitives (str, int, float, bool, None) pass through
     return value
 
@@ -91,13 +102,41 @@ def deserialize_value(value: Any, event_registry: Any | None = None) -> Any:
                 return event_cls(**nested_data)
         if "__bytes__" in value:
             return base64.b64decode(value["__bytes__"])
+        if "__uuid__" in value:
+            return UUID(value["__uuid__"])
         if "__exception__" in value:
             # Reconstruct as a generic Exception with the original message
             return Exception(value.get("message", ""))
+        if "__dataclass__" in value:
+            cls = _resolve_class(value["__dataclass__"])
+            data = {k: deserialize_value(v, event_registry) for k, v in value.get("data", {}).items()}
+            return cls(**data)
+        if "__pydantic__" in value:
+            cls = _resolve_class(value["__pydantic__"])
+            raw = deserialize_value(value.get("data", {}), event_registry)
+            assert issubclass(cls, BaseModel)
+            return cls.model_validate(raw)
         return {k: deserialize_value(v, event_registry) for k, v in value.items()}
     if isinstance(value, list):
         return [deserialize_value(v, event_registry) for v in value]
     return value
+
+
+def _resolve_class(type_path: str) -> type:
+    parts = type_path.split(".")
+    for i in range(len(parts) - 1, 0, -1):
+        module_path = ".".join(parts[:i])
+        attr_chain = parts[i:]
+        try:
+            module = importlib.import_module(module_path)
+            obj: Any = module
+            for attr in attr_chain:
+                obj = getattr(obj, attr)
+            if isinstance(obj, type):
+                return obj
+        except (ImportError, AttributeError):
+            continue
+    raise ImportError(f"Could not resolve class {type_path!r}")
 
 
 def _resolve_event_type(type_name: str, event_registry: Any | None = None) -> "type[BaseEvent] | None":

--- a/autogen/beta/streams/redis/serializer.py
+++ b/autogen/beta/streams/redis/serializer.py
@@ -2,15 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import importlib
 import json
 import pickle
-from dataclasses import fields, is_dataclass
 from enum import Enum
 from typing import Any
-from uuid import UUID
 
-from autogen.beta.events import BaseEvent
+from autogen.beta.events._serialization import deserialize_value, serialize_value
 
 
 class Serializer(Enum):
@@ -24,105 +21,11 @@ def serialize(obj: Any, fmt: Serializer) -> bytes:
     """Serialize an event to bytes using the specified format."""
     if fmt is Serializer.PICKLE:
         return pickle.dumps(obj)
-    return json.dumps(_to_json(obj)).encode()
+    return json.dumps(serialize_value(obj)).encode()
 
 
 def deserialize(data: bytes, fmt: Serializer) -> Any:
     """Deserialize bytes back to an event using the specified format."""
     if fmt is Serializer.PICKLE:
         return pickle.loads(data)  # noqa: S301
-    return _from_json(json.loads(data))
-
-
-def _to_json(obj: Any) -> Any:
-    """Recursively serialize an object to JSON-compatible types."""
-    if obj is None or isinstance(obj, (str, int, float, bool)):
-        return obj
-
-    if isinstance(obj, BaseEvent):
-        cls = type(obj)
-        data: dict[str, Any] = {"__type__": f"{cls.__module__}.{cls.__qualname__}"}
-        for key, value in obj.__dict__.items():
-            if not key.startswith("_"):
-                data[key] = _to_json(value)
-        return data
-
-    if is_dataclass(obj) and not isinstance(obj, type):
-        cls = type(obj)
-        data = {"__type__": f"{cls.__module__}.{cls.__qualname__}"}
-        for f in fields(obj):
-            data[f.name] = _to_json(getattr(obj, f.name))
-        return data
-
-    if isinstance(obj, Exception):
-        return {
-            "__type__": "exception",
-            "exc_type": f"{type(obj).__module__}.{type(obj).__qualname__}",
-            "message": str(obj),
-        }
-
-    if isinstance(obj, dict):
-        return {k: _to_json(v) for k, v in obj.items()}
-
-    if isinstance(obj, Enum):
-        cls = type(obj)
-        return {
-            "__type__": f"{cls.__module__}.{cls.__qualname__}",
-            "__enum_value__": _to_json(obj.value),
-        }
-
-    if isinstance(obj, UUID):
-        return {"__type__": "uuid.UUID", "__uuid__": str(obj)}
-
-    if isinstance(obj, (list, tuple)):
-        return [_to_json(item) for item in obj]
-
-    return str(obj)
-
-
-def _resolve_class(type_path: str) -> type:
-    """Import and return the class from a dotted path."""
-    module_path, _, class_name = type_path.rpartition(".")
-    module = importlib.import_module(module_path)
-    return getattr(module, class_name)
-
-
-def _from_json(data: Any) -> Any:
-    """Recursively deserialize JSON data back to event objects."""
-    if data is None or isinstance(data, (str, int, float, bool)):
-        return data
-
-    if isinstance(data, list):
-        return [_from_json(item) for item in data]
-
-    if isinstance(data, dict):
-        type_path = data.get("__type__")
-        if not type_path:
-            return {k: _from_json(v) for k, v in data.items()}
-
-        if type_path == "exception":
-            try:
-                exc_cls = _resolve_class(data["exc_type"])
-            except (ImportError, AttributeError):
-                exc_cls = Exception
-            return exc_cls(data.get("message", ""))
-
-        if type_path == "uuid.UUID":
-            return UUID(data["__uuid__"])
-
-        if "__enum_value__" in data:
-            cls = _resolve_class(type_path)
-            return cls(_from_json(data["__enum_value__"]))
-
-        cls = _resolve_class(type_path)
-        fields_data = {k: _from_json(v) for k, v in data.items() if k != "__type__"}
-
-        if isinstance(cls, type) and issubclass(cls, BaseEvent):
-            return cls(**fields_data)
-
-        if is_dataclass(cls):
-            return cls(**fields_data)
-
-        return fields_data
-
-    return data
+    return deserialize_value(json.loads(data))

--- a/test/beta/events/test_serialization.py
+++ b/test/beta/events/test_serialization.py
@@ -2,10 +2,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for event-class import utilities used by ``EventLogWriter``."""
+"""Tests for the shared event-serialization layer."""
 
-from autogen.beta.events import BaseEvent, ModelMessage
-from autogen.beta.events._serialization import import_event_class
+import datetime
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import BaseModel
+
+from autogen.beta.events import BaseEvent, ModelMessage, ToolCallEvent
+from autogen.beta.events._serialization import (
+    deserialize_value,
+    import_event_class,
+    serialize_value,
+)
 
 
 class _Outer:
@@ -30,3 +41,126 @@ class TestImportEventClass:
 
     def test_returns_none_for_non_event_class(self) -> None:
         assert import_event_class("builtins.int") is None
+
+
+def _round_trip(value: object) -> object:
+    return deserialize_value(serialize_value(value))
+
+
+class TestPrimitives:
+    @pytest.mark.parametrize("value", [None, "hello", 42, 3.14, True, False])
+    def test_primitive_round_trip(self, value: object) -> None:
+        assert _round_trip(value) == value
+
+
+class TestBytes:
+    def test_bytes_round_trip(self) -> None:
+        raw = b"\x12\x34\x00\x99\xff\xab"
+        result = _round_trip(raw)
+        assert result == raw
+        assert isinstance(result, bytes)
+
+    def test_bytearray_round_trip(self) -> None:
+        raw = bytearray(b"\x01\x02\x03")
+        # bytearray serializes as bytes — round-trip yields bytes (acceptable)
+        result = _round_trip(raw)
+        assert result == bytes(raw)
+
+    def test_bytes_inside_dict(self) -> None:
+        payload = {"signature": b"\x12\x34", "name": "weather"}
+        assert _round_trip(payload) == payload
+
+    def test_bytes_inside_list(self) -> None:
+        payload = [b"\x01", b"\x02"]
+        assert _round_trip(payload) == payload
+
+    def test_bytes_inside_event_provider_data(self) -> None:
+        """The original Gemini thought_signature bug — bytes in provider_data."""
+        sig = b"\x12\x34\n\x32\x01\x0c\x39\xd6\xc7\xa3"
+        event = ToolCallEvent(
+            id="call-1",
+            name="get_weather",
+            arguments='{"city": "Paris"}',
+            provider_data={"thought_signature": sig},
+        )
+        round_tripped = _round_trip(event)
+        assert isinstance(round_tripped, ToolCallEvent)
+        assert round_tripped.provider_data["thought_signature"] == sig
+        assert isinstance(round_tripped.provider_data["thought_signature"], bytes)
+
+
+class TestUUID:
+    def test_uuid_round_trip(self) -> None:
+        u = uuid4()
+        result = _round_trip(u)
+        assert result == u
+        assert isinstance(result, UUID)
+
+
+@dataclass
+class _SamplePoint:
+    x: int
+    y: int
+    label: str = "origin"
+
+
+class TestDataclass:
+    def test_dataclass_round_trip(self) -> None:
+        point = _SamplePoint(1, 2, "p")
+        result = _round_trip(point)
+        assert result == point
+        assert isinstance(result, _SamplePoint)
+
+
+class _SamplePydanticModel(BaseModel):
+    name: str
+    count: int
+    payload: bytes | None = None
+
+
+class TestPydantic:
+    def test_pydantic_round_trip(self) -> None:
+        model = _SamplePydanticModel(name="hello", count=3)
+        result = _round_trip(model)
+        assert result == model
+        assert isinstance(result, _SamplePydanticModel)
+
+    def test_pydantic_with_bytes_field_round_trip(self) -> None:
+        """SDK objects (e.g. OpenAI ImageGenerationCall) embed bytes; pydantic mode='json' handles them."""
+        model = _SamplePydanticModel(name="img", count=1, payload=b"\xff\xd8\xff")
+        result = _round_trip(model)
+        assert result == model
+
+
+class TestUnknownTypePassthrough:
+    """Unknown types pass through ``serialize_value`` unchanged.
+
+    The wire-format boundary (e.g. ``json.dumps`` in the Redis serializer)
+    is what surfaces a ``TypeError`` if the value can't be encoded — keeping
+    ``serialize_value`` itself permissive preserves backwards compatibility
+    for callers like ``BaseEvent.to_dict`` that pair it with their own
+    JSON fallback (e.g. ``json.dumps(..., default=str)``).
+    """
+
+    def test_unknown_type_passes_through(self) -> None:
+        when = datetime.datetime(2026, 4, 29)
+        assert serialize_value(when) is when
+
+    def test_unknown_type_inside_dict_passes_through(self) -> None:
+        when = datetime.datetime(2026, 4, 29)
+        assert serialize_value({"when": when}) == {"when": when}
+
+
+class TestEventRoundTrip:
+    def test_simple_event(self) -> None:
+        event = ModelMessage("hello world")
+        result = _round_trip(event)
+        assert isinstance(result, ModelMessage)
+        assert result.content == "hello world"
+
+    def test_tool_call_event(self) -> None:
+        event = ToolCallEvent(id="abc", name="search", arguments='{"q": "ag2"}')
+        result = _round_trip(event)
+        assert isinstance(result, ToolCallEvent)
+        assert result.name == "search"
+        assert result.arguments == '{"q": "ag2"}'

--- a/test/beta/providers/gemini/test_gemini_integration.py
+++ b/test/beta/providers/gemini/test_gemini_integration.py
@@ -9,6 +9,7 @@ import pytest
 
 from autogen.beta import Agent
 from autogen.beta.config import GeminiConfig
+from autogen.beta.streams.redis.serializer import Serializer, deserialize, serialize
 
 
 @pytest.fixture()
@@ -132,4 +133,40 @@ async def test_multi_turn_after_empty_args_tool_call(gemini_config: GeminiConfig
     assert reply.body is not None
 
     reply2 = await reply.ask("Tell me more about the researcher agent.")
+    assert reply2.body is not None
+
+
+@pytest.mark.gemini
+@pytest.mark.asyncio()
+async def test_history_round_trip_preserves_thought_signature(gemini_config: GeminiConfig) -> None:
+    """Gemini thinking models stash bytes in ``ToolCallEvent.provider_data``;
+    history persisted through the Redis JSON serializer must replay intact."""
+
+    def get_weather(city: str) -> str:
+        """Get the current weather for a city."""
+        return f"The weather in {city} is sunny and 22°C."
+
+    agent = Agent(
+        name="weather_agent",
+        prompt="You are a weather assistant. Use the get_weather tool to answer weather questions. Be concise.",
+        config=gemini_config,
+        tools=[get_weather],
+    )
+
+    reply1 = await agent.ask("What's the weather in Paris?")
+    assert reply1.body is not None
+
+    # Round-trip history through the persistent-stream serializer.
+    events = list(await reply1.history.get_events())
+    round_tripped = [deserialize(serialize(e, Serializer.JSON), Serializer.JSON) for e in events]
+
+    for ev in round_tripped:
+        sig = getattr(ev, "provider_data", {}).get("thought_signature") if hasattr(ev, "provider_data") else None
+        if sig is not None:
+            assert isinstance(sig, bytes), f"thought_signature corrupted to {type(sig).__name__}: {sig!r}"
+
+    await reply1.history.replace(round_tripped)
+
+    # Replay must not 400 with INVALID_ARGUMENT on the corrupted signature.
+    reply2 = await reply1.ask("What about London?")
     assert reply2.body is not None

--- a/test/beta/stream/redis/test_redis_stream.py
+++ b/test/beta/stream/redis/test_redis_stream.py
@@ -12,7 +12,7 @@ import pytest
 import pytest_asyncio
 
 from autogen.beta import Context
-from autogen.beta.events import ModelMessage, TextInput, ToolCallEvent
+from autogen.beta.events import ImageInput, ModelMessage, TextInput, ToolCallEvent
 from autogen.beta.streams.redis.serializer import Serializer
 
 pytestmark = [
@@ -388,3 +388,97 @@ class TestRedisStream:
         assert len(received) == 1
         assert received[0].name == "post_crash"
         assert stream._listener_task is dead_task and dead_task.done()
+
+
+class TestBinaryRoundTrip:
+    """Events carrying binary or provider-SDK fields must round-trip intact."""
+
+    async def test_tool_call_event_with_bytes_provider_data(self, redis_storage, stream_id):
+        """The Gemini thought_signature scenario: bytes nested in provider_data."""
+        storage = redis_storage()
+        sig = b"\x12\x34\n\x32\x01\x0c\x39\xd6\xc7\xa3\x83,t\x95\xa2j\x9c\xb3\xd3"
+
+        original = ToolCallEvent(
+            id="call-1",
+            name="get_weather",
+            arguments='{"city": "Paris"}',
+            provider_data={"thought_signature": sig},
+        )
+        await storage.set_history(stream_id, [original])
+
+        [restored] = list(await storage.get_history(stream_id))
+        assert isinstance(restored, ToolCallEvent)
+        assert restored.provider_data["thought_signature"] == sig
+        assert isinstance(restored.provider_data["thought_signature"], bytes)
+
+    async def test_image_input_round_trip(self, redis_storage, stream_id):
+        """BinaryInput.data (used by ImageInput/AudioInput/...) carries raw bytes."""
+        storage = redis_storage()
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+        original = ImageInput(data=png_bytes, media_type="image/png")
+        await storage.set_history(stream_id, [original])
+
+        [restored] = list(await storage.get_history(stream_id))
+        assert restored.data == png_bytes
+        assert isinstance(restored.data, bytes)
+
+    async def test_gemini_server_tool_call_event(self, redis_storage, stream_id):
+        """Gemini grounding/code-exec events embed a google.genai.types.Part."""
+        google_genai = pytest.importorskip("google.genai")
+        from autogen.beta.config.gemini.events import GeminiServerToolCallEvent
+
+        storage = redis_storage()
+        part = google_genai.types.Part(text="search results for ag2")
+        original = GeminiServerToolCallEvent(
+            id="grounding-1",
+            name="grounding",
+            arguments='{"queries": ["ag2"]}',
+            part=part,
+        )
+        await storage.set_history(stream_id, [original])
+
+        [restored] = list(await storage.get_history(stream_id))
+        assert isinstance(restored, GeminiServerToolCallEvent)
+        assert restored.part is not None
+        assert restored.part.text == "search results for ag2"
+
+    async def test_anthropic_server_tool_call_event(self, redis_storage, stream_id):
+        """Anthropic server-tool events embed an anthropic.types.ServerToolUseBlock."""
+        anthropic_types = pytest.importorskip("anthropic.types")
+        from autogen.beta.config.anthropic.events import AnthropicServerToolCallEvent
+
+        storage = redis_storage()
+        block = anthropic_types.ServerToolUseBlock(
+            id="srvtoolu_1",
+            name="web_search",
+            input={"query": "ag2"},
+            type="server_tool_use",
+        )
+        original = AnthropicServerToolCallEvent.from_block(block)
+        assert original is not None
+        await storage.set_history(stream_id, [original])
+
+        [restored] = list(await storage.get_history(stream_id))
+        assert isinstance(restored, AnthropicServerToolCallEvent)
+        assert restored.block.id == "srvtoolu_1"
+        assert restored.block.input == {"query": "ag2"}
+
+    async def test_openai_reasoning_event(self, redis_storage, stream_id):
+        """OpenAI reasoning events must round-trip — they explicitly opt into persistence."""
+        openai_responses = pytest.importorskip("openai.types.responses")
+        from autogen.beta.config.openai.events import OpenAIReasoningEvent
+
+        storage = redis_storage()
+        item = openai_responses.ResponseReasoningItem(
+            id="rs_1",
+            type="reasoning",
+            summary=[],
+        )
+        original = OpenAIReasoningEvent("thinking...", item=item)
+        await storage.set_history(stream_id, [original])
+
+        [restored] = list(await storage.get_history(stream_id))
+        assert isinstance(restored, OpenAIReasoningEvent)
+        assert restored.item.id == "rs_1"
+        assert restored.item.type == "reasoning"


### PR DESCRIPTION
## Why are these changes needed?

`autogen/beta/streams/redis/serializer.py:_to_json` ended with a silent fallthrough (`return str(obj)`). Anything not in its explicit type list was coerced to its `repr()` string and silently corrupted on Redis round-trip. This was picked up during Gemini use with its thought_signature which needs to reappear on a roundtrip.

This affects other providers and types.

| Provider | Field | Type | Effect |
|----------|-------|------|--------|
| Gemini | `ToolCallEvent.provider_data["thought_signature"]` | `bytes` | Gemini API returns `400 INVALID_ARGUMENT` on the next turn (reproduced) |
| Gemini | `GeminiServerToolCallEvent.part`, `.grounding_metadata` | `google.genai.types.Part` / `GroundingMetadata` | Grounding / code-exec replay broken |
| Anthropic | `AnthropicServerToolCallEvent.block`, `AnthropicServerToolResultEvent.block` | `anthropic.types.ServerToolUseBlock` and result-block union | Web search / web fetch / code execution / bash / text editor replay broken |
| OpenAI | `OpenAIServerToolCallEvent.item` | OpenAI SDK responses items | Web search / code interpreter / image generation replay broken |
| OpenAI | `OpenAIReasoningEvent.item` (`__transient__ = False`) | `ResponseReasoningItem` | o-series / GPT-5 reasoning replay broken |
| Framework | `BinaryInput.data` (`ImageInput` / `AudioInput` / `DocumentInput` / `VideoInput`) | `bytes` | Multimodal input persisted to Redis is corrupted across all providers |

The events JSON serialiser at `autogen/beta/events/_serialization.py` (used by `BaseEvent.to_dict / from_dict` and the Envelope wire format) already handled `bytes` correctly via a `__bytes__` tag. It makes sense to centralise this.

## Related issue number

N/A

## Checks

- [] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
