### PR TITLE
fix(beta): drop empty Gemini text parts + AG-UI guard

### DIFF
--- a/autogen/beta/ag_ui/stream.py
+++ b/autogen/beta/ag_ui/stream.py
@@ -147,6 +147,9 @@ async def run_stream(
         nonlocal streaming_msg_id
 
         if isinstance(event, events.ModelMessageChunk):
+            if not event.content:
+                return
+
             if streaming_msg_id is None:
                 streaming_msg_id = str(uuid4())
                 await write_events_stream.send(
@@ -174,7 +177,7 @@ async def run_stream(
                 )
                 streaming_msg_id = None
 
-            else:
+            elif event.content:
                 await write_events_stream.send(
                     TextMessageChunkEvent(
                         message_id=str(uuid4()),

--- a/autogen/beta/config/gemini/gemini_client.py
+++ b/autogen/beta/config/gemini/gemini_client.py
@@ -139,7 +139,7 @@ class GeminiClient(LLMClient):
                 for part in candidate.content.parts or ():
                     if part.thought and part.text:
                         await context.send(ModelReasoning(part.text))
-                    elif part.text is not None:
+                    elif part.text:
                         model_msg = ModelMessage(part.text)
                         await context.send(model_msg)
                     elif part.function_call:
@@ -215,7 +215,7 @@ class GeminiClient(LLMClient):
                     for part in candidate.content.parts or ():
                         if part.thought and part.text:
                             await context.send(ModelReasoning(part.text))
-                        elif part.text is not None:
+                        elif part.text:
                             full_content += part.text
                             await context.send(ModelMessageChunk(part.text))
                         elif part.function_call:

--- a/test/beta/ag_ui/test_empty_chunks.py
+++ b/test/beta/ag_ui/test_empty_chunks.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the AG-UI subscriber's handling of empty model events.
+
+The AG-UI protocol forbids empty deltas (``MinLen(1)`` on
+``TextMessageContentEvent.delta`` / ``TextMessageChunkEvent.delta``).
+``map_events_to_ag_ui`` must drop empty ``ModelMessageChunk`` and empty
+``ModelMessage`` events instead of forwarding them to the AG-UI encoder.
+"""
+
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+from ag_ui.core import UserMessage
+from typing_extensions import Self
+
+from autogen.beta import Agent, Context
+from autogen.beta.ag_ui import AGUIStream
+from autogen.beta.config import LLMClient, ModelConfig
+from autogen.beta.events import (
+    BaseEvent,
+    ModelMessage,
+    ModelMessageChunk,
+    ModelResponse,
+    ToolCallsEvent,
+)
+
+from .utils import (
+    assert_no_event_type,
+    collect_events,
+    create_run_input,
+    get_events_of_type,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class _StreamingClient(LLMClient):
+    """LLM client that emits a fixed sequence of ``ModelMessageChunk`` events
+    followed by a single ``ModelMessage`` (mirroring how a streaming Gemini
+    response surfaces to subscribers)."""
+
+    def __init__(self, *chunks: str) -> None:
+        self.chunks = chunks
+
+    async def __call__(
+        self,
+        messages: Sequence[BaseEvent],
+        context: Context,
+        **kwargs: Any,
+    ) -> ModelResponse:
+        for chunk in self.chunks:
+            await context.send(ModelMessageChunk(chunk))
+
+        full = "".join(self.chunks)
+        message = ModelMessage(full) if full else None
+        if message is not None:
+            await context.send(message)
+
+        return ModelResponse(message=message, tool_calls=ToolCallsEvent([]))
+
+
+class _StreamingConfig(ModelConfig):
+    def __init__(self, *chunks: str) -> None:
+        self.chunks = chunks
+
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> _StreamingClient:
+        return _StreamingClient(*self.chunks)
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+class _NonStreamingEmptyClient(LLMClient):
+    """Emits a single empty ``ModelMessage`` — exercises the non-streaming
+    branch of ``map_events_to_ag_ui``."""
+
+    async def __call__(
+        self,
+        messages: Sequence[BaseEvent],
+        context: Context,
+        **kwargs: Any,
+    ) -> ModelResponse:
+        message = ModelMessage("")
+        await context.send(message)
+        return ModelResponse(message=message, tool_calls=ToolCallsEvent([]))
+
+
+class _NonStreamingEmptyConfig(ModelConfig):
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> _NonStreamingEmptyClient:
+        return _NonStreamingEmptyClient()
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+class TestEmptyModelMessageChunk:
+    async def test_empty_chunk_does_not_open_text_message(self) -> None:
+        # Empty chunk arrives first — must not emit TEXT_MESSAGE_START.
+        # The non-empty chunk that follows opens the message normally.
+        agent = Agent("test_agent", config=_StreamingConfig("", "Hello"))
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="m1", content="hi"))
+
+        events = await collect_events(stream, run_input)
+
+        starts = get_events_of_type(events, "TEXT_MESSAGE_START")
+        contents = get_events_of_type(events, "TEXT_MESSAGE_CONTENT")
+
+        # Exactly one start (from the non-empty chunk), one content event.
+        assert len(starts) == 1
+        assert len(contents) == 1
+        assert contents[0]["delta"] == "Hello"
+
+    async def test_empty_chunk_between_real_chunks_dropped(self) -> None:
+        agent = Agent("test_agent", config=_StreamingConfig("Hello", "", " world"))
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="m1", content="hi"))
+
+        events = await collect_events(stream, run_input)
+
+        contents = get_events_of_type(events, "TEXT_MESSAGE_CONTENT")
+        assert [c["delta"] for c in contents] == ["Hello", " world"]
+
+        # No content event ever carries an empty delta.
+        for event in contents:
+            assert event["delta"] != ""
+
+
+class TestEmptyModelMessage:
+    async def test_empty_non_streaming_message_emits_no_text_event(self) -> None:
+        agent = Agent("test_agent", config=_NonStreamingEmptyConfig())
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="m1", content="hi"))
+
+        events = await collect_events(stream, run_input)
+
+        assert_no_event_type(events, "TEXT_MESSAGE_CHUNK")
+        assert_no_event_type(events, "TEXT_MESSAGE_CONTENT")
+        assert_no_event_type(events, "TEXT_MESSAGE_START")

--- a/test/beta/config/gemini/test_empty_text_parts.py
+++ b/test/beta/config/gemini/test_empty_text_parts.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests: Gemini emits ``Part(text="")`` at function-call boundaries.
+
+Empty parts must not produce ``ModelMessage`` or ``ModelMessageChunk`` events —
+they crash AG-UI's ``TextMessageContentEvent`` validator (which enforces
+``MinLen(1)`` on ``delta``) and carry no payload for any other subscriber.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from google.genai import types
+
+from autogen.beta import Context, MemoryStream
+from autogen.beta.config.gemini.gemini_client import GeminiClient
+from autogen.beta.context import ConversationContext
+from autogen.beta.events import BaseEvent, ModelMessage, ModelMessageChunk, ModelReasoning
+
+
+def _candidate(parts: list) -> SimpleNamespace:
+    return SimpleNamespace(
+        content=SimpleNamespace(parts=parts),
+        finish_reason=None,
+        grounding_metadata=None,
+    )
+
+
+def _response(candidates: list[SimpleNamespace]) -> SimpleNamespace:
+    return SimpleNamespace(candidates=candidates, usage_metadata=None)
+
+
+@pytest.fixture
+def client() -> GeminiClient:
+    with patch("autogen.beta.config.gemini.gemini_client.genai.Client"):
+        return GeminiClient(model="gemini-2.5-flash", api_key="test-key")
+
+
+@pytest.fixture
+def memory_context() -> tuple[Context, MemoryStream, list[BaseEvent]]:
+    # ``ModelMessageChunk`` / ``ModelMessage`` / ``ModelReasoning`` are
+    # transient and not persisted to history, so capture them via a
+    # subscriber instead.
+    stream = MemoryStream()
+    captured: list[BaseEvent] = []
+
+    async def capture(event: BaseEvent) -> None:
+        captured.append(event)
+
+    stream.subscribe(capture)
+    return ConversationContext(stream=stream), stream, captured
+
+
+@pytest.mark.asyncio
+class TestProcessStreamSkipsEmptyTextParts:
+    async def test_empty_text_chunks_dropped(
+        self,
+        client: GeminiClient,
+        memory_context: tuple[Context, MemoryStream, list[BaseEvent]],
+    ) -> None:
+        ctx, _, captured = memory_context
+
+        async def chunks():
+            yield _response([_candidate([types.Part(text="Hello")])])
+            yield _response([_candidate([types.Part(text="")])])
+            yield _response([_candidate([types.Part(text=" world")])])
+
+        await client._process_stream(chunks(), ctx)
+
+        message_chunks = [e for e in captured if isinstance(e, ModelMessageChunk)]
+        messages = [e for e in captured if isinstance(e, ModelMessage)]
+
+        assert message_chunks == [ModelMessageChunk("Hello"), ModelMessageChunk(" world")]
+        assert messages == [ModelMessage("Hello world")]
+
+    async def test_empty_thought_text_dropped(
+        self,
+        client: GeminiClient,
+        memory_context: tuple[Context, MemoryStream, list[BaseEvent]],
+    ) -> None:
+        ctx, _, captured = memory_context
+
+        async def chunks():
+            yield _response([_candidate([types.Part(text="", thought=True)])])
+            yield _response([_candidate([types.Part(text="real thought", thought=True)])])
+
+        await client._process_stream(chunks(), ctx)
+
+        reasoning = [e for e in captured if isinstance(e, ModelReasoning)]
+        assert reasoning == [ModelReasoning("real thought")]
+
+
+@pytest.mark.asyncio
+class TestProcessResponseSkipsEmptyTextParts:
+    async def test_empty_text_part_does_not_emit_model_message(
+        self,
+        client: GeminiClient,
+        memory_context: tuple[Context, MemoryStream, list[BaseEvent]],
+    ) -> None:
+        ctx, _, captured = memory_context
+        response = _response([_candidate([types.Part(text="")])])
+
+        await client._process_response(response, ctx)
+
+        assert [e for e in captured if isinstance(e, ModelMessage)] == []


### PR DESCRIPTION
## Why are these changes needed?

Gemini produces text parts that are effectively empty, particularly on the boundary of tool calls. These have no value and can be ignored.

A side effect of this was that it was breaking our AG-UI implementation, which couldn't deal with empty content. A guard has been added here as protection from other produces sending through empty content.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
