### PR TITLE
fix(beta): correct OpenAI image handling on Chat Completions and Responses

### DIFF
--- a/autogen/beta/config/openai/mappers.py
+++ b/autogen/beta/config/openai/mappers.py
@@ -230,12 +230,34 @@ def events_to_responses_input(
 
                 elif isinstance(inp, BinaryInput):
                     b64 = base64.b64encode(inp.data).decode()
-                    item: dict[str, Any] = {
-                        "type": "input_file",
-                        "file_data": f"data:{inp.media_type};base64,{b64}",
-                        **inp.vendor_metadata,
-                    }
-                    result.append({"role": "user", "content": [item]})
+                    if inp.kind is BinaryType.IMAGE:
+                        image_block: dict[str, Any] = {
+                            "type": "input_image",
+                            "image_url": f"data:{inp.media_type};base64,{b64}",
+                        }
+                        if "detail" in inp.vendor_metadata:
+                            image_block["detail"] = inp.vendor_metadata["detail"]
+                        result.append({"role": "user", "content": [image_block]})
+
+                    elif inp.kind in (BinaryType.DOCUMENT, BinaryType.BINARY):
+                        # input_file with file_data *requires* filename.
+                        filename = inp.vendor_metadata.get("filename")
+                        if not filename:
+                            suffix = inp.media_type.rsplit("/", 1)[-1].split("+", 1)[0]
+                            filename = f"file.{suffix}"
+                        result.append({
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_file",
+                                    "file_data": f"data:{inp.media_type};base64,{b64}",
+                                    "filename": filename,
+                                }
+                            ],
+                        })
+
+                    else:
+                        raise UnsupportedInputError(f"BinaryInput({inp.kind.value})", "openai-responses")
 
                 elif isinstance(inp, UrlInput):
                     if inp.kind is BinaryType.IMAGE:
@@ -310,7 +332,10 @@ def convert_messages(
                     elif inp.kind is BinaryType.IMAGE:
                         b64 = base64.b64encode(inp.data).decode()
                         data_url = f"data:{inp.media_type};base64,{b64}"
-                        parts.append({"type": "image_url", "image_url": {"url": data_url}, **inp.vendor_metadata})
+                        image_url: dict[str, Any] = {"url": data_url}
+                        if "detail" in inp.vendor_metadata:
+                            image_url["detail"] = inp.vendor_metadata["detail"]
+                        parts.append({"type": "image_url", "image_url": image_url})
 
                     elif inp.kind is BinaryType.DOCUMENT:
                         b64 = base64.b64encode(inp.data).decode()

--- a/test/beta/config/openai/test_convert_messages.py
+++ b/test/beta/config/openai/test_convert_messages.py
@@ -217,31 +217,84 @@ class TestBinaryInput:
             SerializerCls,
         )
 
-        assert result[1] == IsPartialDict({
+        expected_url = f"data:image/png;base64,{base64.b64encode(self.SAMPLE_BYTES).decode()}"
+        assert result[1] == {
             "role": "user",
-            "content": [IsPartialDict({"type": "image_url", "detail": "low"})],
-        })
+            "content": [{"type": "image_url", "image_url": {"url": expected_url, "detail": "low"}}],
+        }
+
+    def test_completions_image_path_no_vendor_leak(self, tmp_path) -> None:
+        """ImageInput(path=...) auto-sets vendor_metadata={'filename': ...}; mapper must not leak it."""
+        png = tmp_path / "plot.png"
+        png.write_bytes(self.SAMPLE_BYTES)
+
+        result = convert_messages([], [ModelRequest([ImageInput(path=str(png))])], SerializerCls)
+
+        image_block = result[1]["content"][0]
+        assert image_block == {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(self.SAMPLE_BYTES).decode()}"},
+        }
 
     def test_responses(self) -> None:
         result = events_to_responses_input(
-            [ModelRequest([BinaryInput(data=self.SAMPLE_BYTES, media_type="image/png")])],
+            [ModelRequest([ImageInput(data=self.SAMPLE_BYTES, media_type="image/png")])],
             SerializerCls,
         )
 
-        expected_data = f"data:image/png;base64,{base64.b64encode(self.SAMPLE_BYTES).decode()}"
+        expected_url = f"data:image/png;base64,{base64.b64encode(self.SAMPLE_BYTES).decode()}"
         assert result == [
             {
                 "role": "user",
-                "content": [{"type": "input_file", "file_data": expected_data}],
+                "content": [{"type": "input_image", "image_url": expected_url}],
             }
         ]
 
-    def test_responses_with_vendor_metadata(self) -> None:
+    def test_responses_image_path_no_vendor_leak(self, tmp_path) -> None:
+        """ImageInput(path=...) on Responses must produce input_image with no filename leak."""
+        png = tmp_path / "plot.png"
+        png.write_bytes(self.SAMPLE_BYTES)
+
+        result = events_to_responses_input([ModelRequest([ImageInput(path=str(png))])], SerializerCls)
+
+        assert result == [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/png;base64,{base64.b64encode(self.SAMPLE_BYTES).decode()}",
+                    }
+                ],
+            }
+        ]
+
+    def test_responses_image_with_detail(self) -> None:
+        """Responses input_image carries 'detail' as a top-level key (schema differs from Chat Completions)."""
         result = events_to_responses_input(
             [
                 ModelRequest([
                     BinaryInput(
-                        data=self.SAMPLE_BYTES, media_type="image/png", vendor_metadata={"filename": "test.png"}
+                        data=self.SAMPLE_BYTES,
+                        media_type="image/png",
+                        vendor_metadata={"detail": "high"},
+                        kind=BinaryType.IMAGE,
+                    )
+                ])
+            ],
+            SerializerCls,
+        )
+
+        assert result[0]["content"][0] == IsPartialDict({"type": "input_image", "detail": "high"})
+
+    def test_responses_document_with_vendor_metadata(self) -> None:
+        result = events_to_responses_input(
+            [
+                ModelRequest([
+                    BinaryInput(
+                        data=self.SAMPLE_BYTES,
+                        media_type="application/pdf",
+                        vendor_metadata={"filename": "test.pdf"},
                     )
                 ])
             ],
@@ -251,7 +304,7 @@ class TestBinaryInput:
         assert result == [
             IsPartialDict({
                 "role": "user",
-                "content": [IsPartialDict({"type": "input_file", "filename": "test.png"})],
+                "content": [IsPartialDict({"type": "input_file", "filename": "test.pdf"})],
             })
         ]
 


### PR DESCRIPTION
## Why are these changes needed?

`ImageInput(path=...)` auto-populates `vendor_metadata={"filename": p.name}` for every local-file image. The OpenAI Chat Completions image branch in `autogen/beta/config/openai/mappers.py` was spreading that metadata directly onto the image content block (`{"type": "image_url", "image_url": {...}, **inp.vendor_metadata}`), which leaks `filename` to the wire and triggers a 400 from the API: *"Invalid chat format. Unexpected keys in a message content image dict."* 

The same call against `OpenAIResponsesConfig` raised a second, independent bug: the Responses user-message input path did not branch on `BinaryType.IMAGE` and always wrapped binary inputs as `input_file`, producing *"unsupported MIME type 'image/png'"*.

This PR extracts specific keys from `vendor_metadata` instead of spreading. The Chat Completions IMAGE branch now lifts `detail` into the nested `image_url` dict (where the OpenAI Chat schema expects it). The Responses input `BinaryInput` branch now splits on kind: IMAGE produces `{"type": "input_image", "image_url": "data:..."}` with optional top-level `detail` (the Responses schema flattens this), and DOCUMENT/BINARY produces `input_file` with explicitly-extracted filename plus a suffix-based fallback that mirrors the existing tool-results output path.

Two existing tests in `test/beta/config/openai/test_convert_messages.py` were asserting the buggy shapes and have been corrected; four new regression tests cover `ImageInput(path=...)` round-trips and `detail` placement on both Chat Completions and Responses. Verified end-to-end against live APIs with sample scripts for all four providers and both `ImageInput`/`DocumentInput`/`AudioInput` paths — every supported `(kind, provider)` combination now serialises correctly.

Anthropic and Gemini were unaffected — they already filter or ignore unknown vendor keys.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
