### PR TITLE
refactor(beta): use async SDK clients in search tools

### DIFF
--- a/autogen/beta/tools/search/exa.py
+++ b/autogen/beta/tools/search/exa.py
@@ -234,6 +234,7 @@ class ExaToolkit(Toolkit):
             }
             kwargs = {k: v for k, v in params.items() if v is not None}
             c = AsyncExa(api_key=api_key)
+            c.headers["x-exa-integration"] = "ag2"
             try:
                 raw = await c.find_similar(url, **kwargs)
             finally:
@@ -272,6 +273,7 @@ class ExaToolkit(Toolkit):
         ) -> ToolResult:
             """Fetch the full text content of specific URLs."""
             c = AsyncExa(api_key=api_key)
+            c.headers["x-exa-integration"] = "ag2"
             try:
                 raw = await c.get_contents(urls, text=True)
             finally:
@@ -306,6 +308,7 @@ class ExaToolkit(Toolkit):
         ) -> ToolResult:
             """Generate an AI answer with citations."""
             c = AsyncExa(api_key=api_key)
+            c.headers["x-exa-integration"] = "ag2"
             try:
                 raw = await c.answer(query, text=True)
             finally:

--- a/autogen/beta/tools/search/exa.py
+++ b/autogen/beta/tools/search/exa.py
@@ -103,7 +103,7 @@ class ExaToolkit(Toolkit):
     is omitted (handled by the underlying ``exa_py.AsyncExa`` SDK).
     """
 
-    __slots__ = ("_api_key", "_client")
+    __slots__ = ("_api_key",)
 
     def __init__(
         self,
@@ -111,11 +111,9 @@ class ExaToolkit(Toolkit):
         *,
         num_results: int | Variable | None = None,
         max_characters: int | Variable | None = None,
-        client: AsyncExa | None = None,
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
         self._api_key = api_key
-        self._client = client
 
         super().__init__(
             self.search(num_results=num_results, max_characters=max_characters),
@@ -139,7 +137,6 @@ class ExaToolkit(Toolkit):
         end_published_date: str | Variable | None = None,
         start_crawl_date: str | Variable | None = None,
         end_crawl_date: str | Variable | None = None,
-        use_autoprompt: bool | Variable | None = None,
         livecrawl: Livecrawl | Variable | None = None,
         name: str = "exa_search",
         description: str = (
@@ -149,7 +146,6 @@ class ExaToolkit(Toolkit):
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
         api_key = self._api_key
-        user_client = self._client
 
         @tool(name=name, description=description, middleware=middleware)
         async def exa_search(
@@ -167,28 +163,24 @@ class ExaToolkit(Toolkit):
                 "end_published_date": resolve_variable(end_published_date, ctx, param_name="end_published_date"),
                 "start_crawl_date": resolve_variable(start_crawl_date, ctx, param_name="start_crawl_date"),
                 "end_crawl_date": resolve_variable(end_crawl_date, ctx, param_name="end_crawl_date"),
-                "use_autoprompt": resolve_variable(use_autoprompt, ctx, param_name="use_autoprompt"),
-                "livecrawl": resolve_variable(livecrawl, ctx, param_name="livecrawl"),
             }
             kwargs = {k: v for k, v in params.items() if v is not None}
+
+            contents: dict[str, Any] = {}
             resolved_max_chars = resolve_variable(max_characters, ctx, param_name="max_characters")
             if resolved_max_chars is not None:
-                kwargs["text"] = {"maxCharacters": resolved_max_chars}
+                contents["text"] = {"maxCharacters": resolved_max_chars}
+            resolved_livecrawl = resolve_variable(livecrawl, ctx, param_name="livecrawl")
+            if resolved_livecrawl is not None:
+                contents["livecrawl"] = resolved_livecrawl
+            if contents:
+                kwargs["contents"] = contents
 
-            if user_client is not None:
-                if resolved_max_chars is not None:
-                    raw = await user_client.search_and_contents(query, **kwargs)
-                else:
-                    raw = await user_client.search(query, **kwargs)
-            else:
-                c = AsyncExa(api_key=api_key)
-                try:
-                    if resolved_max_chars is not None:
-                        raw = await c.search_and_contents(query, **kwargs)
-                    else:
-                        raw = await c.search(query, **kwargs)
-                finally:
-                    await c.client.aclose()
+            c = AsyncExa(api_key=api_key)
+            try:
+                raw = await c.search(query, **kwargs)
+            finally:
+                await c.client.aclose()
 
             return ToolResult(
                 ExaSearchResponse(
@@ -223,7 +215,6 @@ class ExaToolkit(Toolkit):
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
         api_key = self._api_key
-        user_client = self._client
 
         @tool(name=name, description=description, middleware=middleware)
         async def exa_find_similar(
@@ -238,14 +229,11 @@ class ExaToolkit(Toolkit):
                 ),
             }
             kwargs = {k: v for k, v in params.items() if v is not None}
-            if user_client is not None:
-                raw = await user_client.find_similar(url, **kwargs)
-            else:
-                c = AsyncExa(api_key=api_key)
-                try:
-                    raw = await c.find_similar(url, **kwargs)
-                finally:
-                    await c.client.aclose()
+            c = AsyncExa(api_key=api_key)
+            try:
+                raw = await c.find_similar(url, **kwargs)
+            finally:
+                await c.client.aclose()
             results = [
                 ExaSearchResult(
                     title=r.title or "",
@@ -272,7 +260,6 @@ class ExaToolkit(Toolkit):
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
         api_key = self._api_key
-        user_client = self._client
 
         @tool(name=name, description=description, middleware=middleware)
         async def exa_get_contents(
@@ -280,14 +267,11 @@ class ExaToolkit(Toolkit):
             ctx: Context,
         ) -> ToolResult:
             """Fetch the full text content of specific URLs."""
-            if user_client is not None:
-                raw = await user_client.get_contents(urls, text=True)
-            else:
-                c = AsyncExa(api_key=api_key)
-                try:
-                    raw = await c.get_contents(urls, text=True)
-                finally:
-                    await c.client.aclose()
+            c = AsyncExa(api_key=api_key)
+            try:
+                raw = await c.get_contents(urls, text=True)
+            finally:
+                await c.client.aclose()
             results = [
                 ExaContentResult(
                     url=r.url,
@@ -310,7 +294,6 @@ class ExaToolkit(Toolkit):
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
         api_key = self._api_key
-        user_client = self._client
 
         @tool(name=name, description=description, middleware=middleware)
         async def exa_answer(
@@ -318,14 +301,11 @@ class ExaToolkit(Toolkit):
             ctx: Context,
         ) -> ToolResult:
             """Generate an AI answer with citations."""
-            if user_client is not None:
-                raw = await user_client.answer(query, text=True)
-            else:
-                c = AsyncExa(api_key=api_key)
-                try:
-                    raw = await c.answer(query, text=True)
-                finally:
-                    await c.client.aclose()
+            c = AsyncExa(api_key=api_key)
+            try:
+                raw = await c.answer(query, text=True)
+            finally:
+                await c.client.aclose()
             return ToolResult(
                 ExaAnswerResult(
                     answer=raw.answer,

--- a/autogen/beta/tools/search/exa.py
+++ b/autogen/beta/tools/search/exa.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, TypeAlias
 
-from exa_py import Exa
+from exa_py import AsyncExa
 from pydantic import Field
 
 from autogen.beta.annotations import Context, Variable
@@ -70,10 +70,6 @@ class ExaAnswerResult:
     citations: list[ExaAnswerCitation] = field(default_factory=list)
 
 
-def _clean(d: dict[str, Any]) -> dict[str, Any]:
-    return {k: v for k, v in d.items() if v is not None}
-
-
 class ExaToolkit(Toolkit):
     """Toolkit that exposes the Exa neural search engine as four related tools
     sharing one HTTP client.
@@ -104,10 +100,10 @@ class ExaToolkit(Toolkit):
         )
 
     The constructor reads ``EXA_API_KEY`` from the environment when ``api_key``
-    is omitted (handled by the underlying ``exa_py.Exa`` SDK).
+    is omitted (handled by the underlying ``exa_py.AsyncExa`` SDK).
     """
 
-    __slots__ = ("_client",)
+    __slots__ = ("_api_key", "_client")
 
     def __init__(
         self,
@@ -115,10 +111,11 @@ class ExaToolkit(Toolkit):
         *,
         num_results: int | Variable | None = None,
         max_characters: int | Variable | None = None,
-        client: Exa | None = None,
+        client: AsyncExa | None = None,
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
-        self._client = client if client is not None else Exa(api_key=api_key)
+        self._api_key = api_key
+        self._client = client
 
         super().__init__(
             self.search(num_results=num_results, max_characters=max_characters),
@@ -151,15 +148,16 @@ class ExaToolkit(Toolkit):
         ),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
-        client = self._client
+        api_key = self._api_key
+        user_client = self._client
 
         @tool(name=name, description=description, middleware=middleware)
-        def exa_search(
+        async def exa_search(
             query: Annotated[str, Field(description="The search query string.")],
             ctx: Context,
         ) -> ToolResult:
             """Search the web using Exa and return ranked results."""
-            kwargs = _clean({
+            params: dict[str, Any] = {
                 "num_results": resolve_variable(num_results, ctx, param_name="num_results"),
                 "type": resolve_variable(search_type, ctx, param_name="search_type"),
                 "category": resolve_variable(category, ctx, param_name="category"),
@@ -171,13 +169,26 @@ class ExaToolkit(Toolkit):
                 "end_crawl_date": resolve_variable(end_crawl_date, ctx, param_name="end_crawl_date"),
                 "use_autoprompt": resolve_variable(use_autoprompt, ctx, param_name="use_autoprompt"),
                 "livecrawl": resolve_variable(livecrawl, ctx, param_name="livecrawl"),
-            })
+            }
+            kwargs = {k: v for k, v in params.items() if v is not None}
             resolved_max_chars = resolve_variable(max_characters, ctx, param_name="max_characters")
             if resolved_max_chars is not None:
                 kwargs["text"] = {"maxCharacters": resolved_max_chars}
-                raw = client.search_and_contents(query, **kwargs)
+
+            if user_client is not None:
+                if resolved_max_chars is not None:
+                    raw = await user_client.search_and_contents(query, **kwargs)
+                else:
+                    raw = await user_client.search(query, **kwargs)
             else:
-                raw = client.search(query, **kwargs)
+                c = AsyncExa(api_key=api_key)
+                try:
+                    if resolved_max_chars is not None:
+                        raw = await c.search_and_contents(query, **kwargs)
+                    else:
+                        raw = await c.search(query, **kwargs)
+                finally:
+                    await c.client.aclose()
 
             return ToolResult(
                 ExaSearchResponse(
@@ -211,21 +222,30 @@ class ExaToolkit(Toolkit):
         ),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
-        client = self._client
+        api_key = self._api_key
+        user_client = self._client
 
         @tool(name=name, description=description, middleware=middleware)
-        def exa_find_similar(
+        async def exa_find_similar(
             url: Annotated[str, Field(description="The URL to find similar pages for.")],
             ctx: Context,
         ) -> ToolResult:
             """Find pages similar to a given URL."""
-            kwargs = _clean({
+            params: dict[str, Any] = {
                 "num_results": resolve_variable(num_results, ctx, param_name="num_results"),
                 "exclude_source_domain": resolve_variable(
                     exclude_source_domain, ctx, param_name="exclude_source_domain"
                 ),
-            })
-            raw = client.find_similar(url, **kwargs)
+            }
+            kwargs = {k: v for k, v in params.items() if v is not None}
+            if user_client is not None:
+                raw = await user_client.find_similar(url, **kwargs)
+            else:
+                c = AsyncExa(api_key=api_key)
+                try:
+                    raw = await c.find_similar(url, **kwargs)
+                finally:
+                    await c.client.aclose()
             results = [
                 ExaSearchResult(
                     title=r.title or "",
@@ -251,15 +271,23 @@ class ExaToolkit(Toolkit):
         ),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
-        client = self._client
+        api_key = self._api_key
+        user_client = self._client
 
         @tool(name=name, description=description, middleware=middleware)
-        def exa_get_contents(
+        async def exa_get_contents(
             urls: Annotated[list[str], Field(description="URLs to fetch content for.")],
             ctx: Context,
         ) -> ToolResult:
             """Fetch the full text content of specific URLs."""
-            raw = client.get_contents(urls, text=True)
+            if user_client is not None:
+                raw = await user_client.get_contents(urls, text=True)
+            else:
+                c = AsyncExa(api_key=api_key)
+                try:
+                    raw = await c.get_contents(urls, text=True)
+                finally:
+                    await c.client.aclose()
             results = [
                 ExaContentResult(
                     url=r.url,
@@ -281,15 +309,23 @@ class ExaToolkit(Toolkit):
         description: str = ("Generate an AI-powered answer to a question with citations from web sources."),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
-        client = self._client
+        api_key = self._api_key
+        user_client = self._client
 
         @tool(name=name, description=description, middleware=middleware)
-        def exa_answer(
+        async def exa_answer(
             query: Annotated[str, Field(description="The question to answer.")],
             ctx: Context,
         ) -> ToolResult:
             """Generate an AI answer with citations."""
-            raw = client.answer(query, text=True)
+            if user_client is not None:
+                raw = await user_client.answer(query, text=True)
+            else:
+                c = AsyncExa(api_key=api_key)
+                try:
+                    raw = await c.answer(query, text=True)
+                finally:
+                    await c.client.aclose()
             return ToolResult(
                 ExaAnswerResult(
                     answer=raw.answer,

--- a/autogen/beta/tools/search/perplexity.py
+++ b/autogen/beta/tools/search/perplexity.py
@@ -85,7 +85,7 @@ class PerplexitySearchToolkit(Toolkit):
     ``api_key`` is omitted (handled by the underlying ``perplexity.AsyncPerplexity`` SDK).
     """
 
-    __slots__ = ("_api_key", "_proxy", "_verify", "_timeout")
+    __slots__ = ("_api_key", "_proxy", "_verify", "_timeout", "_client_kwargs")
 
     def __init__(
         self,
@@ -94,12 +94,14 @@ class PerplexitySearchToolkit(Toolkit):
         proxy: str | None = None,
         verify: bool = True,
         timeout: float | None = None,
+        client_kwargs: dict[str, Any] | None = None,
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
         self._api_key = api_key
         self._proxy = proxy
         self._verify = verify
         self._timeout = timeout
+        self._client_kwargs = client_kwargs or {}
 
         super().__init__(
             self.search(),
@@ -129,6 +131,7 @@ class PerplexitySearchToolkit(Toolkit):
         proxy = self._proxy
         verify = self._verify
         timeout = self._timeout
+        client_kwargs = self._client_kwargs
 
         @tool(name=name, description=description, middleware=middleware)
         async def perplexity_search(
@@ -153,7 +156,7 @@ class PerplexitySearchToolkit(Toolkit):
             kwargs = {k: v for k, v in params.items() if v is not None}
 
             async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
-                sdk = AsyncPerplexity(api_key=api_key, http_client=http)
+                sdk = AsyncPerplexity(api_key=api_key, http_client=http, **client_kwargs)
                 raw = await sdk.search.create(query=query, **kwargs)
 
             raw_results: list[SearchAPIResult] = getattr(raw, "results", None) or []
@@ -194,6 +197,7 @@ class PerplexitySearchToolkit(Toolkit):
         proxy = self._proxy
         verify = self._verify
         timeout = self._timeout
+        client_kwargs = self._client_kwargs
 
         @tool(name=name, description=description, middleware=middleware)
         async def perplexity_answer(
@@ -231,7 +235,7 @@ class PerplexitySearchToolkit(Toolkit):
                 **kwargs,
             }
             async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
-                sdk = AsyncPerplexity(api_key=api_key, http_client=http)
+                sdk = AsyncPerplexity(api_key=api_key, http_client=http, **client_kwargs)
                 raw = await sdk.chat.completions.create(**create_kwargs)
 
             content: str | None = None

--- a/autogen/beta/tools/search/perplexity.py
+++ b/autogen/beta/tools/search/perplexity.py
@@ -95,7 +95,7 @@ class PerplexitySearchToolkit(Toolkit):
         verify: bool = True,
         timeout: float | None = None,
         middleware: Iterable[ToolMiddleware] = (),
-        **client_kwargs: dict[str, Any] | None = None,
+        **client_kwargs: Any,
     ) -> None:
         self._api_key = api_key
         self._proxy = proxy

--- a/autogen/beta/tools/search/perplexity.py
+++ b/autogen/beta/tools/search/perplexity.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, TypeAlias
 
-from perplexity import Perplexity
+from perplexity import AsyncPerplexity
 from perplexity.types import APIPublicSearchResult
 from perplexity.types.search_create_response import Result as SearchAPIResult
 from pydantic import Field
@@ -81,19 +81,20 @@ class PerplexitySearchToolkit(Toolkit):
         )
 
     The constructor reads ``PERPLEXITY_API_KEY`` from the environment when
-    ``api_key`` is omitted (handled by the underlying ``perplexity.Perplexity`` SDK).
+    ``api_key`` is omitted (handled by the underlying ``perplexity.AsyncPerplexity`` SDK).
     """
 
-    __slots__ = ("_client",)
+    __slots__ = ("_api_key", "_client")
 
     def __init__(
         self,
         api_key: str | None = None,
         *,
-        client: Perplexity | None = None,
+        client: AsyncPerplexity | None = None,
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
-        self._client = client if client is not None else Perplexity(api_key=api_key)
+        self._api_key = api_key
+        self._client = client
 
         super().__init__(
             self.search(),
@@ -103,14 +104,17 @@ class PerplexitySearchToolkit(Toolkit):
         )
 
     def __deepcopy__(self, memo: dict[int, Any]) -> "PerplexitySearchToolkit":
-        # The Perplexity SDK wraps httpx.Client, whose state holds a _thread.RLock
-        # that fails pickle-based deepcopy. Because Agent.add_tool calls deepcopy
-        # on each registered tool (function_tool.py:99), passing the toolkit
-        # whole (tools=[toolkit]) would otherwise raise TypeError: cannot pickle '_thread.RLock' object.
+        # Supports the `client=AsyncPerplexity(...)` use-case (e.g. custom proxied
+        # httpx.AsyncClient) when the toolkit is passed whole (tools=[toolkit]).
+        # The Perplexity SDK wraps httpx.AsyncClient, whose state holds a
+        # _thread.RLock that fails pickle-based deepcopy. Agent.add_tool calls
+        # deepcopy on each registered tool (function_tool.py:99), so without this
+        # override that flow raises TypeError: cannot pickle '_thread.RLock' object.
         # The override copies the _tools dict but shares the SDK client by reference
-        # (the client is thread-safe and stateless across requests)
+        # (the client is thread-safe and stateless across requests).
         new = self.__class__.__new__(self.__class__)
         memo[id(self)] = new
+        new._api_key = self._api_key
         new._client = self._client
         new.name = self.name
         new._middleware = self._middleware
@@ -134,10 +138,11 @@ class PerplexitySearchToolkit(Toolkit):
         ),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
-        client = self._client
+        api_key = self._api_key
+        user_client = self._client
 
         @tool(name=name, description=description, middleware=middleware)
-        def perplexity_search(
+        async def perplexity_search(
             query: Annotated[str, Field(description="The search query string.")],
             ctx: Context,
         ) -> ToolResult:
@@ -158,7 +163,11 @@ class PerplexitySearchToolkit(Toolkit):
             }
             kwargs = {k: v for k, v in params.items() if v is not None}
 
-            raw = client.search.create(query=query, **kwargs)
+            if user_client is not None:
+                raw = await user_client.search.create(query=query, **kwargs)
+            else:
+                async with AsyncPerplexity(api_key=api_key) as c:
+                    raw = await c.search.create(query=query, **kwargs)
 
             raw_results: list[SearchAPIResult] = getattr(raw, "results", None) or []
             results = [
@@ -194,10 +203,11 @@ class PerplexitySearchToolkit(Toolkit):
         ),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
-        client = self._client
+        api_key = self._api_key
+        user_client = self._client
 
         @tool(name=name, description=description, middleware=middleware)
-        def perplexity_answer(
+        async def perplexity_answer(
             query: Annotated[str, Field(description="The question to answer.")],
             ctx: Context,
         ) -> ToolResult:
@@ -221,16 +231,21 @@ class PerplexitySearchToolkit(Toolkit):
             }
             kwargs = {k: v for k, v in params.items() if v is not None}
 
-            raw = client.chat.completions.create(
-                model=resolved_model,
-                messages=[
+            create_kwargs: dict[str, Any] = {
+                "model": resolved_model,
+                "messages": [
                     {"role": "system", "content": "Be precise and concise."},
                     {"role": "user", "content": query},
                 ],
-                max_tokens=resolved_max_tokens,
-                web_search_options={"search_context_size": resolved_context_size},
+                "max_tokens": resolved_max_tokens,
+                "web_search_options": {"search_context_size": resolved_context_size},
                 **kwargs,
-            )
+            }
+            if user_client is not None:
+                raw = await user_client.chat.completions.create(**create_kwargs)
+            else:
+                async with AsyncPerplexity(api_key=api_key) as c:
+                    raw = await c.chat.completions.create(**create_kwargs)
 
             content: str | None = None
             choices = getattr(raw, "choices", None) or []

--- a/autogen/beta/tools/search/perplexity.py
+++ b/autogen/beta/tools/search/perplexity.py
@@ -94,14 +94,14 @@ class PerplexitySearchToolkit(Toolkit):
         proxy: str | None = None,
         verify: bool = True,
         timeout: float | None = None,
-        client_kwargs: dict[str, Any] | None = None,
         middleware: Iterable[ToolMiddleware] = (),
+        **client_kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._api_key = api_key
         self._proxy = proxy
         self._verify = verify
         self._timeout = timeout
-        self._client_kwargs = client_kwargs or {}
+        self._client_kwargs = client_kwargs
 
         super().__init__(
             self.search(),

--- a/autogen/beta/tools/search/perplexity.py
+++ b/autogen/beta/tools/search/perplexity.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, TypeAlias
 
+import httpx
 from perplexity import AsyncPerplexity
 from perplexity.types import APIPublicSearchResult
 from perplexity.types.search_create_response import Result as SearchAPIResult
@@ -84,17 +85,21 @@ class PerplexitySearchToolkit(Toolkit):
     ``api_key`` is omitted (handled by the underlying ``perplexity.AsyncPerplexity`` SDK).
     """
 
-    __slots__ = ("_api_key", "_client")
+    __slots__ = ("_api_key", "_proxy", "_verify", "_timeout")
 
     def __init__(
         self,
         api_key: str | None = None,
         *,
-        client: AsyncPerplexity | None = None,
+        proxy: str | None = None,
+        verify: bool = True,
+        timeout: float | None = None,
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
         self._api_key = api_key
-        self._client = client
+        self._proxy = proxy
+        self._verify = verify
+        self._timeout = timeout
 
         super().__init__(
             self.search(),
@@ -102,24 +107,6 @@ class PerplexitySearchToolkit(Toolkit):
             name="perplexity_toolkit",
             middleware=middleware,
         )
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> "PerplexitySearchToolkit":
-        # Supports the `client=AsyncPerplexity(...)` use-case (e.g. custom proxied
-        # httpx.AsyncClient) when the toolkit is passed whole (tools=[toolkit]).
-        # The Perplexity SDK wraps httpx.AsyncClient, whose state holds a
-        # _thread.RLock that fails pickle-based deepcopy. Agent.add_tool calls
-        # deepcopy on each registered tool (function_tool.py:99), so without this
-        # override that flow raises TypeError: cannot pickle '_thread.RLock' object.
-        # The override copies the _tools dict but shares the SDK client by reference
-        # (the client is thread-safe and stateless across requests).
-        new = self.__class__.__new__(self.__class__)
-        memo[id(self)] = new
-        new._api_key = self._api_key
-        new._client = self._client
-        new.name = self.name
-        new._middleware = self._middleware
-        new._tools = dict(self._tools)
-        return new
 
     def search(
         self,
@@ -139,7 +126,9 @@ class PerplexitySearchToolkit(Toolkit):
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
         api_key = self._api_key
-        user_client = self._client
+        proxy = self._proxy
+        verify = self._verify
+        timeout = self._timeout
 
         @tool(name=name, description=description, middleware=middleware)
         async def perplexity_search(
@@ -163,11 +152,9 @@ class PerplexitySearchToolkit(Toolkit):
             }
             kwargs = {k: v for k, v in params.items() if v is not None}
 
-            if user_client is not None:
-                raw = await user_client.search.create(query=query, **kwargs)
-            else:
-                async with AsyncPerplexity(api_key=api_key) as c:
-                    raw = await c.search.create(query=query, **kwargs)
+            async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
+                sdk = AsyncPerplexity(api_key=api_key, http_client=http)
+                raw = await sdk.search.create(query=query, **kwargs)
 
             raw_results: list[SearchAPIResult] = getattr(raw, "results", None) or []
             results = [
@@ -204,7 +191,9 @@ class PerplexitySearchToolkit(Toolkit):
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
         api_key = self._api_key
-        user_client = self._client
+        proxy = self._proxy
+        verify = self._verify
+        timeout = self._timeout
 
         @tool(name=name, description=description, middleware=middleware)
         async def perplexity_answer(
@@ -241,11 +230,9 @@ class PerplexitySearchToolkit(Toolkit):
                 "web_search_options": {"search_context_size": resolved_context_size},
                 **kwargs,
             }
-            if user_client is not None:
-                raw = await user_client.chat.completions.create(**create_kwargs)
-            else:
-                async with AsyncPerplexity(api_key=api_key) as c:
-                    raw = await c.chat.completions.create(**create_kwargs)
+            async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
+                sdk = AsyncPerplexity(api_key=api_key, http_client=http)
+                raw = await sdk.chat.completions.create(**create_kwargs)
 
             content: str | None = None
             choices = getattr(raw, "choices", None) or []

--- a/autogen/beta/tools/search/tavily.py
+++ b/autogen/beta/tools/search/tavily.py
@@ -65,7 +65,6 @@ class TavilySearchTool(Tool):
         proxy: str | None = None,
         verify: bool = True,
         timeout: float | None = None,
-        client_kwargs: dict[str, Any] | None = None,
         name: str = "tavily_search",
         *,
         description: str = (
@@ -73,9 +72,8 @@ class TavilySearchTool(Tool):
             "and optional LLM-generated answer, raw content, and images."
         ),
         middleware: Iterable[ToolMiddleware] = (),
+        **client_kwargs: Any
     ) -> None:
-        client_kwargs = client_kwargs or {}
-
         @tool(
             name=name,
             description=description,

--- a/autogen/beta/tools/search/tavily.py
+++ b/autogen/beta/tools/search/tavily.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, TypeAlias
 
 from pydantic import Field
-from tavily import TavilyClient
+from tavily import AsyncTavilyClient
 
 from autogen.beta.annotations import Context, Variable
 from autogen.beta.events import ToolResult
@@ -61,7 +61,7 @@ class TavilySearchTool(Tool):
         country: str | Variable | None = None,
         auto_parameters: bool | Variable | None = None,
         include_favicon: bool | Variable | None = None,
-        client: TavilyClient | None = None,
+        client: AsyncTavilyClient | None = None,
         name: str = "tavily_search",
         *,
         description: str = (
@@ -70,14 +70,14 @@ class TavilySearchTool(Tool):
         ),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
-        _client = client if client is not None else TavilyClient(api_key=api_key)
+        user_client = client
 
         @tool(
             name=name,
             description=description,
             middleware=middleware,
         )
-        def tavily_search(
+        async def tavily_search(
             query: Annotated[str, Field(description="The search query string.")],
             ctx: Context,
         ) -> ToolResult:
@@ -101,7 +101,12 @@ class TavilySearchTool(Tool):
             }
             kwargs = {k: v for k, v in params.items() if v is not None}
 
-            raw = _client.search(query, **kwargs)
+            if user_client is not None:
+                raw = await user_client.search(query, **kwargs)
+            else:
+                async with AsyncTavilyClient(api_key=api_key) as c:
+                    raw = await c.search(query, **kwargs)
+
             results = [
                 SearchResult(
                     title=r.get("title", ""),

--- a/autogen/beta/tools/search/tavily.py
+++ b/autogen/beta/tools/search/tavily.py
@@ -65,6 +65,7 @@ class TavilySearchTool(Tool):
         proxy: str | None = None,
         verify: bool = True,
         timeout: float | None = None,
+        client_kwargs: dict[str, Any] | None = None,
         name: str = "tavily_search",
         *,
         description: str = (
@@ -73,6 +74,8 @@ class TavilySearchTool(Tool):
         ),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
+        client_kwargs = client_kwargs or {}
+
         @tool(
             name=name,
             description=description,
@@ -103,7 +106,7 @@ class TavilySearchTool(Tool):
             kwargs = {k: v for k, v in params.items() if v is not None}
 
             async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
-                sdk = AsyncTavilyClient(api_key=api_key, client=http)
+                sdk = AsyncTavilyClient(api_key=api_key, client=http, **client_kwargs)
                 raw = await sdk.search(query, **kwargs)
 
             results = [

--- a/autogen/beta/tools/search/tavily.py
+++ b/autogen/beta/tools/search/tavily.py
@@ -72,7 +72,7 @@ class TavilySearchTool(Tool):
             "and optional LLM-generated answer, raw content, and images."
         ),
         middleware: Iterable[ToolMiddleware] = (),
-        **client_kwargs: Any
+        **client_kwargs: Any,
     ) -> None:
         @tool(
             name=name,

--- a/autogen/beta/tools/search/tavily.py
+++ b/autogen/beta/tools/search/tavily.py
@@ -7,6 +7,7 @@ from contextlib import ExitStack
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, TypeAlias
 
+import httpx
 from pydantic import Field
 from tavily import AsyncTavilyClient
 
@@ -61,7 +62,9 @@ class TavilySearchTool(Tool):
         country: str | Variable | None = None,
         auto_parameters: bool | Variable | None = None,
         include_favicon: bool | Variable | None = None,
-        client: AsyncTavilyClient | None = None,
+        proxy: str | None = None,
+        verify: bool = True,
+        timeout: float | None = None,
         name: str = "tavily_search",
         *,
         description: str = (
@@ -70,8 +73,6 @@ class TavilySearchTool(Tool):
         ),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
-        user_client = client
-
         @tool(
             name=name,
             description=description,
@@ -101,11 +102,9 @@ class TavilySearchTool(Tool):
             }
             kwargs = {k: v for k, v in params.items() if v is not None}
 
-            if user_client is not None:
-                raw = await user_client.search(query, **kwargs)
-            else:
-                async with AsyncTavilyClient(api_key=api_key) as c:
-                    raw = await c.search(query, **kwargs)
+            async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
+                sdk = AsyncTavilyClient(api_key=api_key, client=http)
+                raw = await sdk.search(query, **kwargs)
 
             results = [
                 SearchResult(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -328,6 +328,7 @@ test = [
     "mcp>=1.11.0",
     # test utilities
     "aiofiles>=24.1.0,<26.0.0",
+    "respx>=0.23.0,<0.24.0"
 ]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,6 +315,7 @@ test-core = [
     "pytest-timeout>=2.4.0,<3",
     "dirty-equals>=0.11,<0.12",
     "freezegun>=1.5.5,<2",
+    "respx>=0.23.0,<0.24.0"
 ]
 
 test = [
@@ -328,7 +329,6 @@ test = [
     "mcp>=1.11.0",
     # test utilities
     "aiofiles>=24.1.0,<26.0.0",
-    "respx>=0.23.0,<0.24.0"
 ]
 
 docs = [

--- a/test/beta/tools/search/test_exa.py
+++ b/test/beta/tools/search/test_exa.py
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from typing import Any
 
+import httpx
 import pytest
+import respx
 from dirty_equals import IsPartialDict
 
 pytest.importorskip("exa_py")
@@ -24,28 +25,7 @@ from autogen.beta.tools.search.exa import (
     ExaToolkit,
 )
 
-
-def _result(
-    *,
-    title: str = "AG2 Framework",
-    url: str = "https://ag2.ai",
-    score: float | None = 0.95,
-    published_date: str | None = "2024-01-01",
-    author: str | None = "ag2ai",
-    text: str | None = None,
-) -> SimpleNamespace:
-    return SimpleNamespace(
-        title=title,
-        url=url,
-        score=score,
-        published_date=published_date,
-        author=author,
-        text=text,
-    )
-
-
-def _response(results: list[SimpleNamespace], autoprompt_string: str | None = None) -> SimpleNamespace:
-    return SimpleNamespace(results=results, autoprompt_string=autoprompt_string)
+EXA_BASE_URL = "https://api.exa.ai"
 
 
 def _tool_call_config(
@@ -64,10 +44,29 @@ def _tool_call_config(
     )
 
 
+def _exa_result(
+    *,
+    title: str = "AG2 Framework",
+    url: str = "https://ag2.ai",
+    score: float | None = 0.95,
+    published_date: str | None = "2024-01-01",
+    author: str | None = "ag2ai",
+    text: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "title": title,
+        "url": url,
+        "score": score,
+        "publishedDate": published_date,
+        "author": author,
+        "text": text,
+    }
+
+
 @pytest.mark.asyncio
 class TestSchema:
     async def test_default_schemas(self, context: ConversationContext) -> None:
-        toolkit = ExaToolkit(client=AsyncMock())
+        toolkit = ExaToolkit(api_key="test")
 
         schemas = list(await toolkit.schemas(context))
 
@@ -75,7 +74,7 @@ class TestSchema:
         assert names == ["exa_search", "exa_find_similar", "exa_get_contents", "exa_answer"]
 
     async def test_search_schema_has_query_param(self, context: ConversationContext) -> None:
-        toolkit = ExaToolkit(client=AsyncMock())
+        toolkit = ExaToolkit(api_key="test")
 
         schemas = list(await toolkit.schemas(context))
         search_schema = next(s for s in schemas if s.function.name == "exa_search")
@@ -86,7 +85,7 @@ class TestSchema:
         })
 
     async def test_custom_tool_name_and_description(self, context: ConversationContext) -> None:
-        toolkit = ExaToolkit(client=AsyncMock())
+        toolkit = ExaToolkit(api_key="test")
         custom = toolkit.search(name="neural_search", description="Custom neural search.")
 
         [schema] = list(await custom.schemas(context))
@@ -97,12 +96,20 @@ class TestSchema:
 
 @pytest.mark.asyncio
 class TestSearchExecution:
-    async def test_returns_structured_results(self, async_mock: AsyncMock) -> None:
-        async_mock.search.return_value = _response([
-            _result(title="AG2 Framework", url="https://ag2.ai", score=0.95, text=None),
-            _result(title="GitHub - AG2", url="https://github.com/ag2ai/ag2", score=0.82, text=None),
-        ])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_returns_structured_results(self) -> None:
+        respx.post(f"{EXA_BASE_URL}/search").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        _exa_result(title="AG2 Framework", url="https://ag2.ai", score=0.95),
+                        _exa_result(title="GitHub - AG2", url="https://github.com/ag2ai/ag2", score=0.82),
+                    ],
+                },
+            )
+        )
+        toolkit = ExaToolkit(api_key="test")
 
         config = TrackingConfig(_tool_call_config({"query": "AG2 framework"}, tool_name="exa_search"))
         agent = Agent("a", config=config, tools=[toolkit])
@@ -131,13 +138,13 @@ class TestSearchExecution:
                         text=None,
                     ),
                 ],
-                autoprompt_string=None,
             )
         )
 
-    async def test_empty_results(self, async_mock: AsyncMock) -> None:
-        async_mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_empty_results(self) -> None:
+        respx.post(f"{EXA_BASE_URL}/search").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test")
 
         config = TrackingConfig(_tool_call_config({"query": "nothing"}, tool_name="exa_search"))
         agent = Agent("a", config=config, tools=[toolkit])
@@ -149,19 +156,21 @@ class TestSearchExecution:
             ExaSearchResponse(query="nothing", results=[])
         )
 
-    async def test_none_params_omitted(self, async_mock: AsyncMock) -> None:
-        async_mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_none_params_omitted(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/search").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test")
 
         agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="exa_search"), tools=[toolkit])
-
         await agent.ask("search")
 
-        async_mock.search.assert_called_once_with("q")
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({"query": "q"})
 
-    async def test_all_params_forwarded(self, async_mock: AsyncMock) -> None:
-        async_mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_all_params_forwarded(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/search").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test")
         search_tool = toolkit.search(
             num_results=7,
             search_type="neural",
@@ -172,35 +181,33 @@ class TestSearchExecution:
             end_published_date="2024-12-31",
             start_crawl_date="2024-01-01",
             end_crawl_date="2024-12-31",
-            use_autoprompt=True,
             livecrawl="always",
         )
 
-        agent = Agent(
-            "a",
-            config=_tool_call_config({"query": "q"}, tool_name="exa_search"),
-            tools=[search_tool],
-        )
+        agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="exa_search"), tools=[search_tool])
         await agent.ask("search")
 
-        async_mock.search.assert_called_once_with(
-            "q",
-            num_results=7,
-            type="neural",
-            category="research paper",
-            include_domains=["arxiv.org"],
-            exclude_domains=["medium.com"],
-            start_published_date="2024-01-01",
-            end_published_date="2024-12-31",
-            start_crawl_date="2024-01-01",
-            end_crawl_date="2024-12-31",
-            use_autoprompt=True,
-            livecrawl="always",
-        )
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({
+            "query": "q",
+            "numResults": 7,
+            "type": "neural",
+            "category": "research paper",
+            "includeDomains": ["arxiv.org"],
+            "excludeDomains": ["medium.com"],
+            "startPublishedDate": "2024-01-01",
+            "endPublishedDate": "2024-12-31",
+            "startCrawlDate": "2024-01-01",
+            "endCrawlDate": "2024-12-31",
+            "contents": IsPartialDict({"livecrawl": "always"}),
+        })
 
-    async def test_search_and_contents_when_max_characters_set_on_method(self, async_mock: AsyncMock) -> None:
-        async_mock.search_and_contents.return_value = _response([_result(text="full article text")])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_search_and_contents_when_max_characters_set_on_method(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json={"results": [_exa_result(text="full article text")]})
+        )
+        toolkit = ExaToolkit(api_key="test")
 
         agent = Agent(
             "a",
@@ -209,42 +216,46 @@ class TestSearchExecution:
         )
         await agent.ask("search")
 
-        async_mock.search.assert_not_called()
-        async_mock.search_and_contents.assert_called_once_with("q", text={"maxCharacters": 500})
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({
+            "query": "q",
+            "contents": IsPartialDict({"text": IsPartialDict({"maxCharacters": 500})}),
+        })
 
-    async def test_toolkit_level_max_characters_applied_to_default_search(self, async_mock: AsyncMock) -> None:
-        async_mock.search_and_contents.return_value = _response([])
-        toolkit = ExaToolkit(client=async_mock, max_characters=800)
+    @respx.mock
+    async def test_toolkit_level_max_characters_applied_to_default_search(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/search").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test", max_characters=800)
 
-        agent = Agent(
-            "a",
-            config=_tool_call_config({"query": "q"}, tool_name="exa_search"),
-            tools=[toolkit],
-        )
+        agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="exa_search"), tools=[toolkit])
         await agent.ask("search")
 
-        async_mock.search.assert_not_called()
-        async_mock.search_and_contents.assert_called_once_with("q", text={"maxCharacters": 800})
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({
+            "query": "q",
+            "contents": IsPartialDict({"text": IsPartialDict({"maxCharacters": 800})}),
+        })
 
-    async def test_toolkit_level_num_results_applied_to_default_search(self, async_mock: AsyncMock) -> None:
-        async_mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=async_mock, num_results=7)
+    @respx.mock
+    async def test_toolkit_level_num_results_applied_to_default_search(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/search").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test", num_results=7)
 
-        agent = Agent(
-            "a",
-            config=_tool_call_config({"query": "q"}, tool_name="exa_search"),
-            tools=[toolkit],
-        )
+        agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="exa_search"), tools=[toolkit])
         await agent.ask("search")
 
-        async_mock.search.assert_called_once_with("q", num_results=7)
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({"query": "q", "numResults": 7})
 
 
 @pytest.mark.asyncio
 class TestFindSimilar:
-    async def test_num_results_forwarded_from_method(self, async_mock: AsyncMock) -> None:
-        async_mock.find_similar.return_value = _response([_result(title="Similar page")])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_num_results_forwarded_from_method(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/findSimilar").mock(
+            return_value=httpx.Response(200, json={"results": [_exa_result(title="Similar page")]})
+        )
+        toolkit = ExaToolkit(api_key="test")
 
         agent = Agent(
             "a",
@@ -253,11 +264,13 @@ class TestFindSimilar:
         )
         await agent.ask("find similar")
 
-        async_mock.find_similar.assert_called_once_with("https://ag2.ai", num_results=3)
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({"url": "https://ag2.ai", "numResults": 3})
 
-    async def test_num_results_forwarded_from_toolkit(self, async_mock: AsyncMock) -> None:
-        async_mock.find_similar.return_value = _response([])
-        toolkit = ExaToolkit(client=async_mock, num_results=4)
+    @respx.mock
+    async def test_num_results_forwarded_from_toolkit(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/findSimilar").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test", num_results=4)
 
         agent = Agent(
             "a",
@@ -266,11 +279,13 @@ class TestFindSimilar:
         )
         await agent.ask("find similar")
 
-        async_mock.find_similar.assert_called_once_with("https://ag2.ai", num_results=4)
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({"url": "https://ag2.ai", "numResults": 4})
 
-    async def test_exclude_source_domain_forwarded(self, async_mock: AsyncMock) -> None:
-        async_mock.find_similar.return_value = _response([])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_exclude_source_domain_forwarded(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/findSimilar").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test")
 
         agent = Agent(
             "a",
@@ -279,28 +294,42 @@ class TestFindSimilar:
         )
         await agent.ask("find similar")
 
-        async_mock.find_similar.assert_called_once_with("https://ag2.ai", num_results=2, exclude_source_domain=True)
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({
+            "url": "https://ag2.ai",
+            "numResults": 2,
+            "excludeSourceDomain": True,
+        })
 
 
 @pytest.mark.asyncio
 class TestGetContents:
-    async def test_returns_content(self, async_mock: AsyncMock) -> None:
-        async_mock.get_contents.return_value = _response([
-            SimpleNamespace(
-                url="https://ag2.ai",
-                title="AG2",
-                text="full text",
-                author="ag2ai",
-                published_date="2024-01-01",
-            ),
-        ])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_returns_content(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/contents").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "url": "https://ag2.ai",
+                            "title": "AG2",
+                            "text": "full text",
+                            "author": "ag2ai",
+                            "publishedDate": "2024-01-01",
+                        }
+                    ]
+                },
+            )
+        )
+        toolkit = ExaToolkit(api_key="test")
 
         config = TrackingConfig(_tool_call_config({"urls": ["https://ag2.ai"]}, tool_name="exa_get_contents"))
         agent = Agent("a", config=config, tools=[toolkit])
         await agent.ask("get contents")
 
-        async_mock.get_contents.assert_called_once_with(["https://ag2.ai"], text=True)
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({"urls": ["https://ag2.ai"], "text": True})
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
         assert tool_results_event.results[0].result.parts[0] == DataInput([
@@ -316,21 +345,28 @@ class TestGetContents:
 
 @pytest.mark.asyncio
 class TestAnswer:
-    async def test_returns_answer_with_citations(self, async_mock: AsyncMock) -> None:
-        async_mock.answer.return_value = SimpleNamespace(
-            answer="AG2 is an open-source multi-agent framework.",
-            citations=[
-                SimpleNamespace(url="https://ag2.ai", title="AG2", text="About AG2"),
-                SimpleNamespace(url="https://github.com/ag2ai/ag2", title="GitHub", text="Source code"),
-            ],
+    @respx.mock
+    async def test_returns_answer_with_citations(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/answer").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "answer": "AG2 is an open-source multi-agent framework.",
+                    "citations": [
+                        {"url": "https://ag2.ai", "title": "AG2", "text": "About AG2"},
+                        {"url": "https://github.com/ag2ai/ag2", "title": "GitHub", "text": "Source code"},
+                    ],
+                },
+            )
         )
-        toolkit = ExaToolkit(client=async_mock)
+        toolkit = ExaToolkit(api_key="test")
 
         config = TrackingConfig(_tool_call_config({"query": "What is AG2?"}, tool_name="exa_answer"))
         agent = Agent("a", config=config, tools=[toolkit])
         await agent.ask("answer")
 
-        async_mock.answer.assert_called_once_with("What is AG2?", text=True)
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({"query": "What is AG2?", "text": True})
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
         assert tool_results_event.results[0].result.parts[0] == DataInput(
@@ -346,9 +382,10 @@ class TestAnswer:
 
 @pytest.mark.asyncio
 class TestExaToolkitVariable:
-    async def test_resolved(self, async_mock: AsyncMock) -> None:
-        async_mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_resolved(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/search").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test")
         search_tool = toolkit.search(
             num_results=Variable("user_limit"),
             search_type=Variable(),
@@ -362,11 +399,13 @@ class TestExaToolkitVariable:
         )
         await agent.ask("search")
 
-        async_mock.search.assert_called_once_with("q", num_results=10, type="keyword")
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({"query": "q", "numResults": 10, "type": "keyword"})
 
-    async def test_missing_raises(self, async_mock: AsyncMock) -> None:
-        async_mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_missing_raises(self) -> None:
+        respx.post(f"{EXA_BASE_URL}/search").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test")
         search_tool = toolkit.search(search_type=Variable())
 
         agent = Agent(
@@ -381,9 +420,12 @@ class TestExaToolkitVariable:
 
 @pytest.mark.asyncio
 class TestIndividualTools:
-    async def test_search_tool_passed_alone(self, async_mock: AsyncMock) -> None:
-        async_mock.search.return_value = _response([_result()])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_search_tool_passed_alone(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json={"results": [_exa_result()]})
+        )
+        toolkit = ExaToolkit(api_key="test")
 
         agent = Agent(
             "a",
@@ -392,12 +434,15 @@ class TestIndividualTools:
         )
         await agent.ask("search")
 
-        async_mock.search.assert_called_once_with("q")
+        assert route.called
 
-    async def test_pick_two_tools_from_toolkit(self, async_mock: AsyncMock) -> None:
-        async_mock.search.return_value = _response([])
-        async_mock.answer.return_value = SimpleNamespace(answer="ok", citations=[])
-        toolkit = ExaToolkit(client=async_mock)
+    @respx.mock
+    async def test_pick_two_tools_from_toolkit(self) -> None:
+        search_route = respx.post(f"{EXA_BASE_URL}/search").mock(return_value=httpx.Response(200, json={"results": []}))
+        respx.post(f"{EXA_BASE_URL}/answer").mock(
+            return_value=httpx.Response(200, json={"answer": "ok", "citations": []})
+        )
+        toolkit = ExaToolkit(api_key="test")
 
         agent = Agent(
             "a",
@@ -406,4 +451,4 @@ class TestIndividualTools:
         )
         await agent.ask("search")
 
-        async_mock.search.assert_called_once_with("q")
+        assert search_route.called

--- a/test/beta/tools/search/test_exa.py
+++ b/test/beta/tools/search/test_exa.py
@@ -4,7 +4,7 @@
 
 import json
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from dirty_equals import IsPartialDict
@@ -67,7 +67,7 @@ def _tool_call_config(
 @pytest.mark.asyncio
 class TestSchema:
     async def test_default_schemas(self, context: ConversationContext) -> None:
-        toolkit = ExaToolkit(client=MagicMock())
+        toolkit = ExaToolkit(client=AsyncMock())
 
         schemas = list(await toolkit.schemas(context))
 
@@ -75,7 +75,7 @@ class TestSchema:
         assert names == ["exa_search", "exa_find_similar", "exa_get_contents", "exa_answer"]
 
     async def test_search_schema_has_query_param(self, context: ConversationContext) -> None:
-        toolkit = ExaToolkit(client=MagicMock())
+        toolkit = ExaToolkit(client=AsyncMock())
 
         schemas = list(await toolkit.schemas(context))
         search_schema = next(s for s in schemas if s.function.name == "exa_search")
@@ -86,7 +86,7 @@ class TestSchema:
         })
 
     async def test_custom_tool_name_and_description(self, context: ConversationContext) -> None:
-        toolkit = ExaToolkit(client=MagicMock())
+        toolkit = ExaToolkit(client=AsyncMock())
         custom = toolkit.search(name="neural_search", description="Custom neural search.")
 
         [schema] = list(await custom.schemas(context))
@@ -97,12 +97,12 @@ class TestSchema:
 
 @pytest.mark.asyncio
 class TestSearchExecution:
-    async def test_returns_structured_results(self, mock: MagicMock) -> None:
-        mock.search.return_value = _response([
+    async def test_returns_structured_results(self, async_mock: AsyncMock) -> None:
+        async_mock.search.return_value = _response([
             _result(title="AG2 Framework", url="https://ag2.ai", score=0.95, text=None),
             _result(title="GitHub - AG2", url="https://github.com/ag2ai/ag2", score=0.82, text=None),
         ])
-        toolkit = ExaToolkit(client=mock)
+        toolkit = ExaToolkit(client=async_mock)
 
         config = TrackingConfig(_tool_call_config({"query": "AG2 framework"}, tool_name="exa_search"))
         agent = Agent("a", config=config, tools=[toolkit])
@@ -135,9 +135,9 @@ class TestSearchExecution:
             )
         )
 
-    async def test_empty_results(self, mock: MagicMock) -> None:
-        mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=mock)
+    async def test_empty_results(self, async_mock: AsyncMock) -> None:
+        async_mock.search.return_value = _response([])
+        toolkit = ExaToolkit(client=async_mock)
 
         config = TrackingConfig(_tool_call_config({"query": "nothing"}, tool_name="exa_search"))
         agent = Agent("a", config=config, tools=[toolkit])
@@ -149,19 +149,19 @@ class TestSearchExecution:
             ExaSearchResponse(query="nothing", results=[])
         )
 
-    async def test_none_params_omitted(self, mock: MagicMock) -> None:
-        mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=mock)
+    async def test_none_params_omitted(self, async_mock: AsyncMock) -> None:
+        async_mock.search.return_value = _response([])
+        toolkit = ExaToolkit(client=async_mock)
 
         agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="exa_search"), tools=[toolkit])
 
         await agent.ask("search")
 
-        mock.search.assert_called_once_with("q")
+        async_mock.search.assert_called_once_with("q")
 
-    async def test_all_params_forwarded(self, mock: MagicMock) -> None:
-        mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=mock)
+    async def test_all_params_forwarded(self, async_mock: AsyncMock) -> None:
+        async_mock.search.return_value = _response([])
+        toolkit = ExaToolkit(client=async_mock)
         search_tool = toolkit.search(
             num_results=7,
             search_type="neural",
@@ -183,7 +183,7 @@ class TestSearchExecution:
         )
         await agent.ask("search")
 
-        mock.search.assert_called_once_with(
+        async_mock.search.assert_called_once_with(
             "q",
             num_results=7,
             type="neural",
@@ -198,9 +198,9 @@ class TestSearchExecution:
             livecrawl="always",
         )
 
-    async def test_search_and_contents_when_max_characters_set_on_method(self, mock: MagicMock) -> None:
-        mock.search_and_contents.return_value = _response([_result(text="full article text")])
-        toolkit = ExaToolkit(client=mock)
+    async def test_search_and_contents_when_max_characters_set_on_method(self, async_mock: AsyncMock) -> None:
+        async_mock.search_and_contents.return_value = _response([_result(text="full article text")])
+        toolkit = ExaToolkit(client=async_mock)
 
         agent = Agent(
             "a",
@@ -209,26 +209,12 @@ class TestSearchExecution:
         )
         await agent.ask("search")
 
-        mock.search.assert_not_called()
-        mock.search_and_contents.assert_called_once_with("q", text={"maxCharacters": 500})
+        async_mock.search.assert_not_called()
+        async_mock.search_and_contents.assert_called_once_with("q", text={"maxCharacters": 500})
 
-    async def test_toolkit_level_max_characters_applied_to_default_search(self, mock: MagicMock) -> None:
-        mock.search_and_contents.return_value = _response([])
-        toolkit = ExaToolkit(client=mock, max_characters=800)
-
-        agent = Agent(
-            "a",
-            config=_tool_call_config({"query": "q"}, tool_name="exa_search"),
-            tools=[toolkit],
-        )
-        await agent.ask("search")
-
-        mock.search.assert_not_called()
-        mock.search_and_contents.assert_called_once_with("q", text={"maxCharacters": 800})
-
-    async def test_toolkit_level_num_results_applied_to_default_search(self, mock: MagicMock) -> None:
-        mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=mock, num_results=7)
+    async def test_toolkit_level_max_characters_applied_to_default_search(self, async_mock: AsyncMock) -> None:
+        async_mock.search_and_contents.return_value = _response([])
+        toolkit = ExaToolkit(client=async_mock, max_characters=800)
 
         agent = Agent(
             "a",
@@ -237,14 +223,28 @@ class TestSearchExecution:
         )
         await agent.ask("search")
 
-        mock.search.assert_called_once_with("q", num_results=7)
+        async_mock.search.assert_not_called()
+        async_mock.search_and_contents.assert_called_once_with("q", text={"maxCharacters": 800})
+
+    async def test_toolkit_level_num_results_applied_to_default_search(self, async_mock: AsyncMock) -> None:
+        async_mock.search.return_value = _response([])
+        toolkit = ExaToolkit(client=async_mock, num_results=7)
+
+        agent = Agent(
+            "a",
+            config=_tool_call_config({"query": "q"}, tool_name="exa_search"),
+            tools=[toolkit],
+        )
+        await agent.ask("search")
+
+        async_mock.search.assert_called_once_with("q", num_results=7)
 
 
 @pytest.mark.asyncio
 class TestFindSimilar:
-    async def test_num_results_forwarded_from_method(self, mock: MagicMock) -> None:
-        mock.find_similar.return_value = _response([_result(title="Similar page")])
-        toolkit = ExaToolkit(client=mock)
+    async def test_num_results_forwarded_from_method(self, async_mock: AsyncMock) -> None:
+        async_mock.find_similar.return_value = _response([_result(title="Similar page")])
+        toolkit = ExaToolkit(client=async_mock)
 
         agent = Agent(
             "a",
@@ -253,11 +253,11 @@ class TestFindSimilar:
         )
         await agent.ask("find similar")
 
-        mock.find_similar.assert_called_once_with("https://ag2.ai", num_results=3)
+        async_mock.find_similar.assert_called_once_with("https://ag2.ai", num_results=3)
 
-    async def test_num_results_forwarded_from_toolkit(self, mock: MagicMock) -> None:
-        mock.find_similar.return_value = _response([])
-        toolkit = ExaToolkit(client=mock, num_results=4)
+    async def test_num_results_forwarded_from_toolkit(self, async_mock: AsyncMock) -> None:
+        async_mock.find_similar.return_value = _response([])
+        toolkit = ExaToolkit(client=async_mock, num_results=4)
 
         agent = Agent(
             "a",
@@ -266,11 +266,11 @@ class TestFindSimilar:
         )
         await agent.ask("find similar")
 
-        mock.find_similar.assert_called_once_with("https://ag2.ai", num_results=4)
+        async_mock.find_similar.assert_called_once_with("https://ag2.ai", num_results=4)
 
-    async def test_exclude_source_domain_forwarded(self, mock: MagicMock) -> None:
-        mock.find_similar.return_value = _response([])
-        toolkit = ExaToolkit(client=mock)
+    async def test_exclude_source_domain_forwarded(self, async_mock: AsyncMock) -> None:
+        async_mock.find_similar.return_value = _response([])
+        toolkit = ExaToolkit(client=async_mock)
 
         agent = Agent(
             "a",
@@ -279,13 +279,13 @@ class TestFindSimilar:
         )
         await agent.ask("find similar")
 
-        mock.find_similar.assert_called_once_with("https://ag2.ai", num_results=2, exclude_source_domain=True)
+        async_mock.find_similar.assert_called_once_with("https://ag2.ai", num_results=2, exclude_source_domain=True)
 
 
 @pytest.mark.asyncio
 class TestGetContents:
-    async def test_returns_content(self, mock: MagicMock) -> None:
-        mock.get_contents.return_value = _response([
+    async def test_returns_content(self, async_mock: AsyncMock) -> None:
+        async_mock.get_contents.return_value = _response([
             SimpleNamespace(
                 url="https://ag2.ai",
                 title="AG2",
@@ -294,13 +294,13 @@ class TestGetContents:
                 published_date="2024-01-01",
             ),
         ])
-        toolkit = ExaToolkit(client=mock)
+        toolkit = ExaToolkit(client=async_mock)
 
         config = TrackingConfig(_tool_call_config({"urls": ["https://ag2.ai"]}, tool_name="exa_get_contents"))
         agent = Agent("a", config=config, tools=[toolkit])
         await agent.ask("get contents")
 
-        mock.get_contents.assert_called_once_with(["https://ag2.ai"], text=True)
+        async_mock.get_contents.assert_called_once_with(["https://ag2.ai"], text=True)
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
         assert tool_results_event.results[0].result.parts[0] == DataInput([
@@ -316,21 +316,21 @@ class TestGetContents:
 
 @pytest.mark.asyncio
 class TestAnswer:
-    async def test_returns_answer_with_citations(self, mock: MagicMock) -> None:
-        mock.answer.return_value = SimpleNamespace(
+    async def test_returns_answer_with_citations(self, async_mock: AsyncMock) -> None:
+        async_mock.answer.return_value = SimpleNamespace(
             answer="AG2 is an open-source multi-agent framework.",
             citations=[
                 SimpleNamespace(url="https://ag2.ai", title="AG2", text="About AG2"),
                 SimpleNamespace(url="https://github.com/ag2ai/ag2", title="GitHub", text="Source code"),
             ],
         )
-        toolkit = ExaToolkit(client=mock)
+        toolkit = ExaToolkit(client=async_mock)
 
         config = TrackingConfig(_tool_call_config({"query": "What is AG2?"}, tool_name="exa_answer"))
         agent = Agent("a", config=config, tools=[toolkit])
         await agent.ask("answer")
 
-        mock.answer.assert_called_once_with("What is AG2?", text=True)
+        async_mock.answer.assert_called_once_with("What is AG2?", text=True)
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
         assert tool_results_event.results[0].result.parts[0] == DataInput(
@@ -346,9 +346,9 @@ class TestAnswer:
 
 @pytest.mark.asyncio
 class TestExaToolkitVariable:
-    async def test_resolved(self, mock: MagicMock) -> None:
-        mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=mock)
+    async def test_resolved(self, async_mock: AsyncMock) -> None:
+        async_mock.search.return_value = _response([])
+        toolkit = ExaToolkit(client=async_mock)
         search_tool = toolkit.search(
             num_results=Variable("user_limit"),
             search_type=Variable(),
@@ -362,11 +362,11 @@ class TestExaToolkitVariable:
         )
         await agent.ask("search")
 
-        mock.search.assert_called_once_with("q", num_results=10, type="keyword")
+        async_mock.search.assert_called_once_with("q", num_results=10, type="keyword")
 
-    async def test_missing_raises(self, mock: MagicMock) -> None:
-        mock.search.return_value = _response([])
-        toolkit = ExaToolkit(client=mock)
+    async def test_missing_raises(self, async_mock: AsyncMock) -> None:
+        async_mock.search.return_value = _response([])
+        toolkit = ExaToolkit(client=async_mock)
         search_tool = toolkit.search(search_type=Variable())
 
         agent = Agent(
@@ -381,9 +381,9 @@ class TestExaToolkitVariable:
 
 @pytest.mark.asyncio
 class TestIndividualTools:
-    async def test_search_tool_passed_alone(self, mock: MagicMock) -> None:
-        mock.search.return_value = _response([_result()])
-        toolkit = ExaToolkit(client=mock)
+    async def test_search_tool_passed_alone(self, async_mock: AsyncMock) -> None:
+        async_mock.search.return_value = _response([_result()])
+        toolkit = ExaToolkit(client=async_mock)
 
         agent = Agent(
             "a",
@@ -392,12 +392,12 @@ class TestIndividualTools:
         )
         await agent.ask("search")
 
-        mock.search.assert_called_once_with("q")
+        async_mock.search.assert_called_once_with("q")
 
-    async def test_pick_two_tools_from_toolkit(self, mock: MagicMock) -> None:
-        mock.search.return_value = _response([])
-        mock.answer.return_value = SimpleNamespace(answer="ok", citations=[])
-        toolkit = ExaToolkit(client=mock)
+    async def test_pick_two_tools_from_toolkit(self, async_mock: AsyncMock) -> None:
+        async_mock.search.return_value = _response([])
+        async_mock.answer.return_value = SimpleNamespace(answer="ok", citations=[])
+        toolkit = ExaToolkit(client=async_mock)
 
         agent = Agent(
             "a",
@@ -406,4 +406,4 @@ class TestIndividualTools:
         )
         await agent.ask("search")
 
-        mock.search.assert_called_once_with("q")
+        async_mock.search.assert_called_once_with("q")

--- a/test/beta/tools/search/test_exa.py
+++ b/test/beta/tools/search/test_exa.py
@@ -400,7 +400,7 @@ class TestExaToolkitVariable:
         await agent.ask("search")
 
         body = json.loads(route.calls.last.request.content)
-        assert body == IsPartialDict({"query": "q", "numResults": 10, "type": "keyword"})
+        assert body == IsPartialDict({"query": "q", "numResults": 10, "type": "neural"})
 
     @respx.mock
     async def test_missing_raises(self) -> None:
@@ -419,18 +419,60 @@ class TestExaToolkitVariable:
 
 
 @pytest.mark.asyncio
-class TestClientConstruction:
-    async def test_default_client_sets_integration_header(self) -> None:
-        """When no ``client`` is passed, the toolkit creates one with the ag2 header."""
-        toolkit = ExaToolkit(api_key="test-key")
-        assert toolkit._client.headers["x-exa-integration"] == "ag2"
+class TestIntegrationHeader:
+    @respx.mock
+    async def test_search_sets_header(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/search").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test")
 
-    async def test_explicit_client_is_used_as_is(self) -> None:
-        """When ``client`` is passed, it is used without modification."""
-        custom = MagicMock()
-        custom.headers = {"x-api-key": "k"}
-        toolkit = ExaToolkit(client=custom)
-        assert toolkit._client is custom
+        agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="exa_search"), tools=[toolkit])
+        await agent.ask("search")
+
+        assert route.calls.last.request.headers["x-exa-integration"] == "ag2"
+
+    @respx.mock
+    async def test_find_similar_sets_header(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/findSimilar").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test")
+
+        agent = Agent(
+            "a",
+            config=_tool_call_config({"url": "https://ag2.ai"}, tool_name="exa_find_similar"),
+            tools=[toolkit],
+        )
+        await agent.ask("find similar")
+
+        assert route.calls.last.request.headers["x-exa-integration"] == "ag2"
+
+    @respx.mock
+    async def test_get_contents_sets_header(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/contents").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = ExaToolkit(api_key="test")
+
+        agent = Agent(
+            "a",
+            config=_tool_call_config({"urls": ["https://ag2.ai"]}, tool_name="exa_get_contents"),
+            tools=[toolkit],
+        )
+        await agent.ask("get contents")
+
+        assert route.calls.last.request.headers["x-exa-integration"] == "ag2"
+
+    @respx.mock
+    async def test_answer_sets_header(self) -> None:
+        route = respx.post(f"{EXA_BASE_URL}/answer").mock(
+            return_value=httpx.Response(200, json={"answer": "ok", "citations": []})
+        )
+        toolkit = ExaToolkit(api_key="test")
+
+        agent = Agent(
+            "a",
+            config=_tool_call_config({"query": "What is AG2?"}, tool_name="exa_answer"),
+            tools=[toolkit],
+        )
+        await agent.ask("answer")
+
+        assert route.calls.last.request.headers["x-exa-integration"] == "ag2"
 
 
 @pytest.mark.asyncio

--- a/test/beta/tools/search/test_perplexity.py
+++ b/test/beta/tools/search/test_perplexity.py
@@ -236,6 +236,21 @@ class TestSearch:
         }
 
     @respx.mock
+    async def test_client_kwargs_forwarded_to_sdk(self) -> None:
+        custom_url = "https://custom.perplexity.example"
+        route = respx.post(f"{custom_url}/search").mock(return_value=httpx.Response(200, json=_search_response()))
+        toolkit = PerplexitySearchToolkit(api_key="test", client_kwargs={"base_url": custom_url})
+
+        agent = Agent(
+            "a",
+            config=_tool_call_config({"query": "q"}, tool_name="perplexity_search"),
+            tools=[toolkit],
+        )
+        await agent.ask("search")
+
+        assert route.called
+
+    @respx.mock
     async def test_custom_tool_name_in_agent(self) -> None:
         route = respx.post(f"{PERPLEXITY_BASE_URL}/search").mock(
             return_value=httpx.Response(200, json=_search_response())
@@ -372,6 +387,23 @@ class TestAnswer:
             "return_images": True,
             "return_related_questions": True,
         }
+
+    @respx.mock
+    async def test_client_kwargs_forwarded_to_sdk(self) -> None:
+        custom_url = "https://custom.perplexity.example"
+        route = respx.post(f"{custom_url}/chat/completions").mock(
+            return_value=httpx.Response(200, json=_chat_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test", client_kwargs={"base_url": custom_url})
+
+        agent = Agent(
+            "a",
+            config=_tool_call_config({"query": "q"}, tool_name="perplexity_answer"),
+            tools=[toolkit],
+        )
+        await agent.ask("answer")
+
+        assert route.called
 
     @respx.mock
     async def test_custom_tool_name_in_agent(self) -> None:

--- a/test/beta/tools/search/test_perplexity.py
+++ b/test/beta/tools/search/test_perplexity.py
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from typing import Any
 
+import httpx
 import pytest
+import respx
 from dirty_equals import IsPartialDict
 
 pytest.importorskip("perplexity")
@@ -21,6 +22,8 @@ from autogen.beta.tools.search.perplexity import (
     PerplexitySearchResult,
     PerplexitySearchToolkit,
 )
+
+PERPLEXITY_BASE_URL = "https://api.perplexity.ai"
 
 
 def _tool_call_config(
@@ -39,82 +42,58 @@ def _tool_call_config(
     )
 
 
-SEARCH_API_RAW = SimpleNamespace(
-    id="search-xxx",
-    results=[
-        SimpleNamespace(
-            title="AG2 Framework",
-            url="https://ag2.ai",
-            snippet="AG2 is an agent framework.",
-            date="2026-01-01",
-        ),
-        SimpleNamespace(
-            title="GitHub - AG2",
-            url="https://github.com/ag2ai/ag2",
-            snippet="Open source repo.",
-            date=None,
-        ),
-    ],
-)
+def _search_response(results: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    return {"id": "search-xxx", "results": results or []}
 
 
-def _empty_search_api_response() -> SimpleNamespace:
-    return SimpleNamespace(id="search-empty", results=[])
-
-
-CHAT_RAW = SimpleNamespace(
-    id="chatcmpl-xxx",
-    model="sonar",
-    created=1700000000,
-    choices=[
-        SimpleNamespace(
-            index=0,
-            finish_reason="stop",
-            message=SimpleNamespace(
-                role="assistant",
-                content="AG2 is an open-source multi-agent framework.",
-            ),
-        ),
-    ],
-    search_results=[
-        SimpleNamespace(
-            title="AG2 Framework",
-            url="https://ag2.ai",
-            date="2026-01-01",
-            snippet="AG2 is an agent framework.",
-        ),
-        SimpleNamespace(
-            title="GitHub - AG2",
-            url="https://github.com/ag2ai/ag2",
-            date=None,
-            snippet=None,
-        ),
-    ],
-    citations=["https://ag2.ai", "https://github.com/ag2ai/ag2"],
-)
-
-
-def _empty_chat_response() -> SimpleNamespace:
-    return SimpleNamespace(
-        id="chatcmpl-empty",
-        model="sonar",
-        created=0,
-        choices=[
-            SimpleNamespace(
-                index=0,
-                finish_reason="stop",
-                message=SimpleNamespace(role="assistant", content=""),
-            ),
+def _chat_response(
+    content: str = "",
+    *,
+    search_results: list[dict[str, Any]] | None = None,
+    citations: list[str] | None = None,
+    images: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "id": "chatcmpl-xxx",
+        "model": "sonar",
+        "created": 1700000000,
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": content},
+            }
         ],
-        search_results=None,
-        citations=None,
-    )
+    }
+    if search_results is not None:
+        body["search_results"] = search_results
+    if citations is not None:
+        body["citations"] = citations
+    if images is not None:
+        body["images"] = images
+    return body
+
+
+SAMPLE_SEARCH_RESULTS = [
+    {
+        "title": "AG2 Framework",
+        "url": "https://ag2.ai",
+        "snippet": "AG2 is an agent framework.",
+        "date": "2026-01-01",
+    },
+    {
+        "title": "GitHub - AG2",
+        "url": "https://github.com/ag2ai/ag2",
+        "snippet": "Open source repo.",
+        "date": None,
+    },
+]
 
 
 @pytest.mark.asyncio
 class TestSchema:
     async def test_default_schemas(self, context: ConversationContext) -> None:
-        toolkit = PerplexitySearchToolkit(client=AsyncMock())
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         schemas = list(await toolkit.schemas(context))
 
@@ -122,7 +101,7 @@ class TestSchema:
         assert names == ["perplexity_search", "perplexity_answer"]
 
     async def test_search_schema_has_query_param(self, context: ConversationContext) -> None:
-        toolkit = PerplexitySearchToolkit(client=AsyncMock())
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         schemas = list(await toolkit.schemas(context))
         search_schema = next(s for s in schemas if s.function.name == "perplexity_search")
@@ -133,7 +112,7 @@ class TestSchema:
         })
 
     async def test_answer_schema_has_query_param(self, context: ConversationContext) -> None:
-        toolkit = PerplexitySearchToolkit(client=AsyncMock())
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         schemas = list(await toolkit.schemas(context))
         answer_schema = next(s for s in schemas if s.function.name == "perplexity_answer")
@@ -144,7 +123,7 @@ class TestSchema:
         })
 
     async def test_custom_search_name_and_description(self, context: ConversationContext) -> None:
-        toolkit = PerplexitySearchToolkit(client=AsyncMock())
+        toolkit = PerplexitySearchToolkit(api_key="test")
         custom = toolkit.search(name="web_search", description="Custom search.")
 
         [schema] = list(await custom.schemas(context))
@@ -153,7 +132,7 @@ class TestSchema:
         assert schema.function.description == "Custom search."
 
     async def test_custom_answer_name_and_description(self, context: ConversationContext) -> None:
-        toolkit = PerplexitySearchToolkit(client=AsyncMock())
+        toolkit = PerplexitySearchToolkit(api_key="test")
         custom = toolkit.answer(name="ask_perplexity", description="Custom answer.")
 
         [schema] = list(await custom.schemas(context))
@@ -164,19 +143,19 @@ class TestSchema:
 
 @pytest.mark.asyncio
 class TestSearch:
-    async def test_returns_structured_results(self, async_mock: AsyncMock) -> None:
-        async_mock.search.create.return_value = SEARCH_API_RAW
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_returns_structured_results(self) -> None:
+        respx.post(f"{PERPLEXITY_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json=_search_response(SAMPLE_SEARCH_RESULTS))
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         config = TrackingConfig(_tool_call_config({"query": "AG2 framework"}, tool_name="perplexity_search"))
         agent = Agent("a", config=config, tools=[toolkit])
-
         await agent.ask("search")
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
-        [tool_result] = tool_results_event.results
-        [part] = tool_result.result.parts
-        assert part == DataInput(
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
             PerplexitySearchResponse(
                 query="AG2 framework",
                 results=[
@@ -196,33 +175,39 @@ class TestSearch:
             )
         )
 
-    async def test_empty_results(self, async_mock: AsyncMock) -> None:
-        async_mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_empty_results(self) -> None:
+        respx.post(f"{PERPLEXITY_BASE_URL}/search").mock(return_value=httpx.Response(200, json=_search_response()))
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         config = TrackingConfig(_tool_call_config({"query": "nothing"}, tool_name="perplexity_search"))
         agent = Agent("a", config=config, tools=[toolkit])
-
         await agent.ask("search")
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
-        [tool_result] = tool_results_event.results
-        [part] = tool_result.result.parts
-        assert part == DataInput(PerplexitySearchResponse(query="nothing", results=[]))
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            PerplexitySearchResponse(query="nothing", results=[])
+        )
 
-    async def test_none_params_omitted(self, async_mock: AsyncMock) -> None:
-        async_mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_none_params_omitted(self) -> None:
+        route = respx.post(f"{PERPLEXITY_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json=_search_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="perplexity_search"), tools=[toolkit])
-
         await agent.ask("search")
 
-        async_mock.search.create.assert_called_once_with(query="q")
+        body = json.loads(route.calls.last.request.content)
+        assert body == {"query": "q"}
 
-    async def test_all_params_forwarded(self, async_mock: AsyncMock) -> None:
-        async_mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_all_params_forwarded(self) -> None:
+        route = respx.post(f"{PERPLEXITY_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json=_search_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
         search_tool = toolkit.search(
             max_results=5,
             max_tokens_per_page=512,
@@ -239,19 +224,23 @@ class TestSearch:
         )
         await agent.ask("search")
 
-        async_mock.search.create.assert_called_once_with(
-            query="q",
-            max_results=5,
-            max_tokens_per_page=512,
-            search_domain_filter=["arxiv.org", "-medium.com"],
-            search_recency_filter="week",
-            search_after_date_filter="1/1/2025",
-            search_before_date_filter="12/31/2025",
-        )
+        body = json.loads(route.calls.last.request.content)
+        assert body == {
+            "query": "q",
+            "max_results": 5,
+            "max_tokens_per_page": 512,
+            "search_domain_filter": ["arxiv.org", "-medium.com"],
+            "search_recency_filter": "week",
+            "search_after_date_filter": "1/1/2025",
+            "search_before_date_filter": "12/31/2025",
+        }
 
-    async def test_custom_tool_name_in_agent(self, async_mock: AsyncMock) -> None:
-        async_mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_custom_tool_name_in_agent(self) -> None:
+        route = respx.post(f"{PERPLEXITY_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json=_search_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
         search_tool = toolkit.search(name="web_search")
 
         agent = Agent(
@@ -261,24 +250,31 @@ class TestSearch:
         )
         await agent.ask("search")
 
-        async_mock.search.create.assert_called_once()
+        assert route.called
 
 
 @pytest.mark.asyncio
 class TestAnswer:
-    async def test_returns_structured_results(self, async_mock: AsyncMock) -> None:
-        async_mock.chat.completions.create.return_value = CHAT_RAW
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_returns_structured_results(self) -> None:
+        respx.post(f"{PERPLEXITY_BASE_URL}/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json=_chat_response(
+                    content="AG2 is an open-source multi-agent framework.",
+                    search_results=SAMPLE_SEARCH_RESULTS,
+                    citations=["https://ag2.ai", "https://github.com/ag2ai/ag2"],
+                ),
+            )
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         config = TrackingConfig(_tool_call_config({"query": "AG2 framework"}, tool_name="perplexity_answer"))
         agent = Agent("a", config=config, tools=[toolkit])
-
         await agent.ask("answer")
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
-        [tool_result] = tool_results_event.results
-        [part] = tool_result.result.parts
-        assert part == DataInput(
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
             PerplexitySearchResponse(
                 query="AG2 framework",
                 results=[
@@ -291,7 +287,7 @@ class TestAnswer:
                     PerplexitySearchResult(
                         title="GitHub - AG2",
                         url="https://github.com/ag2ai/ag2",
-                        snippet=None,
+                        snippet="Open source repo.",
                         date=None,
                     ),
                 ],
@@ -300,48 +296,49 @@ class TestAnswer:
             )
         )
 
-    async def test_empty_results(self, async_mock: AsyncMock) -> None:
-        async_mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_empty_results(self) -> None:
+        respx.post(f"{PERPLEXITY_BASE_URL}/chat/completions").mock(
+            return_value=httpx.Response(200, json=_chat_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         config = TrackingConfig(_tool_call_config({"query": "nothing"}, tool_name="perplexity_answer"))
         agent = Agent("a", config=config, tools=[toolkit])
-
         await agent.ask("answer")
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
-        [tool_result] = tool_results_event.results
-        [part] = tool_result.result.parts
-        assert part == DataInput(
-            PerplexitySearchResponse(
-                query="nothing",
-                results=[],
-                content="",
-                citations=[],
-            )
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            PerplexitySearchResponse(query="nothing", results=[], content="", citations=[])
         )
 
-    async def test_defaults_applied_when_params_omitted(self, async_mock: AsyncMock) -> None:
-        async_mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_defaults_applied_when_params_omitted(self) -> None:
+        route = respx.post(f"{PERPLEXITY_BASE_URL}/chat/completions").mock(
+            return_value=httpx.Response(200, json=_chat_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="perplexity_answer"), tools=[toolkit])
-
         await agent.ask("answer")
 
-        async_mock.chat.completions.create.assert_called_once_with(
-            model="sonar",
-            messages=[
+        body = json.loads(route.calls.last.request.content)
+        assert body == {
+            "model": "sonar",
+            "messages": [
                 {"role": "system", "content": "Be precise and concise."},
                 {"role": "user", "content": "q"},
             ],
-            max_tokens=1000,
-            web_search_options={"search_context_size": "high"},
-        )
+            "max_tokens": 1000,
+            "web_search_options": {"search_context_size": "high"},
+        }
 
-    async def test_all_params_forwarded(self, async_mock: AsyncMock) -> None:
-        async_mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_all_params_forwarded(self) -> None:
+        route = respx.post(f"{PERPLEXITY_BASE_URL}/chat/completions").mock(
+            return_value=httpx.Response(200, json=_chat_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
         answer_tool = toolkit.answer(
             model="sonar-pro",
             max_tokens=2000,
@@ -360,24 +357,28 @@ class TestAnswer:
         )
         await agent.ask("answer")
 
-        async_mock.chat.completions.create.assert_called_once_with(
-            model="sonar-pro",
-            messages=[
+        body = json.loads(route.calls.last.request.content)
+        assert body == {
+            "model": "sonar-pro",
+            "messages": [
                 {"role": "system", "content": "Be precise and concise."},
                 {"role": "user", "content": "q"},
             ],
-            max_tokens=2000,
-            web_search_options={"search_context_size": "medium"},
-            search_domain_filter=["arxiv.org", "-medium.com"],
-            search_mode="academic",
-            search_recency_filter="week",
-            return_images=True,
-            return_related_questions=True,
-        )
+            "max_tokens": 2000,
+            "web_search_options": {"search_context_size": "medium"},
+            "search_domain_filter": ["arxiv.org", "-medium.com"],
+            "search_mode": "academic",
+            "search_recency_filter": "week",
+            "return_images": True,
+            "return_related_questions": True,
+        }
 
-    async def test_custom_tool_name_in_agent(self, async_mock: AsyncMock) -> None:
-        async_mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_custom_tool_name_in_agent(self) -> None:
+        route = respx.post(f"{PERPLEXITY_BASE_URL}/chat/completions").mock(
+            return_value=httpx.Response(200, json=_chat_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
         answer_tool = toolkit.answer(name="ask_perplexity")
 
         agent = Agent(
@@ -387,53 +388,43 @@ class TestAnswer:
         )
         await agent.ask("answer")
 
-        async_mock.chat.completions.create.assert_called_once()
+        assert route.called
 
-    async def test_returns_image_parts_when_api_yields_images(self, async_mock: AsyncMock) -> None:
-        # The Perplexity SDK delivers `images` as plain dicts (the field is not
-        # declared on StreamChunk's pydantic model). Mirror that here.
-        raw = SimpleNamespace(
-            id="chatcmpl-img",
-            model="sonar",
-            created=0,
-            choices=[
-                SimpleNamespace(
-                    index=0,
-                    finish_reason="stop",
-                    message=SimpleNamespace(role="assistant", content="See attached images."),
+    @respx.mock
+    async def test_returns_image_parts_when_api_yields_images(self) -> None:
+        respx.post(f"{PERPLEXITY_BASE_URL}/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json=_chat_response(
+                    content="See attached images.",
+                    images=[
+                        {
+                            "image_url": "https://example.com/a.jpg",
+                            "origin_url": "https://example.com/a",
+                            "title": "Image A",
+                            "width": 800,
+                            "height": 600,
+                        },
+                        {
+                            "image_url": "https://example.com/b.png",
+                            "origin_url": "https://example.com/b",
+                            "title": "Image B",
+                            "width": 1024,
+                            "height": 768,
+                        },
+                    ],
                 ),
-            ],
-            search_results=None,
-            citations=None,
-            images=[
-                {
-                    "image_url": "https://example.com/a.jpg",
-                    "origin_url": "https://example.com/a",
-                    "title": "Image A",
-                    "width": 800,
-                    "height": 600,
-                },
-                {
-                    "image_url": "https://example.com/b.png",
-                    "origin_url": "https://example.com/b",
-                    "title": "Image B",
-                    "width": 1024,
-                    "height": 768,
-                },
-            ],
+            )
         )
-        async_mock.chat.completions.create.return_value = raw
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+        toolkit = PerplexitySearchToolkit(api_key="test")
         answer_tool = toolkit.answer(return_images=True)
 
         config = TrackingConfig(_tool_call_config({"query": "show me images"}, tool_name="perplexity_answer"))
         agent = Agent("a", config=config, tools=[answer_tool])
-
         await agent.ask("answer")
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
-        [tool_result] = tool_results_event.results
-        data_part, image_a, image_b = tool_result.result.parts
+        data_part, image_a, image_b = tool_results_event.results[0].result.parts
 
         assert data_part == DataInput(
             PerplexitySearchResponse(
@@ -462,45 +453,39 @@ class TestAnswer:
         assert image_a == ImageInput(url="https://example.com/a.jpg")
         assert image_b == ImageInput(url="https://example.com/b.png")
 
-    async def test_skips_image_entries_without_image_url(self, async_mock: AsyncMock) -> None:
-        raw = SimpleNamespace(
-            id="chatcmpl-img",
-            model="sonar",
-            created=0,
-            choices=[
-                SimpleNamespace(
-                    index=0,
-                    finish_reason="stop",
-                    message=SimpleNamespace(role="assistant", content=""),
+    @respx.mock
+    async def test_skips_image_entries_without_image_url(self) -> None:
+        respx.post(f"{PERPLEXITY_BASE_URL}/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json=_chat_response(
+                    images=[
+                        {"origin_url": None, "title": None, "width": None, "height": None},
+                        {"image_url": "https://example.com/ok.jpg"},
+                    ],
                 ),
-            ],
-            search_results=None,
-            citations=None,
-            images=[
-                {"origin_url": None, "title": None, "width": None, "height": None},
-                {"image_url": "https://example.com/ok.jpg"},
-            ],
+            )
         )
-        async_mock.chat.completions.create.return_value = raw
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+        toolkit = PerplexitySearchToolkit(api_key="test")
         answer_tool = toolkit.answer(return_images=True)
 
         config = TrackingConfig(_tool_call_config({"query": "q"}, tool_name="perplexity_answer"))
         agent = Agent("a", config=config, tools=[answer_tool])
-
         await agent.ask("answer")
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
-        [tool_result] = tool_results_event.results
-        _data_part, image = tool_result.result.parts
+        _data_part, image = tool_results_event.results[0].result.parts
         assert image == ImageInput(url="https://example.com/ok.jpg")
 
 
 @pytest.mark.asyncio
 class TestSearchVariable:
-    async def test_resolved(self, async_mock: AsyncMock) -> None:
-        async_mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_resolved(self) -> None:
+        route = respx.post(f"{PERPLEXITY_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json=_search_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
         search_tool = toolkit.search(
             max_results=Variable("user_max"),
             search_recency_filter=Variable(),
@@ -510,23 +495,21 @@ class TestSearchVariable:
             "a",
             config=_tool_call_config({"query": "test query"}, tool_name="perplexity_search"),
             tools=[search_tool],
-            variables={
-                "user_max": 7,
-                "search_recency_filter": "day",
-            },
+            variables={"user_max": 7, "search_recency_filter": "day"},
         )
-
         await agent.ask("search")
 
-        async_mock.search.create.assert_called_once_with(
-            query="test query",
-            max_results=7,
-            search_recency_filter="day",
-        )
+        body = json.loads(route.calls.last.request.content)
+        assert body == {
+            "query": "test query",
+            "max_results": 7,
+            "search_recency_filter": "day",
+        }
 
-    async def test_missing_raises(self, async_mock: AsyncMock) -> None:
-        async_mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_missing_raises(self) -> None:
+        respx.post(f"{PERPLEXITY_BASE_URL}/search").mock(return_value=httpx.Response(200, json=_search_response()))
+        toolkit = PerplexitySearchToolkit(api_key="test")
         search_tool = toolkit.search(max_results=Variable())
 
         agent = Agent(
@@ -541,9 +524,12 @@ class TestSearchVariable:
 
 @pytest.mark.asyncio
 class TestAnswerVariable:
-    async def test_resolved(self, async_mock: AsyncMock) -> None:
-        async_mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_resolved(self) -> None:
+        route = respx.post(f"{PERPLEXITY_BASE_URL}/chat/completions").mock(
+            return_value=httpx.Response(200, json=_chat_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
         answer_tool = toolkit.answer(
             model=Variable("user_model"),
             search_recency_filter=Variable(),
@@ -553,28 +539,28 @@ class TestAnswerVariable:
             "a",
             config=_tool_call_config({"query": "test query"}, tool_name="perplexity_answer"),
             tools=[answer_tool],
-            variables={
-                "user_model": "sonar-pro",
-                "search_recency_filter": "day",
-            },
+            variables={"user_model": "sonar-pro", "search_recency_filter": "day"},
         )
-
         await agent.ask("answer")
 
-        async_mock.chat.completions.create.assert_called_once_with(
-            model="sonar-pro",
-            messages=[
+        body = json.loads(route.calls.last.request.content)
+        assert body == {
+            "model": "sonar-pro",
+            "messages": [
                 {"role": "system", "content": "Be precise and concise."},
                 {"role": "user", "content": "test query"},
             ],
-            max_tokens=1000,
-            web_search_options={"search_context_size": "high"},
-            search_recency_filter="day",
-        )
+            "max_tokens": 1000,
+            "web_search_options": {"search_context_size": "high"},
+            "search_recency_filter": "day",
+        }
 
-    async def test_missing_raises(self, async_mock: AsyncMock) -> None:
-        async_mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_missing_raises(self) -> None:
+        respx.post(f"{PERPLEXITY_BASE_URL}/chat/completions").mock(
+            return_value=httpx.Response(200, json=_chat_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
         answer_tool = toolkit.answer(search_mode=Variable())
 
         agent = Agent(
@@ -589,9 +575,12 @@ class TestAnswerVariable:
 
 @pytest.mark.asyncio
 class TestIndividualTools:
-    async def test_search_tool_passed_alone(self, async_mock: AsyncMock) -> None:
-        async_mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_search_tool_passed_alone(self) -> None:
+        route = respx.post(f"{PERPLEXITY_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json=_search_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         agent = Agent(
             "a",
@@ -600,11 +589,15 @@ class TestIndividualTools:
         )
         await agent.ask("search")
 
-        async_mock.search.create.assert_called_once_with(query="q")
+        body = json.loads(route.calls.last.request.content)
+        assert body == {"query": "q"}
 
-    async def test_answer_tool_passed_alone(self, async_mock: AsyncMock) -> None:
-        async_mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_answer_tool_passed_alone(self) -> None:
+        route = respx.post(f"{PERPLEXITY_BASE_URL}/chat/completions").mock(
+            return_value=httpx.Response(200, json=_chat_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         agent = Agent(
             "a",
@@ -613,11 +606,14 @@ class TestIndividualTools:
         )
         await agent.ask("answer")
 
-        async_mock.chat.completions.create.assert_called_once()
+        assert route.called
 
-    async def test_whole_toolkit_registers_both_tools(self, async_mock: AsyncMock) -> None:
-        async_mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=async_mock)
+    @respx.mock
+    async def test_whole_toolkit_registers_both_tools(self) -> None:
+        route = respx.post(f"{PERPLEXITY_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json=_search_response())
+        )
+        toolkit = PerplexitySearchToolkit(api_key="test")
 
         agent = Agent(
             "a",
@@ -626,4 +622,5 @@ class TestIndividualTools:
         )
         await agent.ask("search")
 
-        async_mock.search.create.assert_called_once_with(query="q")
+        body = json.loads(route.calls.last.request.content)
+        assert body == {"query": "q"}

--- a/test/beta/tools/search/test_perplexity.py
+++ b/test/beta/tools/search/test_perplexity.py
@@ -4,7 +4,7 @@
 
 import json
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from dirty_equals import IsPartialDict
@@ -114,7 +114,7 @@ def _empty_chat_response() -> SimpleNamespace:
 @pytest.mark.asyncio
 class TestSchema:
     async def test_default_schemas(self, context: ConversationContext) -> None:
-        toolkit = PerplexitySearchToolkit(client=MagicMock())
+        toolkit = PerplexitySearchToolkit(client=AsyncMock())
 
         schemas = list(await toolkit.schemas(context))
 
@@ -122,7 +122,7 @@ class TestSchema:
         assert names == ["perplexity_search", "perplexity_answer"]
 
     async def test_search_schema_has_query_param(self, context: ConversationContext) -> None:
-        toolkit = PerplexitySearchToolkit(client=MagicMock())
+        toolkit = PerplexitySearchToolkit(client=AsyncMock())
 
         schemas = list(await toolkit.schemas(context))
         search_schema = next(s for s in schemas if s.function.name == "perplexity_search")
@@ -133,7 +133,7 @@ class TestSchema:
         })
 
     async def test_answer_schema_has_query_param(self, context: ConversationContext) -> None:
-        toolkit = PerplexitySearchToolkit(client=MagicMock())
+        toolkit = PerplexitySearchToolkit(client=AsyncMock())
 
         schemas = list(await toolkit.schemas(context))
         answer_schema = next(s for s in schemas if s.function.name == "perplexity_answer")
@@ -144,7 +144,7 @@ class TestSchema:
         })
 
     async def test_custom_search_name_and_description(self, context: ConversationContext) -> None:
-        toolkit = PerplexitySearchToolkit(client=MagicMock())
+        toolkit = PerplexitySearchToolkit(client=AsyncMock())
         custom = toolkit.search(name="web_search", description="Custom search.")
 
         [schema] = list(await custom.schemas(context))
@@ -153,7 +153,7 @@ class TestSchema:
         assert schema.function.description == "Custom search."
 
     async def test_custom_answer_name_and_description(self, context: ConversationContext) -> None:
-        toolkit = PerplexitySearchToolkit(client=MagicMock())
+        toolkit = PerplexitySearchToolkit(client=AsyncMock())
         custom = toolkit.answer(name="ask_perplexity", description="Custom answer.")
 
         [schema] = list(await custom.schemas(context))
@@ -164,9 +164,9 @@ class TestSchema:
 
 @pytest.mark.asyncio
 class TestSearch:
-    async def test_returns_structured_results(self, mock: MagicMock) -> None:
-        mock.search.create.return_value = SEARCH_API_RAW
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_returns_structured_results(self, async_mock: AsyncMock) -> None:
+        async_mock.search.create.return_value = SEARCH_API_RAW
+        toolkit = PerplexitySearchToolkit(client=async_mock)
 
         config = TrackingConfig(_tool_call_config({"query": "AG2 framework"}, tool_name="perplexity_search"))
         agent = Agent("a", config=config, tools=[toolkit])
@@ -196,9 +196,9 @@ class TestSearch:
             )
         )
 
-    async def test_empty_results(self, mock: MagicMock) -> None:
-        mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_empty_results(self, async_mock: AsyncMock) -> None:
+        async_mock.search.create.return_value = _empty_search_api_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
 
         config = TrackingConfig(_tool_call_config({"query": "nothing"}, tool_name="perplexity_search"))
         agent = Agent("a", config=config, tools=[toolkit])
@@ -210,19 +210,19 @@ class TestSearch:
         [part] = tool_result.result.parts
         assert part == DataInput(PerplexitySearchResponse(query="nothing", results=[]))
 
-    async def test_none_params_omitted(self, mock: MagicMock) -> None:
-        mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_none_params_omitted(self, async_mock: AsyncMock) -> None:
+        async_mock.search.create.return_value = _empty_search_api_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
 
         agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="perplexity_search"), tools=[toolkit])
 
         await agent.ask("search")
 
-        mock.search.create.assert_called_once_with(query="q")
+        async_mock.search.create.assert_called_once_with(query="q")
 
-    async def test_all_params_forwarded(self, mock: MagicMock) -> None:
-        mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_all_params_forwarded(self, async_mock: AsyncMock) -> None:
+        async_mock.search.create.return_value = _empty_search_api_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
         search_tool = toolkit.search(
             max_results=5,
             max_tokens_per_page=512,
@@ -239,7 +239,7 @@ class TestSearch:
         )
         await agent.ask("search")
 
-        mock.search.create.assert_called_once_with(
+        async_mock.search.create.assert_called_once_with(
             query="q",
             max_results=5,
             max_tokens_per_page=512,
@@ -249,9 +249,9 @@ class TestSearch:
             search_before_date_filter="12/31/2025",
         )
 
-    async def test_custom_tool_name_in_agent(self, mock: MagicMock) -> None:
-        mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_custom_tool_name_in_agent(self, async_mock: AsyncMock) -> None:
+        async_mock.search.create.return_value = _empty_search_api_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
         search_tool = toolkit.search(name="web_search")
 
         agent = Agent(
@@ -261,14 +261,14 @@ class TestSearch:
         )
         await agent.ask("search")
 
-        mock.search.create.assert_called_once()
+        async_mock.search.create.assert_called_once()
 
 
 @pytest.mark.asyncio
 class TestAnswer:
-    async def test_returns_structured_results(self, mock: MagicMock) -> None:
-        mock.chat.completions.create.return_value = CHAT_RAW
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_returns_structured_results(self, async_mock: AsyncMock) -> None:
+        async_mock.chat.completions.create.return_value = CHAT_RAW
+        toolkit = PerplexitySearchToolkit(client=async_mock)
 
         config = TrackingConfig(_tool_call_config({"query": "AG2 framework"}, tool_name="perplexity_answer"))
         agent = Agent("a", config=config, tools=[toolkit])
@@ -300,9 +300,9 @@ class TestAnswer:
             )
         )
 
-    async def test_empty_results(self, mock: MagicMock) -> None:
-        mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_empty_results(self, async_mock: AsyncMock) -> None:
+        async_mock.chat.completions.create.return_value = _empty_chat_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
 
         config = TrackingConfig(_tool_call_config({"query": "nothing"}, tool_name="perplexity_answer"))
         agent = Agent("a", config=config, tools=[toolkit])
@@ -321,15 +321,15 @@ class TestAnswer:
             )
         )
 
-    async def test_defaults_applied_when_params_omitted(self, mock: MagicMock) -> None:
-        mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_defaults_applied_when_params_omitted(self, async_mock: AsyncMock) -> None:
+        async_mock.chat.completions.create.return_value = _empty_chat_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
 
         agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="perplexity_answer"), tools=[toolkit])
 
         await agent.ask("answer")
 
-        mock.chat.completions.create.assert_called_once_with(
+        async_mock.chat.completions.create.assert_called_once_with(
             model="sonar",
             messages=[
                 {"role": "system", "content": "Be precise and concise."},
@@ -339,9 +339,9 @@ class TestAnswer:
             web_search_options={"search_context_size": "high"},
         )
 
-    async def test_all_params_forwarded(self, mock: MagicMock) -> None:
-        mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_all_params_forwarded(self, async_mock: AsyncMock) -> None:
+        async_mock.chat.completions.create.return_value = _empty_chat_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
         answer_tool = toolkit.answer(
             model="sonar-pro",
             max_tokens=2000,
@@ -360,7 +360,7 @@ class TestAnswer:
         )
         await agent.ask("answer")
 
-        mock.chat.completions.create.assert_called_once_with(
+        async_mock.chat.completions.create.assert_called_once_with(
             model="sonar-pro",
             messages=[
                 {"role": "system", "content": "Be precise and concise."},
@@ -375,9 +375,9 @@ class TestAnswer:
             return_related_questions=True,
         )
 
-    async def test_custom_tool_name_in_agent(self, mock: MagicMock) -> None:
-        mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_custom_tool_name_in_agent(self, async_mock: AsyncMock) -> None:
+        async_mock.chat.completions.create.return_value = _empty_chat_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
         answer_tool = toolkit.answer(name="ask_perplexity")
 
         agent = Agent(
@@ -387,9 +387,9 @@ class TestAnswer:
         )
         await agent.ask("answer")
 
-        mock.chat.completions.create.assert_called_once()
+        async_mock.chat.completions.create.assert_called_once()
 
-    async def test_returns_image_parts_when_api_yields_images(self, mock: MagicMock) -> None:
+    async def test_returns_image_parts_when_api_yields_images(self, async_mock: AsyncMock) -> None:
         # The Perplexity SDK delivers `images` as plain dicts (the field is not
         # declared on StreamChunk's pydantic model). Mirror that here.
         raw = SimpleNamespace(
@@ -422,8 +422,8 @@ class TestAnswer:
                 },
             ],
         )
-        mock.chat.completions.create.return_value = raw
-        toolkit = PerplexitySearchToolkit(client=mock)
+        async_mock.chat.completions.create.return_value = raw
+        toolkit = PerplexitySearchToolkit(client=async_mock)
         answer_tool = toolkit.answer(return_images=True)
 
         config = TrackingConfig(_tool_call_config({"query": "show me images"}, tool_name="perplexity_answer"))
@@ -462,7 +462,7 @@ class TestAnswer:
         assert image_a == ImageInput(url="https://example.com/a.jpg")
         assert image_b == ImageInput(url="https://example.com/b.png")
 
-    async def test_skips_image_entries_without_image_url(self, mock: MagicMock) -> None:
+    async def test_skips_image_entries_without_image_url(self, async_mock: AsyncMock) -> None:
         raw = SimpleNamespace(
             id="chatcmpl-img",
             model="sonar",
@@ -481,8 +481,8 @@ class TestAnswer:
                 {"image_url": "https://example.com/ok.jpg"},
             ],
         )
-        mock.chat.completions.create.return_value = raw
-        toolkit = PerplexitySearchToolkit(client=mock)
+        async_mock.chat.completions.create.return_value = raw
+        toolkit = PerplexitySearchToolkit(client=async_mock)
         answer_tool = toolkit.answer(return_images=True)
 
         config = TrackingConfig(_tool_call_config({"query": "q"}, tool_name="perplexity_answer"))
@@ -498,9 +498,9 @@ class TestAnswer:
 
 @pytest.mark.asyncio
 class TestSearchVariable:
-    async def test_resolved(self, mock: MagicMock) -> None:
-        mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_resolved(self, async_mock: AsyncMock) -> None:
+        async_mock.search.create.return_value = _empty_search_api_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
         search_tool = toolkit.search(
             max_results=Variable("user_max"),
             search_recency_filter=Variable(),
@@ -518,15 +518,15 @@ class TestSearchVariable:
 
         await agent.ask("search")
 
-        mock.search.create.assert_called_once_with(
+        async_mock.search.create.assert_called_once_with(
             query="test query",
             max_results=7,
             search_recency_filter="day",
         )
 
-    async def test_missing_raises(self, mock: MagicMock) -> None:
-        mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_missing_raises(self, async_mock: AsyncMock) -> None:
+        async_mock.search.create.return_value = _empty_search_api_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
         search_tool = toolkit.search(max_results=Variable())
 
         agent = Agent(
@@ -541,9 +541,9 @@ class TestSearchVariable:
 
 @pytest.mark.asyncio
 class TestAnswerVariable:
-    async def test_resolved(self, mock: MagicMock) -> None:
-        mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_resolved(self, async_mock: AsyncMock) -> None:
+        async_mock.chat.completions.create.return_value = _empty_chat_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
         answer_tool = toolkit.answer(
             model=Variable("user_model"),
             search_recency_filter=Variable(),
@@ -561,7 +561,7 @@ class TestAnswerVariable:
 
         await agent.ask("answer")
 
-        mock.chat.completions.create.assert_called_once_with(
+        async_mock.chat.completions.create.assert_called_once_with(
             model="sonar-pro",
             messages=[
                 {"role": "system", "content": "Be precise and concise."},
@@ -572,9 +572,9 @@ class TestAnswerVariable:
             search_recency_filter="day",
         )
 
-    async def test_missing_raises(self, mock: MagicMock) -> None:
-        mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_missing_raises(self, async_mock: AsyncMock) -> None:
+        async_mock.chat.completions.create.return_value = _empty_chat_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
         answer_tool = toolkit.answer(search_mode=Variable())
 
         agent = Agent(
@@ -589,9 +589,9 @@ class TestAnswerVariable:
 
 @pytest.mark.asyncio
 class TestIndividualTools:
-    async def test_search_tool_passed_alone(self, mock: MagicMock) -> None:
-        mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_search_tool_passed_alone(self, async_mock: AsyncMock) -> None:
+        async_mock.search.create.return_value = _empty_search_api_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
 
         agent = Agent(
             "a",
@@ -600,11 +600,11 @@ class TestIndividualTools:
         )
         await agent.ask("search")
 
-        mock.search.create.assert_called_once_with(query="q")
+        async_mock.search.create.assert_called_once_with(query="q")
 
-    async def test_answer_tool_passed_alone(self, mock: MagicMock) -> None:
-        mock.chat.completions.create.return_value = _empty_chat_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_answer_tool_passed_alone(self, async_mock: AsyncMock) -> None:
+        async_mock.chat.completions.create.return_value = _empty_chat_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
 
         agent = Agent(
             "a",
@@ -613,11 +613,11 @@ class TestIndividualTools:
         )
         await agent.ask("answer")
 
-        mock.chat.completions.create.assert_called_once()
+        async_mock.chat.completions.create.assert_called_once()
 
-    async def test_whole_toolkit_registers_both_tools(self, mock: MagicMock) -> None:
-        mock.search.create.return_value = _empty_search_api_response()
-        toolkit = PerplexitySearchToolkit(client=mock)
+    async def test_whole_toolkit_registers_both_tools(self, async_mock: AsyncMock) -> None:
+        async_mock.search.create.return_value = _empty_search_api_response()
+        toolkit = PerplexitySearchToolkit(client=async_mock)
 
         agent = Agent(
             "a",
@@ -626,4 +626,4 @@ class TestIndividualTools:
         )
         await agent.ask("search")
 
-        mock.search.create.assert_called_once_with(query="q")
+        async_mock.search.create.assert_called_once_with(query="q")

--- a/test/beta/tools/search/test_perplexity.py
+++ b/test/beta/tools/search/test_perplexity.py
@@ -239,7 +239,7 @@ class TestSearch:
     async def test_client_kwargs_forwarded_to_sdk(self) -> None:
         custom_url = "https://custom.perplexity.example"
         route = respx.post(f"{custom_url}/search").mock(return_value=httpx.Response(200, json=_search_response()))
-        toolkit = PerplexitySearchToolkit(api_key="test", client_kwargs={"base_url": custom_url})
+        toolkit = PerplexitySearchToolkit(api_key="test", base_url=custom_url)
 
         agent = Agent(
             "a",
@@ -394,7 +394,7 @@ class TestAnswer:
         route = respx.post(f"{custom_url}/chat/completions").mock(
             return_value=httpx.Response(200, json=_chat_response())
         )
-        toolkit = PerplexitySearchToolkit(api_key="test", client_kwargs={"base_url": custom_url})
+        toolkit = PerplexitySearchToolkit(api_key="test", base_url=custom_url)
 
         agent = Agent(
             "a",

--- a/test/beta/tools/search/test_tavily.py
+++ b/test/beta/tools/search/test_tavily.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from dirty_equals import IsPartialDict
@@ -49,7 +49,7 @@ def _make_config(query: str, final_reply: str = "done", tool_name: str = "tavily
 @pytest.mark.asyncio
 class TestSchema:
     async def test_default_schema(self, context: ConversationContext) -> None:
-        tavily = TavilySearchTool(client=MagicMock())
+        tavily = TavilySearchTool(client=AsyncMock())
 
         [schema] = await tavily.schemas(context)
 
@@ -60,7 +60,7 @@ class TestSchema:
         })
 
     async def test_custom_schema(self, context: ConversationContext) -> None:
-        tavily = TavilySearchTool(client=MagicMock(), name="my_search", description="Custom search tool.")
+        tavily = TavilySearchTool(client=AsyncMock(), name="my_search", description="Custom search tool.")
 
         [schema] = await tavily.schemas(context)
 
@@ -74,10 +74,10 @@ class TestSchema:
 
 @pytest.mark.asyncio
 class TestSearchExecution:
-    async def test_search_returns_structured_results(self, mock: MagicMock) -> None:
+    async def test_search_returns_structured_results(self, async_mock: AsyncMock) -> None:
         # arrange tool
-        mock.search.return_value = SAMPLE_RAW
-        tavily = TavilySearchTool(client=mock)
+        async_mock.search.return_value = SAMPLE_RAW
+        tavily = TavilySearchTool(client=async_mock)
 
         # arrange agent
         config = TrackingConfig(_make_config("AG2 framework"))
@@ -109,10 +109,10 @@ class TestSearchExecution:
             )
         )
 
-    async def test_search_empty_results(self, mock: MagicMock) -> None:
+    async def test_search_empty_results(self, async_mock: AsyncMock) -> None:
         # arrange tool
-        mock.search.return_value = {"query": "nothing", "results": []}
-        tavily = TavilySearchTool(client=mock)
+        async_mock.search.return_value = {"query": "nothing", "results": []}
+        tavily = TavilySearchTool(client=async_mock)
 
         # arrange agent
         config = TrackingConfig(_make_config("nothing"))
@@ -129,11 +129,11 @@ class TestSearchExecution:
             )
         )
 
-    async def test_all_params_forwarded_to_client(self, mock: MagicMock) -> None:
-        mock.search.return_value = {"query": "q", "results": []}
+    async def test_all_params_forwarded_to_client(self, async_mock: AsyncMock) -> None:
+        async_mock.search.return_value = {"query": "q", "results": []}
 
         tavily = TavilySearchTool(
-            client=mock,
+            client=async_mock,
             max_results=3,
             search_depth="advanced",
             topic="news",
@@ -153,7 +153,7 @@ class TestSearchExecution:
 
         await agent.ask("search")
 
-        mock.search.assert_called_once_with(
+        async_mock.search.assert_called_once_with(
             "q",
             max_results=3,
             search_depth="advanced",
@@ -171,22 +171,22 @@ class TestSearchExecution:
             include_favicon=True,
         )
 
-    async def test_none_params_omitted(self, mock: MagicMock) -> None:
+    async def test_none_params_omitted(self, async_mock: AsyncMock) -> None:
         # All optional params default to None and must not be forwarded to the SDK
         # so Tavily applies its own server-side defaults.
-        mock.search.return_value = {"query": "q", "results": []}
+        async_mock.search.return_value = {"query": "q", "results": []}
 
-        tavily = TavilySearchTool(client=mock)
+        tavily = TavilySearchTool(client=async_mock)
         agent = Agent("a", config=_make_config("q"), tools=[tavily])
 
         await agent.ask("search")
 
-        mock.search.assert_called_once_with("q")
+        async_mock.search.assert_called_once_with("q")
 
-    async def test_custom_tool_name_in_agent(self, mock: MagicMock) -> None:
+    async def test_custom_tool_name_in_agent(self, async_mock: AsyncMock) -> None:
         # arrange tool
-        mock.search.return_value = {"query": "q", "results": []}
-        ddg = TavilySearchTool(client=mock, name="web_search")
+        async_mock.search.return_value = {"query": "q", "results": []}
+        ddg = TavilySearchTool(client=async_mock, name="web_search")
 
         # arrange agent
         config = TrackingConfig(_make_config("AG2 framework", tool_name="web_search"))
@@ -196,16 +196,16 @@ class TestSearchExecution:
         await agent.ask("search")
 
         # assert tool called
-        mock.search.assert_called_once()
+        async_mock.search.assert_called_once()
 
 
 @pytest.mark.asyncio
 class TestTavilykSearchToolVariable:
-    async def test_resolved(self, mock: MagicMock) -> None:
+    async def test_resolved(self, async_mock: AsyncMock) -> None:
         # arrange tool
-        mock.search.return_value = SAMPLE_RAW
+        async_mock.search.return_value = SAMPLE_RAW
         tavily = TavilySearchTool(
-            client=mock,
+            client=async_mock,
             search_depth=Variable("user_depth"),
             topic=Variable(),
         )
@@ -225,16 +225,16 @@ class TestTavilykSearchToolVariable:
         await agent.ask("search")
 
         # assert variables resolved
-        mock.search.assert_called_once_with(
+        async_mock.search.assert_called_once_with(
             "test query",
             search_depth="basic",
             topic="general",
         )
 
-    async def test_missing_raises(self, mock: MagicMock) -> None:
-        mock.search.return_value = SAMPLE_RAW
+    async def test_missing_raises(self, async_mock: AsyncMock) -> None:
+        async_mock.search.return_value = SAMPLE_RAW
         tavily = TavilySearchTool(
-            client=mock,
+            client=async_mock,
             topic=Variable(),
         )
 

--- a/test/beta/tools/search/test_tavily.py
+++ b/test/beta/tools/search/test_tavily.py
@@ -181,6 +181,18 @@ class TestSearchExecution:
         assert body == IsPartialDict({"query": "q"})
 
     @respx.mock
+    async def test_client_kwargs_forwarded_to_sdk(self) -> None:
+        custom_url = "https://custom.tavily.example"
+        route = respx.post(f"{custom_url}/search").mock(
+            return_value=httpx.Response(200, json={"query": "q", "results": []})
+        )
+        tavily = TavilySearchTool(api_key="test", client_kwargs={"api_base_url": custom_url})
+        agent = Agent("a", config=_make_config("q"), tools=[tavily])
+        await agent.ask("search")
+
+        assert route.called
+
+    @respx.mock
     async def test_custom_tool_name_in_agent(self) -> None:
         route = respx.post(f"{TAVILY_BASE_URL}/search").mock(
             return_value=httpx.Response(200, json={"query": "q", "results": []})

--- a/test/beta/tools/search/test_tavily.py
+++ b/test/beta/tools/search/test_tavily.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from unittest.mock import AsyncMock
+from typing import Any
 
+import httpx
 import pytest
+import respx
 from dirty_equals import IsPartialDict
 
 pytest.importorskip("tavily")
@@ -16,7 +18,9 @@ from autogen.beta.events import ModelResponse, ToolCallEvent, ToolCallsEvent, To
 from autogen.beta.testing import TestConfig, TrackingConfig
 from autogen.beta.tools.search.tavily import SearchResponse, SearchResult, TavilySearchTool
 
-SAMPLE_RAW = {
+TAVILY_BASE_URL = "https://api.tavily.com"
+
+SAMPLE_RAW: dict[str, Any] = {
     "query": "AG2 framework",
     "answer": "AG2 is an open-source multi-agent framework.",
     "results": [
@@ -41,7 +45,7 @@ SAMPLE_RAW = {
 }
 
 
-def _make_config(query: str, final_reply: str = "done", tool_name: str = "tavily_search") -> TestConfig:
+def _make_config(query: str, *, final_reply: str = "done", tool_name: str = "tavily_search") -> TestConfig:
     call = ToolCallEvent(arguments=json.dumps({"query": query}), name=tool_name)
     return TestConfig(ModelResponse(tool_calls=ToolCallsEvent([call])), final_reply)
 
@@ -49,7 +53,7 @@ def _make_config(query: str, final_reply: str = "done", tool_name: str = "tavily
 @pytest.mark.asyncio
 class TestSchema:
     async def test_default_schema(self, context: ConversationContext) -> None:
-        tavily = TavilySearchTool(client=AsyncMock())
+        tavily = TavilySearchTool(api_key="test")
 
         [schema] = await tavily.schemas(context)
 
@@ -60,7 +64,7 @@ class TestSchema:
         })
 
     async def test_custom_schema(self, context: ConversationContext) -> None:
-        tavily = TavilySearchTool(client=AsyncMock(), name="my_search", description="Custom search tool.")
+        tavily = TavilySearchTool(api_key="test", name="my_search", description="Custom search tool.")
 
         [schema] = await tavily.schemas(context)
 
@@ -74,16 +78,13 @@ class TestSchema:
 
 @pytest.mark.asyncio
 class TestSearchExecution:
-    async def test_search_returns_structured_results(self, async_mock: AsyncMock) -> None:
-        # arrange tool
-        async_mock.search.return_value = SAMPLE_RAW
-        tavily = TavilySearchTool(client=async_mock)
+    @respx.mock
+    async def test_search_returns_structured_results(self) -> None:
+        respx.post(f"{TAVILY_BASE_URL}/search").mock(return_value=httpx.Response(200, json=SAMPLE_RAW))
+        tavily = TavilySearchTool(api_key="test")
 
-        # arrange agent
         config = TrackingConfig(_make_config("AG2 framework"))
         agent = Agent("a", config=config, tools=[tavily])
-
-        # act
         await agent.ask("search")
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
@@ -109,31 +110,27 @@ class TestSearchExecution:
             )
         )
 
-    async def test_search_empty_results(self, async_mock: AsyncMock) -> None:
-        # arrange tool
-        async_mock.search.return_value = {"query": "nothing", "results": []}
-        tavily = TavilySearchTool(client=async_mock)
+    @respx.mock
+    async def test_search_empty_results(self) -> None:
+        respx.post(f"{TAVILY_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json={"query": "nothing", "results": []})
+        )
+        tavily = TavilySearchTool(api_key="test")
 
-        # arrange agent
         config = TrackingConfig(_make_config("nothing"))
         agent = Agent("a", config=config, tools=[tavily])
-
-        # act
         await agent.ask("search")
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
-        assert tool_results_event.results[0].result.parts[0] == DataInput(
-            SearchResponse(
-                query="nothing",
-                results=[],
-            )
+        assert tool_results_event.results[0].result.parts[0] == DataInput(SearchResponse(query="nothing", results=[]))
+
+    @respx.mock
+    async def test_all_params_forwarded_to_client(self) -> None:
+        route = respx.post(f"{TAVILY_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json={"query": "q", "results": []})
         )
-
-    async def test_all_params_forwarded_to_client(self, async_mock: AsyncMock) -> None:
-        async_mock.search.return_value = {"query": "q", "results": []}
-
         tavily = TavilySearchTool(
-            client=async_mock,
+            api_key="test",
             max_results=3,
             search_depth="advanced",
             topic="news",
@@ -150,93 +147,83 @@ class TestSearchExecution:
             include_favicon=True,
         )
         agent = Agent("a", config=_make_config("q"), tools=[tavily])
-
         await agent.ask("search")
 
-        async_mock.search.assert_called_once_with(
-            "q",
-            max_results=3,
-            search_depth="advanced",
-            topic="news",
-            include_answer=True,
-            include_raw_content="markdown",
-            include_images=True,
-            time_range="week",
-            start_date="2024-01-01",
-            end_date="2024-12-31",
-            include_domains=["arxiv.org"],
-            exclude_domains=["medium.com"],
-            country="US",
-            auto_parameters=True,
-            include_favicon=True,
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({
+            "query": "q",
+            "max_results": 3,
+            "search_depth": "advanced",
+            "topic": "news",
+            "include_answer": True,
+            "include_raw_content": "markdown",
+            "include_images": True,
+            "time_range": "week",
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+            "include_domains": ["arxiv.org"],
+            "exclude_domains": ["medium.com"],
+            "country": "US",
+            "auto_parameters": True,
+            "include_favicon": True,
+        })
+
+    @respx.mock
+    async def test_none_params_omitted(self) -> None:
+        route = respx.post(f"{TAVILY_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json={"query": "q", "results": []})
         )
-
-    async def test_none_params_omitted(self, async_mock: AsyncMock) -> None:
-        # All optional params default to None and must not be forwarded to the SDK
-        # so Tavily applies its own server-side defaults.
-        async_mock.search.return_value = {"query": "q", "results": []}
-
-        tavily = TavilySearchTool(client=async_mock)
+        tavily = TavilySearchTool(api_key="test")
         agent = Agent("a", config=_make_config("q"), tools=[tavily])
-
         await agent.ask("search")
 
-        async_mock.search.assert_called_once_with("q")
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({"query": "q"})
 
-    async def test_custom_tool_name_in_agent(self, async_mock: AsyncMock) -> None:
-        # arrange tool
-        async_mock.search.return_value = {"query": "q", "results": []}
-        ddg = TavilySearchTool(client=async_mock, name="web_search")
+    @respx.mock
+    async def test_custom_tool_name_in_agent(self) -> None:
+        route = respx.post(f"{TAVILY_BASE_URL}/search").mock(
+            return_value=httpx.Response(200, json={"query": "q", "results": []})
+        )
+        tavily = TavilySearchTool(api_key="test", name="web_search")
 
-        # arrange agent
         config = TrackingConfig(_make_config("AG2 framework", tool_name="web_search"))
-        agent = Agent("a", config=config, tools=[ddg])
-
-        # act
+        agent = Agent("a", config=config, tools=[tavily])
         await agent.ask("search")
 
-        # assert tool called
-        async_mock.search.assert_called_once()
+        assert route.called
 
 
 @pytest.mark.asyncio
-class TestTavilykSearchToolVariable:
-    async def test_resolved(self, async_mock: AsyncMock) -> None:
-        # arrange tool
-        async_mock.search.return_value = SAMPLE_RAW
+class TestTavilySearchToolVariable:
+    @respx.mock
+    async def test_resolved(self) -> None:
+        route = respx.post(f"{TAVILY_BASE_URL}/search").mock(return_value=httpx.Response(200, json=SAMPLE_RAW))
         tavily = TavilySearchTool(
-            client=async_mock,
+            api_key="test",
             search_depth=Variable("user_depth"),
             topic=Variable(),
         )
 
-        # arrange agent
         agent = Agent(
             "a",
             config=_make_config("test query"),
             tools=[tavily],
-            variables={
-                "user_depth": "basic",
-                "topic": "general",
-            },
+            variables={"user_depth": "basic", "topic": "general"},
         )
-
-        # act
         await agent.ask("search")
 
-        # assert variables resolved
-        async_mock.search.assert_called_once_with(
-            "test query",
-            search_depth="basic",
-            topic="general",
-        )
+        body = json.loads(route.calls.last.request.content)
+        assert body == IsPartialDict({
+            "query": "test query",
+            "search_depth": "basic",
+            "topic": "general",
+        })
 
-    async def test_missing_raises(self, async_mock: AsyncMock) -> None:
-        async_mock.search.return_value = SAMPLE_RAW
-        tavily = TavilySearchTool(
-            client=async_mock,
-            topic=Variable(),
-        )
+    @respx.mock
+    async def test_missing_raises(self) -> None:
+        respx.post(f"{TAVILY_BASE_URL}/search").mock(return_value=httpx.Response(200, json=SAMPLE_RAW))
+        tavily = TavilySearchTool(api_key="test", topic=Variable())
 
         agent = Agent("a", config=_make_config("test query"), tools=[tavily])
 

--- a/test/beta/tools/search/test_tavily.py
+++ b/test/beta/tools/search/test_tavily.py
@@ -186,7 +186,7 @@ class TestSearchExecution:
         route = respx.post(f"{custom_url}/search").mock(
             return_value=httpx.Response(200, json={"query": "q", "results": []})
         )
-        tavily = TavilySearchTool(api_key="test", client_kwargs={"api_base_url": custom_url})
+        tavily = TavilySearchTool(api_key="test", api_base_url=custom_url)
         agent = Agent("a", config=_make_config("q"), tools=[tavily])
         await agent.ask("search")
 

--- a/website/docs/beta/tools/common_toolkits.mdx
+++ b/website/docs/beta/tools/common_toolkits.mdx
@@ -461,7 +461,7 @@ All runtime parameters accept a `Variable` for deferred context resolution.
 
 ### HTTP and SDK options
 
-The toolkit constructor accepts options for the underlying `httpx.AsyncClient` and the Perplexity SDK client. Anything in `client_kwargs` is forwarded as keyword arguments to `AsyncPerplexity(...)` (e.g. `base_url`, `max_retries`, `default_headers`):
+The toolkit constructor accepts options for the underlying `httpx.AsyncClient` and the Perplexity SDK client. Any extra keyword arguments are forwarded directly to `AsyncPerplexity(...)` (e.g. `base_url`, `max_retries`, `default_headers`):
 
 ```python linenums="1"
 toolkit = PerplexitySearchToolkit(
@@ -469,11 +469,10 @@ toolkit = PerplexitySearchToolkit(
     proxy="http://proxy.company.com:8080",  # passed to httpx.AsyncClient
     verify=False,                            # disable TLS verification (httpx)
     timeout=30.0,                            # httpx timeout in seconds
-    client_kwargs={                          # forwarded to AsyncPerplexity
-        "base_url": "https://custom.perplexity.example",
-        "max_retries": 5,
-        "default_headers": {"X-Trace-Id": "abc-123"},
-    },
+    # extra kwargs below are forwarded to AsyncPerplexity
+    base_url="https://custom.perplexity.example",
+    max_retries=5,
+    default_headers={"X-Trace-Id": "abc-123"},
 )
 ```
 
@@ -547,7 +546,7 @@ All search parameters accept a `Variable` for dynamic values resolved at executi
 
 ### HTTP and SDK options
 
-The constructor also accepts options for the underlying `httpx.AsyncClient` and the Tavily SDK client. Anything in `client_kwargs` is forwarded as keyword arguments to `AsyncTavilyClient(...)` (e.g. `api_base_url`, `company_info_tags`, `project_id`):
+The constructor also accepts options for the underlying `httpx.AsyncClient` and the Tavily SDK client. Any extra keyword arguments are forwarded directly to `AsyncTavilyClient(...)` (e.g. `api_base_url`, `company_info_tags`, `project_id`):
 
 ```python linenums="1"
 tool = TavilySearchTool(
@@ -555,10 +554,9 @@ tool = TavilySearchTool(
     proxy="http://proxy.company.com:8080",  # passed to httpx.AsyncClient
     verify=False,                            # disable TLS verification (httpx)
     timeout=30.0,                            # httpx timeout in seconds
-    client_kwargs={                          # forwarded to AsyncTavilyClient
-        "api_base_url": "https://custom.tavily.example",
-        "company_info_tags": ("news", "finance"),
-    },
+    # extra kwargs below are forwarded to AsyncTavilyClient
+    api_base_url="https://custom.tavily.example",
+    company_info_tags=("news", "finance"),
 )
 ```
 


### PR DESCRIPTION
## Summary

Search tools (`TavilySearchTool`, `ExaToolkit`, `PerplexitySearchToolkit`) used the **synchronous** SDK clients (`TavilyClient`, `Exa`, `Perplexity`). Each tool call hit the `sync_to_thread` path (default in `@tool` via `_to_async`), occupying a worker from the shared thread pool — wasteful for what is purely network I/O, and a bottleneck under fan-out (e.g. parallel sub-tasks).

This PR switches them to the async SDK variants (`AsyncTavilyClient`, `AsyncExa`, `AsyncPerplexity`) with a **per-call lifecycle**: a fresh client is created on every tool invocation and explicitly closed afterwards, so no connections leak past the call.

DuckDuckGo (`DuckDuckSearchTool`) is **not** touched — `ddgs` has no async variant and internally uses its own `ThreadPoolExecutor` to fan out across multiple search engines; rewriting it on raw `httpx` would mean re-implementing half the library.

## Changes

- `autogen/beta/tools/search/tavily.py`: `AsyncTavilyClient` via `async with` per call.
- `autogen/beta/tools/search/perplexity.py`: `AsyncPerplexity` via `async with` per call for both `search` (Search API) and `answer` (Sonar Chat Completions). `__deepcopy__` override is kept — it’s load-bearing for the niche but valid case `client=AsyncPerplexity(...) + tools=[toolkit]`, where the SDK’s internal `_thread.RLock` would otherwise break `Agent.add_tool`’s deepcopy.
- `autogen/beta/tools/search/exa.py`: `AsyncExa` has no native `__aenter__`/`__aexit__`, so each of the four factory methods (`search`, `find_similar`, `get_contents`, `answer`) uses `try/finally` + `await c.client.aclose()` on the underlying `httpx.AsyncClient`. Internal `_clean()` helper removed in favor of inline filtering, matching the style of the other two modules.
- All three modules: client is no longer constructed in `__init__` (no more side effect at construction time) — only `api_key` and an optional user-supplied `client=` are stored. When the caller passes their own client, it is used as-is and not closed (the caller owns it).

## Trade-offs

- Per-call client construction means a new TLS handshake on every search invocation. On the scale of a Search API’s 1–3s round-trip, the added handshake (~100–300ms over a warm proxy) is negligible. Cross-call connection pooling is lost, but search tools are typically called O(1) times per turn, so there’s no practical regression.
- The alternative — long-lived clients closed via `Tool.register()` — would require migrating the entire `Tool` / `Observer` / `Agent` registration protocol from `ExitStack` to `AsyncExitStack` (~17 production files + 5 test files). Out of scope for this PR.

