### PR TITLE
docs: fix Python version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For a step-by-step walk through of AG2 concepts and code, see [Basic Concepts](h
 
 ### Installation
 
-AG2 requires **Python version >= 3.10, < 3.14**. AG2 is available via `ag2` (or its alias `autogen`) on PyPI.
+AG2 requires **Python version >= 3.10**. AG2 is available via `ag2` (or its alias `autogen`) on PyPI.
 
 **Windows/Linux:**
 ```bash


### PR DESCRIPTION
## Summary

The README states `Python version >= 3.10, < 3.14` but:
- `pyproject.toml` specifies `requires-python = ">=3.10"` (no upper bound)
- Classifiers include `Programming Language :: Python :: 3.14`
- CI (`beta-test.yml`) tests against `["3.10", "3.11", "3.12", "3.13", "3.14"]`

Updated the README to match the actual project configuration.

## Changes

- `README.md` line 85: `>= 3.10, < 3.14` → `>= 3.10`

closes issue #2766 