### PR TITLE
feat(beta): update Exa search types and add x-exa-integration tracking header

### DIFF
--- a/autogen/beta/tools/search/exa.py
+++ b/autogen/beta/tools/search/exa.py
@@ -16,17 +16,22 @@ from autogen.beta.tools.builtin._resolve import resolve_variable
 from autogen.beta.tools.final import Toolkit, tool
 from autogen.beta.tools.final.function_tool import FunctionTool
 
-SearchType: TypeAlias = Literal["neural", "keyword", "hybrid", "auto", "fast", "deep"]
+SearchType: TypeAlias = Literal[
+    "auto",
+    "neural",
+    "fast",
+    "instant",
+    "deep",
+    "deep-lite",
+    "deep-reasoning",
+]
 Category: TypeAlias = Literal[
     "company",
     "research paper",
     "news",
-    "pdf",
-    "github",
-    "tweet",
     "personal site",
-    "linkedin profile",
     "financial report",
+    "people",
 ]
 Livecrawl: TypeAlias = Literal["never", "fallback", "always", "preferred"]
 
@@ -109,6 +114,8 @@ class ExaToolkit(Toolkit):
 
     __slots__ = ("_client",)
 
+    INTEGRATION_NAME = "ag2"
+
     def __init__(
         self,
         api_key: str | None = None,
@@ -119,6 +126,8 @@ class ExaToolkit(Toolkit):
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
         self._client = client if client is not None else Exa(api_key=api_key)
+        if hasattr(self._client, "headers") and isinstance(self._client.headers, dict):
+            self._client.headers["x-exa-integration"] = self.INTEGRATION_NAME
 
         super().__init__(
             self.search(num_results=num_results, max_characters=max_characters),

--- a/test/beta/tools/search/test_exa.py
+++ b/test/beta/tools/search/test_exa.py
@@ -64,6 +64,23 @@ def _tool_call_config(
     )
 
 
+class TestIntegrationHeader:
+    def test_header_set_on_dict_headers(self) -> None:
+        client = MagicMock()
+        client.headers = {"x-api-key": "secret"}
+
+        ExaToolkit(client=client)
+
+        assert client.headers["x-exa-integration"] == "ag2"
+
+    def test_header_skipped_when_headers_not_a_dict(self) -> None:
+        client = MagicMock(spec=[])
+
+        ExaToolkit(client=client)
+
+        assert not hasattr(client, "headers") or not isinstance(client.headers, dict)
+
+
 @pytest.mark.asyncio
 class TestSchema:
     async def test_default_schemas(self, context: ConversationContext) -> None:
@@ -358,11 +375,11 @@ class TestExaToolkitVariable:
             "a",
             config=_tool_call_config({"query": "q"}, tool_name="exa_search"),
             tools=[search_tool],
-            variables={"user_limit": 10, "search_type": "keyword"},
+            variables={"user_limit": 10, "search_type": "neural"},
         )
         await agent.ask("search")
 
-        mock.search.assert_called_once_with("q", num_results=10, type="keyword")
+        mock.search.assert_called_once_with("q", num_results=10, type="neural")
 
     async def test_missing_raises(self, mock: MagicMock) -> None:
         mock.search.return_value = _response([])


### PR DESCRIPTION
## Summary

Bring the `ExaToolkit` in `autogen/beta/tools/search/exa.py` up to date with the current Exa `/search` API reference and add the `x-exa-integration` tracking header so Exa can attribute API usage from ag2 deployments.

- **`SearchType`**: drop deprecated `keyword` and `hybrid`; add `instant`, `deep-lite`, `deep-reasoning` (current valid values per https://exa.ai/docs/reference/search).
- **`Category`**: drop `pdf`, `github`, `tweet`, `linkedin profile` (no longer valid categories); add `people` (replaces `linkedin profile` for LinkedIn-quality results).
- **Tracking header**: when `ExaToolkit` constructs an `Exa` client, set `client.headers["x-exa-integration"] = "ag2"`. The header is only set when the client exposes a real `dict` for `headers`, so existing tests using `MagicMock` are unaffected.

## Usage

No public API change; existing code keeps working:

```python
from autogen.beta.tools.search.exa import ExaToolkit

toolkit = ExaToolkit(api_key="...")  # tracking header applied automatically

# Use a current search type:
toolkit.search(search_type="instant", category="people")
```

## Files changed

- `autogen/beta/tools/search/exa.py` -- update `SearchType` / `Category` literals; set tracking header on the underlying `Exa` client
- `test/beta/tools/search/test_exa.py` -- add `TestIntegrationHeader` covering header-set / no-header paths; update an existing variable test to use a valid search type

## Test plan

- [x] `pytest test/beta/tools/search/test_exa.py` -- 21 passed
- [x] `ruff check` and `ruff format --check` on changed files -- clean
- [x] `mypy autogen/beta/tools/search/exa.py` -- no new errors (3 pre-existing union-attr errors on `client.answer()` are unrelated to this change)