### PR TITLE
Feat(Beta): foundation for network (1/4)

### DIFF
--- a/autogen/beta/__init__.py
+++ b/autogen/beta/__init__.py
@@ -21,6 +21,7 @@ from .observer import observer
 from .response import PromptedSchema, ResponseSchema, response_schema
 from .spec import AgentSpec
 from .stream import MemoryStream
+from .task import Task, TaskInject, TaskSpec
 from .tools import ToolResult, Toolkit, tool
 
 __all__ = (
@@ -41,7 +42,10 @@ __all__ = (
     "Middleware",
     "PromptedSchema",
     "ResponseSchema",
+    "Task",
     "TaskConfig",
+    "TaskInject",
+    "TaskSpec",
     "TextInput",
     "ToolResult",
     "Toolkit",

--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -71,6 +71,7 @@ from .observer import Observer
 from .observer import observer as observer_factory
 from .response import ResponseProto, ResponseSchema
 from .stream import MemoryStream, Stream
+from .task import Task, TaskSpec
 from .tools.executor import ToolExecutor
 from .tools.final import FunctionParameters, FunctionTool, FunctionToolSchema, tool
 from .tools.schemas import ToolSchema
@@ -607,6 +608,39 @@ class Agent(Generic[TResult]):
     def add_observer(self, observer: Observer) -> None:
         """Register an observer (before calling ask())."""
         self._observers.append(observer)
+
+    def task(
+        self,
+        title: str,
+        *,
+        description: str = "",
+        payload: dict[str, Any] | None = None,
+        ttl_seconds: int | None = None,
+        context: Context | None = None,
+    ) -> Task:
+        """Create a ``Task`` whose lifecycle this Agent owns.
+
+        Returns an unentered ``Task``; use as ``async with agent.task(...)``.
+        Events flow on ``context.stream`` if a ``ConversationContext`` is
+        supplied; else the Task creates a private ``MemoryStream`` on entry
+        and events fire on it (only observers attached to that private
+        stream see them).
+
+        Inside the ``async with`` block, ``ag2.task`` is stamped into
+        ``context.dependencies`` so any tool annotated with ``TaskInject``
+        resolves to this Task.
+        """
+        spec = TaskSpec(
+            title=title,
+            description=description,
+            payload=dict(payload) if payload else {},
+        )
+        return Task(
+            owner_id=self.name,
+            spec=spec,
+            context=context,
+            ttl_seconds=ttl_seconds,
+        )
 
     def tool(
         self,

--- a/autogen/beta/events/__init__.py
+++ b/autogen/beta/events/__init__.py
@@ -26,7 +26,7 @@ from .lifecycle import (
     ObserverStarted,
     UnknownEvent,
 )
-from .task_events import TaskCompleted, TaskFailed, TaskProgress, TaskStarted
+from .task_events import TaskCompleted, TaskExpired, TaskFailed, TaskProgress, TaskStarted
 from .tool_events import (
     BuiltinToolCallEvent,
     BuiltinToolResultEvent,
@@ -81,6 +81,7 @@ __all__ = (
     "ObserverStarted",
     "Severity",
     "TaskCompleted",
+    "TaskExpired",
     "TaskFailed",
     "TaskProgress",
     "TaskStarted",

--- a/autogen/beta/events/task_events.py
+++ b/autogen/beta/events/task_events.py
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import traceback
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .base import BaseEvent, Field
 from .types import Usage
 
 if TYPE_CHECKING:
     from autogen.beta.context import StreamId
+    from autogen.beta.task import TaskSpec
 
 
 class TaskEvent(BaseEvent):
@@ -19,22 +20,36 @@ class TaskEvent(BaseEvent):
 
 
 class TaskStarted(TaskEvent):
-    pass
+    # Optional ``TaskSpec`` describing what the task is doing. Set by the
+    # framework-core ``Task`` primitive (``autogen.beta.task``); legacy
+    # ``run_task`` callers leave it ``None``.
+    spec: "TaskSpec | None" = Field(None)
 
 
 class TaskProgress(TaskEvent):
-    """Streamed progress update from a running task sub-agent.
+    """Progress update for a running task.
 
-    Transient: superseded by the final ``TaskCompleted``.
+    Two distinct uses on one event:
+
+    * ``content`` carries streamed sub-agent output (``run_subtask`` /
+      ``subagent_tool``). Marked transient — superseded by the final
+      ``TaskCompleted``.
+    * ``payload`` carries structured checkpoint data emitted by the task
+      owner via ``Task.progress({...})``. Persistent within the parent
+      stream until the task terminates.
     """
 
     __transient__ = True
 
-    content: str
+    content: str = Field("")
+    payload: dict[str, Any] = Field(default_factory=dict)
 
 
 class TaskCompleted(TaskEvent):
-    result: str | None
+    # Widened from ``str | None`` to ``Any`` so framework-core ``Task``
+    # owners can return structured results. ``run_task`` still passes a
+    # string, so existing callers are unaffected.
+    result: Any = Field(None)
     task_stream: "StreamId"  # Stream reference for inspection
     usage: Usage = Field(default_factory=Usage)
 
@@ -59,3 +74,13 @@ class TaskFailed(TaskEvent):
                 )
             )
         return self._content
+
+
+class TaskExpired(TaskEvent):
+    """Terminal event — task TTL elapsed without a terminal event.
+
+    Emitted by whichever observer holds the TTL clock. Standalone agents
+    receive no expiry unless app code arranges it; networked agents
+    receive it via the hub's TTL sweeper, mirrored back through
+    ``AgentClient``.
+    """

--- a/autogen/beta/network/__init__.py
+++ b/autogen/beta/network/__init__.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""autogen.beta.network — agent registry, durable messaging, and protocol-driven sessions.
+
+V1 ships in three internal milestones (see ``design/PLAN.md``):
+
+* M1 — Foundation: identity, envelope, rule, auth, transport, hub plumbing
+* M2 — Consulting loop: first end-to-end LLM-driven session adapter + tools
+* M3 — Multi-party + observability: discussion adapter, expectations, full tool surface
+
+Importing ``autogen.beta.network`` is opt-in — bare ``Agent`` continues
+to work standalone with no behavioural change when this package is not
+imported.
+"""
+
+from .auth import AuthAdapter, AuthRegistry, NoAuth, default_registry
+from .client import AgentClient, HubClient, NetworkClient
+from .hub import Hub
+from .transport import (
+    AcceptFrame,
+    ErrorFrame,
+    EventFrame,
+    Frame,
+    HelloFrame,
+    LinkClient,
+    LinkEndpoint,
+    LocalLink,
+    LocalLinkClient,
+    LocalLinkEndpoint,
+    NotifyFrame,
+    PingFrame,
+    PongFrame,
+    ReceiptFrame,
+    SendFrame,
+    SubscribeFrame,
+    UnsubscribeFrame,
+    WelcomeFrame,
+    decode_frame,
+    encode_frame,
+)
+from .envelope import (
+    EV_ERROR,
+    EV_EXPECTATION_VIOLATED,
+    EV_PARTICIPANT_REMOVED,
+    EV_PEER_RECONNECTED,
+    EV_PEER_UNREACHABLE,
+    EV_SESSION_CLOSED,
+    EV_SESSION_EXPIRED,
+    EV_SESSION_IDLE,
+    EV_SESSION_INVITE,
+    EV_SESSION_INVITE_ACK,
+    EV_SESSION_INVITE_REJECT,
+    EV_SESSION_OPENED,
+    EV_SESSION_QUORUM_CHANGED,
+    EV_TASK_ERROR,
+    EV_TASK_EXPIRED,
+    EV_TASK_PROGRESS,
+    EV_TASK_RESULT,
+    EV_TASK_STALLED,
+    EV_TASK_STARTED,
+    EV_TEXT,
+    Envelope,
+    Priority,
+    visible_to,
+)
+from .errors import (
+    AccessDeniedError,
+    AuthError,
+    InboxFull,
+    NetworkError,
+    NotFoundError,
+    ProtocolError,
+)
+from .identity import (
+    AgentRuntime,
+    AuthBlock,
+    CostProfile,
+    ObservedStat,
+    Passport,
+    Resume,
+    ResumeExample,
+)
+from .ids import make_id
+from .policies import AGENT_CLIENT_DEP, HUB_DEP, SESSION_DEP, TASK_DEP
+from .rule import (
+    AccessBlock,
+    InboxBlock,
+    LimitsBlock,
+    RateBlock,
+    Rule,
+    SessionTypeAccess,
+    parse_duration,
+)
+
+__all__ = (
+    "AGENT_CLIENT_DEP",
+    "AcceptFrame",
+    "AccessBlock",
+    "AccessDeniedError",
+    "AgentClient",
+    "AgentRuntime",
+    "AuthAdapter",
+    "AuthBlock",
+    "AuthError",
+    "AuthRegistry",
+    "CostProfile",
+    "EV_ERROR",
+    "EV_EXPECTATION_VIOLATED",
+    "EV_PARTICIPANT_REMOVED",
+    "EV_PEER_RECONNECTED",
+    "EV_PEER_UNREACHABLE",
+    "EV_SESSION_CLOSED",
+    "EV_SESSION_EXPIRED",
+    "EV_SESSION_IDLE",
+    "EV_SESSION_INVITE",
+    "EV_SESSION_INVITE_ACK",
+    "EV_SESSION_INVITE_REJECT",
+    "EV_SESSION_OPENED",
+    "EV_SESSION_QUORUM_CHANGED",
+    "EV_TASK_ERROR",
+    "EV_TASK_EXPIRED",
+    "EV_TASK_PROGRESS",
+    "EV_TASK_RESULT",
+    "EV_TASK_STALLED",
+    "EV_TASK_STARTED",
+    "EV_TEXT",
+    "Envelope",
+    "ErrorFrame",
+    "EventFrame",
+    "Frame",
+    "HUB_DEP",
+    "HelloFrame",
+    "Hub",
+    "HubClient",
+    "InboxBlock",
+    "InboxFull",
+    "LimitsBlock",
+    "LinkClient",
+    "LinkEndpoint",
+    "LocalLink",
+    "LocalLinkClient",
+    "LocalLinkEndpoint",
+    "NetworkClient",
+    "NetworkError",
+    "NoAuth",
+    "NotFoundError",
+    "NotifyFrame",
+    "ObservedStat",
+    "Passport",
+    "PingFrame",
+    "PongFrame",
+    "Priority",
+    "ProtocolError",
+    "RateBlock",
+    "ReceiptFrame",
+    "Resume",
+    "ResumeExample",
+    "Rule",
+    "SESSION_DEP",
+    "SendFrame",
+    "SessionTypeAccess",
+    "SubscribeFrame",
+    "TASK_DEP",
+    "UnsubscribeFrame",
+    "WelcomeFrame",
+    "decode_frame",
+    "default_registry",
+    "encode_frame",
+    "make_id",
+    "parse_duration",
+    "visible_to",
+)

--- a/autogen/beta/network/auth.py
+++ b/autogen/beta/network/auth.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authentication adapters.
+
+V1 ships ``NoAuth`` only — every claim is accepted. ``ApiKeyAuth``
+lands in Phase 3 alongside the WebSocket transport. The ``AuthAdapter``
+Protocol stays open so further schemes ship additively (JWT, mTLS, and
+signed-challenge are AG2 Cloud features).
+"""
+
+from typing import Any, Protocol, runtime_checkable
+
+from .errors import AuthError
+from .identity import Passport
+
+__all__ = (
+    "AuthAdapter",
+    "AuthRegistry",
+    "NoAuth",
+    "default_registry",
+)
+
+
+@runtime_checkable
+class AuthAdapter(Protocol):
+    """Validates a passport's auth claim at the connection handshake."""
+
+    scheme: str
+
+    async def validate(self, passport: Passport, claim: dict[str, Any]) -> None:
+        """Raise ``AuthError`` on failure; return ``None`` on success."""
+        ...
+
+
+class NoAuth:
+    """No-op adapter — accepts every claim. V1 default."""
+
+    scheme = "none"
+
+    async def validate(self, passport: Passport, claim: dict[str, Any]) -> None:
+        return None
+
+
+class AuthRegistry:
+    """Registry mapping ``scheme`` strings to ``AuthAdapter`` impls."""
+
+    def __init__(self, adapters: list[AuthAdapter]) -> None:
+        # __init__ stores params; no side effects.
+        self._adapters: dict[str, AuthAdapter] = {a.scheme: a for a in adapters}
+
+    def get(self, scheme: str) -> AuthAdapter:
+        try:
+            return self._adapters[scheme]
+        except KeyError as exc:
+            raise AuthError(f"unknown auth scheme: {scheme!r}") from exc
+
+    def schemes(self) -> list[str]:
+        return list(self._adapters.keys())
+
+
+# Default registry — ``NoAuth`` only. Apps wanting ``ApiKeyAuth`` (Phase
+# 3) construct their own ``AuthRegistry([NoAuth(), ApiKeyAuth()])`` and
+# pass it to ``Hub(... auth=...)``.
+default_registry = AuthRegistry([NoAuth()])

--- a/autogen/beta/network/client/__init__.py
+++ b/autogen/beta/network/client/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tenant-side clients — ``NetworkClient`` Protocol, ``HubClient``, ``AgentClient``.
+
+The trust boundary runs through this package: tenant code (notify
+handlers, future transforms, LLM tool execution) only runs inside the
+tenant process. The hub never imports anything from here.
+"""
+
+from .agent_client import AgentClient
+from .hub_client import HubClient
+from .network_client import NetworkClient
+
+__all__ = ("AgentClient", "HubClient", "NetworkClient")

--- a/autogen/beta/network/client/agent_client.py
+++ b/autogen/beta/network/client/agent_client.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``AgentClient`` — per-registration tenant handle.
+
+M1 surface: properties (agent, passport, resume, agent_id), receive
+callback (M1 testing seam — M2 wires the per-session-type notify
+handler registry), tenant-driven mutation (``set_resume`` /
+``set_skill`` / ``set_rule``), unregister, disconnect, and a direct
+``send_envelope`` helper that bypasses the link's ``SendFrame`` path
+for in-process simplicity.
+
+M2 will attach the ``NetworkPlugin`` at registration so the LLM verbs
+become ``agent.tools``; M1 keeps the agent untouched.
+"""
+
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from autogen.beta.agent import Agent
+
+from ..envelope import Envelope
+from ..identity import Passport, Resume
+from ..rule import Rule
+
+if TYPE_CHECKING:
+    from ..hub import Hub
+    from .hub_client import HubClient
+
+__all__ = ("AgentClient",)
+
+
+EnvelopeHandler = Callable[[Envelope], Awaitable[None]]
+
+
+class AgentClient:
+    """Tenant-side handle for one ``(Agent, identity, hub)`` registration.
+
+    M1 ships the bare bones — properties, receive callback (testing
+    seam), envelope post helper, and tenant-driven mutation passthroughs
+    to the hub. The notify-handler registry, ``open(...)`` for sessions,
+    and ``NetworkPlugin`` attachment all arrive in M2.
+    """
+
+    def __init__(
+        self,
+        *,
+        agent: Agent,
+        passport: Passport,
+        resume: Resume,
+        rule: Rule,
+        hub: "Hub",
+        hub_client: "HubClient",
+    ) -> None:
+        # __init__ stores params; no side effects.
+        self._agent = agent
+        self._passport = passport
+        self._resume = resume
+        self._rule = rule
+        self._hub = hub
+        self._hub_client = hub_client
+        self._on_envelope: EnvelopeHandler | None = None
+        self._disconnected = False
+
+    # ── Properties ───────────────────────────────────────────────────────────
+
+    @property
+    def agent(self) -> Agent:
+        return self._agent
+
+    @property
+    def passport(self) -> Passport:
+        return self._passport
+
+    @property
+    def resume(self) -> Resume:
+        return self._resume
+
+    @property
+    def rule(self) -> Rule:
+        return self._rule
+
+    @property
+    def agent_id(self) -> str:
+        if self._passport.agent_id is None:
+            raise RuntimeError("AgentClient has unstamped passport (not registered)")
+        return self._passport.agent_id
+
+    # ── NetworkClient impl ───────────────────────────────────────────────────
+
+    async def receive(self, envelope: Envelope) -> None:
+        """Hub delivers an envelope (via ``HubClient`` demux).
+
+        M1 routes to ``on_envelope`` callback for testing. M2 dispatches
+        to the per-session-type notify handler registry, which in turn
+        calls the default handler (read WAL → project view → ask agent
+        → send reply).
+        """
+        if self._on_envelope is not None:
+            await self._on_envelope(envelope)
+
+    def on_envelope(self, callback: EnvelopeHandler) -> None:
+        """Register a callback for incoming envelopes (M1 testing seam).
+
+        M2 replaces this with the ``@client.on(session_type)`` registry.
+        Multiple registrations overwrite; one callback at a time in M1.
+        """
+        self._on_envelope = callback
+
+    async def disconnect(self) -> None:
+        """Drop the AgentClient's local state. Idempotent.
+
+        Does not unregister the identity from the hub — call
+        :meth:`unregister` for that. Does not close the underlying
+        link — that's owned by ``HubClient``.
+        """
+        self._disconnected = True
+        self._on_envelope = None
+
+    # ── Envelope send (M1 helper — direct hub call) ──────────────────────────
+
+    async def send_envelope(self, envelope: Envelope) -> str:
+        """Post an envelope through the hub. Returns the stamped ``envelope_id``.
+
+        M1 simplification: bypasses the link's ``SendFrame`` path and
+        calls ``Hub.post_envelope`` directly. This works because V1 is
+        in-process; M2 / Phase 3 add the round-trip ``SendFrame`` →
+        ``AcceptFrame`` flow with request/response correlation.
+        """
+        if self._disconnected:
+            raise RuntimeError("AgentClient is disconnected")
+        if envelope.sender_id == "":
+            envelope.sender_id = self.agent_id
+        return await self._hub.post_envelope(envelope)
+
+    # ── Tenant-driven mutation ───────────────────────────────────────────────
+
+    async def set_resume(self, resume: Resume) -> None:
+        await self._hub.set_resume(self.agent_id, resume)
+        self._resume = resume
+
+    async def set_skill(self, skill_md: str | None) -> None:
+        await self._hub.set_skill(self.agent_id, skill_md)
+
+    async def set_rule(self, rule: Rule) -> None:
+        await self._hub.set_rule(self.agent_id, rule)
+        self._rule = rule
+
+    async def unregister(self) -> None:
+        """Unregister this identity from the hub.
+
+        After this returns, subsequent ``send_envelope`` calls will fail
+        with ``NotFoundError`` (sender not registered). The
+        ``AgentClient`` instance becomes inert.
+        """
+        if not self._disconnected:
+            await self._hub.unregister(self.agent_id)
+            self._disconnected = True

--- a/autogen/beta/network/client/hub_client.py
+++ b/autogen/beta/network/client/hub_client.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``HubClient`` — one connection to one hub per process.
+
+M1 surface: lazy-connects the underlying ``LinkClient`` on first
+``register``; demultiplexes inbound frames (only ``NotifyFrame`` in M1)
+to the appropriate ``AgentClient``; provides discovery passthroughs.
+
+In V1 (LocalLink only) the ``HubClient`` is constructed with both the
+``link`` and a direct ``hub`` reference — frames carry the wire
+contract but discovery / register paths cut through to the hub
+in-process. Phase 3 adds ``WsLink`` + HTTP discovery, where ``hub`` is
+``None`` and every operation goes through frames.
+"""
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from autogen.beta.agent import Agent
+
+from ..envelope import Envelope
+from ..identity import Passport, Resume
+from ..rule import Rule
+from ..transport.frames import NotifyFrame
+from ..transport.local import LocalLink, LocalLinkClient
+from .agent_client import AgentClient
+
+if TYPE_CHECKING:
+    from ..hub import Hub
+
+__all__ = ("HubClient",)
+
+
+class HubClient:
+    """One connection to a hub. Multiple ``AgentClient``s register through it.
+
+    M1 takes both ``link`` (V1 ``LocalLink`` only) and an explicit
+    ``hub`` reference. The link carries dispatched envelopes via
+    ``NotifyFrame``; the direct hub reference is used for register /
+    discovery / mutation calls (cuts through wire serialisation when
+    we're in-process).
+
+    A single tenant process should hold one ``HubClient`` per hub it
+    connects to.
+    """
+
+    def __init__(self, link: LocalLink, *, hub: "Hub | None" = None) -> None:
+        # __init__ stores params; side effects deferred to register()/close().
+        self._link = link
+        self._hub = hub if hub is not None else link.hub
+        self._client_link: LocalLinkClient | None = None
+        self._receive_task: asyncio.Task[None] | None = None
+        self._clients: dict[str, AgentClient] = {}
+        self._closed = False
+
+    # ── Connection ───────────────────────────────────────────────────────────
+
+    def _ensure_connected(self) -> LocalLinkClient:
+        """Open the link on first use; subsequent calls reuse the connection."""
+        if self._client_link is None:
+            self._client_link = self._link.client()
+            self._receive_task = asyncio.create_task(self._receive_loop())
+        return self._client_link
+
+    async def _receive_loop(self) -> None:
+        """Demultiplex inbound frames to the appropriate ``AgentClient``."""
+        assert self._client_link is not None
+        try:
+            async for frame in self._client_link.frames():
+                if isinstance(frame, NotifyFrame):
+                    await self._dispatch_notify(frame.envelope)
+                # Other frame kinds (Accept/Error/Pong/Event) are M3 routes —
+                # M1's send path goes direct via Hub.post_envelope so AcceptFrame
+                # is unused here.
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Receive loops must not propagate; M3 audit logs the cause.
+            pass
+
+    async def _dispatch_notify(self, envelope: Envelope) -> None:
+        if envelope.audience is None:
+            # M1 doesn't broadcast (Hub doesn't dispatch broadcasts);
+            # M2 wires participant tracking.
+            return
+        for recipient_id in envelope.audience:
+            client = self._clients.get(recipient_id)
+            if client is not None:
+                await client.receive(envelope)
+
+    # ── Registration ─────────────────────────────────────────────────────────
+
+    async def register(
+        self,
+        agent: Agent,
+        passport: Passport,
+        resume: Resume,
+        *,
+        skill_md: str | None = None,
+        rule: Rule | None = None,
+    ) -> AgentClient:
+        """Register an agent and return its ``AgentClient`` handle.
+
+        M1 simplification: register goes direct to the hub (in-process),
+        then the resulting ``agent_id`` is bound to this connection's
+        endpoint so dispatched ``NotifyFrame``s reach the right
+        ``AgentClient``. M3 / Phase 3 will swap to a ``HelloFrame``-driven
+        bind for cross-process correctness.
+        """
+        if self._closed:
+            raise RuntimeError("HubClient is closed")
+
+        client_link = self._ensure_connected()
+
+        effective_rule = rule if rule is not None else Rule()
+        passport = await self._hub.register(passport, resume, skill_md=skill_md, rule=effective_rule)
+        assert passport.agent_id is not None
+        self._hub.bind_endpoint(client_link.endpoint_id, passport.agent_id)
+
+        client = AgentClient(
+            agent=agent,
+            passport=passport,
+            resume=resume,
+            rule=effective_rule,
+            hub=self._hub,
+            hub_client=self,
+        )
+        self._clients[passport.agent_id] = client
+        return client
+
+    # ── Discovery passthrough ────────────────────────────────────────────────
+
+    async def get_agent(self, name_or_id: str) -> Passport:
+        return await self._hub.get_agent(name_or_id)
+
+    async def get_resume(self, agent_id: str) -> Resume:
+        return await self._hub.get_resume(agent_id)
+
+    async def get_skill(self, agent_id: str) -> str | None:
+        return await self._hub.get_skill(agent_id)
+
+    async def list_agents(
+        self,
+        *,
+        capability: str | None = None,
+        query: str | None = None,
+        sort_by: str | None = None,
+        limit: int = 50,
+    ) -> list[Passport]:
+        return await self._hub.list_agents(
+            capability=capability,
+            query=query,
+            sort_by=sort_by,
+            limit=limit,
+        )
+
+    # ── Lifecycle ────────────────────────────────────────────────────────────
+
+    async def close(self) -> None:
+        """Close the connection and stop the receive loop. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._client_link is not None:
+            await self._client_link.close()
+        if self._receive_task is not None:
+            self._receive_task.cancel()
+            try:
+                await self._receive_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    async def shutdown(self) -> None:
+        """Unregister every ``AgentClient`` then ``close()``."""
+        for client in list(self._clients.values()):
+            try:
+                await client.unregister()
+            except Exception:
+                pass
+        self._clients.clear()
+        await self.close()

--- a/autogen/beta/network/client/network_client.py
+++ b/autogen/beta/network/client/network_client.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``NetworkClient`` Protocol — abstract participant in a network.
+
+V1 ships ``AgentClient`` as the only implementation (backed by an
+``Agent``). Future ``HumanClient`` (queue + UI bridge) and
+``AdminClient`` (operational tools, no LLM) plug into the same Protocol
+without inheriting from ``AgentClient`` — implementing the four members
+below is enough.
+
+Session opening is M2: ``Session`` doesn't exist in the framework yet,
+so ``open()`` is intentionally absent from the M1 Protocol surface and
+will be added when the session adapter machinery lands.
+"""
+
+from typing import Protocol, runtime_checkable
+
+from ..envelope import Envelope
+from ..identity import Passport, Resume
+
+__all__ = ("NetworkClient",)
+
+
+@runtime_checkable
+class NetworkClient(Protocol):
+    """A participant in a network.
+
+    ``AgentClient`` is the V1 implementation backed by an ``Agent``.
+    Future ``HumanClient`` / ``AdminClient`` implement the same
+    Protocol. M2 will add ``open(...)`` for session creation; M1 keeps
+    the surface to identity + receive + disconnect.
+    """
+
+    @property
+    def agent_id(self) -> str: ...
+
+    @property
+    def passport(self) -> Passport: ...
+
+    @property
+    def resume(self) -> Resume: ...
+
+    async def receive(self, envelope: Envelope) -> None:
+        """Hub delivers an envelope to this participant.
+
+        Implementations translate it into the local execution model —
+        ``Agent.ask`` for ``AgentClient``, queue push for
+        ``HumanClient``, etc.
+        """
+        ...
+
+    async def disconnect(self) -> None:
+        """Tear down resources. Idempotent."""
+        ...

--- a/autogen/beta/network/envelope.py
+++ b/autogen/beta/network/envelope.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Envelope — the wire shape for every message between agents.
+
+Every Agent-to-Agent exchange (post-M2) happens inside a session and
+the carrier is an ``Envelope``. Envelopes are JSON-serialisable, hub-
+stamped at ``post_envelope``, and persisted to the per-session WAL.
+``audience`` is the addressing primitive: ``None`` broadcasts within
+the session, a list targets a subset.
+
+Streaming chunks use a separate transport-level ``chunk`` frame (Phase
+2 surface) and are not envelopes — they bypass the WAL entirely.
+"""
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+__all__ = (
+    "EV_ERROR",
+    "EV_EXPECTATION_VIOLATED",
+    "EV_PARTICIPANT_REMOVED",
+    "EV_PEER_RECONNECTED",
+    "EV_PEER_UNREACHABLE",
+    "EV_SESSION_CLOSED",
+    "EV_SESSION_EXPIRED",
+    "EV_SESSION_IDLE",
+    "EV_SESSION_INVITE",
+    "EV_SESSION_INVITE_ACK",
+    "EV_SESSION_INVITE_REJECT",
+    "EV_SESSION_OPENED",
+    "EV_SESSION_QUORUM_CHANGED",
+    "EV_TASK_ERROR",
+    "EV_TASK_EXPIRED",
+    "EV_TASK_PROGRESS",
+    "EV_TASK_RESULT",
+    "EV_TASK_STALLED",
+    "EV_TASK_STARTED",
+    "EV_TEXT",
+    "Envelope",
+    "Priority",
+    "visible_to",
+)
+
+
+Priority = Literal["background", "normal", "urgent"]
+
+
+# ── Stable event-type names ──────────────────────────────────────────────────
+# V1 ships a fixed set; new names are added in code, not at runtime. User-
+# defined event types may be posted with arbitrary strings (no namespace
+# check in V1) — the framework only special-cases the names below.
+
+EV_TEXT = "ag2.msg.text"
+
+EV_SESSION_INVITE = "ag2.session.invite"
+EV_SESSION_INVITE_ACK = "ag2.session.invite.ack"
+EV_SESSION_INVITE_REJECT = "ag2.session.invite.reject"
+EV_SESSION_OPENED = "ag2.session.opened"
+EV_SESSION_CLOSED = "ag2.session.closed"
+EV_SESSION_EXPIRED = "ag2.session.expired"
+EV_SESSION_IDLE = "ag2.session.idle"
+EV_SESSION_QUORUM_CHANGED = "ag2.session.quorum_changed"
+
+EV_TASK_STARTED = "ag2.task.started"
+EV_TASK_PROGRESS = "ag2.task.progress"
+EV_TASK_RESULT = "ag2.task.result"
+EV_TASK_ERROR = "ag2.task.error"
+EV_TASK_EXPIRED = "ag2.task.expired"
+EV_TASK_STALLED = "ag2.task.stalled"
+
+EV_PEER_UNREACHABLE = "ag2.peer.unreachable"
+EV_PEER_RECONNECTED = "ag2.peer.reconnected"
+
+EV_EXPECTATION_VIOLATED = "ag2.expectation.violated"
+EV_PARTICIPANT_REMOVED = "ag2.participant.removed"
+
+EV_ERROR = "ag2.error"
+
+
+@dataclass(slots=True)
+class Envelope:
+    """Wire shape for every Agent-to-Agent message.
+
+    Field semantics:
+
+    * ``envelope_id`` — hub-stamped on accept (UUID7-like). Sender-side
+      construction leaves this empty; ``Hub.post_envelope`` populates.
+    * ``audience`` — ``None`` broadcasts within the session; a list
+      targets a subset. Hub WAL stores the full envelope regardless of
+      addressing (audit + debug); ``notify`` lands only on listed peers.
+    * ``causation_id`` — envelope this is responding to. Used by view
+      policies to thread replies to their prompts.
+    * ``depth`` — delegation hop count. Hub auto-increments on the
+      reply path; ``Rule.limits.delegation_depth`` caps it.
+    * ``ttl_seconds`` — per-envelope TTL. ``None`` defers to the
+      session's ``expires_at``.
+    * ``idempotency_key`` — Phase 3 dedup key; ignored in V1.
+    """
+
+    session_id: str
+    sender_id: str
+    audience: list[str] | None
+    event_type: str
+    event_data: dict[str, Any]
+
+    envelope_id: str = ""  # hub-stamped on accept
+    task_id: str | None = None
+    causation_id: str | None = None
+    trace_id: str | None = None
+    priority: Priority = "normal"
+    depth: int = 0
+    idempotency_key: str | None = None  # Phase 3
+
+    created_at: str = ""  # ISO-Z, hub-stamped on accept
+    ttl_seconds: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-compatible dict (every field round-trips byte-stable)."""
+        return asdict(self)
+
+    def to_json(self) -> str:
+        """Serialise to JSON. Sort keys so cross-process hashes match."""
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Envelope":
+        return cls(**data)
+
+    @classmethod
+    def from_json(cls, text: str) -> "Envelope":
+        return cls.from_dict(json.loads(text))
+
+
+def visible_to(envelope: Envelope, participant_id: str) -> bool:
+    """Pure delivery / view-filtering predicate.
+
+    Sender always sees their own envelope; broadcasts (``audience=None``)
+    are visible to all session participants; subset addressing is
+    visible only to listed peers.
+    """
+    if envelope.sender_id == participant_id:
+        return True
+    if envelope.audience is None:
+        return True
+    return participant_id in envelope.audience

--- a/autogen/beta/network/errors.py
+++ b/autogen/beta/network/errors.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Error hierarchy for ``autogen.beta.network``.
+
+All network-specific exceptions inherit from ``NetworkError`` so callers
+can catch the family with one ``except`` clause.
+"""
+
+__all__ = (
+    "AccessDeniedError",
+    "AuthError",
+    "InboxFull",
+    "NetworkError",
+    "NotFoundError",
+    "ProtocolError",
+)
+
+
+class NetworkError(Exception):
+    """Base class for all ``autogen.beta.network`` exceptions."""
+
+
+class NotFoundError(NetworkError):
+    """Lookup of a registered identity, session, or task failed."""
+
+
+class AccessDeniedError(NetworkError):
+    """Sender's ``Rule.access`` does not permit the requested operation."""
+
+
+class AuthError(NetworkError):
+    """Authentication failed at the transport handshake."""
+
+
+class ProtocolError(NetworkError):
+    """Envelope violated a session adapter's protocol contract.
+
+    Raised by ``SessionAdapter.validate_send``. The hub returns this as a
+    structured ``error`` frame (``code="protocol_error"``) and does not
+    append the offending envelope to the WAL.
+    """
+
+
+class InboxFull(NetworkError):
+    """Recipient inbox is at capacity and overflow policy is ``reject``.
+
+    V1 ships ``reject`` only; ``drop_oldest`` and ``drop_newest`` arrive
+    in Phase 2.
+    """

--- a/autogen/beta/network/hub/__init__.py
+++ b/autogen/beta/network/hub/__init__.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hub — registry, dispatcher, and state-machine owner.
+
+The hub is the only place that has cross-tenant visibility. It owns
+the registry, session and task state machines, the WAL, the dispatch
+path, the adapter state cache, and the internal sweepers. It never
+calls ``Agent.ask``, executes tenant transforms, or imports tenant
+modules — the trust boundary runs through ``HubClient`` /
+``AgentClient`` (see ``client/``).
+"""
+
+from .core import Hub
+from .layout import (
+    agents_root,
+    audit_path,
+    by_capability_path,
+    by_name_path,
+    passport_path,
+    resume_path,
+    rule_path,
+    runtime_path,
+    session_metadata_path,
+    sessions_root,
+    skill_path,
+    task_metadata_path,
+    tasks_root,
+    wal_path,
+)
+
+__all__ = (
+    "Hub",
+    "agents_root",
+    "audit_path",
+    "by_capability_path",
+    "by_name_path",
+    "passport_path",
+    "resume_path",
+    "rule_path",
+    "runtime_path",
+    "session_metadata_path",
+    "sessions_root",
+    "skill_path",
+    "task_metadata_path",
+    "tasks_root",
+    "wal_path",
+)

--- a/autogen/beta/network/hub/core.py
+++ b/autogen/beta/network/hub/core.py
@@ -1,0 +1,565 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``Hub`` — registry, dispatcher, persistence root.
+
+M1 surface only — no sweepers, no expectations, no audit log, no
+session adapter machinery. Sessions are M2; observability is M3.
+
+The hub is the only place that has cross-tenant visibility:
+
+* Validates senders are registered.
+* Stamps ``envelope_id`` and ``created_at`` on accept.
+* Persists envelopes to ``sessions/{session_id}/wal.jsonl``.
+* Dispatches notifies to explicit ``audience`` via ``Link.send_frame``.
+
+Broadcast (``audience=None``) is **deferred to M2** because M1 does not
+track session participants. Tests must address envelopes explicitly.
+
+The hub never calls ``Agent.ask``, executes tenant transforms, or
+imports tenant modules — the trust boundary runs through ``HubClient``
+/ ``AgentClient``.
+"""
+
+import asyncio
+import fnmatch
+import json
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+
+from autogen.beta.knowledge import KnowledgeStore
+
+from ..auth import AuthRegistry, default_registry
+from ..envelope import Envelope
+from ..errors import AccessDeniedError, NetworkError, NotFoundError
+from ..identity import Passport, Resume
+from ..ids import make_id
+from ..rule import Rule
+from ..transport.frames import (
+    AcceptFrame,
+    ErrorFrame,
+    Frame,
+    HelloFrame,
+    NotifyFrame,
+    PingFrame,
+    PongFrame,
+    SendFrame,
+    WelcomeFrame,
+)
+from ..transport.link import LinkEndpoint
+from .layout import (
+    agents_root,
+    passport_path,
+    resume_path,
+    rule_path,
+    skill_path,
+    wal_path,
+)
+
+__all__ = ("Hub",)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+_ERROR_CODE_MAP: dict[type, str] = {
+    NotFoundError: "not_found",
+    AccessDeniedError: "access_denied",
+}
+
+
+def _error_code(exc: BaseException) -> str:
+    for cls, code in _ERROR_CODE_MAP.items():
+        if isinstance(exc, cls):
+            return code
+    return "error"
+
+
+def _match_any(name: str, patterns: list[str]) -> bool:
+    """True if ``name`` matches any of the glob patterns (``["*"]`` allows all)."""
+    return any(fnmatch.fnmatchcase(name, p) for p in patterns)
+
+
+class Hub:
+    """In-process registry, dispatcher, and persistence root.
+
+    M1 construction takes a ``KnowledgeStore`` and an optional
+    ``AuthRegistry``, ``clock``, and a ``Callable`` to register an
+    "on connect" hook with the transport — see :meth:`attach_endpoint`.
+
+    Use :meth:`open` for production (async constructor that hydrates
+    from disk before returning); the sync ``__init__`` is for tests
+    that bring up a hub with no prior state.
+    """
+
+    def __init__(
+        self,
+        store: KnowledgeStore,
+        *,
+        auth: AuthRegistry | None = None,
+        clock: Callable[[], str] | None = None,
+    ) -> None:
+        # __init__ stores params; side effects deferred to start()/hydrate().
+        self._store = store
+        self._auth = auth if auth is not None else default_registry
+        self._clock = clock if clock is not None else _utc_now_iso
+
+        # In-memory caches — rebuilt by hydrate() from disk.
+        self._passports: dict[str, Passport] = {}
+        self._resumes: dict[str, Resume] = {}
+        self._rules: dict[str, Rule] = {}
+        self._skills: dict[str, str] = {}
+        self._name_to_id: dict[str, str] = {}
+
+        # Transport-side state.
+        self._endpoints_by_id: dict[str, LinkEndpoint] = {}
+        self._agent_to_endpoint: dict[str, str] = {}
+        self._endpoint_to_agents: dict[str, set[str]] = {}
+        self._endpoint_tasks: set[asyncio.Task[None]] = set()
+
+        # Per-session locks for WAL append + dispatch ordering.
+        self._session_locks: dict[str, asyncio.Lock] = {}
+        self._registration_lock = asyncio.Lock()
+
+        self._closed = False
+
+    # ── Lifecycle ────────────────────────────────────────────────────────────
+
+    @classmethod
+    async def open(
+        cls,
+        store: KnowledgeStore,
+        *,
+        auth: AuthRegistry | None = None,
+        clock: Callable[[], str] | None = None,
+    ) -> "Hub":
+        """Construct + hydrate from disk. Production entry point.
+
+        M1 has no sweepers to start; M3 will spawn them here.
+        """
+        hub = cls(store, auth=auth, clock=clock)
+        await hub.hydrate()
+        return hub
+
+    async def hydrate(self) -> None:
+        """Walk the store; rebuild identity caches. Idempotent.
+
+        M1 hydrates ``passport`` / ``resume`` / ``rule`` / ``SKILL.md``
+        for every registered agent. Session WAL re-folding lands in M2
+        when adapters ship.
+        """
+        self._passports.clear()
+        self._resumes.clear()
+        self._rules.clear()
+        self._skills.clear()
+        self._name_to_id.clear()
+
+        children = await self._store.list(agents_root())
+        for child in children:
+            if not child.endswith("/"):
+                continue
+            agent_id = child.rstrip("/")
+            await self._load_agent(agent_id)
+
+    async def close(self) -> None:
+        """Cancel endpoint handler tasks and drain pending frames."""
+        if self._closed:
+            return
+        self._closed = True
+        for task in list(self._endpoint_tasks):
+            task.cancel()
+        if self._endpoint_tasks:
+            await asyncio.gather(*self._endpoint_tasks, return_exceptions=True)
+        self._endpoint_tasks.clear()
+
+    async def __aenter__(self) -> "Hub":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.close()
+
+    # ── Registration ────────────────────────────────────────────────────────
+
+    async def register(
+        self,
+        passport: Passport,
+        resume: Resume,
+        *,
+        skill_md: str | None = None,
+        rule: Rule | None = None,
+    ) -> Passport:
+        """Stamp ``agent_id`` (UUID-based), persist records, return passport.
+
+        Validates ``passport.auth`` against the registered ``AuthRegistry``
+        before stamping the id. Auth failure raises ``AuthError`` and
+        nothing is persisted.
+        """
+        adapter = self._auth.get(passport.auth.scheme)
+        await adapter.validate(passport, passport.auth.claim)
+
+        async with self._registration_lock:
+            if passport.name in self._name_to_id:
+                # Re-registration with the same name yields a fresh id and
+                # supersedes the prior registration. The prior agent_id's
+                # files remain on disk for audit; cache pointers move.
+                pass
+
+            agent_id = make_id()
+            passport.agent_id = agent_id
+            passport.created_at = self._clock()
+
+            effective_rule = rule if rule is not None else Rule()
+
+            await self._persist_passport(passport)
+            await self._persist_resume(agent_id, resume)
+            await self._persist_rule(agent_id, effective_rule)
+            if skill_md is not None:
+                await self._persist_skill(agent_id, skill_md)
+
+            self._passports[agent_id] = passport
+            self._resumes[agent_id] = resume
+            self._rules[agent_id] = effective_rule
+            if skill_md is not None:
+                self._skills[agent_id] = skill_md
+            self._name_to_id[passport.name] = agent_id
+
+        return passport
+
+    async def unregister(self, agent_id: str) -> None:
+        """Remove registry entries; closed sessions remain on disk.
+
+        M1 does not touch the agent's session WAL or task records on
+        unregister. Inbox cursor / nack / overflow files are deleted in
+        Phase 3 when the inbox model lands.
+        """
+        if agent_id not in self._passports:
+            raise NotFoundError(f"agent not registered: {agent_id}")
+
+        async with self._registration_lock:
+            passport = self._passports.pop(agent_id, None)
+            self._resumes.pop(agent_id, None)
+            self._rules.pop(agent_id, None)
+            self._skills.pop(agent_id, None)
+            if passport is not None and self._name_to_id.get(passport.name) == agent_id:
+                self._name_to_id.pop(passport.name, None)
+
+            endpoint_id = self._agent_to_endpoint.pop(agent_id, None)
+            if endpoint_id is not None:
+                bound = self._endpoint_to_agents.get(endpoint_id)
+                if bound is not None:
+                    bound.discard(agent_id)
+                    if not bound:
+                        self._endpoint_to_agents.pop(endpoint_id, None)
+
+    # ── Discovery (read-side) ────────────────────────────────────────────────
+
+    async def get_agent(self, name_or_id: str) -> Passport:
+        agent_id = self._name_to_id.get(name_or_id, name_or_id)
+        passport = self._passports.get(agent_id)
+        if passport is None:
+            raise NotFoundError(f"agent not found: {name_or_id}")
+        return passport
+
+    async def get_resume(self, agent_id: str) -> Resume:
+        resume = self._resumes.get(agent_id)
+        if resume is None:
+            raise NotFoundError(f"resume not found: {agent_id}")
+        return resume
+
+    async def get_skill(self, agent_id: str) -> str | None:
+        if agent_id in self._skills:
+            return self._skills[agent_id]
+        # Lazy load from disk so re-registered agents pick up their SKILL.md
+        # without a full hydrate cycle.
+        if agent_id not in self._passports:
+            return None
+        body = await self._store.read(skill_path(agent_id))
+        if body is not None:
+            self._skills[agent_id] = body
+        return body
+
+    async def list_agents(
+        self,
+        *,
+        capability: str | None = None,
+        query: str | None = None,
+        sort_by: str | None = None,
+        limit: int = 50,
+    ) -> list[Passport]:
+        """Filter + rank registered agents.
+
+        M1 supports ``capability`` (matches ``claimed_capabilities ∪
+        observed.keys()``) and ``query`` (substring on ``Resume.summary``,
+        case-insensitive). ``sort_by`` honours ``"name"`` (lex);
+        ``"cost"`` and ``"track_record"`` arrive in M3 once
+        ``CostProfile`` and ``ObservedStat`` are populated by real
+        traffic.
+        """
+        results: list[Passport] = []
+        query_lower = query.lower() if query else None
+        for agent_id, passport in self._passports.items():
+            if capability is not None:
+                resume = self._resumes.get(agent_id)
+                if resume is None:
+                    continue
+                claimed = set(resume.claimed_capabilities)
+                observed = set(resume.observed.keys())
+                if capability not in claimed and capability not in observed:
+                    continue
+            if query_lower is not None:
+                resume = self._resumes.get(agent_id)
+                summary = resume.summary.lower() if resume else ""
+                if query_lower not in summary:
+                    continue
+            results.append(passport)
+
+        if sort_by == "name":
+            results.sort(key=lambda p: p.name)
+        # "cost" and "track_record" sorts ship in M3 when the data
+        # they require is being populated by real traffic.
+
+        return results[:limit]
+
+    # ── Mutation ─────────────────────────────────────────────────────────────
+
+    async def set_resume(self, agent_id: str, resume: Resume) -> None:
+        if agent_id not in self._passports:
+            raise NotFoundError(f"agent not registered: {agent_id}")
+        resume.last_updated = self._clock()
+        resume.version = (self._resumes[agent_id].version + 1) if agent_id in self._resumes else resume.version
+        await self._persist_resume(agent_id, resume)
+        self._resumes[agent_id] = resume
+
+    async def set_skill(self, agent_id: str, skill_md: str | None) -> None:
+        if agent_id not in self._passports:
+            raise NotFoundError(f"agent not registered: {agent_id}")
+        if skill_md is None:
+            await self._store.delete(skill_path(agent_id))
+            self._skills.pop(agent_id, None)
+        else:
+            await self._persist_skill(agent_id, skill_md)
+            self._skills[agent_id] = skill_md
+
+    async def set_rule(self, agent_id: str, rule: Rule) -> None:
+        if agent_id not in self._passports:
+            raise NotFoundError(f"agent not registered: {agent_id}")
+        rule.version = (self._rules[agent_id].version + 1) if agent_id in self._rules else rule.version
+        await self._persist_rule(agent_id, rule)
+        self._rules[agent_id] = rule
+
+    # ── Envelope dispatch (M1 simplified — no session machinery) ─────────────
+
+    async def post_envelope(self, envelope: Envelope) -> str:
+        """Validate sender + stamp + WAL append + dispatch.
+
+        M1 simplifications:
+
+        * No session adapter validation — the envelope is accepted as-is
+          (M2 wires ``adapter.validate_send`` via the per-session
+          ``AdapterState`` cache).
+        * No broadcast (``audience=None``) — M1 has no session
+          participant tracking, so broadcast envelopes are persisted to
+          the WAL but not dispatched. M2 fills this in.
+        * Access enforcement is sender-side ``access.outbound_to`` only;
+          recipient-side ``access.inbound_from`` is checked at dispatch.
+        """
+        sender = self._passports.get(envelope.sender_id)
+        if sender is None:
+            raise NotFoundError(f"sender not registered: {envelope.sender_id}")
+
+        sender_rule = self._rules.get(envelope.sender_id, Rule())
+
+        # Sender-side outbound access check.
+        if envelope.audience is not None:
+            for recipient_id in envelope.audience:
+                recipient = self._passports.get(recipient_id)
+                if recipient is None:
+                    continue  # silently skip unknown recipients (offline)
+                if not _match_any(recipient.name, sender_rule.access.outbound_to):
+                    raise AccessDeniedError(
+                        f"sender {sender.name!r} not permitted to send to {recipient.name!r}"
+                    )
+
+        envelope.envelope_id = make_id()
+        envelope.created_at = self._clock()
+
+        async with self._wal_lock(envelope.session_id):
+            await self._store.append(
+                wal_path(envelope.session_id),
+                envelope.to_json() + "\n",
+            )
+
+        await self._dispatch(envelope)
+        return envelope.envelope_id
+
+    async def read_wal(self, session_id: str) -> list[Envelope]:
+        """Read all envelopes for a session. M1 helper for tests."""
+        body = await self._store.read(wal_path(session_id))
+        if not body:
+            return []
+        envelopes: list[Envelope] = []
+        for line in body.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            envelopes.append(Envelope.from_json(line))
+        return envelopes
+
+    # ── Endpoint management (transport-facing) ───────────────────────────────
+
+    def attach_endpoint(self, endpoint: LinkEndpoint) -> None:
+        """Register a new connection; spawn its frame-processor task.
+
+        Called by ``LocalLink.set_on_connect`` for every new client.
+        Endpoint ``agent_id`` is bound separately via
+        :meth:`bind_endpoint` once the identity is known.
+        """
+        if self._closed:
+            return
+        self._endpoints_by_id[endpoint.endpoint_id] = endpoint
+        task = asyncio.create_task(self._handle_endpoint(endpoint))
+        self._endpoint_tasks.add(task)
+        task.add_done_callback(self._endpoint_tasks.discard)
+
+    def bind_endpoint(self, endpoint_id: str, agent_id: str) -> None:
+        """Associate an existing endpoint with a registered identity.
+
+        Multiple agent_ids may share one endpoint (one ``HubClient``
+        connection hosts every ``AgentClient`` registered through it).
+        """
+        if endpoint_id not in self._endpoints_by_id:
+            raise NotFoundError(f"endpoint not attached: {endpoint_id}")
+        if agent_id not in self._passports:
+            raise NotFoundError(f"agent not registered: {agent_id}")
+        self._endpoints_by_id[endpoint_id].agent_id = agent_id
+        self._agent_to_endpoint[agent_id] = endpoint_id
+        self._endpoint_to_agents.setdefault(endpoint_id, set()).add(agent_id)
+
+    # ── Internal helpers ─────────────────────────────────────────────────────
+
+    def _wal_lock(self, session_id: str) -> asyncio.Lock:
+        lock = self._session_locks.get(session_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._session_locks[session_id] = lock
+        return lock
+
+    async def _dispatch(self, envelope: Envelope) -> None:
+        """Send NotifyFrames to the explicit audience, honouring inbound access.
+
+        Broadcast (``audience=None``) is M2 — M1 returns silently for
+        broadcasts, having already persisted to the WAL.
+        """
+        if envelope.audience is None:
+            return
+        sender_passport = self._passports.get(envelope.sender_id)
+        sender_name = sender_passport.name if sender_passport is not None else envelope.sender_id
+        for recipient_id in envelope.audience:
+            recipient_rule = self._rules.get(recipient_id)
+            if recipient_rule is not None and not _match_any(
+                sender_name, recipient_rule.access.inbound_from
+            ):
+                continue  # silently drop blocked inbound; M3 may emit ag2.error
+            endpoint = self._endpoint_for(recipient_id)
+            if endpoint is None:
+                continue  # recipient not connected — M2's inbox model will queue
+            await endpoint.send_frame(NotifyFrame(envelope=envelope))
+
+    def _endpoint_for(self, agent_id: str) -> LinkEndpoint | None:
+        endpoint_id = self._agent_to_endpoint.get(agent_id)
+        if endpoint_id is None:
+            return None
+        return self._endpoints_by_id.get(endpoint_id)
+
+    async def _handle_endpoint(self, endpoint: LinkEndpoint) -> None:
+        """Long-running frame loop for one connection."""
+        try:
+            async for frame in endpoint.frames():
+                await self._dispatch_frame(endpoint, frame)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Swallow — endpoint loops must not propagate to the gather.
+            # Production builds should log at this point; M1 keeps quiet.
+            pass
+
+    async def _dispatch_frame(self, endpoint: LinkEndpoint, frame: Frame) -> None:
+        """Per-frame dispatch. M1 supports hello/ping/send only."""
+        if isinstance(frame, SendFrame):
+            try:
+                envelope_id = await self.post_envelope(frame.envelope)
+                await endpoint.send_frame(AcceptFrame(envelope_id=envelope_id))
+            except NetworkError as exc:
+                await endpoint.send_frame(
+                    ErrorFrame(
+                        code=_error_code(exc),
+                        message=str(exc),
+                    )
+                )
+        elif isinstance(frame, HelloFrame):
+            agent_id = self._name_to_id.get(frame.name)
+            if agent_id is None:
+                await endpoint.send_frame(
+                    ErrorFrame(code="not_found", message=f"unknown name: {frame.name}")
+                )
+                return
+            try:
+                self.bind_endpoint(endpoint.endpoint_id, agent_id)
+            except NetworkError as exc:
+                await endpoint.send_frame(
+                    ErrorFrame(code=_error_code(exc), message=str(exc))
+                )
+                return
+            await endpoint.send_frame(
+                WelcomeFrame(endpoint_id=endpoint.endpoint_id, hub_time=self._clock())
+            )
+        elif isinstance(frame, PingFrame):
+            await endpoint.send_frame(PongFrame())
+        # ReceiptFrame (audit) ships in M3.
+        # SubscribeFrame / UnsubscribeFrame ship in M3.
+
+    # ── Persistence helpers ──────────────────────────────────────────────────
+
+    async def _persist_passport(self, passport: Passport) -> None:
+        assert passport.agent_id is not None
+        await self._store.write(
+            passport_path(passport.agent_id),
+            json.dumps(passport.to_dict()),
+        )
+
+    async def _persist_resume(self, agent_id: str, resume: Resume) -> None:
+        await self._store.write(
+            resume_path(agent_id),
+            json.dumps(resume.to_dict()),
+        )
+
+    async def _persist_rule(self, agent_id: str, rule: Rule) -> None:
+        await self._store.write(
+            rule_path(agent_id),
+            json.dumps(rule.to_dict()),
+        )
+
+    async def _persist_skill(self, agent_id: str, skill_md: str) -> None:
+        await self._store.write(skill_path(agent_id), skill_md)
+
+    async def _load_agent(self, agent_id: str) -> None:
+        passport_data = await self._store.read(passport_path(agent_id))
+        if passport_data is None:
+            return
+        passport = Passport.from_dict(json.loads(passport_data))
+        self._passports[agent_id] = passport
+        self._name_to_id[passport.name] = agent_id
+
+        resume_data = await self._store.read(resume_path(agent_id))
+        if resume_data is not None:
+            self._resumes[agent_id] = Resume.from_dict(json.loads(resume_data))
+
+        rule_data = await self._store.read(rule_path(agent_id))
+        if rule_data is not None:
+            self._rules[agent_id] = Rule.from_dict(json.loads(rule_data))
+        else:
+            self._rules[agent_id] = Rule()
+
+        # SKILL.md loaded on demand via get_skill.

--- a/autogen/beta/network/hub/layout.py
+++ b/autogen/beta/network/hub/layout.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Filesystem path helpers for the hub's ``KnowledgeStore`` layout.
+
+Path conventions match ``design/persistence.md``. All paths are Unix-
+style with a leading ``/`` (the ``KnowledgeStore`` Protocol normalises
+internally). Centralising path construction here means changes to the
+on-disk layout (chunked WALs, namespace migration) only touch this
+module.
+"""
+
+__all__ = (
+    "agents_root",
+    "audit_path",
+    "by_capability_path",
+    "by_name_path",
+    "inbox_cursor_path",
+    "inbox_nacks_path",
+    "inbox_overflow_path",
+    "passport_path",
+    "registry_root",
+    "resume_path",
+    "rule_path",
+    "runtime_path",
+    "session_metadata_path",
+    "session_tasks_index_path",
+    "sessions_root",
+    "skill_path",
+    "task_events_path",
+    "task_metadata_path",
+    "tasks_root",
+    "wal_path",
+)
+
+
+# ── Agent files ──────────────────────────────────────────────────────────────
+
+
+def agents_root() -> str:
+    return "/agents"
+
+
+def passport_path(agent_id: str) -> str:
+    return f"/agents/{agent_id}/passport.json"
+
+
+def resume_path(agent_id: str) -> str:
+    return f"/agents/{agent_id}/resume.json"
+
+
+def skill_path(agent_id: str) -> str:
+    return f"/agents/{agent_id}/SKILL.md"
+
+
+def runtime_path(agent_id: str) -> str:
+    return f"/agents/{agent_id}/runtime.json"
+
+
+def rule_path(agent_id: str) -> str:
+    return f"/agents/{agent_id}/rule.json"
+
+
+def inbox_cursor_path(agent_id: str) -> str:
+    return f"/agents/{agent_id}/inbox.cursor"
+
+
+def inbox_nacks_path(agent_id: str) -> str:
+    return f"/agents/{agent_id}/inbox_nacks.jsonl"
+
+
+def inbox_overflow_path(agent_id: str) -> str:
+    return f"/agents/{agent_id}/inbox_overflow.jsonl"
+
+
+# ── Registry caches ──────────────────────────────────────────────────────────
+
+
+def registry_root() -> str:
+    return "/registry"
+
+
+def by_name_path() -> str:
+    return "/registry/by_name.json"
+
+
+def by_capability_path() -> str:
+    return "/registry/by_capability.json"
+
+
+# ── Sessions ─────────────────────────────────────────────────────────────────
+
+
+def sessions_root() -> str:
+    return "/sessions"
+
+
+def session_metadata_path(session_id: str) -> str:
+    return f"/sessions/{session_id}/metadata.json"
+
+
+def wal_path(session_id: str) -> str:
+    return f"/sessions/{session_id}/wal.jsonl"
+
+
+def session_tasks_index_path(session_id: str) -> str:
+    return f"/sessions/{session_id}/tasks.json"
+
+
+# ── Tasks ────────────────────────────────────────────────────────────────────
+
+
+def tasks_root() -> str:
+    return "/tasks"
+
+
+def task_metadata_path(task_id: str) -> str:
+    return f"/tasks/{task_id}/metadata.json"
+
+
+def task_events_path(task_id: str) -> str:
+    return f"/tasks/{task_id}/events.jsonl"
+
+
+# ── Audit ────────────────────────────────────────────────────────────────────
+
+
+def audit_path(date_yyyy_mm_dd: str) -> str:
+    """Daily-rotated audit log path. Date string in ``YYYY-MM-DD`` form."""
+    return f"/audit/{date_yyyy_mm_dd}.jsonl"

--- a/autogen/beta/network/identity.py
+++ b/autogen/beta/network/identity.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Identity records: ``Passport``, ``Resume``, ``AgentRuntime``.
+
+Three records back every registered agent — see ``design/identity.md``:
+
+* ``Passport`` — immutable id + billing facts. Hub-stamps ``agent_id``
+  at registration.
+* ``Resume`` — capability claims and observed track record. Mutates
+  over time via tenant-driven ``set_resume`` and hub-driven
+  ``record_observation``.
+* ``SKILL.md`` — Markdown document with Anthropic frontmatter, stored
+  as plain text in M1 (frontmatter parser arrives in M3).
+
+``AgentRuntime`` is hub-owned bookkeeping for the current connection
+(transport binding, last heartbeat). It lives next to the identity
+files but readers should treat it as cache-only.
+"""
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+__all__ = (
+    "AgentRuntime",
+    "AuthBlock",
+    "CostProfile",
+    "ObservedStat",
+    "Passport",
+    "Resume",
+    "ResumeExample",
+)
+
+
+@dataclass(slots=True)
+class CostProfile:
+    """Optional billing / routing hints. None of these fields are validated by V1."""
+
+    input_per_mtok: float | None = None
+    output_per_mtok: float | None = None
+    latency_tier: str | None = None  # "fast" | "balanced" | "deep"
+
+
+@dataclass(slots=True)
+class AuthBlock:
+    """How the hub validates this identity at the connection handshake."""
+
+    scheme: str = "none"  # "none" | "api_key" (Phase 3) | future
+    issuer: str | None = None
+    audience: str | None = None
+    key_fingerprint: str | None = None
+    claim: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class Passport:
+    """Immutable identity + billing record for one registration.
+
+    ``agent_id`` is hub-stamped at registration. Mutating any field
+    requires unregister + re-register, which yields a fresh ``agent_id``.
+    """
+
+    name: str  # human/LLM-facing address; unique per hub
+    owner: str = ""
+    provider: str | None = None  # "anthropic" | "openai" | None
+    model: str | None = None
+    cost: CostProfile | None = None
+    region: str | None = None
+    auth: AuthBlock = field(default_factory=AuthBlock)
+    version: int = 1
+
+    # Hub-stamped at registration. None on construction.
+    agent_id: str | None = None
+    created_at: str = ""  # ISO-Z, hub-stamped
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Passport":
+        payload = dict(data)
+        if isinstance(payload.get("auth"), dict):
+            payload["auth"] = AuthBlock(**payload["auth"])
+        if isinstance(payload.get("cost"), dict):
+            payload["cost"] = CostProfile(**payload["cost"])
+        return cls(**payload)
+
+
+@dataclass(slots=True)
+class ResumeExample:
+    title: str
+    outcome: str = ""  # "completed" | "failed" | free-form
+    task_id: str | None = None
+    session_id: str | None = None
+    when: str | None = None
+    note: str = ""
+
+
+@dataclass(slots=True)
+class ObservedStat:
+    """Hub-derived per-capability track record. Updated on terminal task events."""
+
+    n: int = 0
+    completed: int = 0
+    failed: int = 0
+    expired: int = 0
+    p50_latency_ms: int | None = None
+
+
+@dataclass(slots=True)
+class Resume:
+    """Mutable capability claim + observed track record.
+
+    Tenant code provides ``claimed_capabilities``, ``domains``,
+    ``summary``, and ``examples`` at registration. The hub mutates
+    ``observed`` on terminal task events (M3); tenant code may also
+    replace the resume via ``Hub.set_resume(...)``.
+    """
+
+    claimed_capabilities: list[str] = field(default_factory=list)
+    domains: list[str] = field(default_factory=list)
+    summary: str = ""  # one-line, indexed for `peers(action="find")`
+    examples: list[ResumeExample] = field(default_factory=list)
+    observed: dict[str, ObservedStat] = field(default_factory=dict)
+    version: int = 1
+    last_updated: str = ""  # ISO-Z, hub-stamped on every mutation
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Resume":
+        payload = dict(data)
+        if "examples" in payload:
+            payload["examples"] = [
+                ResumeExample(**e) if isinstance(e, dict) else e for e in payload["examples"]
+            ]
+        if "observed" in payload:
+            payload["observed"] = {
+                k: ObservedStat(**v) if isinstance(v, dict) else v
+                for k, v in payload["observed"].items()
+            }
+        return cls(**payload)
+
+
+@dataclass(slots=True)
+class AgentRuntime:
+    """Hub-owned per-connection bookkeeping for a registered agent.
+
+    Re-read on hub failover only; rewritten on every heartbeat. Identity
+    readers should not depend on its freshness.
+    """
+
+    agent_id: str
+    binding: str  # "local" | "ws"
+    target: str  # opaque endpoint id (local queue id / ws connection id)
+    reachable: bool
+    last_heartbeat: str  # ISO-Z

--- a/autogen/beta/network/ids.py
+++ b/autogen/beta/network/ids.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Identifier helpers for the network layer.
+
+Uses ``uuid.uuid7`` if the Python stdlib provides it (3.14+) for
+chronologically sortable identifiers; falls back to ``uuid.uuid4`` on
+older runtimes. Both produce 32-char hex strings, so the wire format is
+stable across versions.
+"""
+
+import uuid
+
+__all__ = ("make_id",)
+
+
+def make_id() -> str:
+    """Return a fresh UUID-based identifier as a 32-char hex string.
+
+    Prefers UUID7 (time-ordered, cross-process sortable) when available;
+    falls back to UUID4 on older Pythons. Cross-process ordering becomes
+    load-bearing when ``WsLink`` ships in Phase 3; in V1 the hub stamps
+    every envelope under a single per-session lock so process-local
+    ordering is sufficient.
+    """
+    if hasattr(uuid, "uuid7"):
+        return uuid.uuid7().hex  # type: ignore[attr-defined]
+    return uuid.uuid4().hex

--- a/autogen/beta/network/policies.py
+++ b/autogen/beta/network/policies.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qualified-key constants for ``ConversationContext.dependencies`` injection.
+
+Network plugin tools (M2/M3) resolve their bindings via these keys —
+mirroring how framework-core's ``TaskInject`` resolves to ``ag2.task``.
+Centralising the keys here prevents drift between the side that stamps
+into ``context.dependencies`` and the side that injects them.
+
+The ``ag2.network.*`` namespace is reserved for network-only injects;
+``ag2.task`` re-exported here intentionally so consumers see one
+canonical key list.
+"""
+
+__all__ = (
+    "AGENT_CLIENT_DEP",
+    "HUB_DEP",
+    "SESSION_DEP",
+    "TASK_DEP",
+)
+
+
+SESSION_DEP = "ag2.network.session"
+AGENT_CLIENT_DEP = "ag2.network.agent_client"
+HUB_DEP = "ag2.network.hub"
+TASK_DEP = "ag2.task"  # framework-core key; re-exported for symmetry

--- a/autogen/beta/network/rule.py
+++ b/autogen/beta/network/rule.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-(hub, agent) rules — access + limits.
+
+V1 ships ``access`` + ``limits`` only; transforms (per-envelope local
+enforcement) ship in Phase 3 alongside the WebSocket transport.
+Defaults are permissive: a freshly registered Agent with no rule
+changes can talk to anyone, accept any session type, and has no rate
+limit. Apps tighten by passing a non-default ``Rule`` to
+``hub_client.register(...)``.
+
+Both blocks are enforced at the **hub**, never the client.
+"""
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+__all__ = (
+    "AccessBlock",
+    "InboxBlock",
+    "LimitsBlock",
+    "RateBlock",
+    "Rule",
+    "SessionTypeAccess",
+    "parse_duration",
+)
+
+
+_DURATION_UNITS: dict[str, int] = {
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86400,
+}
+
+
+def parse_duration(s: str | int) -> int:
+    """Parse a duration string into seconds.
+
+    Accepts ``"30s"``, ``"15m"``, ``"2h"``, ``"1d"``, plain integer
+    strings (treated as seconds), or already-parsed ``int``. Empty
+    string returns 0. Raises ``ValueError`` on unknown unit.
+    """
+    if isinstance(s, int):
+        return s
+    if not s:
+        return 0
+    if s[-1] in _DURATION_UNITS:
+        unit = s[-1]
+        value = s[:-1]
+        return int(value) * _DURATION_UNITS[unit]
+    return int(s)
+
+
+@dataclass(slots=True)
+class SessionTypeAccess:
+    initiate: list[str] = field(default_factory=lambda: ["*"])
+    accept: list[str] = field(default_factory=lambda: ["*"])
+
+
+@dataclass(slots=True)
+class AccessBlock:
+    inbound_from: list[str] = field(default_factory=lambda: ["*"])  # globs over `name`
+    outbound_to: list[str] = field(default_factory=lambda: ["*"])
+    session_types: SessionTypeAccess = field(default_factory=SessionTypeAccess)
+
+
+@dataclass(slots=True)
+class RateBlock:
+    """Token-bucket rate limiter (Phase 2). M1 stores the values but
+    does not enforce — ``per_minute = 0`` keeps the limiter disabled
+    by default, so the no-op behaviour matches the eventual default.
+    """
+
+    per_minute: int = 0
+    burst: int = 0
+
+
+@dataclass(slots=True)
+class InboxBlock:
+    """Inbox capacity policy.
+
+    M1 ships ``reject`` overflow only; ``drop_oldest`` and
+    ``drop_newest`` arrive in Phase 2.
+    """
+
+    max_pending: int = 1000
+    overflow: str = "reject"  # "reject" | "drop_oldest" | "drop_newest"
+
+
+@dataclass(slots=True)
+class LimitsBlock:
+    """Concurrency caps + parsed duration TTLs + failure-mode thresholds.
+
+    ``0`` disables a numeric cap. Duration strings are parsed via
+    :func:`parse_duration`; values may be passed pre-parsed as ``int``
+    seconds.
+    """
+
+    max_concurrent_sessions: int = 0
+    max_concurrent_tasks: int = 0
+    session_ttl_default: str = "2h"
+    task_ttl_default: str = "15m"
+    rate: RateBlock = field(default_factory=RateBlock)
+    delegation_depth: int = 5
+    inbox: InboxBlock = field(default_factory=InboxBlock)
+
+    # Failure-mode thresholds (M3 sweepers honour these)
+    peer_heartbeat_timeout: str = "30s"
+    task_stall_threshold: str = "60s"
+    session_idle_threshold: str = "5m"
+
+
+@dataclass(slots=True)
+class Rule:
+    version: int = 1
+    access: AccessBlock = field(default_factory=AccessBlock)
+    limits: LimitsBlock = field(default_factory=LimitsBlock)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Rule":
+        payload = dict(data)
+        access = payload.get("access")
+        if isinstance(access, dict):
+            access_payload = dict(access)
+            session_types = access_payload.get("session_types")
+            if isinstance(session_types, dict):
+                access_payload["session_types"] = SessionTypeAccess(**session_types)
+            payload["access"] = AccessBlock(**access_payload)
+        limits = payload.get("limits")
+        if isinstance(limits, dict):
+            limits_payload = dict(limits)
+            rate = limits_payload.get("rate")
+            if isinstance(rate, dict):
+                limits_payload["rate"] = RateBlock(**rate)
+            inbox = limits_payload.get("inbox")
+            if isinstance(inbox, dict):
+                limits_payload["inbox"] = InboxBlock(**inbox)
+            payload["limits"] = LimitsBlock(**limits_payload)
+        return cls(**payload)

--- a/autogen/beta/network/transport/__init__.py
+++ b/autogen/beta/network/transport/__init__.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transport layer — frames + Link Protocol + ``LocalLink`` (V1).
+
+V1 ships only ``LocalLink`` (in-memory duplex). Phase 3 adds ``WsLink``
+(WebSocket) on the same ``Link`` Protocol surface; nothing above this
+layer changes when transports are swapped.
+"""
+
+from .frames import (
+    AcceptFrame,
+    ErrorFrame,
+    EventFrame,
+    Frame,
+    HelloFrame,
+    NotifyFrame,
+    PingFrame,
+    PongFrame,
+    ReceiptFrame,
+    SendFrame,
+    SubscribeFrame,
+    UnsubscribeFrame,
+    WelcomeFrame,
+    decode_frame,
+    encode_frame,
+)
+from .link import LinkClient, LinkEndpoint
+from .local import LocalLink, LocalLinkClient, LocalLinkEndpoint
+
+__all__ = (
+    "AcceptFrame",
+    "ErrorFrame",
+    "EventFrame",
+    "Frame",
+    "HelloFrame",
+    "LinkClient",
+    "LinkEndpoint",
+    "LocalLink",
+    "LocalLinkClient",
+    "LocalLinkEndpoint",
+    "NotifyFrame",
+    "PingFrame",
+    "PongFrame",
+    "ReceiptFrame",
+    "SendFrame",
+    "SubscribeFrame",
+    "UnsubscribeFrame",
+    "WelcomeFrame",
+    "decode_frame",
+    "encode_frame",
+)

--- a/autogen/beta/network/transport/frames.py
+++ b/autogen/beta/network/transport/frames.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wire frames for the ``Link`` Protocol.
+
+V1 ships the subset of frames required by ``LocalLink`` plus
+``HelloFrame`` / ``WelcomeFrame`` so the same wire vocabulary works
+for ``WsLink`` (Phase 3) without renaming. Streaming ``ChunkFrame``
+and Phase-3 ``RuleChangedFrame`` are intentionally omitted.
+
+``encode_frame`` / ``decode_frame`` produce JSON-compatible dicts.
+``LocalLink`` passes Frame dataclasses through in-memory queues
+without serialisation; the encode/decode helpers exist so the same
+frame vocabulary serialises losslessly on ``WsLink``.
+"""
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, ClassVar, TypeAlias
+
+from ..envelope import Envelope
+
+__all__ = (
+    "AcceptFrame",
+    "ErrorFrame",
+    "EventFrame",
+    "Frame",
+    "HelloFrame",
+    "NotifyFrame",
+    "PingFrame",
+    "PongFrame",
+    "ReceiptFrame",
+    "SendFrame",
+    "SubscribeFrame",
+    "UnsubscribeFrame",
+    "WelcomeFrame",
+    "decode_frame",
+    "encode_frame",
+)
+
+
+@dataclass(slots=True)
+class HelloFrame:
+    """client → hub: open the connection and authenticate.
+
+    ``name`` lets the hub bind the connection to an existing identity
+    (re-connect) or onboard a new one. ``auth_scheme`` + ``auth_claim``
+    feed the registered ``AuthAdapter``. V1 ships ``NoAuth`` only.
+    """
+
+    kind: ClassVar[str] = "hello"
+    name: str
+    auth_scheme: str = "none"
+    auth_claim: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class WelcomeFrame:
+    """hub → client: handshake accepted; carries hub clock + connection id."""
+
+    kind: ClassVar[str] = "welcome"
+    endpoint_id: str
+    hub_time: str  # ISO-Z
+
+
+@dataclass(slots=True)
+class PingFrame:
+    """Heartbeat — both directions. ``LocalLink`` skips wire pings."""
+
+    kind: ClassVar[str] = "ping"
+
+
+@dataclass(slots=True)
+class PongFrame:
+    """Heartbeat reply — both directions."""
+
+    kind: ClassVar[str] = "pong"
+
+
+@dataclass(slots=True)
+class SendFrame:
+    """client → hub: post an envelope into a session.
+
+    Hub stamps ``envelope_id`` and ``created_at`` at accept and replies
+    with ``AcceptFrame`` (or ``ErrorFrame`` on rejection).
+    """
+
+    kind: ClassVar[str] = "send"
+    envelope: Envelope
+
+
+@dataclass(slots=True)
+class AcceptFrame:
+    """hub → client: ack of a ``send`` with the hub-stamped ``envelope_id``."""
+
+    kind: ClassVar[str] = "accept"
+    envelope_id: str
+
+
+@dataclass(slots=True)
+class ErrorFrame:
+    """hub → client: structured rejection.
+
+    ``code`` is a stable identifier (``"protocol_error"``,
+    ``"access_denied"``, ``"not_found"``, ``"inbox_full"``, …).
+    ``envelope_id`` is set when the error relates to a specific send.
+    """
+
+    kind: ClassVar[str] = "error"
+    code: str
+    message: str
+    envelope_id: str | None = None
+
+
+@dataclass(slots=True)
+class NotifyFrame:
+    """hub → client: deliver an envelope to a participant.
+
+    The receiving ``AgentClient`` routes to the registered notify
+    handler for the envelope's session.
+    """
+
+    kind: ClassVar[str] = "notify"
+    envelope: Envelope
+
+
+@dataclass(slots=True)
+class ReceiptFrame:
+    """client → hub: ack or nack a ``notify``.
+
+    ``status`` is ``"ack"`` (advances ``inbox.cursor`` in Phase 3) or
+    ``"nack"`` (records to ``inbox_nacks.jsonl``). ``reason`` is a
+    free-form diagnostic for the audit log.
+    """
+
+    kind: ClassVar[str] = "receipt"
+    envelope_id: str
+    status: str  # "ack" | "nack"
+    reason: str = ""
+
+
+@dataclass(slots=True)
+class SubscribeFrame:
+    """client → hub: open a push subscription on a session or task.
+
+    At least one of ``session_id`` / ``task_id`` must be set.
+    ``since_envelope_id`` is the cursor for at-least-once replay
+    (Phase 3 — V1 in-process is exactly-once by lock).
+    """
+
+    kind: ClassVar[str] = "subscribe"
+    subscription_id: str
+    session_id: str | None = None
+    task_id: str | None = None
+    event_types: list[str] | None = None
+    since_envelope_id: str | None = None
+
+
+@dataclass(slots=True)
+class UnsubscribeFrame:
+    """client → hub: close a subscription."""
+
+    kind: ClassVar[str] = "unsubscribe"
+    subscription_id: str
+
+
+@dataclass(slots=True)
+class EventFrame:
+    """hub → client: subscription delivery."""
+
+    kind: ClassVar[str] = "event"
+    subscription_id: str
+    envelope: Envelope
+
+
+Frame: TypeAlias = (
+    HelloFrame
+    | WelcomeFrame
+    | PingFrame
+    | PongFrame
+    | SendFrame
+    | AcceptFrame
+    | ErrorFrame
+    | NotifyFrame
+    | ReceiptFrame
+    | SubscribeFrame
+    | UnsubscribeFrame
+    | EventFrame
+)
+
+
+_FRAME_CLASSES: dict[str, type] = {
+    "hello": HelloFrame,
+    "welcome": WelcomeFrame,
+    "ping": PingFrame,
+    "pong": PongFrame,
+    "send": SendFrame,
+    "accept": AcceptFrame,
+    "error": ErrorFrame,
+    "notify": NotifyFrame,
+    "receipt": ReceiptFrame,
+    "subscribe": SubscribeFrame,
+    "unsubscribe": UnsubscribeFrame,
+    "event": EventFrame,
+}
+
+
+def encode_frame(frame: Frame) -> dict[str, Any]:
+    """Serialise a Frame to a JSON-compatible dict.
+
+    Adds the ``kind`` discriminator (a ``ClassVar``, so ``asdict`` does
+    not include it). Nested ``Envelope`` is auto-flattened by
+    ``dataclasses.asdict``.
+    """
+    data = asdict(frame)
+    data["kind"] = frame.kind
+    return data
+
+
+def decode_frame(data: dict[str, Any]) -> Frame:
+    """Reconstruct a Frame from a JSON dict.
+
+    Looks up the dataclass via ``kind``, rehydrates a nested
+    ``Envelope`` if present, and constructs the frame. Raises
+    ``ValueError`` on unknown ``kind``.
+    """
+    payload = dict(data)  # shallow copy — caller's dict is preserved
+    kind = payload.pop("kind", None)
+    if kind not in _FRAME_CLASSES:
+        raise ValueError(f"unknown frame kind: {kind!r}")
+    cls = _FRAME_CLASSES[kind]
+    if "envelope" in payload and isinstance(payload["envelope"], dict):
+        payload["envelope"] = Envelope.from_dict(payload["envelope"])
+    return cls(**payload)

--- a/autogen/beta/network/transport/link.py
+++ b/autogen/beta/network/transport/link.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``Link`` Protocol — wire abstraction between ``HubClient`` and ``Hub``.
+
+Two roles:
+
+* ``LinkClient`` — tenant-side handle to the hub. ``HubClient`` holds
+  one per process per hub.
+* ``LinkEndpoint`` — hub-side handle to one connected client.
+
+V1 ships ``LocalLink`` only (see ``.local``). Phase 3 adds ``WsLink``
+on the same Protocol surface.
+"""
+
+from collections.abc import AsyncIterator
+from typing import Protocol, runtime_checkable
+
+from .frames import Frame
+
+__all__ = ("LinkClient", "LinkEndpoint")
+
+
+@runtime_checkable
+class LinkClient(Protocol):
+    """Tenant-side handle to the hub.
+
+    The ``HubClient`` opens one ``LinkClient`` per process per hub and
+    multiplexes any number of registered ``AgentClient``s through it.
+    """
+
+    endpoint_id: str
+
+    async def open(self) -> None:
+        """Connect, perform ``hello`` handshake, await ``welcome``.
+
+        ``LocalLink`` makes this a no-op — connection is implicit when
+        the link is created.
+        """
+        ...
+
+    async def send_frame(self, frame: Frame) -> None:
+        """Push a frame towards the hub."""
+        ...
+
+    def frames(self) -> AsyncIterator[Frame]:
+        """Async iterator of inbound frames from the hub.
+
+        Iteration ends when ``close()`` is called.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Drain queues, signal close to the hub-side handler."""
+        ...
+
+
+@runtime_checkable
+class LinkEndpoint(Protocol):
+    """Hub-side handle to one connected client.
+
+    Lives for the duration of a single connection; replaced on
+    reconnect (the ``HubClient`` re-opens after a transport drop).
+    """
+
+    endpoint_id: str
+    agent_id: str | None  # set after the hub binds an identity to this connection
+
+    async def send_frame(self, frame: Frame) -> None:
+        """Push a frame towards the client."""
+        ...
+
+    def frames(self) -> AsyncIterator[Frame]:
+        """Async iterator of inbound frames from the client."""
+        ...
+
+    async def close(self) -> None:
+        """Drain queues, signal close to the client-side handler."""
+        ...

--- a/autogen/beta/network/transport/local.py
+++ b/autogen/beta/network/transport/local.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``LocalLink`` — in-memory duplex implementing the ``Link`` Protocol.
+
+V1's only transport. Each ``LocalLink.client()`` call creates a paired
+``LocalLinkClient`` / ``LocalLinkEndpoint`` sharing two ``asyncio.Queue``s
+(client→hub and hub→client). The hub is notified of the new endpoint
+via ``LocalLink.on_connect`` so it can spawn a frame-processor task.
+
+Tests run real protocol traffic through the same Frame vocabulary used
+by Phase 3's ``WsLink`` — no socket, no serialization overhead, but
+the protocol coverage is identical.
+
+``LocalLinkClient.open()`` is a no-op (connection is implicit at
+``client()`` time). Heartbeat refresh is synchronous: every frame
+operation refreshes ``last_heartbeat``; no wire ping is sent.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING
+
+from ..ids import make_id
+from .frames import Frame
+
+if TYPE_CHECKING:
+    from ..hub import Hub
+
+__all__ = ("LocalLink", "LocalLinkClient", "LocalLinkEndpoint")
+
+
+class LocalLinkClient:
+    """Tenant-side half of an in-memory duplex.
+
+    Holds the two queues; ``send_frame`` writes to the client→hub queue,
+    ``frames()`` reads from the hub→client queue. ``close()`` pushes a
+    sentinel so the iterator terminates cleanly on both ends.
+    """
+
+    def __init__(
+        self,
+        endpoint_id: str,
+        client_to_hub: "asyncio.Queue[Frame | None]",
+        hub_to_client: "asyncio.Queue[Frame | None]",
+    ) -> None:
+        # __init__ stores params; no side effects.
+        self.endpoint_id = endpoint_id
+        self._c2h = client_to_hub
+        self._h2c = hub_to_client
+        self._closed = False
+
+    async def open(self) -> None:
+        """No-op — connection is implicit at ``LocalLink.client()`` time."""
+        return None
+
+    async def send_frame(self, frame: Frame) -> None:
+        if self._closed:
+            return
+        await self._c2h.put(frame)
+
+    def frames(self) -> AsyncIterator[Frame]:
+        return self._frames_impl()
+
+    async def _frames_impl(self) -> AsyncIterator[Frame]:
+        while True:
+            frame = await self._h2c.get()
+            if frame is None:
+                return
+            yield frame
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        # Sentinel both directions so handlers on both sides stop iterating.
+        await self._c2h.put(None)
+        await self._h2c.put(None)
+
+
+class LocalLinkEndpoint:
+    """Hub-side half of an in-memory duplex.
+
+    Mirror of ``LocalLinkClient``: ``send_frame`` writes hub→client,
+    ``frames()`` reads client→hub. ``agent_id`` is set by the hub once
+    a ``HelloFrame`` (or direct in-process binding) associates this
+    endpoint with an identity.
+    """
+
+    def __init__(
+        self,
+        endpoint_id: str,
+        client_to_hub: "asyncio.Queue[Frame | None]",
+        hub_to_client: "asyncio.Queue[Frame | None]",
+    ) -> None:
+        # __init__ stores params; no side effects.
+        self.endpoint_id = endpoint_id
+        self.agent_id: str | None = None
+        self._c2h = client_to_hub
+        self._h2c = hub_to_client
+        self._closed = False
+
+    async def send_frame(self, frame: Frame) -> None:
+        if self._closed:
+            return
+        await self._h2c.put(frame)
+
+    def frames(self) -> AsyncIterator[Frame]:
+        return self._frames_impl()
+
+    async def _frames_impl(self) -> AsyncIterator[Frame]:
+        while True:
+            frame = await self._c2h.get()
+            if frame is None:
+                return
+            yield frame
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._c2h.put(None)
+        await self._h2c.put(None)
+
+
+class LocalLink:
+    """Factory creating in-process duplex pairs against one ``Hub``.
+
+    Pass to ``HubClient(link=LocalLink(hub), hub=hub)``. Each
+    ``HubClient`` requests one ``LocalLinkClient`` (held for the life
+    of the process); multiple ``AgentClient``s registered through that
+    ``HubClient`` share the connection.
+
+    Each ``client()`` call constructs a fresh endpoint and immediately
+    hands it to ``Hub.attach_endpoint`` so the hub spawns its
+    frame-processor task. WS transport (Phase 3) follows the same
+    shape — the WebSocket server's connect handler is what calls
+    ``Hub.attach_endpoint`` there.
+    """
+
+    def __init__(self, hub: "Hub") -> None:
+        # __init__ stores params; side effects deferred to client().
+        self._hub = hub
+
+    @property
+    def hub(self) -> "Hub":
+        return self._hub
+
+    def client(self) -> LocalLinkClient:
+        """Create a fresh client+endpoint pair; attach to the hub."""
+        endpoint_id = make_id()
+        c2h: "asyncio.Queue[Frame | None]" = asyncio.Queue()
+        h2c: "asyncio.Queue[Frame | None]" = asyncio.Queue()
+        endpoint = LocalLinkEndpoint(endpoint_id=endpoint_id, client_to_hub=c2h, hub_to_client=h2c)
+        client = LocalLinkClient(endpoint_id=endpoint_id, client_to_hub=c2h, hub_to_client=h2c)
+        self._hub.attach_endpoint(endpoint)
+        return client

--- a/autogen/beta/task.py
+++ b/autogen/beta/task.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task — framework-core lifecycle primitive.
+
+A ``Task`` is a wrapper any ``Agent`` (or other actor) can use to give a
+unit of work a trackable lifecycle. The Task emits ``TaskStarted``,
+``TaskProgress``, ``TaskCompleted``, ``TaskFailed``, and ``TaskExpired``
+events on a bound stream so any observer (network mirror, watcher, UI,
+test harness) can follow along without participating in execution.
+
+Tasks are agent-owned. The framework does not assign or schedule them.
+Standalone usage requires no hub or network — events fly past harmlessly
+if no observer subscribes. Network observation is layered on top via
+``autogen.beta.network`` (see ``design/tasks.md``).
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Annotated, Any
+from uuid import uuid4
+
+from .annotations import Inject
+from .context import ConversationContext
+from .events import TaskCompleted, TaskExpired, TaskFailed, TaskProgress, TaskStarted
+from .stream import MemoryStream
+
+__all__ = (
+    "TERMINAL_TASK_STATES",
+    "Task",
+    "TaskInject",
+    "TaskMetadata",
+    "TaskSpec",
+    "TaskState",
+)
+
+
+_TASK_DEP_KEY = "ag2.task"
+
+
+class TaskState(str, Enum):
+    """Lifecycle state of a ``Task``. Terminal states are immutable."""
+
+    CREATED = "created"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    EXPIRED = "expired"
+
+
+TERMINAL_TASK_STATES: frozenset[TaskState] = frozenset({
+    TaskState.COMPLETED,
+    TaskState.FAILED,
+    TaskState.EXPIRED,
+})
+
+
+@dataclass(slots=True)
+class TaskSpec:
+    """What a ``Task`` is doing — title plus optional description and payload."""
+
+    title: str
+    description: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TaskMetadata:
+    """Mutable lifecycle record for a Task. Updated on state transitions."""
+
+    task_id: str
+    owner_id: str
+    spec: TaskSpec
+    state: TaskState
+    created_at: str = ""
+    started_at: str | None = None
+    completed_at: str | None = None
+    expires_at: str | None = None
+    last_progress_at: str | None = None
+    progress: dict[str, Any] = field(default_factory=dict)
+    result: Any = None
+    error: str = ""
+    # Optional network association — set when an AgentClient mirrors this task.
+    session_id: str | None = None
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _expires_iso(ttl_seconds: int | None, base: datetime) -> str | None:
+    if ttl_seconds is None:
+        return None
+    return (base + timedelta(seconds=ttl_seconds)).isoformat()
+
+
+class Task:
+    """Lifecycle handle for a unit of work.
+
+    Created via ``Agent.task(...)`` or directly. Use as an async context
+    manager::
+
+        async with agent.task("research framework X") as task:
+            await task.progress({"step": "search"})
+            findings = await search(...)
+            await task.complete(findings)
+
+    On clean exit, auto-completes with ``result=None`` if the user did not
+    call ``complete()`` or ``fail()``. On exception, auto-fails with the
+    raised exception (the exception still propagates).
+
+    If a ``ConversationContext`` is passed, events flow on that stream and
+    ``ag2.task`` is stamped into ``context.dependencies`` for the duration
+    of the ``async with`` block (so ``TaskInject`` resolves to the active
+    task). With no context, the Task creates a private ``MemoryStream`` —
+    standalone use; events still fire but only observers attached to that
+    private stream see them.
+    """
+
+    def __init__(
+        self,
+        *,
+        owner_id: str,
+        spec: TaskSpec,
+        context: ConversationContext | None = None,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        # __init__ stores params; side effects happen in __aenter__.
+        self._owner_id = owner_id
+        self._spec = spec
+        self._ttl_seconds = ttl_seconds
+        self._context = context
+        self._owns_context = False
+        self._metadata: TaskMetadata | None = None
+        self._had_previous_dep = False
+        self._previous_dep: Any = None
+
+    @property
+    def task_id(self) -> str:
+        if self._metadata is None:
+            raise RuntimeError("Task.task_id is not available before __aenter__")
+        return self._metadata.task_id
+
+    @property
+    def state(self) -> TaskState:
+        if self._metadata is None:
+            return TaskState.CREATED
+        return self._metadata.state
+
+    @property
+    def metadata(self) -> TaskMetadata:
+        if self._metadata is None:
+            raise RuntimeError("Task.metadata is not available before __aenter__")
+        return self._metadata
+
+    @property
+    def context(self) -> ConversationContext:
+        if self._context is None:
+            raise RuntimeError("Task has no bound context (use 'async with task: ...')")
+        return self._context
+
+    async def progress(self, payload: dict[str, Any]) -> None:
+        """Emit ``TaskProgress``; merges payload into ``metadata.progress``.
+
+        No-op if the task is already in a terminal state.
+        """
+        if self._metadata is None:
+            raise RuntimeError("Task.progress() called before __aenter__")
+        if self._metadata.state in TERMINAL_TASK_STATES:
+            return
+        self._metadata.progress.update(payload)
+        self._metadata.last_progress_at = _now_iso()
+        await self.context.send(
+            TaskProgress(
+                task_id=self._metadata.task_id,
+                agent_name=self._owner_id,
+                objective=self._spec.title,
+                content="",
+                payload=dict(payload),
+            )
+        )
+
+    async def complete(self, result: Any = None) -> None:
+        """Terminal: emit ``TaskCompleted``; state ← COMPLETED.
+
+        No-op if already terminal.
+        """
+        if self._metadata is None:
+            raise RuntimeError("Task.complete() called before __aenter__")
+        if self._metadata.state in TERMINAL_TASK_STATES:
+            return
+        self._metadata.state = TaskState.COMPLETED
+        self._metadata.result = result
+        self._metadata.completed_at = _now_iso()
+        await self.context.send(
+            TaskCompleted(
+                task_id=self._metadata.task_id,
+                agent_name=self._owner_id,
+                objective=self._spec.title,
+                result=result,
+                task_stream=self.context.stream.id,
+            )
+        )
+
+    async def fail(self, error: str | BaseException) -> None:
+        """Terminal: emit ``TaskFailed``; state ← FAILED.
+
+        Accepts a string (wrapped in ``RuntimeError``) or any
+        ``BaseException``. No-op if already terminal.
+        """
+        if self._metadata is None:
+            raise RuntimeError("Task.fail() called before __aenter__")
+        if self._metadata.state in TERMINAL_TASK_STATES:
+            return
+        if isinstance(error, str):
+            exc: BaseException = RuntimeError(error)
+        else:
+            exc = error
+        self._metadata.state = TaskState.FAILED
+        self._metadata.error = str(exc)
+        self._metadata.completed_at = _now_iso()
+        await self.context.send(
+            TaskFailed(
+                task_id=self._metadata.task_id,
+                agent_name=self._owner_id,
+                objective=self._spec.title,
+                error=exc,
+            )
+        )
+
+    async def expire(self) -> None:
+        """Terminal: emit ``TaskExpired``; state ← EXPIRED.
+
+        Called by an external TTL observer (e.g. the network hub's TTL
+        sweeper, mirrored back to the agent's stream). No-op if already
+        terminal.
+        """
+        if self._metadata is None:
+            raise RuntimeError("Task.expire() called before __aenter__")
+        if self._metadata.state in TERMINAL_TASK_STATES:
+            return
+        self._metadata.state = TaskState.EXPIRED
+        self._metadata.completed_at = _now_iso()
+        await self.context.send(
+            TaskExpired(
+                task_id=self._metadata.task_id,
+                agent_name=self._owner_id,
+                objective=self._spec.title,
+            )
+        )
+
+    async def __aenter__(self) -> "Task":
+        if self._metadata is not None:
+            raise RuntimeError(f"Task already entered (state={self._metadata.state})")
+
+        if self._context is None:
+            self._context = ConversationContext(stream=MemoryStream())
+            self._owns_context = True
+
+        now = datetime.now(timezone.utc)
+        now_iso = now.isoformat()
+        self._metadata = TaskMetadata(
+            task_id=uuid4().hex,
+            owner_id=self._owner_id,
+            spec=self._spec,
+            state=TaskState.RUNNING,
+            created_at=now_iso,
+            started_at=now_iso,
+            expires_at=_expires_iso(self._ttl_seconds, now),
+        )
+
+        existing = self._context.dependencies.get(_TASK_DEP_KEY)
+        if existing is not None:
+            self._had_previous_dep = True
+            self._previous_dep = existing
+        self._context.dependencies[_TASK_DEP_KEY] = self
+
+        await self._context.send(
+            TaskStarted(
+                task_id=self._metadata.task_id,
+                agent_name=self._owner_id,
+                objective=self._spec.title,
+                spec=self._spec,
+            )
+        )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: Any,
+    ) -> None:
+        try:
+            if self._metadata is None:
+                return
+            if exc is not None and self._metadata.state not in TERMINAL_TASK_STATES:
+                await self.fail(exc)
+            elif self._metadata.state == TaskState.RUNNING:
+                await self.complete()
+        finally:
+            if self._context is not None:
+                if self._had_previous_dep:
+                    self._context.dependencies[_TASK_DEP_KEY] = self._previous_dep
+                else:
+                    self._context.dependencies.pop(_TASK_DEP_KEY, None)
+            self._had_previous_dep = False
+            self._previous_dep = None
+
+
+TaskInject = Annotated[Task, Inject(_TASK_DEP_KEY, default=None)]

--- a/test/beta/network/test_m1_foundation.py
+++ b/test/beta/network/test_m1_foundation.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""M1 foundation integration tests.
+
+Covers the M1 exit criterion from ``design/PLAN.md``: two
+``AgentClient``s register through ``LocalLink`` and exchange raw
+envelopes; ``Hub.hydrate()`` rebuilds passport/resume/rule caches from
+disk.
+
+No sessions, no LLM, no expectation sweeper — those land in M2/M3.
+"""
+
+import asyncio
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.config import AnthropicConfig
+from autogen.beta.knowledge import DiskKnowledgeStore, MemoryKnowledgeStore
+from autogen.beta.network import (
+    EV_TEXT,
+    AccessBlock,
+    AccessDeniedError,
+    Envelope,
+    Hub,
+    HubClient,
+    LimitsBlock,
+    LocalLink,
+    NotFoundError,
+    Passport,
+    Resume,
+    Rule,
+)
+
+
+def _agent(name: str) -> Agent:
+    return Agent(name=name, config=AnthropicConfig(model="claude-sonnet-4-6"))
+
+
+@pytest.mark.asyncio
+async def test_register_and_exchange_envelope_via_hub_client() -> None:
+    """End-to-end M1 happy path: register both, send, receive."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store)
+    link = LocalLink(hub)
+
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    bob = await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+
+    received: list[Envelope] = []
+
+    async def on_envelope(env: Envelope) -> None:
+        received.append(env)
+
+    bob.on_envelope(on_envelope)
+
+    envelope = Envelope(
+        session_id="s1",
+        sender_id=alice.agent_id,
+        audience=[bob.agent_id],
+        event_type=EV_TEXT,
+        event_data={"text": "hello bob"},
+    )
+    eid = await alice.send_envelope(envelope)
+
+    # Allow the demuxing loop to drain.
+    for _ in range(20):
+        if received:
+            break
+        await asyncio.sleep(0.01)
+
+    assert len(received) == 1
+    assert received[0].envelope_id == eid
+    assert received[0].event_data == {"text": "hello bob"}
+
+    # Hub WAL persisted.
+    wal = await hub.read_wal("s1")
+    assert len(wal) == 1
+    assert wal[0].sender_id == alice.agent_id
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_sender_raises_not_found() -> None:
+    """Posting an envelope from an unregistered sender_id raises NotFoundError."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store)
+
+    envelope = Envelope(
+        session_id="s1",
+        sender_id="ghost",
+        audience=["someone"],
+        event_type=EV_TEXT,
+        event_data={},
+    )
+    with pytest.raises(NotFoundError):
+        await hub.post_envelope(envelope)
+
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_hydrate_reloads_identities_from_disk(tmp_path) -> None:
+    """Close hub, reopen with same store, verify identities + resumes survive."""
+    store = DiskKnowledgeStore(str(tmp_path))
+    hub1 = await Hub.open(store)
+    link1 = LocalLink(hub1)
+    hc1 = HubClient(link1, hub=hub1)
+
+    alice = await hc1.register(
+        _agent("alice"),
+        Passport(name="alice", owner="acme"),
+        Resume(claimed_capabilities=["analysis", "research"], summary="senior analyst"),
+        skill_md="# Alice\nuse for research",
+    )
+    bob = await hc1.register(
+        _agent("bob"),
+        Passport(name="bob"),
+        Resume(claimed_capabilities=["debate"]),
+        rule=Rule(limits=LimitsBlock(session_ttl_default="4h")),
+    )
+
+    alice_id = alice.agent_id
+    bob_id = bob.agent_id
+
+    await hc1.close()
+    await hub1.close()
+
+    # Reopen — no shared in-memory state with hub1.
+    store2 = DiskKnowledgeStore(str(tmp_path))
+    hub2 = await Hub.open(store2)
+
+    alice_p = await hub2.get_agent("alice")
+    assert alice_p.agent_id == alice_id
+    assert alice_p.owner == "acme"
+
+    bob_p = await hub2.get_agent("bob")
+    assert bob_p.agent_id == bob_id
+
+    alice_resume = await hub2.get_resume(alice_id)
+    assert "analysis" in alice_resume.claimed_capabilities
+    assert alice_resume.summary == "senior analyst"
+
+    alice_skill = await hub2.get_skill(alice_id)
+    assert alice_skill is not None
+    assert "Alice" in alice_skill
+
+    # Capability filter on the rebuilt index.
+    found = await hub2.list_agents(capability="debate")
+    assert {p.name for p in found} == {"bob"}
+
+    found_query = await hub2.list_agents(query="senior")
+    assert {p.name for p in found_query} == {"alice"}
+
+    await hub2.close()
+
+
+@pytest.mark.asyncio
+async def test_outbound_access_denied() -> None:
+    """Sender's outbound_to whitelist blocks the recipient."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store)
+    link = LocalLink(hub)
+    hc = HubClient(link, hub=hub)
+
+    alice = await hc.register(
+        _agent("alice"),
+        Passport(name="alice"),
+        Resume(),
+        rule=Rule(access=AccessBlock(outbound_to=["carol"])),  # bob not allowed
+    )
+    bob = await hc.register(_agent("bob"), Passport(name="bob"), Resume())
+
+    envelope = Envelope(
+        session_id="s1",
+        sender_id=alice.agent_id,
+        audience=[bob.agent_id],
+        event_type=EV_TEXT,
+        event_data={},
+    )
+    with pytest.raises(AccessDeniedError):
+        await alice.send_envelope(envelope)
+
+    await hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_inbound_access_silently_drops() -> None:
+    """Recipient's inbound_from whitelist drops the notify silently."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store)
+    link = LocalLink(hub)
+    hc = HubClient(link, hub=hub)
+
+    alice = await hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    bob = await hc.register(
+        _agent("bob"),
+        Passport(name="bob"),
+        Resume(),
+        rule=Rule(access=AccessBlock(inbound_from=["carol"])),  # alice not allowed in
+    )
+
+    received: list[Envelope] = []
+    bob.on_envelope(lambda env: received.append(env))  # type: ignore[arg-type, return-value]
+
+    envelope = Envelope(
+        session_id="s1",
+        sender_id=alice.agent_id,
+        audience=[bob.agent_id],
+        event_type=EV_TEXT,
+        event_data={},
+    )
+    eid = await alice.send_envelope(envelope)
+    assert eid  # post succeeds (envelope is in WAL for audit)
+
+    # Wait briefly to confirm bob's callback never fires.
+    await asyncio.sleep(0.05)
+    assert received == []
+
+    await hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_unregister_makes_send_fail() -> None:
+    """After unregister, the AgentClient instance is inert.
+
+    The local guard short-circuits before reaching the hub. If a
+    different sender_id is used through ``Hub.post_envelope`` directly,
+    the hub itself raises ``NotFoundError`` (already covered by
+    ``test_unknown_sender_raises_not_found``).
+    """
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store)
+    link = LocalLink(hub)
+    hc = HubClient(link, hub=hub)
+
+    alice = await hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    bob = await hc.register(_agent("bob"), Passport(name="bob"), Resume())
+
+    await alice.unregister()
+
+    envelope = Envelope(
+        session_id="s1",
+        sender_id=alice.agent_id,
+        audience=[bob.agent_id],
+        event_type=EV_TEXT,
+        event_data={},
+    )
+    with pytest.raises(RuntimeError, match="disconnected"):
+        await alice.send_envelope(envelope)
+
+    # And the hub itself no longer knows the agent_id.
+    with pytest.raises(NotFoundError):
+        await hub.get_agent(alice.agent_id)
+    remaining_names = {p.name for p in await hub.list_agents()}
+    assert remaining_names == {"bob"}
+
+    await hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_set_resume_updates_index() -> None:
+    """Tenant-driven set_resume swaps the cached resume; queries reflect it."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store)
+    link = LocalLink(hub)
+    hc = HubClient(link, hub=hub)
+
+    alice = await hc.register(_agent("alice"), Passport(name="alice"), Resume())
+
+    new_resume = Resume(claimed_capabilities=["new-skill"], summary="updated")
+    await alice.set_resume(new_resume)
+
+    found = await hc.list_agents(capability="new-skill")
+    assert {p.name for p in found} == {"alice"}
+
+    fetched = await hc.get_resume(alice.agent_id)
+    assert fetched.summary == "updated"
+    assert fetched.last_updated != ""
+
+    await hc.close()
+    await hub.close()

--- a/test/beta/test_task.py
+++ b/test/beta/test_task.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the framework-core ``Task`` primitive.
+
+Covers standalone usage with no hub or network — pure
+``autogen.beta.task`` lifecycle, event emission, dependency stamping
+for ``TaskInject``, and TTL field population.
+"""
+
+import pytest
+
+from autogen.beta import Agent, TaskSpec
+from autogen.beta.config import AnthropicConfig
+from autogen.beta.context import ConversationContext
+from autogen.beta.events import (
+    BaseEvent,
+    TaskCompleted,
+    TaskExpired,
+    TaskFailed,
+    TaskProgress,
+    TaskStarted,
+)
+from autogen.beta.stream import MemoryStream
+from autogen.beta.task import TERMINAL_TASK_STATES, TaskState
+
+
+def _agent() -> Agent:
+    """A bare Agent — no model calls, just a name."""
+    return Agent(name="researcher", config=AnthropicConfig(model="claude-sonnet-4-6"))
+
+
+async def _persisted(stream: MemoryStream) -> list[BaseEvent]:
+    """Read durably-persisted events from a MemoryStream's storage.
+
+    Note: transient events (``TaskProgress``, ``ModelMessageChunk``) are
+    not persisted — use ``_subscribe`` to capture them live.
+    """
+    return list(await stream.history.storage.get_history(stream.id))
+
+
+def _subscribe(stream: MemoryStream) -> list[BaseEvent]:
+    """Subscribe to ``stream`` and return a list mutated as events flow.
+
+    Captures all events (including transient). Subscription must happen
+    before any event of interest fires.
+    """
+    events: list[BaseEvent] = []
+    stream.subscribe(lambda ev: events.append(ev), sync_to_thread=False)
+    return events
+
+
+class TestTaskState:
+    def test_terminal_set(self) -> None:
+        assert TaskState.COMPLETED in TERMINAL_TASK_STATES
+        assert TaskState.FAILED in TERMINAL_TASK_STATES
+        assert TaskState.EXPIRED in TERMINAL_TASK_STATES
+        assert TaskState.CREATED not in TERMINAL_TASK_STATES
+        assert TaskState.RUNNING not in TERMINAL_TASK_STATES
+
+
+class TestTaskSpec:
+    def test_defaults(self) -> None:
+        spec = TaskSpec(title="hello")
+        assert spec.title == "hello"
+        assert spec.description == ""
+        assert spec.payload == {}
+
+    def test_payload_isolated(self) -> None:
+        # Default factory produces a fresh dict each construction.
+        a = TaskSpec(title="a")
+        b = TaskSpec(title="b")
+        a.payload["k"] = 1
+        assert "k" not in b.payload
+
+
+class TestStandaloneLifecycle:
+    """Task with no bound context — creates its own MemoryStream."""
+
+    @pytest.mark.asyncio
+    async def test_clean_exit_auto_completes(self) -> None:
+        agent = _agent()
+        async with agent.task("research X") as task:
+            assert task.state == TaskState.RUNNING
+            assert task.metadata.spec.title == "research X"
+            stream = task.context.stream
+
+        assert task.state == TaskState.COMPLETED
+        events = await _persisted(stream)
+        types = [type(e) for e in events]
+        assert TaskStarted in types
+        assert TaskCompleted in types
+
+    @pytest.mark.asyncio
+    async def test_explicit_complete_records_result(self) -> None:
+        agent = _agent()
+        async with agent.task("compute") as task:
+            await task.complete({"answer": 42})
+            assert task.state == TaskState.COMPLETED
+            assert task.metadata.result == {"answer": 42}
+            stream = task.context.stream
+
+        events = await _persisted(stream)
+        completed = [e for e in events if isinstance(e, TaskCompleted)]
+        assert len(completed) == 1
+        assert completed[0].result == {"answer": 42}
+        assert completed[0].agent_name == "researcher"
+        assert completed[0].objective == "compute"
+
+    @pytest.mark.asyncio
+    async def test_complete_is_idempotent(self) -> None:
+        agent = _agent()
+        async with agent.task("once") as task:
+            await task.complete("first")
+            await task.complete("second")  # no-op
+            assert task.metadata.result == "first"
+            stream = task.context.stream
+
+        events = await _persisted(stream)
+        assert sum(1 for e in events if isinstance(e, TaskCompleted)) == 1
+
+    @pytest.mark.asyncio
+    async def test_exception_emits_task_failed_and_propagates(self) -> None:
+        agent = _agent()
+        boom = ValueError("kaboom")
+        captured_stream = None
+        captured_task = None
+
+        with pytest.raises(ValueError) as exc_info:
+            async with agent.task("flaky") as task:
+                captured_task = task
+                captured_stream = task.context.stream
+                raise boom
+
+        assert exc_info.value is boom
+        assert captured_task is not None
+        assert captured_task.state == TaskState.FAILED
+        assert captured_task.metadata.error == "kaboom"
+
+        assert captured_stream is not None
+        events = await _persisted(captured_stream)
+        failed = [e for e in events if isinstance(e, TaskFailed)]
+        assert len(failed) == 1
+        assert failed[0].error is boom
+
+    @pytest.mark.asyncio
+    async def test_explicit_fail_with_string(self) -> None:
+        agent = _agent()
+        async with agent.task("rejected") as task:
+            await task.fail("not authorized")
+            assert task.state == TaskState.FAILED
+            assert task.metadata.error == "not authorized"
+            stream = task.context.stream
+
+        events = await _persisted(stream)
+        failed = [e for e in events if isinstance(e, TaskFailed)]
+        assert len(failed) == 1
+        assert isinstance(failed[0].error, RuntimeError)
+        assert str(failed[0].error) == "not authorized"
+
+
+class TestProgress:
+    @pytest.mark.asyncio
+    async def test_progress_accumulates_into_metadata(self) -> None:
+        agent = _agent()
+        stream = MemoryStream()
+        ctx = ConversationContext(stream=stream)
+        events = _subscribe(stream)
+
+        async with agent.task("pipeline", context=ctx) as task:
+            await task.progress({"step": "search"})
+            await task.progress({"hits": 12})
+            assert task.metadata.progress == {"step": "search", "hits": 12}
+            assert task.metadata.last_progress_at is not None
+
+        progress_events = [e for e in events if isinstance(e, TaskProgress)]
+        assert len(progress_events) == 2
+        assert progress_events[0].payload == {"step": "search"}
+        assert progress_events[1].payload == {"hits": 12}
+
+    @pytest.mark.asyncio
+    async def test_progress_after_terminal_is_noop(self) -> None:
+        agent = _agent()
+        stream = MemoryStream()
+        ctx = ConversationContext(stream=stream)
+        events = _subscribe(stream)
+
+        async with agent.task("done-fast", context=ctx) as task:
+            await task.complete("ok")
+            await task.progress({"too": "late"})
+            assert "too" not in task.metadata.progress
+
+        assert not [e for e in events if isinstance(e, TaskProgress)]
+
+
+class TestExpire:
+    @pytest.mark.asyncio
+    async def test_expire_emits_task_expired(self) -> None:
+        agent = _agent()
+        async with agent.task("slow") as task:
+            await task.expire()
+            assert task.state == TaskState.EXPIRED
+            stream = task.context.stream
+
+        events = await _persisted(stream)
+        expired = [e for e in events if isinstance(e, TaskExpired)]
+        assert len(expired) == 1
+        assert expired[0].objective == "slow"
+
+
+class TestBoundContext:
+    """Task fed an explicit ConversationContext — events flow on caller's stream."""
+
+    @pytest.mark.asyncio
+    async def test_events_fire_on_supplied_stream(self) -> None:
+        agent = _agent()
+        stream = MemoryStream()
+        ctx = ConversationContext(stream=stream)
+        events = _subscribe(stream)
+
+        async with agent.task("with-ctx", context=ctx) as task:
+            await task.progress({"k": "v"})
+            await task.complete("done")
+
+        types = [type(e) for e in events]
+        assert types.count(TaskStarted) == 1
+        assert types.count(TaskProgress) == 1
+        assert types.count(TaskCompleted) == 1
+
+    @pytest.mark.asyncio
+    async def test_task_inject_stamped_during_block(self) -> None:
+        agent = _agent()
+        stream = MemoryStream()
+        ctx = ConversationContext(stream=stream)
+        assert "ag2.task" not in ctx.dependencies
+
+        async with agent.task("inject-test", context=ctx) as task:
+            assert ctx.dependencies["ag2.task"] is task
+
+        assert "ag2.task" not in ctx.dependencies
+
+    @pytest.mark.asyncio
+    async def test_nested_tasks_restore_previous(self) -> None:
+        agent = _agent()
+        stream = MemoryStream()
+        ctx = ConversationContext(stream=stream)
+
+        async with agent.task("outer", context=ctx) as outer:
+            assert ctx.dependencies["ag2.task"] is outer
+            async with agent.task("inner", context=ctx) as inner:
+                assert ctx.dependencies["ag2.task"] is inner
+            assert ctx.dependencies["ag2.task"] is outer
+
+        assert "ag2.task" not in ctx.dependencies
+
+
+class TestTtl:
+    @pytest.mark.asyncio
+    async def test_ttl_seconds_populates_expires_at(self) -> None:
+        agent = _agent()
+        async with agent.task("with-ttl", ttl_seconds=60) as task:
+            assert task.metadata.expires_at is not None
+            assert task.metadata.started_at is not None
+            # expires_at should be later than started_at
+            assert task.metadata.expires_at > task.metadata.started_at
+
+    @pytest.mark.asyncio
+    async def test_no_ttl_leaves_expires_at_none(self) -> None:
+        agent = _agent()
+        async with agent.task("no-ttl") as task:
+            assert task.metadata.expires_at is None
+
+
+class TestPropertiesBeforeEntry:
+    def test_state_returns_created(self) -> None:
+        agent = _agent()
+        task = agent.task("not-yet-entered")
+        assert task.state == TaskState.CREATED
+
+    def test_task_id_raises_before_entry(self) -> None:
+        agent = _agent()
+        task = agent.task("not-yet-entered")
+        with pytest.raises(RuntimeError, match="before __aenter__"):
+            _ = task.task_id
+
+    def test_metadata_raises_before_entry(self) -> None:
+        agent = _agent()
+        task = agent.task("not-yet-entered")
+        with pytest.raises(RuntimeError, match="before __aenter__"):
+            _ = task.metadata
+
+    @pytest.mark.asyncio
+    async def test_double_enter_raises(self) -> None:
+        agent = _agent()
+        task = agent.task("once-only")
+        async with task:
+            pass
+        with pytest.raises(RuntimeError, match="already entered"):
+            async with task:
+                pass
+
+
+class TestMetadata:
+    @pytest.mark.asyncio
+    async def test_owner_id_is_agent_name(self) -> None:
+        agent = _agent()
+        async with agent.task("ownership") as task:
+            assert task.metadata.owner_id == "researcher"
+            assert task.metadata.spec.title == "ownership"
+
+    @pytest.mark.asyncio
+    async def test_payload_passed_through(self) -> None:
+        agent = _agent()
+        async with agent.task("payload-test", payload={"capability": "search"}) as task:
+            assert task.metadata.spec.payload == {"capability": "search"}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

## Why are these changes needed?

First of a 4-PR stack publishing **AG2 Beta Network V1**: a layer on top of `autogen.beta.Agent` that lets multiple agents discover each other, exchange durable messages, and coordinate long-running work — purely additive, opt-in by import path. Bare `Agent` continues to work standalone unchanged.

This PR ships:

* **Framework-core `Task` primitive** (`autogen/beta/task.py`) — a lifecycle-tracked unit of work that any Agent can wrap via `agent.task(...)`. Adds `TaskExpired` event; widens `TaskCompleted.result` to `Any`; adds optional `spec`/`payload` fields. Backward-compatible.
* **Network foundation (M1)** under `autogen/beta/network/`:
  * Identity — `Passport` (immutable id + billing) + `Resume` (mutable claims)
  * Envelope, rule, error hierarchy
  * `LocalLink` transport (`Link` Protocol, in-memory duplex)
  * Hub bare bones: registry + `register` / `unregister` / `post_envelope` only — no sweepers, no expectations, no audit log yet
  * Bare-bones `NetworkClient` / `HubClient` / `AgentClient` capable of raw envelope `send`
  * `NoAuth` adapter (V1 default; `ApiKeyAuth` lands in Phase 3)

No LLM call yet — tested with raw envelopes through `LocalLink`. Adapters, sessions, expectations, audit log, and the LLM tool surface land in the follow-up PRs (M2 → M3 → M4).

**Stack:** This PR (M1) ← M2 (consulting loop) ← M3 (multi-party + observability) ← M4 (workflow orchestration). Each later PR's `--base` is the previous PR's branch.

**Test validation:**

* `pytest test/beta/test_task.py test/beta/network/test_m1_foundation.py` — 29 passed
* `pytest test/beta` (excluding `test/beta/network` + `test/beta/smoke` + `test/beta/providers`) — 1459 passed; no regressions

## Related issue number

N/A — internal V1 contract; tracked under `design/` on the `network-design` branch.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. (Internal design docs live under `design/` on the `network-design` branch and are excluded from this PR by intent — they document the V1 contract during development; user-facing docs land in Phase 4 of the rollout.)
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
