### PR TITLE
feat(beta): add Task lifecycle primitive

### DIFF
--- a/autogen/beta/__init__.py
+++ b/autogen/beta/__init__.py
@@ -21,6 +21,7 @@ from .observer import observer
 from .response import PromptedSchema, ResponseSchema, response_schema
 from .spec import AgentSpec
 from .stream import MemoryStream
+from .task import Task, TaskInject, TaskSpec
 from .tools import ToolResult, Toolkit, tool
 
 __all__ = (
@@ -41,7 +42,10 @@ __all__ = (
     "Middleware",
     "PromptedSchema",
     "ResponseSchema",
+    "Task",
     "TaskConfig",
+    "TaskInject",
+    "TaskSpec",
     "TextInput",
     "ToolResult",
     "Toolkit",

--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -71,6 +71,7 @@ from .observer import Observer
 from .observer import observer as observer_factory
 from .response import ResponseProto, ResponseSchema
 from .stream import MemoryStream, Stream
+from .task import Task, TaskSpec
 from .tools.executor import ToolExecutor
 from .tools.final import FunctionParameters, FunctionTool, FunctionToolSchema, tool
 from .tools.schemas import ToolSchema
@@ -607,6 +608,58 @@ class Agent(Generic[TResult]):
     def add_observer(self, observer: Observer) -> None:
         """Register an observer (before calling ask())."""
         self._observers.append(observer)
+
+    def add_policy(self, policy: AssemblyPolicy) -> "Agent[TResult]":
+        """Append an assembly policy to this agent's chain.
+
+        Policies run in order; a newly added policy runs after existing
+        ones. Construction-time ordering validation (warning on suspicious
+        sequences) only runs over policies passed via ``assembly=`` — late
+        additions skip the check, so callers should be confident in the
+        ordering they introduce.
+        """
+        self._policies.append(policy)
+        return self
+
+    def task(
+        self,
+        title: str,
+        *,
+        description: str = "",
+        payload: dict[str, Any] | None = None,
+        capability: str | None = None,
+        ttl_seconds: int | None = None,
+        context: Context | None = None,
+    ) -> Task:
+        """Create a ``Task`` whose lifecycle this Agent owns.
+
+        Returns an unentered ``Task``; use as ``async with agent.task(...)``.
+        Events flow on ``context.stream`` if a ``ConversationContext`` is
+        supplied; else the Task creates a private ``MemoryStream`` on entry
+        and events fire on it (only observers attached to that private
+        stream see them).
+
+        Inside the ``async with`` block, ``ag2.task`` is stamped into
+        ``context.dependencies`` so any tool annotated with ``TaskInject``
+        resolves to this Task.
+
+        ``capability`` tags the task with a capability name. When the
+        agent is registered with the network, the ``TaskMirror`` calls
+        ``Hub.record_observation`` on the terminal event so the matching
+        ``Resume.observed[capability]`` track record updates.
+        """
+        spec = TaskSpec(
+            title=title,
+            description=description,
+            payload=dict(payload) if payload else {},
+            capability=capability,
+        )
+        return Task(
+            owner_id=self.name,
+            spec=spec,
+            context=context,
+            ttl_seconds=ttl_seconds,
+        )
 
     def tool(
         self,

--- a/autogen/beta/events/__init__.py
+++ b/autogen/beta/events/__init__.py
@@ -26,7 +26,7 @@ from .lifecycle import (
     ObserverStarted,
     UnknownEvent,
 )
-from .task_events import TaskCompleted, TaskFailed, TaskProgress, TaskStarted
+from .task_events import TaskCompleted, TaskExpired, TaskFailed, TaskProgress, TaskStarted
 from .tool_events import (
     BuiltinToolCallEvent,
     BuiltinToolResultEvent,
@@ -81,6 +81,7 @@ __all__ = (
     "ObserverStarted",
     "Severity",
     "TaskCompleted",
+    "TaskExpired",
     "TaskFailed",
     "TaskProgress",
     "TaskStarted",

--- a/autogen/beta/events/task_events.py
+++ b/autogen/beta/events/task_events.py
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import traceback
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .base import BaseEvent, Field
 from .types import Usage
 
 if TYPE_CHECKING:
     from autogen.beta.context import StreamId
+    from autogen.beta.task import TaskSpec
 
 
 class TaskEvent(BaseEvent):
@@ -19,22 +20,36 @@ class TaskEvent(BaseEvent):
 
 
 class TaskStarted(TaskEvent):
-    pass
+    # Optional ``TaskSpec`` describing what the task is doing. Set by the
+    # framework-core ``Task`` primitive (``autogen.beta.task``); legacy
+    # ``run_task`` callers leave it ``None``.
+    spec: "TaskSpec | None" = Field(None)
 
 
 class TaskProgress(TaskEvent):
-    """Streamed progress update from a running task sub-agent.
+    """Progress update for a running task.
 
-    Transient: superseded by the final ``TaskCompleted``.
+    Two distinct uses on one event:
+
+    * ``content`` carries streamed sub-agent output (``run_subtask`` /
+      ``subagent_tool``). Marked transient — superseded by the final
+      ``TaskCompleted``.
+    * ``payload`` carries structured checkpoint data emitted by the task
+      owner via ``Task.progress({...})``. Persistent within the parent
+      stream until the task terminates.
     """
 
     __transient__ = True
 
-    content: str
+    content: str = Field("")
+    payload: dict[str, Any] = Field(default_factory=dict)
 
 
 class TaskCompleted(TaskEvent):
-    result: str | None
+    # Widened from ``str | None`` to ``Any`` so framework-core ``Task``
+    # owners can return structured results. ``run_task`` still passes a
+    # string, so existing callers are unaffected.
+    result: Any = Field(None)
     task_stream: "StreamId"  # Stream reference for inspection
     usage: Usage = Field(default_factory=Usage)
 
@@ -59,3 +74,13 @@ class TaskFailed(TaskEvent):
                 )
             )
         return self._content
+
+
+class TaskExpired(TaskEvent):
+    """Terminal event — task TTL elapsed without a terminal event.
+
+    Emitted by whichever observer holds the TTL clock. Standalone agents
+    receive no expiry unless app code arranges it; networked agents
+    receive it via the hub's TTL sweeper, mirrored back through
+    ``AgentClient``.
+    """

--- a/autogen/beta/task.py
+++ b/autogen/beta/task.py
@@ -319,4 +319,4 @@ class Task:
             self._previous_dep = None
 
 
-TaskInject = Annotated[Task, Inject(_TASK_DEP_KEY, default=None)]
+TaskInject = Annotated[Task | None, Inject(_TASK_DEP_KEY, default=None)]

--- a/autogen/beta/task.py
+++ b/autogen/beta/task.py
@@ -1,0 +1,322 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task — framework-core lifecycle primitive.
+
+A ``Task`` is a wrapper any ``Agent`` (or other actor) can use to give a
+unit of work a trackable lifecycle. The Task emits ``TaskStarted``,
+``TaskProgress``, ``TaskCompleted``, ``TaskFailed``, and ``TaskExpired``
+events on a bound stream so any observer (network mirror, watcher, UI,
+test harness) can follow along without participating in execution.
+
+Tasks are agent-owned. The framework does not assign or schedule them.
+Standalone usage requires no hub or network — events fly past harmlessly
+if no observer subscribes. Network observation is layered on top via
+``autogen.beta.network``.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Annotated, Any
+from uuid import uuid4
+
+from .annotations import Inject
+from .context import ConversationContext
+from .events import TaskCompleted, TaskExpired, TaskFailed, TaskProgress, TaskStarted
+from .stream import MemoryStream
+
+__all__ = (
+    "TERMINAL_TASK_STATES",
+    "Task",
+    "TaskInject",
+    "TaskMetadata",
+    "TaskSpec",
+    "TaskState",
+)
+
+
+_TASK_DEP_KEY = "ag2.task"
+
+
+class TaskState(str, Enum):
+    """Lifecycle state of a ``Task``. Terminal states are immutable."""
+
+    CREATED = "created"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    EXPIRED = "expired"
+
+
+TERMINAL_TASK_STATES: frozenset[TaskState] = frozenset({
+    TaskState.COMPLETED,
+    TaskState.FAILED,
+    TaskState.EXPIRED,
+})
+
+
+@dataclass(slots=True)
+class TaskSpec:
+    """What a ``Task`` is doing — title plus optional description and payload.
+
+    ``capability`` tags the task with a capability name from the
+    owning agent's ``Resume.claimed_capabilities``. When set, the
+    network's ``TaskMirror`` calls ``Hub.record_observation`` on the
+    terminal event so the matching ``Resume.observed[capability]``
+    track record is updated. Untagged tasks are still observed but
+    don't update any ``observed`` stat.
+    """
+
+    title: str
+    description: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)
+    capability: str | None = None
+
+
+@dataclass(slots=True)
+class TaskMetadata:
+    """Mutable lifecycle record for a Task. Updated on state transitions."""
+
+    task_id: str
+    owner_id: str
+    spec: TaskSpec
+    state: TaskState
+    created_at: str = ""
+    started_at: str | None = None
+    completed_at: str | None = None
+    expires_at: str | None = None
+    last_progress_at: str | None = None
+    progress: dict[str, Any] = field(default_factory=dict)
+    result: Any = None
+    error: str = ""
+    # Optional network association — set when an AgentClient mirrors this task.
+    session_id: str | None = None
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _expires_iso(ttl_seconds: int | None, base: datetime) -> str | None:
+    if ttl_seconds is None:
+        return None
+    return (base + timedelta(seconds=ttl_seconds)).isoformat()
+
+
+class Task:
+    """Lifecycle handle for a unit of work.
+
+    Created via ``Agent.task(...)`` or directly. Use as an async context
+    manager::
+
+        async with agent.task("research framework X") as task:
+            await task.progress({"step": "search"})
+            findings = await search(...)
+            await task.complete(findings)
+
+    On clean exit, auto-completes with ``result=None`` if the user did not
+    call ``complete()`` or ``fail()``. On exception, auto-fails with the
+    raised exception (the exception still propagates).
+
+    If a ``ConversationContext`` is passed, events flow on that stream and
+    ``ag2.task`` is stamped into ``context.dependencies`` for the duration
+    of the ``async with`` block (so ``TaskInject`` resolves to the active
+    task). With no context, the Task creates a private ``MemoryStream`` —
+    standalone use; events still fire but only observers attached to that
+    private stream see them.
+    """
+
+    def __init__(
+        self,
+        *,
+        owner_id: str,
+        spec: TaskSpec,
+        context: ConversationContext | None = None,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        # __init__ stores params; side effects happen in __aenter__.
+        self._owner_id = owner_id
+        self._spec = spec
+        self._ttl_seconds = ttl_seconds
+        self._context = context
+        self._owns_context = False
+        self._metadata: TaskMetadata | None = None
+        self._had_previous_dep = False
+        self._previous_dep: Any = None
+
+    @property
+    def task_id(self) -> str:
+        if self._metadata is None:
+            raise RuntimeError("Task.task_id is not available before __aenter__")
+        return self._metadata.task_id
+
+    @property
+    def state(self) -> TaskState:
+        if self._metadata is None:
+            return TaskState.CREATED
+        return self._metadata.state
+
+    @property
+    def metadata(self) -> TaskMetadata:
+        if self._metadata is None:
+            raise RuntimeError("Task.metadata is not available before __aenter__")
+        return self._metadata
+
+    @property
+    def context(self) -> ConversationContext:
+        if self._context is None:
+            raise RuntimeError("Task has no bound context (use 'async with task: ...')")
+        return self._context
+
+    async def progress(self, payload: dict[str, Any]) -> None:
+        """Emit ``TaskProgress``; merges payload into ``metadata.progress``.
+
+        No-op if the task is already in a terminal state.
+        """
+        if self._metadata is None:
+            raise RuntimeError("Task.progress() called before __aenter__")
+        if self._metadata.state in TERMINAL_TASK_STATES:
+            return
+        self._metadata.progress.update(payload)
+        self._metadata.last_progress_at = _now_iso()
+        await self.context.send(
+            TaskProgress(
+                task_id=self._metadata.task_id,
+                agent_name=self._owner_id,
+                objective=self._spec.title,
+                content="",
+                payload=dict(payload),
+            )
+        )
+
+    async def complete(self, result: Any = None) -> None:
+        """Terminal: emit ``TaskCompleted``; state ← COMPLETED.
+
+        No-op if already terminal.
+        """
+        if self._metadata is None:
+            raise RuntimeError("Task.complete() called before __aenter__")
+        if self._metadata.state in TERMINAL_TASK_STATES:
+            return
+        self._metadata.state = TaskState.COMPLETED
+        self._metadata.result = result
+        self._metadata.completed_at = _now_iso()
+        await self.context.send(
+            TaskCompleted(
+                task_id=self._metadata.task_id,
+                agent_name=self._owner_id,
+                objective=self._spec.title,
+                result=result,
+                task_stream=self.context.stream.id,
+            )
+        )
+
+    async def fail(self, error: str | BaseException) -> None:
+        """Terminal: emit ``TaskFailed``; state ← FAILED.
+
+        Accepts a string (wrapped in ``RuntimeError``) or any
+        ``BaseException``. No-op if already terminal.
+        """
+        if self._metadata is None:
+            raise RuntimeError("Task.fail() called before __aenter__")
+        if self._metadata.state in TERMINAL_TASK_STATES:
+            return
+        if isinstance(error, str):
+            exc: BaseException = RuntimeError(error)
+        else:
+            exc = error
+        self._metadata.state = TaskState.FAILED
+        self._metadata.error = str(exc)
+        self._metadata.completed_at = _now_iso()
+        await self.context.send(
+            TaskFailed(
+                task_id=self._metadata.task_id,
+                agent_name=self._owner_id,
+                objective=self._spec.title,
+                error=exc,
+            )
+        )
+
+    async def expire(self) -> None:
+        """Terminal: emit ``TaskExpired``; state ← EXPIRED.
+
+        Called by an external TTL observer (e.g. the network hub's TTL
+        sweeper, mirrored back to the agent's stream). No-op if already
+        terminal.
+        """
+        if self._metadata is None:
+            raise RuntimeError("Task.expire() called before __aenter__")
+        if self._metadata.state in TERMINAL_TASK_STATES:
+            return
+        self._metadata.state = TaskState.EXPIRED
+        self._metadata.completed_at = _now_iso()
+        await self.context.send(
+            TaskExpired(
+                task_id=self._metadata.task_id,
+                agent_name=self._owner_id,
+                objective=self._spec.title,
+            )
+        )
+
+    async def __aenter__(self) -> "Task":
+        if self._metadata is not None:
+            raise RuntimeError(f"Task already entered (state={self._metadata.state})")
+
+        if self._context is None:
+            self._context = ConversationContext(stream=MemoryStream())
+            self._owns_context = True
+
+        now = datetime.now(timezone.utc)
+        now_iso = now.isoformat()
+        self._metadata = TaskMetadata(
+            task_id=uuid4().hex,
+            owner_id=self._owner_id,
+            spec=self._spec,
+            state=TaskState.RUNNING,
+            created_at=now_iso,
+            started_at=now_iso,
+            expires_at=_expires_iso(self._ttl_seconds, now),
+        )
+
+        existing = self._context.dependencies.get(_TASK_DEP_KEY)
+        if existing is not None:
+            self._had_previous_dep = True
+            self._previous_dep = existing
+        self._context.dependencies[_TASK_DEP_KEY] = self
+
+        await self._context.send(
+            TaskStarted(
+                task_id=self._metadata.task_id,
+                agent_name=self._owner_id,
+                objective=self._spec.title,
+                spec=self._spec,
+            )
+        )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: Any,
+    ) -> None:
+        try:
+            if self._metadata is None:
+                return
+            if exc is not None and self._metadata.state not in TERMINAL_TASK_STATES:
+                await self.fail(exc)
+            elif self._metadata.state == TaskState.RUNNING:
+                await self.complete()
+        finally:
+            if self._context is not None:
+                if self._had_previous_dep:
+                    self._context.dependencies[_TASK_DEP_KEY] = self._previous_dep
+                else:
+                    self._context.dependencies.pop(_TASK_DEP_KEY, None)
+            self._had_previous_dep = False
+            self._previous_dep = None
+
+
+TaskInject = Annotated[Task, Inject(_TASK_DEP_KEY, default=None)]

--- a/test/beta/test_task.py
+++ b/test/beta/test_task.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the framework-core ``Task`` primitive.
+
+Covers standalone usage with no hub or network — pure
+``autogen.beta.task`` lifecycle, event emission, dependency stamping
+for ``TaskInject``, and TTL field population.
+"""
+
+import pytest
+
+from autogen.beta import Agent, TaskSpec
+from autogen.beta.config import AnthropicConfig
+from autogen.beta.context import ConversationContext
+from autogen.beta.events import (
+    BaseEvent,
+    TaskCompleted,
+    TaskExpired,
+    TaskFailed,
+    TaskProgress,
+    TaskStarted,
+)
+from autogen.beta.stream import MemoryStream
+from autogen.beta.task import TERMINAL_TASK_STATES, TaskState
+
+
+def _agent() -> Agent:
+    """A bare Agent — no model calls, just a name."""
+    return Agent(name="researcher", config=AnthropicConfig(model="claude-sonnet-4-6"))
+
+
+async def _persisted(stream: MemoryStream) -> list[BaseEvent]:
+    """Read durably-persisted events from a MemoryStream's storage.
+
+    Note: transient events (``TaskProgress``, ``ModelMessageChunk``) are
+    not persisted — use ``_subscribe`` to capture them live.
+    """
+    return list(await stream.history.storage.get_history(stream.id))
+
+
+def _subscribe(stream: MemoryStream) -> list[BaseEvent]:
+    """Subscribe to ``stream`` and return a list mutated as events flow.
+
+    Captures all events (including transient). Subscription must happen
+    before any event of interest fires.
+    """
+    events: list[BaseEvent] = []
+    stream.subscribe(lambda ev: events.append(ev), sync_to_thread=False)
+    return events
+
+
+class TestTaskState:
+    def test_terminal_set(self) -> None:
+        assert TaskState.COMPLETED in TERMINAL_TASK_STATES
+        assert TaskState.FAILED in TERMINAL_TASK_STATES
+        assert TaskState.EXPIRED in TERMINAL_TASK_STATES
+        assert TaskState.CREATED not in TERMINAL_TASK_STATES
+        assert TaskState.RUNNING not in TERMINAL_TASK_STATES
+
+
+class TestTaskSpec:
+    def test_defaults(self) -> None:
+        spec = TaskSpec(title="hello")
+        assert spec.title == "hello"
+        assert spec.description == ""
+        assert spec.payload == {}
+
+    def test_payload_isolated(self) -> None:
+        # Default factory produces a fresh dict each construction.
+        a = TaskSpec(title="a")
+        b = TaskSpec(title="b")
+        a.payload["k"] = 1
+        assert "k" not in b.payload
+
+
+class TestStandaloneLifecycle:
+    """Task with no bound context — creates its own MemoryStream."""
+
+    @pytest.mark.asyncio
+    async def test_clean_exit_auto_completes(self) -> None:
+        agent = _agent()
+        async with agent.task("research X") as task:
+            assert task.state == TaskState.RUNNING
+            assert task.metadata.spec.title == "research X"
+            stream = task.context.stream
+
+        assert task.state == TaskState.COMPLETED
+        events = await _persisted(stream)
+        types = [type(e) for e in events]
+        assert TaskStarted in types
+        assert TaskCompleted in types
+
+    @pytest.mark.asyncio
+    async def test_explicit_complete_records_result(self) -> None:
+        agent = _agent()
+        async with agent.task("compute") as task:
+            await task.complete({"answer": 42})
+            assert task.state == TaskState.COMPLETED
+            assert task.metadata.result == {"answer": 42}
+            stream = task.context.stream
+
+        events = await _persisted(stream)
+        completed = [e for e in events if isinstance(e, TaskCompleted)]
+        assert len(completed) == 1
+        assert completed[0].result == {"answer": 42}
+        assert completed[0].agent_name == "researcher"
+        assert completed[0].objective == "compute"
+
+    @pytest.mark.asyncio
+    async def test_complete_is_idempotent(self) -> None:
+        agent = _agent()
+        async with agent.task("once") as task:
+            await task.complete("first")
+            await task.complete("second")  # no-op
+            assert task.metadata.result == "first"
+            stream = task.context.stream
+
+        events = await _persisted(stream)
+        assert sum(1 for e in events if isinstance(e, TaskCompleted)) == 1
+
+    @pytest.mark.asyncio
+    async def test_exception_emits_task_failed_and_propagates(self) -> None:
+        agent = _agent()
+        boom = ValueError("kaboom")
+        captured_stream = None
+        captured_task = None
+
+        with pytest.raises(ValueError) as exc_info:
+            async with agent.task("flaky") as task:
+                captured_task = task
+                captured_stream = task.context.stream
+                raise boom
+
+        assert exc_info.value is boom
+        assert captured_task is not None
+        assert captured_task.state == TaskState.FAILED
+        assert captured_task.metadata.error == "kaboom"
+
+        assert captured_stream is not None
+        events = await _persisted(captured_stream)
+        failed = [e for e in events if isinstance(e, TaskFailed)]
+        assert len(failed) == 1
+        assert failed[0].error is boom
+
+    @pytest.mark.asyncio
+    async def test_explicit_fail_with_string(self) -> None:
+        agent = _agent()
+        async with agent.task("rejected") as task:
+            await task.fail("not authorized")
+            assert task.state == TaskState.FAILED
+            assert task.metadata.error == "not authorized"
+            stream = task.context.stream
+
+        events = await _persisted(stream)
+        failed = [e for e in events if isinstance(e, TaskFailed)]
+        assert len(failed) == 1
+        assert isinstance(failed[0].error, RuntimeError)
+        assert str(failed[0].error) == "not authorized"
+
+
+class TestProgress:
+    @pytest.mark.asyncio
+    async def test_progress_accumulates_into_metadata(self) -> None:
+        agent = _agent()
+        stream = MemoryStream()
+        ctx = ConversationContext(stream=stream)
+        events = _subscribe(stream)
+
+        async with agent.task("pipeline", context=ctx) as task:
+            await task.progress({"step": "search"})
+            await task.progress({"hits": 12})
+            assert task.metadata.progress == {"step": "search", "hits": 12}
+            assert task.metadata.last_progress_at is not None
+
+        progress_events = [e for e in events if isinstance(e, TaskProgress)]
+        assert len(progress_events) == 2
+        assert progress_events[0].payload == {"step": "search"}
+        assert progress_events[1].payload == {"hits": 12}
+
+    @pytest.mark.asyncio
+    async def test_progress_after_terminal_is_noop(self) -> None:
+        agent = _agent()
+        stream = MemoryStream()
+        ctx = ConversationContext(stream=stream)
+        events = _subscribe(stream)
+
+        async with agent.task("done-fast", context=ctx) as task:
+            await task.complete("ok")
+            await task.progress({"too": "late"})
+            assert "too" not in task.metadata.progress
+
+        assert not [e for e in events if isinstance(e, TaskProgress)]
+
+
+class TestExpire:
+    @pytest.mark.asyncio
+    async def test_expire_emits_task_expired(self) -> None:
+        agent = _agent()
+        async with agent.task("slow") as task:
+            await task.expire()
+            assert task.state == TaskState.EXPIRED
+            stream = task.context.stream
+
+        events = await _persisted(stream)
+        expired = [e for e in events if isinstance(e, TaskExpired)]
+        assert len(expired) == 1
+        assert expired[0].objective == "slow"
+
+
+class TestBoundContext:
+    """Task fed an explicit ConversationContext — events flow on caller's stream."""
+
+    @pytest.mark.asyncio
+    async def test_events_fire_on_supplied_stream(self) -> None:
+        agent = _agent()
+        stream = MemoryStream()
+        ctx = ConversationContext(stream=stream)
+        events = _subscribe(stream)
+
+        async with agent.task("with-ctx", context=ctx) as task:
+            await task.progress({"k": "v"})
+            await task.complete("done")
+
+        types = [type(e) for e in events]
+        assert types.count(TaskStarted) == 1
+        assert types.count(TaskProgress) == 1
+        assert types.count(TaskCompleted) == 1
+
+    @pytest.mark.asyncio
+    async def test_task_inject_stamped_during_block(self) -> None:
+        agent = _agent()
+        stream = MemoryStream()
+        ctx = ConversationContext(stream=stream)
+        assert "ag2.task" not in ctx.dependencies
+
+        async with agent.task("inject-test", context=ctx) as task:
+            assert ctx.dependencies["ag2.task"] is task
+
+        assert "ag2.task" not in ctx.dependencies
+
+    @pytest.mark.asyncio
+    async def test_nested_tasks_restore_previous(self) -> None:
+        agent = _agent()
+        stream = MemoryStream()
+        ctx = ConversationContext(stream=stream)
+
+        async with agent.task("outer", context=ctx) as outer:
+            assert ctx.dependencies["ag2.task"] is outer
+            async with agent.task("inner", context=ctx) as inner:
+                assert ctx.dependencies["ag2.task"] is inner
+            assert ctx.dependencies["ag2.task"] is outer
+
+        assert "ag2.task" not in ctx.dependencies
+
+
+class TestTtl:
+    @pytest.mark.asyncio
+    async def test_ttl_seconds_populates_expires_at(self) -> None:
+        agent = _agent()
+        async with agent.task("with-ttl", ttl_seconds=60) as task:
+            assert task.metadata.expires_at is not None
+            assert task.metadata.started_at is not None
+            # expires_at should be later than started_at
+            assert task.metadata.expires_at > task.metadata.started_at
+
+    @pytest.mark.asyncio
+    async def test_no_ttl_leaves_expires_at_none(self) -> None:
+        agent = _agent()
+        async with agent.task("no-ttl") as task:
+            assert task.metadata.expires_at is None
+
+
+class TestPropertiesBeforeEntry:
+    def test_state_returns_created(self) -> None:
+        agent = _agent()
+        task = agent.task("not-yet-entered")
+        assert task.state == TaskState.CREATED
+
+    def test_task_id_raises_before_entry(self) -> None:
+        agent = _agent()
+        task = agent.task("not-yet-entered")
+        with pytest.raises(RuntimeError, match="before __aenter__"):
+            _ = task.task_id
+
+    def test_metadata_raises_before_entry(self) -> None:
+        agent = _agent()
+        task = agent.task("not-yet-entered")
+        with pytest.raises(RuntimeError, match="before __aenter__"):
+            _ = task.metadata
+
+    @pytest.mark.asyncio
+    async def test_double_enter_raises(self) -> None:
+        agent = _agent()
+        task = agent.task("once-only")
+        async with task:
+            pass
+        with pytest.raises(RuntimeError, match="already entered"):
+            async with task:
+                pass
+
+
+class TestMetadata:
+    @pytest.mark.asyncio
+    async def test_owner_id_is_agent_name(self) -> None:
+        agent = _agent()
+        async with agent.task("ownership") as task:
+            assert task.metadata.owner_id == "researcher"
+            assert task.metadata.spec.title == "ownership"
+
+    @pytest.mark.asyncio
+    async def test_payload_passed_through(self) -> None:
+        agent = _agent()
+        async with agent.task("payload-test", payload={"capability": "search"}) as task:
+            assert task.metadata.spec.payload == {"capability": "search"}

--- a/website/docs/beta/task_delegation.mdx
+++ b/website/docs/beta/task_delegation.mdx
@@ -1,9 +1,9 @@
 ---
-title: Task Delegation
-sidebarTitle: Task Delegation
+title: Sub-task Delegation
+sidebarTitle: Sub-task Delegation
 ---
 
-Task delegation allows agents to delegate work to other agents through tool calling. The calling agent's LLM decides when and what to delegate, and each sub-task runs on its own isolated stream with independent history.
+Sub-task delegation allows agents to delegate work to other agents through tool calling. The calling agent's LLM decides when and what to delegate, and each sub-task runs on its own isolated stream with independent history.
 
 ## Why Use Subagents
 

--- a/website/docs/beta/tasks.mdx
+++ b/website/docs/beta/tasks.mdx
@@ -1,0 +1,217 @@
+---
+title: Tasks
+sidebarTitle: Tasks
+---
+
+A `#!python Task` is a framework-core wrapper any `#!python Agent` can use to give a unit of work a trackable lifecycle. While the task is active, the framework emits `#!python TaskStarted`, `#!python TaskProgress`, `#!python TaskCompleted`, `#!python TaskFailed`, and `#!python TaskExpired` events on a stream — so observers (UIs, watchers, mirrors, test harnesses) can follow along without participating in execution.
+
+!!! note
+    Tasks are **agent-owned**. The framework does not assign or schedule them. Standalone usage requires no observers — events fly past harmlessly if nothing subscribes.
+
+## When to Use a Task
+
+Use a Task whenever a unit of work has a beginning, an end, and observable progress that you want to surface beyond your own function's return value:
+
+- **Long-running pipelines** where downstream consumers want progress checkpoints.
+- **HITL approvals** where a UI needs to know the task is waiting on a human.
+- **Test harnesses** that assert a sequence of lifecycle events.
+
+For lightweight LLM-driven sub-agent delegation see [Sub-task Delegation](/docs/beta/task_delegation) — that's a different feature that wraps an Agent in a `#!python run_subtask` tool.
+
+## Quick Start
+
+```python linenums="1" hl_lines="6"
+from autogen.beta import Agent
+from autogen.beta.config import AnthropicConfig
+
+agent = Agent("indexer", config=AnthropicConfig(model="claude-sonnet-4-6"))
+
+async with agent.task("index documents") as task:
+    await task.progress({"stage": "discover", "files": 12})
+    await task.progress({"stage": "index", "indexed": 12})
+    await task.complete({"indexed": 12})
+
+print(task.state)        # TaskState.COMPLETED
+print(task.metadata.result)  # {'indexed': 12}
+```
+
+The `#!python async with` block opens the lifecycle. On clean exit the task auto-completes with `#!python result=None` if you didn't call `#!python complete()` or `#!python fail()` yourself.
+
+## Lifecycle States
+
+```
+CREATED -> RUNNING -> COMPLETED   (terminal, success)
+                   -> FAILED      (terminal, exception or explicit fail)
+                   -> EXPIRED     (terminal, TTL elapsed)
+```
+
+| State | Meaning |
+|---|---|
+| `CREATED` | The Task object exists but `#!python __aenter__` has not run. `#!python task.task_id` and `#!python task.metadata` raise. |
+| `RUNNING` | Inside the `#!python async with` block. Progress events allowed. |
+| `COMPLETED` | Reached `#!python complete()` or clean block exit. |
+| `FAILED` | Reached `#!python fail()` or block exited via exception. |
+| `EXPIRED` | TTL elapsed; emitted by an external observer (e.g. a network hub's TTL sweeper). |
+
+The terminal states are immutable — once set, further `#!python complete() / fail() / progress()` calls are silent no-ops. The set is exported as `#!python autogen.beta.task.TERMINAL_TASK_STATES`.
+
+## API Reference
+
+### `#!python Agent.task(...)`
+
+```python
+agent.task(
+    title: str,
+    *,
+    description: str = "",
+    payload: dict[str, Any] | None = None,
+    capability: str | None = None,
+    ttl_seconds: int | None = None,
+    context: ConversationContext | None = None,
+) -> Task
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `title` | `str` | Short objective shown on every event. |
+| `description` | `str` | Optional longer description. |
+| `payload` | `dict[str, Any] \| None` | Initial payload merged into `#!python TaskSpec`. |
+| `capability` | `str \| None` | Tags the task with a capability name; used by network mirrors. |
+| `ttl_seconds` | `int \| None` | Sets `#!python metadata.expires_at`. The Task does not self-expire — an external observer must call `#!python task.expire()` when the TTL elapses. |
+| `context` | `ConversationContext \| None` | If supplied, events flow on `#!python context.stream` and `#!python ag2.task` is stamped into `#!python context.dependencies` for the duration of the block. If omitted, the Task creates a private `#!python MemoryStream` on entry. |
+
+Returns an unentered `#!python Task`. Use as `#!python async with agent.task(...) as task:`.
+
+### `#!python Task` instance methods
+
+| Method | Description |
+|---|---|
+| `#!python await task.progress(payload)` | Emits `#!python TaskProgress`; merges `payload` into `#!python metadata.progress` and stamps `#!python last_progress_at`. No-op if already terminal. |
+| `#!python await task.complete(result=None)` | Terminal. Emits `#!python TaskCompleted`; sets `#!python metadata.result` and `#!python state = COMPLETED`. |
+| `#!python await task.fail(error)` | Terminal. Accepts a string (wrapped in `#!python RuntimeError`) or any `#!python BaseException`. Emits `#!python TaskFailed`; sets `#!python state = FAILED`. |
+| `#!python await task.expire()` | Terminal. Emits `#!python TaskExpired`; sets `#!python state = EXPIRED`. Called by external TTL observers. |
+
+### Properties
+
+| Property | Available before `#!python __aenter__`? |
+|---|---|
+| `#!python task.state` | Yes — returns `#!python TaskState.CREATED`. |
+| `#!python task.task_id` | No — raises `#!python RuntimeError`. |
+| `#!python task.metadata` | No — raises `#!python RuntimeError`. |
+| `#!python task.context` | No — raises `#!python RuntimeError`. |
+
+## Bound Context vs. Standalone
+
+```python linenums="1" hl_lines="3 6"
+from autogen.beta.context import ConversationContext
+from autogen.beta.stream import MemoryStream
+
+ctx = ConversationContext(stream=MemoryStream())
+
+async with agent.task("with-ctx", context=ctx) as task:
+    ...
+```
+
+Passing a `#!python ConversationContext` shares the stream with the rest of your agent's run, so observers and middleware already attached to that stream see the lifecycle events.
+
+Without a context, the Task creates a private stream on entry. Events still fire — but only observers attached to that private stream see them. Useful for one-off background work that doesn't need to surface anywhere.
+
+## Auto-Complete and Auto-Fail
+
+The `#!python async with` block has these guarantees:
+
+- **Clean exit, no terminal call** -> auto `#!python complete(result=None)`.
+- **Exception inside the block** -> auto `#!python fail(exc)`, then the exception propagates.
+- **Already terminal at exit time** -> nothing further happens.
+
+```python linenums="1" hl_lines="4"
+try:
+    async with agent.task("flaky") as task:
+        raise ValueError("boom")
+except ValueError as exc:
+    print(task.state)            # TaskState.FAILED
+    print(task.metadata.error)   # 'boom'
+```
+
+## Observing the Lifecycle
+
+Subscribe directly on the bound stream to capture every lifecycle event in order.
+
+```python linenums="1" hl_lines="6 7 8"
+from autogen.beta.events import TaskCompleted, TaskProgress, TaskStarted
+
+stream = MemoryStream()
+ctx = ConversationContext(stream=stream)
+
+stream.subscribe(
+    lambda ev: print(type(ev).__name__, getattr(ev, "payload", "")),
+    sync_to_thread=False,
+)
+
+async with agent.task("watched", context=ctx) as task:
+    await task.progress({"step": "fetch"})
+    await task.complete({"ok": True})
+```
+
+!!! note
+    `#!python TaskProgress` is marked transient — it is delivered live to subscribers but **not** persisted to the stream's storage. Subscribe before the events fire to capture them. `#!python TaskStarted`, `#!python TaskCompleted`, `#!python TaskFailed`, and `#!python TaskExpired` are persisted normally.
+
+## Reading the Active Task with `#!python TaskInject`
+
+Inside an `#!python async with agent.task(...)` block, the framework stamps the active Task into `#!python context.dependencies["ag2.task"]`. Two ways to read it:
+
+### Direct access
+
+```python linenums="1"
+async with agent.task("work", context=ctx) as task:
+    active = ctx.dependencies["ag2.task"]
+    assert active is task
+```
+
+### `#!python TaskInject` annotation
+
+`#!python TaskInject` is a fast_depends-resolvable annotation that injects the active Task into any function the dependency-injection machinery resolves — most usefully a `#!python @tool` body.
+
+```python linenums="1" hl_lines="1 5"
+from autogen.beta import tool
+from autogen.beta.task import TaskInject
+
+@tool
+async def report(message: str, task: TaskInject) -> str:
+    if task is None:
+        return "no active task"
+    await task.progress({"tool_message": message})
+    return f"reported on task {task.task_id}"
+```
+
+The injection has `#!python default=None`, so always treat `task` as possibly `#!python None` and null-check before use.
+
+## TTL and Expiry
+
+Setting `#!python ttl_seconds=N` populates `#!python metadata.expires_at` but **does not** start a timer. The Task primitive itself never self-expires — that's by design, so a standalone Task with no observer doesn't spawn a background task. Instead, an external observer (e.g. a network hub's TTL sweeper, a periodic watch) checks `#!python expires_at` and calls `#!python task.expire()` when due.
+
+For self-contained TTL behaviour, wire up a sweeper in your application:
+
+```python linenums="1" hl_lines="6 7"
+async def sweep(task: Task, deadline: datetime) -> None:
+    while task.state == TaskState.RUNNING:
+        if datetime.now(timezone.utc) >= deadline:
+            await task.expire()
+            return
+        await asyncio.sleep(1.0)
+```
+
+## TaskSpec and TaskMetadata
+
+Two small dataclasses surface around a Task:
+
+- `#!python TaskSpec` — what the task is doing: `title`, `description`, `payload`, optional `capability`. Created by `#!python Agent.task(...)`.
+- `#!python TaskMetadata` — mutable lifecycle record updated on each transition: `task_id`, `owner_id`, `spec`, `state`, ISO-8601 timestamps, `progress`, `result`, `error`, optional `session_id`.
+
+```python linenums="1"
+async with agent.task("survey", description="probe upstream", payload={"region": "us"}) as task:
+    print(task.metadata.spec.title)        # 'survey'
+    print(task.metadata.spec.payload)      # {'region': 'us'}
+    print(task.metadata.owner_id)          # 'researcher'
+    print(task.metadata.started_at)        # ISO 8601 string
+```

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -377,6 +377,7 @@
           ]
         },
         "docs/beta/system_prompts",
+        "docs/beta/tasks",
         "docs/beta/task_delegation",
         {
           "group": "Tools",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

## Why are these changes needed?

First of a 3-PR stack publishing **AG2 Beta Network V1**: a layer on top of `autogen.beta.Agent` that lets multiple agents discover each other, exchange durable messages, and coordinate long-running work — purely additive, opt-in by import path. Bare `Agent` continues to work standalone unchanged.

This PR ships only the framework-core `Task` primitive — a lifecycle-tracked unit of work that any Agent can wrap via `agent.task(...)`. The network module that observes these task events lands in the follow-up PRs.

## What ships

**Public surface (`autogen.beta.*`)**
- `Task` — the lifecycle handle (used as an async context manager)
- `TaskSpec` — what the task is doing (title, description, payload, optional capability tag)
- `TaskState` — `CREATED`, `RUNNING`, `COMPLETED`, `FAILED`, `EXPIRED`
- `TaskMetadata` — mutable lifecycle record
- `TaskInject` — `Annotated` injection for the active task, resolved by `fast_depends` inside an `async with agent.task(...):` block
- `Agent.task(...)` — context-manager entry point that yields a `Task`
- `Agent.add_policy(...)` — public assembly-policy registration

**Event additions (backward-compatible)**
- `TaskExpired` event (new) emitted when a task TTL elapses
- `TaskCompleted.result` widened to `Any`
- `TaskStarted` gains optional `spec` field
- `TaskProgress` gains optional `payload` field

## Usage

```python
async with agent.task("research framework X") as task:
    await task.progress({"step": "search"})
    findings = await search(...)
    await task.complete(findings)
```

On clean exit, the task auto-completes if `complete()` / `fail()` was not called. On exception, it auto-fails with the raised exception (the exception still propagates).

## Stack

This PR ← network protocol + state + control plane ← LLM tool surface + workflow. Each later PR's `--base` is the previous PR's branch.

## Test plan

- `pytest test/beta/test_task.py` — 22 passed
- `pytest test/beta` (excluding `test/beta/network` + `test/beta/smoke` + `test/beta/providers`) — 1459 passed; no regressions

## Related issue number

N/A — internal V1 contract.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. (User-facing docs land in a later phase of the rollout.)
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.