### PR TITLE
fix(beta): update ExaToolkit for current Exa API

### DIFF
--- a/autogen/beta/tools/search/exa.py
+++ b/autogen/beta/tools/search/exa.py
@@ -16,17 +16,15 @@ from autogen.beta.tools.builtin._resolve import resolve_variable
 from autogen.beta.tools.final import Toolkit, tool
 from autogen.beta.tools.final.function_tool import FunctionTool
 
-SearchType: TypeAlias = Literal["neural", "keyword", "hybrid", "auto", "fast", "deep"]
+SearchType: TypeAlias = Literal["auto", "neural", "fast", "deep-lite", "deep", "deep-reasoning", "instant"]
 Category: TypeAlias = Literal[
     "company",
     "research paper",
     "news",
     "pdf",
-    "github",
-    "tweet",
     "personal site",
-    "linkedin profile",
     "financial report",
+    "people",
 ]
 Livecrawl: TypeAlias = Literal["never", "fallback", "always", "preferred"]
 
@@ -45,7 +43,6 @@ class ExaSearchResult:
 class ExaSearchResponse:
     query: str
     results: list[ExaSearchResult] = field(default_factory=list)
-    autoprompt_string: str | None = None
 
 
 @dataclass(slots=True)
@@ -79,7 +76,7 @@ class ExaToolkit(Toolkit):
     sharing one HTTP client.
 
     The four tools mirror Exa's primary endpoints:
-      - ``exa_search``: neural/keyword/hybrid web search with optional text content
+      - ``exa_search``: web search with optional text content
       - ``exa_find_similar``: find pages similar to a given URL
       - ``exa_get_contents``: fetch full text for specific URLs
       - ``exa_answer``: get an AI-generated answer with citations
@@ -118,7 +115,14 @@ class ExaToolkit(Toolkit):
         client: Exa | None = None,
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
-        self._client = client if client is not None else Exa(api_key=api_key)
+        self._client = (
+            client
+            if client is not None
+            else Exa(
+                api_key=api_key,
+                integration_source="ag2",
+            )
+        )
 
         super().__init__(
             self.search(num_results=num_results, max_characters=max_characters),
@@ -140,10 +144,9 @@ class ExaToolkit(Toolkit):
         exclude_domains: Sequence[str] | Variable | None = None,
         start_published_date: str | Variable | None = None,
         end_published_date: str | Variable | None = None,
-        start_crawl_date: str | Variable | None = None,
-        end_crawl_date: str | Variable | None = None,
-        use_autoprompt: bool | Variable | None = None,
         livecrawl: Livecrawl | Variable | None = None,
+        user_location: str | Variable | None = None,
+        moderation: bool | Variable | None = None,
         name: str = "exa_search",
         description: str = (
             "Search the web using Exa's neural search engine. "
@@ -167,17 +170,15 @@ class ExaToolkit(Toolkit):
                 "exclude_domains": resolve_variable(exclude_domains, ctx, param_name="exclude_domains"),
                 "start_published_date": resolve_variable(start_published_date, ctx, param_name="start_published_date"),
                 "end_published_date": resolve_variable(end_published_date, ctx, param_name="end_published_date"),
-                "start_crawl_date": resolve_variable(start_crawl_date, ctx, param_name="start_crawl_date"),
-                "end_crawl_date": resolve_variable(end_crawl_date, ctx, param_name="end_crawl_date"),
-                "use_autoprompt": resolve_variable(use_autoprompt, ctx, param_name="use_autoprompt"),
                 "livecrawl": resolve_variable(livecrawl, ctx, param_name="livecrawl"),
+                "user_location": resolve_variable(user_location, ctx, param_name="user_location"),
+                "moderation": resolve_variable(moderation, ctx, param_name="moderation"),
             })
             resolved_max_chars = resolve_variable(max_characters, ctx, param_name="max_characters")
             if resolved_max_chars is not None:
-                kwargs["text"] = {"maxCharacters": resolved_max_chars}
-                raw = client.search_and_contents(query, **kwargs)
-            else:
-                raw = client.search(query, **kwargs)
+                kwargs["contents"] = {"text": {"max_characters": resolved_max_chars}}
+
+            raw = client.search(query, **kwargs)
 
             return ToolResult(
                 ExaSearchResponse(
@@ -186,14 +187,13 @@ class ExaToolkit(Toolkit):
                         ExaSearchResult(
                             title=r.title or "",
                             url=r.url,
-                            score=getattr(r, "score", None),
-                            published_date=getattr(r, "published_date", None),
-                            author=getattr(r, "author", None),
-                            text=getattr(r, "text", None),
+                            score=r.score,
+                            published_date=r.published_date,
+                            author=r.author,
+                            text=r.text,
                         )
                         for r in raw.results
                     ],
-                    autoprompt_string=getattr(raw, "autoprompt_string", None) or getattr(raw, "autoprompt", None),
                 )
             )
 
@@ -203,7 +203,10 @@ class ExaToolkit(Toolkit):
         self,
         *,
         num_results: int | Variable | None = None,
+        include_domains: Sequence[str] | Variable | None = None,
+        exclude_domains: Sequence[str] | Variable | None = None,
         exclude_source_domain: bool | Variable | None = None,
+        category: Category | Variable | None = None,
         name: str = "exa_find_similar",
         description: str = (
             "Find web pages similar to a given URL. Useful for discovering "
@@ -221,19 +224,22 @@ class ExaToolkit(Toolkit):
             """Find pages similar to a given URL."""
             kwargs = _clean({
                 "num_results": resolve_variable(num_results, ctx, param_name="num_results"),
+                "include_domains": resolve_variable(include_domains, ctx, param_name="include_domains"),
+                "exclude_domains": resolve_variable(exclude_domains, ctx, param_name="exclude_domains"),
                 "exclude_source_domain": resolve_variable(
                     exclude_source_domain, ctx, param_name="exclude_source_domain"
                 ),
+                "category": resolve_variable(category, ctx, param_name="category"),
             })
             raw = client.find_similar(url, **kwargs)
             results = [
                 ExaSearchResult(
                     title=r.title or "",
                     url=r.url,
-                    score=getattr(r, "score", None),
-                    published_date=getattr(r, "published_date", None),
-                    author=getattr(r, "author", None),
-                    text=getattr(r, "text", None),
+                    score=r.score,
+                    published_date=r.published_date,
+                    author=r.author,
+                    text=r.text,
                 )
                 for r in raw.results
             ]
@@ -265,8 +271,8 @@ class ExaToolkit(Toolkit):
                     url=r.url,
                     title=r.title or "",
                     text=r.text or "",
-                    author=getattr(r, "author", None),
-                    published_date=getattr(r, "published_date", None),
+                    author=r.author,
+                    published_date=r.published_date,
                 )
                 for r in raw.results
             ]

--- a/test/beta/tools/search/test_exa.py
+++ b/test/beta/tools/search/test_exa.py
@@ -25,6 +25,15 @@ from autogen.beta.tools.search.exa import (
 )
 
 
+def _mock_client() -> MagicMock:
+    """Return a MagicMock that behaves like an Exa client.
+
+    Using this instead of bare ``MagicMock()`` skips the real
+    ``Exa.__init__`` (which would try to set up HTTP sessions).
+    """
+    return MagicMock(spec_set=["search", "find_similar", "get_contents", "answer"])
+
+
 def _result(
     *,
     title: str = "AG2 Framework",
@@ -44,8 +53,8 @@ def _result(
     )
 
 
-def _response(results: list[SimpleNamespace], autoprompt_string: str | None = None) -> SimpleNamespace:
-    return SimpleNamespace(results=results, autoprompt_string=autoprompt_string)
+def _response(results: list[SimpleNamespace]) -> SimpleNamespace:
+    return SimpleNamespace(results=results)
 
 
 def _tool_call_config(
@@ -131,7 +140,6 @@ class TestSearchExecution:
                         text=None,
                     ),
                 ],
-                autoprompt_string=None,
             )
         )
 
@@ -145,9 +153,7 @@ class TestSearchExecution:
         await agent.ask("search")
 
         tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
-        assert tool_results_event.results[0].result.parts[0] == DataInput(
-            ExaSearchResponse(query="nothing", results=[])
-        )
+        assert tool_results_event.results[0].result.parts[0] == DataInput(ExaSearchResponse(query="nothing"))
 
     async def test_none_params_omitted(self, mock: MagicMock) -> None:
         mock.search.return_value = _response([])
@@ -170,10 +176,9 @@ class TestSearchExecution:
             exclude_domains=["medium.com"],
             start_published_date="2024-01-01",
             end_published_date="2024-12-31",
-            start_crawl_date="2024-01-01",
-            end_crawl_date="2024-12-31",
-            use_autoprompt=True,
             livecrawl="always",
+            user_location="US",
+            moderation=True,
         )
 
         agent = Agent(
@@ -192,14 +197,13 @@ class TestSearchExecution:
             exclude_domains=["medium.com"],
             start_published_date="2024-01-01",
             end_published_date="2024-12-31",
-            start_crawl_date="2024-01-01",
-            end_crawl_date="2024-12-31",
-            use_autoprompt=True,
             livecrawl="always",
+            user_location="US",
+            moderation=True,
         )
 
-    async def test_search_and_contents_when_max_characters_set_on_method(self, mock: MagicMock) -> None:
-        mock.search_and_contents.return_value = _response([_result(text="full article text")])
+    async def test_contents_requested_when_max_characters_set_on_method(self, mock: MagicMock) -> None:
+        mock.search.return_value = _response([_result(text="full article text")])
         toolkit = ExaToolkit(client=mock)
 
         agent = Agent(
@@ -209,11 +213,10 @@ class TestSearchExecution:
         )
         await agent.ask("search")
 
-        mock.search.assert_not_called()
-        mock.search_and_contents.assert_called_once_with("q", text={"maxCharacters": 500})
+        mock.search.assert_called_once_with("q", contents={"text": {"max_characters": 500}})
 
     async def test_toolkit_level_max_characters_applied_to_default_search(self, mock: MagicMock) -> None:
-        mock.search_and_contents.return_value = _response([])
+        mock.search.return_value = _response([])
         toolkit = ExaToolkit(client=mock, max_characters=800)
 
         agent = Agent(
@@ -223,8 +226,7 @@ class TestSearchExecution:
         )
         await agent.ask("search")
 
-        mock.search.assert_not_called()
-        mock.search_and_contents.assert_called_once_with("q", text={"maxCharacters": 800})
+        mock.search.assert_called_once_with("q", contents={"text": {"max_characters": 800}})
 
     async def test_toolkit_level_num_results_applied_to_default_search(self, mock: MagicMock) -> None:
         mock.search.return_value = _response([])
@@ -358,11 +360,11 @@ class TestExaToolkitVariable:
             "a",
             config=_tool_call_config({"query": "q"}, tool_name="exa_search"),
             tools=[search_tool],
-            variables={"user_limit": 10, "search_type": "keyword"},
+            variables={"user_limit": 10, "search_type": "neural"},
         )
         await agent.ask("search")
 
-        mock.search.assert_called_once_with("q", num_results=10, type="keyword")
+        mock.search.assert_called_once_with("q", num_results=10, type="neural")
 
     async def test_missing_raises(self, mock: MagicMock) -> None:
         mock.search.return_value = _response([])


### PR DESCRIPTION
## Summary

Updates `ExaToolkit` to align with the current Exa API (exa-py v2), removing deprecated parameters that were hard-removed on May 1 2026 and adding missing features.

## Changes

### Breaking / deprecated removals
- Remove `start_crawl_date` / `end_crawl_date` parameters from `search()` (hard-removed from API on May 1 2026)
- Remove `use_autoprompt` parameter from `search()` (deprecated since Oct 28 2025)
- Remove `autoprompt_string` field from `ExaSearchResponse` (no longer returned by API)

### Type definition fixes
- **`SearchType`**: Remove non-existent `keyword` and `hybrid` values; add `deep-lite`, `deep-reasoning`, and `instant`
- **`Category`**: Remove discontinued `github`, `tweet`, and `linkedin profile` values; add `people`

### API migration
- Replace `search_and_contents()` with `search(contents=...)` to use the v2 unified search endpoint
- Add `integration_source="ag2"` to the Exa client constructor for usage tracking

### New parameters
- Add `user_location` and `moderation` to `search()`
- Add `include_domains`, `exclude_domains`, and `category` to `find_similar()`

### Code quality
- Replace `getattr(r, ...)` calls with direct attribute access on typed `Result` dataclass fields

## Testing
- All 19 existing tests updated and passing
- Lint (`ruff check`) and format (`ruff format`) clean