### PR TITLE
fix(beta): set Exa integration header via client.headers

### DIFF
--- a/autogen/beta/tools/search/exa.py
+++ b/autogen/beta/tools/search/exa.py
@@ -115,14 +115,11 @@ class ExaToolkit(Toolkit):
         client: Exa | None = None,
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
-        self._client = (
-            client
-            if client is not None
-            else Exa(
-                api_key=api_key,
-                integration_source="ag2",
-            )
-        )
+        if client is not None:
+            self._client = client
+        else:
+            self._client = Exa(api_key=api_key)
+            self._client.headers["x-exa-integration"] = "ag2"
 
         super().__init__(
             self.search(num_results=num_results, max_characters=max_characters),

--- a/test/beta/tools/search/test_exa.py
+++ b/test/beta/tools/search/test_exa.py
@@ -382,6 +382,21 @@ class TestExaToolkitVariable:
 
 
 @pytest.mark.asyncio
+class TestClientConstruction:
+    async def test_default_client_sets_integration_header(self) -> None:
+        """When no ``client`` is passed, the toolkit creates one with the ag2 header."""
+        toolkit = ExaToolkit(api_key="test-key")
+        assert toolkit._client.headers["x-exa-integration"] == "ag2"
+
+    async def test_explicit_client_is_used_as_is(self) -> None:
+        """When ``client`` is passed, it is used without modification."""
+        custom = MagicMock()
+        custom.headers = {"x-api-key": "k"}
+        toolkit = ExaToolkit(client=custom)
+        assert toolkit._client is custom
+
+
+@pytest.mark.asyncio
 class TestIndividualTools:
     async def test_search_tool_passed_alone(self, mock: MagicMock) -> None:
         mock.search.return_value = _response([_result()])


### PR DESCRIPTION
## Why are these changes needed?

`ExaToolkit.__init__` passes `integration_source="ag2"` to `Exa()`, but exa-py v2.12.1 does not accept that keyword argument — every `ExaToolkit()` call without an explicit `client` raises `TypeError`.

This was introduced in #2778 and is currently broken on `main`.

## What does this PR do?

Constructs the client with `Exa(api_key=...)` and then sets the `x-exa-integration` header directly on `client.headers`. The header still reaches Exa servers for usage tracking, but no longer relies on an unsupported constructor parameter.

## How was this tested?

- All 19 Exa unit tests pass (`test/beta/tools/search/test_exa.py`)
- Live smoke test against the Exa API: search returned results, answer returned 1261 chars + 8 citations
- Verified `x-exa-integration: ag2` is present in `client.headers`

## Related issue number

Follow-up fix to #2778