### PR TITLE
Handle None content in ModelMessage

### DIFF
--- a/autogen/beta/ag_ui/stream.py
+++ b/autogen/beta/ag_ui/stream.py
@@ -368,7 +368,7 @@ def map_agui_messages_to_events(command: AGStreamInput) -> tuple[list[str], list
 
             messages.append(
                 events.ModelResponse(
-                    events.ModelMessage(m.content),
+                    events.ModelMessage(m.content) if m.content else None,
                     tool_calls=events.ToolCallsEvent(tool_calls),
                 )
             )


### PR DESCRIPTION
Fixes bug with processing tool called messages without content