### PR TITLE
feat(beta): Add Thinking Level support to Gemini/Vertex AI client + Thinking token usage

### DIFF
--- a/autogen/beta/config/gemini/config.py
+++ b/autogen/beta/config/gemini/config.py
@@ -6,12 +6,13 @@ from dataclasses import dataclass, replace
 from typing import TypedDict
 
 import google.auth
+from google.genai import types
 from typing_extensions import Unpack
 
 from autogen.beta.config.config import ModelConfig
 
 from .files import GeminiFilesClient
-from .gemini_client import CreateConfig, GeminiClient
+from .gemini_client import CreateConfig, GeminiClient, ThinkingLevel
 
 
 class GeminiBaseConfigOverrides(TypedDict, total=False):
@@ -26,6 +27,9 @@ class GeminiBaseConfigOverrides(TypedDict, total=False):
     frequency_penalty: float | None
     seed: int | None
     cached_content: str | None
+    thinking_config: types.ThinkingConfig | None
+    thinking_level: ThinkingLevel | None
+    thinking_budget: int | None
 
 
 class GeminiConfigOverrides(GeminiBaseConfigOverrides, total=False):
@@ -51,6 +55,9 @@ class GeminiBaseConfig:
     frequency_penalty: float | None = None
     seed: int | None = None
     cached_content: str | None = None
+    thinking_config: types.ThinkingConfig | None = None
+    thinking_level: ThinkingLevel | None = None
+    thinking_budget: int | None = None
 
     def _build_create_config(self) -> CreateConfig:
         config = CreateConfig()
@@ -72,7 +79,23 @@ class GeminiBaseConfig:
         if self.seed is not None:
             config["seed"] = self.seed
 
+        thinking = self._resolve_thinking_config()
+        if thinking is not None:
+            config["thinking_config"] = thinking
+
         return config
+
+    def _resolve_thinking_config(self) -> types.ThinkingConfig | None:
+        if self.thinking_config is not None:
+            return self.thinking_config
+        if self.thinking_level is None and self.thinking_budget is None:
+            return None
+        kwargs: dict[str, object] = {}
+        if self.thinking_level is not None:
+            kwargs["thinking_level"] = self.thinking_level
+        if self.thinking_budget is not None:
+            kwargs["thinking_budget"] = self.thinking_budget
+        return types.ThinkingConfig(**kwargs)
 
 
 @dataclass(slots=True)

--- a/autogen/beta/config/gemini/gemini_client.py
+++ b/autogen/beta/config/gemini/gemini_client.py
@@ -5,7 +5,7 @@
 import json
 from collections.abc import Iterable, Sequence
 from itertools import chain
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict
 from uuid import uuid4
 
 import google.auth
@@ -39,6 +39,8 @@ from .mappers import (
     response_proto_to_config,
 )
 
+ThinkingLevel = Literal["low", "medium", "high"]
+
 
 class CreateConfig(TypedDict, total=False):
     temperature: float | None
@@ -49,6 +51,7 @@ class CreateConfig(TypedDict, total=False):
     presence_penalty: float | None
     frequency_penalty: float | None
     seed: int | None
+    thinking_config: types.ThinkingConfig | None
 
 
 class GeminiClient(LLMClient):

--- a/autogen/beta/config/gemini/mappers.py
+++ b/autogen/beta/config/gemini/mappers.py
@@ -285,11 +285,13 @@ def normalize_usage(metadata: Any) -> Usage:
     """Build usage from Gemini UsageMetadata, normalizing to standard keys."""
 
     cache_read = _to_float(metadata.cached_content_token_count) or None
+    thinking = _to_float(getattr(metadata, "thoughts_token_count", None)) or None
     return Usage(
         prompt_tokens=_to_float(metadata.prompt_token_count),
         completion_tokens=_to_float(metadata.candidates_token_count),
         total_tokens=_to_float(metadata.total_token_count),
         cache_read_input_tokens=cache_read,
+        thinking_tokens=thinking,
     )
 
 

--- a/autogen/beta/events/types.py
+++ b/autogen/beta/events/types.py
@@ -20,6 +20,7 @@ class Usage:
     total_tokens: float | None = None
     cache_read_input_tokens: float | None = None
     cache_creation_input_tokens: float | None = None
+    thinking_tokens: float | None = None
 
     def __bool__(self) -> bool:
         return any((
@@ -28,6 +29,7 @@ class Usage:
             self.total_tokens,
             self.cache_read_input_tokens,
             self.cache_creation_input_tokens,
+            self.thinking_tokens,
         ))
 
 

--- a/autogen/beta/middleware/builtin/telemetry.py
+++ b/autogen/beta/middleware/builtin/telemetry.py
@@ -191,6 +191,8 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
                 span.set_attribute("gen_ai.usage.cache_creation_input_tokens", int(usage.cache_creation_input_tokens))
             if usage.cache_read_input_tokens:
                 span.set_attribute("gen_ai.usage.cache_read_input_tokens", int(usage.cache_read_input_tokens))
+            if usage.thinking_tokens:
+                span.set_attribute("gen_ai.usage.thinking_tokens", int(usage.thinking_tokens))
 
             if self._capture_content and response.message:
                 span.set_attribute("gen_ai.output.messages", json.dumps([response.to_api()]))

--- a/test/beta/config/gemini/test_gemini_config.py
+++ b/test/beta/config/gemini/test_gemini_config.py
@@ -4,6 +4,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from google.genai import types
 from google.oauth2 import service_account
 
 from autogen.beta.config import GeminiConfig, VertexAIConfig
@@ -143,3 +144,76 @@ def test_credentials_none_passes_through(mock_from_file, mock_client) -> None:
     mock_from_file.assert_not_called()
     _, kwargs = mock_client.call_args
     assert kwargs["credentials"] is None
+
+
+class TestThinkingConfig:
+    def test_default_omits_thinking_config(self) -> None:
+        config = GeminiConfig(model="gemini-3.1-pro-preview")
+        assert "thinking_config" not in config._build_create_config()
+
+    def test_explicit_thinking_config_passes_through(self) -> None:
+        thinking = types.ThinkingConfig(thinking_level="low")
+        config = GeminiConfig(model="gemini-3.1-pro-preview", thinking_config=thinking)
+        assert config._build_create_config()["thinking_config"] is thinking
+
+    def test_thinking_level_shorthand_builds_config(self) -> None:
+        config = GeminiConfig(model="gemini-3.1-pro-preview", thinking_level="low")
+        built = config._build_create_config()["thinking_config"]
+        assert isinstance(built, types.ThinkingConfig)
+        assert built.thinking_level == types.ThinkingLevel.LOW
+        assert built.thinking_budget is None
+
+    def test_thinking_budget_shorthand_builds_config(self) -> None:
+        config = GeminiConfig(model="gemini-2.5-pro", thinking_budget=1024)
+        built = config._build_create_config()["thinking_config"]
+        assert isinstance(built, types.ThinkingConfig)
+        assert built.thinking_budget == 1024
+        assert built.thinking_level is None
+
+    def test_thinking_level_and_budget_combined(self) -> None:
+        config = GeminiConfig(
+            model="gemini-2.5-pro",
+            thinking_level="medium",
+            thinking_budget=2048,
+        )
+        built = config._build_create_config()["thinking_config"]
+        assert isinstance(built, types.ThinkingConfig)
+        assert built.thinking_level == types.ThinkingLevel.MEDIUM
+        assert built.thinking_budget == 2048
+
+    def test_explicit_thinking_config_wins_over_shorthand(self) -> None:
+        explicit = types.ThinkingConfig(thinking_level="high")
+        config = GeminiConfig(
+            model="gemini-3.1-pro-preview",
+            thinking_config=explicit,
+            thinking_level="low",
+        )
+        assert config._build_create_config()["thinking_config"] is explicit
+
+    def test_vertex_ai_thinking_level_shorthand_builds_config(self) -> None:
+        config = VertexAIConfig(
+            model="gemini-3.1-pro-preview",
+            project="proj",
+            location="us-central1",
+            thinking_level="low",
+        )
+        built = config._build_create_config()["thinking_config"]
+        assert isinstance(built, types.ThinkingConfig)
+        assert built.thinking_level == types.ThinkingLevel.LOW
+
+    def test_vertex_ai_explicit_thinking_config_passes_through(self) -> None:
+        thinking = types.ThinkingConfig(thinking_budget=512)
+        config = VertexAIConfig(
+            model="gemini-2.5-pro",
+            project="proj",
+            location="us-central1",
+            thinking_config=thinking,
+        )
+        assert config._build_create_config()["thinking_config"] is thinking
+
+    def test_copy_overrides_thinking_level(self) -> None:
+        config = GeminiConfig(model="gemini-3.1-pro-preview", thinking_level="low")
+        copied = config.copy(thinking_level="high")
+
+        assert copied.thinking_level == "high"
+        assert config.thinking_level == "low"

--- a/test/beta/config/gemini/test_gemini_usage.py
+++ b/test/beta/config/gemini/test_gemini_usage.py
@@ -10,12 +10,13 @@ from autogen.beta.config.gemini.mappers import normalize_usage
 from autogen.beta.events import Usage
 
 
-def _make_metadata(prompt=100, candidates=20, total=120, cached=None):
+def _make_metadata(prompt=100, candidates=20, total=120, cached=None, thoughts=None):
     m = MagicMock()
     m.prompt_token_count = prompt
     m.candidates_token_count = candidates
     m.total_token_count = total
     m.cached_content_token_count = cached
+    m.thoughts_token_count = thoughts
     return m
 
 
@@ -51,3 +52,33 @@ class TestNormalizeUsage:
     def test_handles_partial_token_counts(self):
         result = normalize_usage(_make_metadata(prompt=50, candidates=None, total=None))
         assert result == Usage(prompt_tokens=50)
+
+    def test_includes_thinking_tokens(self):
+        result = normalize_usage(_make_metadata(thoughts=296))
+        assert result == Usage(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            thinking_tokens=296,
+        )
+
+    def test_no_thinking_key_when_none(self):
+        result = normalize_usage(_make_metadata(thoughts=None))
+        assert result.thinking_tokens is None
+
+    def test_no_thinking_key_when_zero(self):
+        result = normalize_usage(_make_metadata(thoughts=0))
+        assert result.thinking_tokens is None
+
+    def test_handles_metadata_without_thoughts_field(self):
+        """Older google-genai versions may not expose ``thoughts_token_count``."""
+        m = MagicMock(
+            spec=["prompt_token_count", "candidates_token_count", "total_token_count", "cached_content_token_count"]
+        )
+        m.prompt_token_count = 100
+        m.candidates_token_count = 20
+        m.total_token_count = 120
+        m.cached_content_token_count = None
+
+        result = normalize_usage(m)
+        assert result.thinking_tokens is None

--- a/test/beta/middleware/telemetry/test_telemetry.py
+++ b/test/beta/middleware/telemetry/test_telemetry.py
@@ -440,3 +440,61 @@ async def test_cache_read_tokens_when_nonzero(otel_setup):
     llm_span = next(s for s in spans if s.attributes.get("ag2.span.type") == "llm")
     assert llm_span.attributes["gen_ai.usage.cache_read_input_tokens"] == 75
     assert "gen_ai.usage.cache_creation_input_tokens" not in llm_span.attributes
+
+
+@pytest.mark.asyncio()
+async def test_thinking_tokens_when_nonzero(otel_setup):
+    """thinking_tokens appears as gen_ai.usage.thinking_tokens when non-zero."""
+    exporter, provider = otel_setup
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(
+            ModelResponse(
+                message=ModelMessage("Hi!"),
+                usage=Usage(
+                    prompt_tokens=100,
+                    completion_tokens=20,
+                    thinking_tokens=296,
+                ),
+                model="gemini-3.1-pro-preview",
+                provider="google",
+            ),
+        ),
+        middleware=[TelemetryMiddleware(tracer_provider=provider, agent_name="assistant")],
+    )
+
+    await agent.ask("Hello")
+
+    spans = exporter.get_finished_spans()
+    llm_span = next(s for s in spans if s.attributes.get("ag2.span.type") == "llm")
+    assert llm_span.attributes["gen_ai.usage.thinking_tokens"] == 296
+
+
+@pytest.mark.asyncio()
+async def test_thinking_tokens_omitted_when_zero(otel_setup):
+    """thinking_tokens=0 is treated as absent and not exported."""
+    exporter, provider = otel_setup
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(
+            ModelResponse(
+                message=ModelMessage("Hi!"),
+                usage=Usage(
+                    prompt_tokens=100,
+                    completion_tokens=20,
+                    thinking_tokens=0,
+                ),
+                model="gemini-3.1-pro-preview",
+                provider="google",
+            ),
+        ),
+        middleware=[TelemetryMiddleware(tracer_provider=provider, agent_name="assistant")],
+    )
+
+    await agent.ask("Hello")
+
+    spans = exporter.get_finished_spans()
+    llm_span = next(s for s in spans if s.attributes.get("ag2.span.type") == "llm")
+    assert "gen_ai.usage.thinking_tokens" not in llm_span.attributes

--- a/test/beta/providers/gemini/test_gemini_integration.py
+++ b/test/beta/providers/gemini/test_gemini_integration.py
@@ -138,6 +138,45 @@ async def test_multi_turn_after_empty_args_tool_call(gemini_config: GeminiConfig
 
 @pytest.mark.gemini
 @pytest.mark.asyncio()
+async def test_thinking_level_low_reports_thinking_tokens(gemini_config: GeminiConfig) -> None:
+    """thinking_level='low' is accepted by the SDK on Gemini 3 thinking models
+    and ``thoughts_token_count`` is surfaced in ``Usage.thinking_tokens``."""
+    config = gemini_config.copy(thinking_level="low")
+
+    agent = Agent(
+        name="thinker",
+        prompt="You are a careful reasoner. Be concise.",
+        config=config,
+    )
+
+    reply = await agent.ask("What is 17 * 23? Think briefly, then answer with just the number.")
+
+    assert reply.body is not None
+    usage = reply.response.usage
+    assert usage.thinking_tokens is not None and usage.thinking_tokens > 0
+
+
+@pytest.mark.gemini
+@pytest.mark.asyncio()
+async def test_thinking_budget_reports_thinking_tokens(gemini_config: GeminiConfig) -> None:
+    """thinking_budget shorthand is accepted on Gemini 2.5 thinking models."""
+    config = gemini_config.copy(model="gemini-2.5-flash", thinking_budget=512)
+
+    agent = Agent(
+        name="budgeted-thinker",
+        prompt="You are a careful reasoner. Be concise.",
+        config=config,
+    )
+
+    reply = await agent.ask("What is 17 * 23? Think briefly, then answer with just the number.")
+
+    assert reply.body is not None
+    usage = reply.response.usage
+    assert usage.thinking_tokens is not None and usage.thinking_tokens > 0
+
+
+@pytest.mark.gemini
+@pytest.mark.asyncio()
 async def test_history_round_trip_preserves_thought_signature(gemini_config: GeminiConfig) -> None:
     """Gemini thinking models stash bytes in ``ToolCallEvent.provider_data``;
     history persisted through the Redis JSON serializer must replay intact."""

--- a/website/docs/beta/model_configuration.mdx
+++ b/website/docs/beta/model_configuration.mdx
@@ -215,6 +215,34 @@ from autogen.beta.config import VertexAIConfig
 config = VertexAIConfig(model="gemini-3-flash-preview")
 ```
 
+### Controlling Gemini Thinking
+
+Gemini 3 Pro models default to **dynamic / unbounded** thinking, which can cause individual calls to spend a large internal token budget before responding. Both `GeminiConfig` and `VertexAIConfig` accept thinking controls that map directly to [Google's Thinking API](https://ai.google.dev/gemini-api/docs/thinking){.external-link target="_blank"}.
+
+Use `thinking_level` for **Gemini 3** models, or `thinking_budget` for **Gemini 2.5** models:
+
+```python linenums="1" hl_lines="6 13"
+from autogen.beta.config import GeminiConfig, VertexAIConfig
+
+# Gemini 3 — bound thinking with a level
+gemini3 = GeminiConfig(
+    model="gemini-3-flash-preview",
+    thinking_level="low",  # "low" | "medium" | "high"
+)
+
+# Gemini 2.5 — bound thinking with an explicit token budget
+gemini25 = VertexAIConfig(
+    model="gemini-2.5-pro",
+    project="my-gcp-project",
+    location="us-central1",
+    thinking_budget=512,  # 0 disables thinking entirely
+)
+```
+
+For full control (e.g. enabling `include_thoughts`), pass a `google.genai.types.ThinkingConfig` directly via `thinking_config`. When set, it takes precedence over the shorthand fields.
+
+The number of thinking tokens consumed is reported on `ModelResponse.usage.thinking_tokens` and emitted as the `gen_ai.usage.thinking_tokens` OpenTelemetry attribute by `TelemetryMiddleware`.
+
 ### Self-Hosted and OpenAI-Compatible Models (vLLM, LM Studio, etc.)
 
 If you are using a self-hosted model or an API that is compatible with the OpenAI format (such as **vLLM**, **LM Studio**, **FastChat**, or **Together AI**), you can use the `OpenAIConfig` class and specify a custom `base_url`.


### PR DESCRIPTION
## Why are these changes needed?

Gemini and Vertex AI configs and the client didn't support thinking level, so thinking level, if supported by the model, was always at its default.

Additionally, telemetry didn't cater for thinking token usage, which created a gap in real token numbers.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
