### PR TITLE
fix: avoid double-registering pre-registered tools in run() (#1770)

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -4386,14 +4386,25 @@ class ConversableAgent(LLMAgent):
             for tool in all_tools:
                 tool.register_for_execution(self.run_executor)
 
-            # Register only newly passed tools for LLM (agent's pre-existing tools are already registered)
+            # Register only newly passed tools for LLM (agent's pre-existing tools are already registered).
+            # Dedup against the current llm_config["tools"] (not self._tools) so we skip re-registration
+            # for tools the caller already registered on the agent — this avoids spurious "Function ... is
+            # being overridden" warnings when callers pass agent.tools back in (see issue #1770).
+            existing_tool_names: set[str] = {
+                t["function"]["name"]
+                for t in (self.llm_config or {}).get("tools", [])
+                if isinstance(t, dict) and isinstance(t.get("function"), dict)
+            }
+            newly_registered_tools: list[Tool] = []
             for tool in passed_tools:
-                tool.register_for_llm(self)
+                if tool.tool_schema["function"]["name"] not in existing_tool_names:
+                    tool.register_for_llm(self)
+                    newly_registered_tools.append(tool)
             yield self.run_executor
         finally:
-            # Clean up only newly passed tools (not agent's pre-existing tools)
-            if "passed_tools" in locals():
-                for tool in passed_tools:
+            # Clean up only the tools newly registered above (leave pre-existing tools in place).
+            if "newly_registered_tools" in locals():
+                for tool in newly_registered_tools:
                     self.update_tool_signature(tool_sig=tool.tool_schema["function"]["name"], is_remove=True)
 
     def _deprecated_run(

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -4386,10 +4386,7 @@ class ConversableAgent(LLMAgent):
             for tool in all_tools:
                 tool.register_for_execution(self.run_executor)
 
-            # Register only newly passed tools for LLM (agent's pre-existing tools are already registered).
-            # Dedup against the current llm_config["tools"] (not self._tools) so we skip re-registration
-            # for tools the caller already registered on the agent — this avoids spurious "Function ... is
-            # being overridden" warnings when callers pass agent.tools back in (see issue #1770).
+            # Register only tools not already in llm_config["tools"], to avoid re-registration warnings
             existing_tool_names: set[str] = {
                 t["function"]["name"]
                 for t in (self.llm_config or {}).get("tools", [])

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -15,6 +15,7 @@ import os
 import threading
 import time
 import unittest
+import warnings
 from collections.abc import Callable
 from typing import Annotated, Any, Literal
 from unittest.mock import MagicMock, patch
@@ -2243,6 +2244,36 @@ def test_run_method_no_double_tool_registration(mock_credentials: Credentials):
         assert len(executor.function_map) == 2
         assert "pre_tool" in executor.function_map
         assert "runtime_tool" in executor.function_map
+
+
+def test_run_method_passing_pre_registered_tool_no_warning_or_loss(mock_credentials: Credentials):
+    """Regression for #1770: passing tools=agent.tools to run() must not warn,
+    must not duplicate the tool entry, and must leave pre-registered tools intact
+    on the agent after the executor context exits.
+    """
+
+    agent = ConversableAgent(name="agent", llm_config=mock_credentials.llm_config)
+
+    def pre_registered_tool(message: str) -> str:
+        return f"Pre-registered: {message}"
+
+    pre_tool = Tool(name="pre_tool", description="Pre-registered tool", func_or_tool=pre_registered_tool)
+    agent.register_for_llm()(pre_tool)
+
+    assert len(agent.llm_config.get("tools", [])) == 1
+
+    # Mirrors the user-facing pattern that triggers the bug (e.g., DeepResearchAgent
+    # called as agent.run(tools=agent.tools, ...)).
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        with agent._create_or_get_executor(tools=agent.tools) as executor:
+            tool_names = [tool["function"]["name"] for tool in agent.llm_config.get("tools", [])]
+            assert tool_names == ["pre_tool"]
+            assert "pre_tool" in executor.function_map
+
+    # Pre-existing tool must remain registered on the agent after the context exits.
+    tool_names_after = [tool["function"]["name"] for tool in agent.llm_config.get("tools", [])]
+    assert tool_names_after == ["pre_tool"]
 
 
 class TestAsyncReplyFunctionSkipping:


### PR DESCRIPTION
## Summary

Fixes #1770. `ConversableAgent._create_or_get_executor` re-registered every passed tool on `self`, even when the same tool was already present in `self.llm_config[\"tools\"]`. This is the path hit by the DeepResearchAgent example in `build-with-ag2/deep-research-agent/main.py`, which calls:

```python
agent = DeepResearchAgent(...)        # registers `delegate_research_task` once
agent.run(tools=agent.tools, ...)     # passes the same tool back in
```

The duplicate registration trips `update_tool_signature`'s `if any(tool[\"function\"][\"name\"] == tool_sig[\"function\"][\"name\"] ...)` check and emits `Function 'delegate_research_task' is being overridden.` — exactly the warning users see in the issue.

A second, more subtle bug lived in the cleanup branch: it unconditionally unregistered every passed tool in `finally`, so a pre-registered tool that was passed in via `tools=...` was silently stripped off the agent after `run()` returned.

## Fix

In `_create_or_get_executor`:

- Dedup `passed_tools` against the names already in `llm_config[\"tools\"]` before calling `tool.register_for_llm(self)`. Dedup is by tool name (matches the override check itself), and against `llm_config[\"tools\"]` rather than `self._tools` because `_tools` retains stale entries after the cleanup branch removes them from `llm_config`.
- Track the tools we actually registered (`newly_registered_tools`) and only undo those in `finally`, leaving pre-existing tools intact.

## Validation

- Added `test_run_method_passing_pre_registered_tool_no_warning_or_loss` that mirrors the issue repro (`tools=agent.tools`), asserts no `UserWarning` is raised (via `warnings.simplefilter(\"error\", UserWarning)`), and asserts the pre-registered tool is still present after the executor context exits.
- Existing `test_run_method_no_double_tool_registration` and `test_create_or_get_executor` still pass — verified the latter still relies on the per-iteration cleanup-then-reregister cycle, which the dedup-by-`llm_config` approach preserves.
- Full `test/agentchat/test_conversable_agent.py` non-integration suite green (79 passed); only failures in the broader run are unrelated tests that auth against a real OpenAI key.

## Test plan

- [x] `pytest test/agentchat/test_conversable_agent.py::test_create_or_get_executor`
- [x] `pytest test/agentchat/test_conversable_agent.py::test_run_method_no_double_tool_registration`
- [x] `pytest test/agentchat/test_conversable_agent.py::test_run_method_passing_pre_registered_tool_no_warning_or_loss`
- [x] Full `pytest test/agentchat/test_conversable_agent.py` non-integration tests
- [x] `ruff check` and `ruff format --check` on changed files

## Notes

- The `None` printed in the original repro is a separate symptom (the chat with `gpt-5-nano` doesn't reach the `Answer confirmed:` termination prefix, so `result.summary` is empty). Out of scope for this PR — this PR fixes the warning and the silent tool-loss bug, which is what the title \"DeepResearchAgent not working\" describes from the autogen side.