### PR TITLE
feat(beta): Anthropic extra_body config support

### DIFF
--- a/autogen/beta/config/anthropic/anthropic_client.py
+++ b/autogen/beta/config/anthropic/anthropic_client.py
@@ -69,6 +69,7 @@ class AnthropicClient(LLMClient):
         http_client: httpx.AsyncClient | None = None,
         create_options: CreateOptions | None = None,
         prompt_caching: bool = True,
+        extra_body: dict[str, Any] | None = None,
     ) -> None:
         self._client = AsyncAnthropic(
             api_key=api_key,
@@ -82,6 +83,7 @@ class AnthropicClient(LLMClient):
         self._create_options = {k: v for k, v in (create_options or {}).items() if k != "stream"}
         self._streaming = (create_options or {}).get("stream", False)
         self._prompt_caching = prompt_caching
+        self._extra_body = extra_body
 
     async def __call__(
         self,
@@ -151,6 +153,11 @@ class AnthropicClient(LLMClient):
             existing_betas.add("files-api-2025-04-14")
             create_kwargs.setdefault("extra_headers", {})
             create_kwargs["extra_headers"]["anthropic-beta"] = ",".join(sorted(existing_betas))
+
+        # User keys win over framework-set keys (e.g. mcp_servers) on collision.
+        if self._extra_body:
+            existing = create_kwargs.get("extra_body") or {}
+            create_kwargs["extra_body"] = {**existing, **self._extra_body}
 
         max_continuations = 5
 

--- a/autogen/beta/config/anthropic/config.py
+++ b/autogen/beta/config/anthropic/config.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass, replace
-from typing import TypedDict
+from typing import Any, TypedDict
 
 import httpx
 from anthropic.types import ModelParam
@@ -32,6 +32,7 @@ class AnthropicConfigOverrides(TypedDict, total=False):
     metadata: dict[str, str] | None
     service_tier: str | None
     prompt_caching: bool
+    extra_body: dict[str, Any] | None
 
 
 @dataclass(slots=True)
@@ -52,6 +53,7 @@ class AnthropicConfig(ModelConfig):
     metadata: dict[str, str] | None = None
     service_tier: str | None = None
     prompt_caching: bool = True
+    extra_body: dict[str, Any] | None = None
 
     def copy(self, /, **overrides: Unpack[AnthropicConfigOverrides]) -> "AnthropicConfig":
         return replace(self, **overrides)
@@ -85,6 +87,7 @@ class AnthropicConfig(ModelConfig):
             http_client=self.http_client,
             create_options=options,
             prompt_caching=self.prompt_caching,
+            extra_body=self.extra_body,
         )
 
     def create_files_client(self) -> AnthropicFilesClient:

--- a/test/beta/config/anthropic/test_anthropic_config.py
+++ b/test/beta/config/anthropic/test_anthropic_config.py
@@ -46,3 +46,34 @@ def test_max_tokens_defaults_to_4096() -> None:
 def test_max_tokens_can_be_overridden() -> None:
     config = AnthropicConfig(model="claude-sonnet-4-6", max_tokens=8192)
     assert config.max_tokens == 8192
+
+
+def test_extra_body_defaults_to_none() -> None:
+    config = AnthropicConfig(model="claude-sonnet-4-6")
+    assert config.extra_body is None
+
+
+def test_extra_body_can_be_set() -> None:
+    extra = {"tool_choice": {"type": "auto", "disable_parallel_tool_use": True}}
+    config = AnthropicConfig(model="claude-sonnet-4-6", extra_body=extra)
+
+    assert config.extra_body == extra
+
+
+def test_extra_body_passed_to_client() -> None:
+    extra = {"tool_choice": {"type": "auto", "disable_parallel_tool_use": True}}
+    config = AnthropicConfig(model="claude-sonnet-4-6", api_key="test-key", extra_body=extra)
+
+    client = config.create()
+
+    assert client._extra_body == extra
+
+
+def test_copy_with_extra_body() -> None:
+    base = AnthropicConfig(model="claude-sonnet-4-6")
+    extra = {"thinking": {"type": "enabled", "budget_tokens": 5000}}
+
+    copied = base.copy(extra_body=extra)
+
+    assert copied.extra_body == extra
+    assert base.extra_body is None

--- a/test/beta/config/anthropic/test_anthropic_usage.py
+++ b/test/beta/config/anthropic/test_anthropic_usage.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fast_depends.pydantic import PydanticSerializer
 
 from autogen.beta.config.anthropic import AnthropicClient
 from autogen.beta.events import ModelResponse, Usage
@@ -147,3 +148,64 @@ async def test_process_stream_normalizes_usage():
 async def _async_iter(items):
     for item in items:
         yield item
+
+
+def _call_context() -> AsyncMock:
+    ctx = AsyncMock()
+    ctx.send = AsyncMock()
+    ctx.prompt = []
+    return ctx
+
+
+def _serializer() -> PydanticSerializer:
+    return PydanticSerializer(
+        pydantic_config={"arbitrary_types_allowed": True},
+        use_fastdepends_errors=False,
+    )
+
+
+@pytest.mark.asyncio()
+async def test_extra_body_lands_in_messages_create_kwargs() -> None:
+    extra = {"tool_choice": {"type": "auto", "disable_parallel_tool_use": True}}
+    client = AnthropicClient(api_key="test", prompt_caching=False, extra_body=extra)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _make_response(_make_usage(input_tokens=1, output_tokens=1))
+
+    client._client.messages.create = fake_create  # type: ignore[method-assign]
+
+    await client(
+        messages=[],
+        context=_call_context(),
+        tools=[],
+        response_schema=None,
+        serializer=_serializer(),
+    )
+
+    assert captured.get("extra_body") == extra
+
+
+@pytest.mark.asyncio()
+async def test_no_extra_body_means_no_extra_body_kwarg() -> None:
+    client = AnthropicClient(api_key="test", prompt_caching=False)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _make_response(_make_usage(input_tokens=1, output_tokens=1))
+
+    client._client.messages.create = fake_create  # type: ignore[method-assign]
+
+    await client(
+        messages=[],
+        context=_call_context(),
+        tools=[],
+        response_schema=None,
+        serializer=_serializer(),
+    )
+
+    assert "extra_body" not in captured


### PR DESCRIPTION
## Why are these changes needed?

Anthropic's configuration includes an `extra_body` parameter to allow custom settings for inference. An example is for disabling parallel tool calling.

This PR enables the use of this parameter, e.g.
```
config = AnthropicConfig(model="claude-sonnet-4-6", extra_body={"tool_choice": {"type": "auto", "disable_parallel_tool_use": True}})
```

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
