### PR TITLE
fix(beta/gemini): strip additionalProperties recursively to fix anyOf rejections

### DIFF
--- a/autogen/beta/config/gemini/mappers.py
+++ b/autogen/beta/config/gemini/mappers.py
@@ -55,17 +55,36 @@ def build_system_instruction(
     return joined or None
 
 
+def _strip_additional_properties(node: Any) -> Any:
+    """Recursively remove ``additionalProperties`` from a JSON Schema.
+
+    Gemini's API rejects ``additionalProperties`` when it appears
+    inside ``anyOf`` / ``oneOf`` branches (the proto field is named
+    ``additional_properties`` and only allowed in specific positions).
+    Gemini doesn't enforce additional-properties anyway, so dropping
+    everywhere is safe.
+    """
+    if isinstance(node, dict):
+        return {k: _strip_additional_properties(v) for k, v in node.items() if k != "additionalProperties"}
+    if isinstance(node, list):
+        return [_strip_additional_properties(v) for v in node]
+    return node
+
+
 def _ensure_object_schema(params: dict[str, Any]) -> dict[str, Any]:
     """Gemini requires every function's parameters schema to be type=object.
 
     Parameterless functions produce ``{"type": "null"}`` (from pydantic/fast_depends)
     or ``{}`` — both rejected by Gemini with ``INVALID_ARGUMENT``.
     Normalise to ``{"type": "object", "properties": {}}``.
+
+    Strips ``additionalProperties`` recursively because Gemini
+    rejects it inside ``anyOf`` branches.
     """
     raw_type = str(params.get("type", "")).lower()
     if not params or raw_type in ("null", "none", ""):
         return {"type": "object", "properties": {}}
-    return params
+    return _strip_additional_properties(params)
 
 
 def build_tools(schemas: list[ToolSchema]) -> list[types.Tool] | None:

--- a/test/beta/config/gemini/tools/test_tool_to_api.py
+++ b/test/beta/config/gemini/tools/test_tool_to_api.py
@@ -72,3 +72,54 @@ def test_parameterless_tool_null_type_gets_object_schema() -> None:
             ]
         )
     ]
+
+
+def test_additional_properties_stripped_from_anyof_branches() -> None:
+    """Gemini rejects ``additionalProperties`` inside ``anyOf`` items.
+
+    pydantic emits ``Optional[dict]`` as
+    ``{"anyOf": [{"type": "object", "additionalProperties": false}, {"type": "null"}]}``.
+    Gemini rejects this with ``Unknown name 'additional_properties'``.
+    The mapper must strip ``additionalProperties`` recursively.
+    """
+    schema = FunctionToolSchema(
+        function=FunctionDefinition(
+            name="emit",
+            description="Emit some payload.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "payload": {
+                        "anyOf": [
+                            {"type": "object", "additionalProperties": False},
+                            {"type": "null"},
+                        ],
+                    },
+                },
+                "additionalProperties": False,
+            },
+        )
+    )
+    api_tool = build_tools([schema])
+
+    assert api_tool == [
+        types.Tool(
+            function_declarations=[
+                types.FunctionDeclaration(
+                    name="emit",
+                    description="Emit some payload.",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "payload": {
+                                "anyOf": [
+                                    {"type": "object"},
+                                    {"type": "null"},
+                                ],
+                            },
+                        },
+                    },
+                )
+            ]
+        )
+    ]


### PR DESCRIPTION
## Why are these changes needed?

Gemini's API rejects `additionalProperties` when it appears inside `anyOf` / `oneOf` branches — pydantic emits `Optional[dict]` as `{"anyOf": [{"type": "object", "additionalProperties": false}, {"type": "null"}]}`, which Gemini fails with `Unknown name 'additional_properties'`.

This change adds a recursive `_strip_additional_properties` helper to `autogen/beta/config/gemini/mappers.py` and applies it from `_ensure_object_schema` so the field is removed everywhere in the function-parameters schema before tools are sent. Gemini doesn't enforce `additionalProperties` anyway, so dropping it across the board is safe. A new test, `test_additional_properties_stripped_from_anyof_branches` in `test/beta/config/gemini/tools/test_tool_to_api.py`, exercises the exact pydantic-emitted shape end-to-end through `build_tools`.


## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
