### PR TITLE
fix(beta): drop orphan ToolResults across the sliding window

### DIFF
--- a/autogen/beta/policies/sliding_window.py
+++ b/autogen/beta/policies/sliding_window.py
@@ -5,7 +5,7 @@
 """SlidingWindowPolicy — keep the last N events."""
 
 from autogen.beta.context import ConversationContext as Context
-from autogen.beta.events import BaseEvent, ToolResultsEvent
+from autogen.beta.events import BaseEvent, ModelResponse, ToolResultsEvent
 
 
 class SlidingWindowPolicy:
@@ -27,12 +27,53 @@ class SlidingWindowPolicy:
         context: Context,
     ) -> tuple[list[str], list[BaseEvent]]:
         total = len(events)
-        if total <= self._max:
-            return prompts, events
-        trimmed = events[-self._max :]
-        # Skip leading ToolResultsEvents whose matching tool_use was trimmed away.
-        while trimmed and isinstance(trimmed[0], ToolResultsEvent):
-            trimmed = trimmed[1:]
-        if self._transparent:
-            prompts = prompts + [f"[{self.name}] Showing last {len(trimmed)} of {total} events."]
-        return prompts, trimmed
+        if total > self._max:
+            window = events[-self._max :]
+        else:
+            window = events
+        repaired = _drop_orphan_tool_results(window)
+        if self._transparent and total > self._max:
+            prompts = prompts + [f"[{self.name}] Showing last {len(repaired)} of {total} events."]
+        return prompts, repaired
+
+
+def _drop_orphan_tool_results(events: list[BaseEvent]) -> list[BaseEvent]:
+    """Remove ToolResultEvents whose matching ToolCallEvent is not in the window.
+
+    OpenAI rejects the assembled messages with HTTP 400 when a ``tool``-role
+    message references a ``tool_call_id`` that is not present in any preceding
+    ``assistant`` message's ``tool_calls`` (see issue #2793). The window can
+    contain such orphans for two reasons:
+
+    1. The matching ModelResponse holding the ToolCallsEvent was older than
+       the window and got trimmed away. The orphan can sit at the head of
+       the window or, if a complete tool round-trip survived in front of it,
+       in the middle.
+    2. Sequential agents share context across separate streams, so the
+       assembled history can carry tool results emitted on one stream
+       alongside no matching call from another stream — and this can occur
+       even when no trimming has happened.
+
+    For each ToolResultsEvent we keep only the individual ToolResultEvents
+    whose ``parent_id`` matches a ToolCallEvent ``id`` already seen earlier
+    in the window (extracted from ModelResponse.tool_calls). If every result
+    in a container is orphaned, the whole container is dropped.
+    """
+    seen_call_ids: set[str] = set()
+    kept: list[BaseEvent] = []
+    for event in events:
+        if isinstance(event, ModelResponse):
+            seen_call_ids.update(call.id for call in event.tool_calls.calls)
+            kept.append(event)
+            continue
+        if isinstance(event, ToolResultsEvent):
+            paired = [r for r in event.results if r.parent_id in seen_call_ids]
+            if not paired:
+                continue
+            if len(paired) == len(event.results):
+                kept.append(event)
+            else:
+                kept.append(ToolResultsEvent(results=paired))
+            continue
+        kept.append(event)
+    return kept

--- a/test/beta/policies/test_sliding_window.py
+++ b/test/beta/policies/test_sliding_window.py
@@ -78,7 +78,7 @@ class TestTrimming:
 
 
 class TestOrphanedToolResults:
-    """After trimming, leading ToolResultsEvents without a matching tool_use should be dropped."""
+    """ToolResultsEvents whose matching ToolCallsEvent is not in the window must be dropped."""
 
     @pytest.mark.asyncio
     async def test_leading_orphaned_tool_result_is_skipped(self, context: Context) -> None:
@@ -132,6 +132,71 @@ class TestOrphanedToolResults:
         assert isinstance(result[0], ModelResponse)
         assert isinstance(result[1], ToolResultsEvent)
         assert isinstance(result[2], ModelRequest)
+
+    @pytest.mark.asyncio
+    async def test_mid_window_orphaned_tool_result_is_dropped(self, context: Context) -> None:
+        """An orphan ToolResultsEvent past the head of the window must also be dropped.
+
+        Reproduces the second case in #2793: a complete tool round-trip
+        survives at the front of the window, then a ToolResultsEvent whose
+        matching ToolCallsEvent was trimmed appears in the middle.
+        """
+        events = [
+            _tool_response("tc_old"),  # trimmed away
+            _tool_response("tc_kept"),  # survives
+            _tool_results("tc_kept"),  # paired
+            _tool_results("tc_old"),  # orphan in the MIDDLE of the window
+            ModelRequest([TextInput("after")]),
+        ]
+        policy = SlidingWindowPolicy(max_events=4)
+
+        _, result = await policy.apply([], events, context)
+
+        # Window is the last 4 events; the mid-window orphan must be dropped.
+        assert len(result) == 3
+        assert isinstance(result[0], ModelResponse)
+        assert isinstance(result[1], ToolResultsEvent)
+        assert result[1].results[0].parent_id == "tc_kept"
+        assert isinstance(result[2], ModelRequest)
+
+    @pytest.mark.asyncio
+    async def test_partially_orphaned_tool_results_keeps_paired_results(self, context: Context) -> None:
+        """A ToolResultsEvent containing a mix of paired and orphaned results
+        must keep only the paired ones."""
+        events = [
+            _tool_response("tc_1"),  # only tc_1 is in the window
+            ToolResultsEvent(
+                results=[
+                    ToolResultEvent(parent_id="tc_1", name="get", result=ToolResult("ok")),
+                    ToolResultEvent(parent_id="tc_lost", name="get", result=ToolResult("ok")),
+                ],
+            ),
+            ModelRequest([TextInput("after")]),
+        ]
+        policy = SlidingWindowPolicy(max_events=3)
+
+        _, result = await policy.apply([], events, context)
+
+        assert len(result) == 3
+        assert isinstance(result[1], ToolResultsEvent)
+        assert [r.parent_id for r in result[1].results] == ["tc_1"]
+
+    @pytest.mark.asyncio
+    async def test_carryover_tool_result_from_separate_stream_is_dropped(self, context: Context) -> None:
+        """When events from another stream are carried over (per #2793 case 2),
+        results without a matching call in the assembled history must be dropped
+        even when they appear before any local tool call."""
+        events = [
+            ModelRequest([TextInput("from another agent")]),
+            _tool_results("tc_other_stream"),  # call lives on a different stream
+            ModelRequest([TextInput("local turn")]),
+        ]
+        policy = SlidingWindowPolicy(max_events=3)
+
+        _, result = await policy.apply([], events, context)
+
+        assert len(result) == 2
+        assert all(not isinstance(e, ToolResultsEvent) for e in result)
 
     @pytest.mark.asyncio
     async def test_transparent_count_reflects_skipped_orphans(self, context: Context) -> None:


### PR DESCRIPTION
### Summary

Closes #2793.

`SlidingWindowPolicy` previously only stripped orphan `ToolResultsEvent`s at the **head** of the trimmed window. The check missed two real cases the issue calls out, so the assembled messages could still arrive at OpenAI with a `tool` message whose `tool_call_id` had no matching prior `tool_calls`, and the request would be rejected with:

```
Invalid parameter: messages with role 'tool' must be a response to a preceeding message with 'tool_calls'.
```

The two missed cases:

1. **Mid-window orphans** — a complete tool round-trip survives at the front of the window, then a `ToolResultsEvent` whose matching `ToolCallsEvent` was trimmed appears in the middle.
2. **Cross-stream carryover** — sequential agents share context across separate streams, so the assembled history can carry results from one stream alongside no matching call from another. This can occur even when no trimming has happened (`total <= max_events`), so the early-return path also missed it.

### Change

Replace the single leading-position check with a left-to-right pass over the window:

- Collect every `ToolCallEvent.id` seen so far from each `ModelResponse.tool_calls.calls`.
- For each `ToolResultsEvent`, keep only the individual `ToolResultEvent`s whose `parent_id` is in that set. Drop the whole container when nothing pairs.
- Run the pass on every `apply()` call (not only after trimming), so the cross-stream carryover case is covered.

Public API and the `transparent` prompt unchanged. The reported event count in transparent mode already reflected post-orphan length, so the existing test still passes.

### Test plan

New tests added alongside the existing ones in `test/beta/policies/test_sliding_window.py`:

- `test_mid_window_orphaned_tool_result_is_dropped` — case 1 above
- `test_partially_orphaned_tool_results_keeps_paired_results` — partial-orphan container
- `test_carryover_tool_result_from_separate_stream_is_dropped` — case 2 above, no trimming required

Existing tests for leading orphans, normal trimming, and the transparent counter still pass.

```
$ pytest test/beta/policies/test_sliding_window.py -vv
... 11 passed

$ pytest test/beta/policies/ test/beta/middleware/ -q
... 71 passed, 1 skipped
```