### PR TITLE
feat(beta/network): adapter-owned tools + subclass surface

### DIFF
--- a/autogen/beta/network/__init__.py
+++ b/autogen/beta/network/__init__.py
@@ -27,6 +27,12 @@ from .adapters import (
     DiscussionState,
     WorkflowAdapter,
     WorkflowState,
+    default_build_packet_envelope,
+    default_build_round_envelope,
+    default_build_text_envelope,
+    default_extract_turn_input,
+    default_render_envelope,
+    default_tools_for,
 )
 from .auth import AuthAdapter, AuthRegistry, NoAuth
 from .channel import (
@@ -342,9 +348,15 @@ __all__ = (
     "WorkflowGraphError",
     "WorkflowState",
     "decode_frame",
+    "default_build_packet_envelope",
+    "default_build_round_envelope",
+    "default_build_text_envelope",
     "default_evaluators",
+    "default_extract_turn_input",
     "default_handler",
     "default_handlers",
+    "default_render_envelope",
+    "default_tools_for",
     "encode_frame",
     "make_id",
     "parse_duration",

--- a/autogen/beta/network/adapters/__init__.py
+++ b/autogen/beta/network/adapters/__init__.py
@@ -15,7 +15,17 @@ bidirectional), ``DiscussionAdapter`` (multi-party round-robin), and
 ``WorkflowAdapter`` (transition-graph orchestration).
 """
 
-from .base import AdapterResult, AdapterState, ChannelAdapter
+from .base import (
+    AdapterResult,
+    AdapterState,
+    ChannelAdapter,
+    default_build_packet_envelope,
+    default_build_round_envelope,
+    default_build_text_envelope,
+    default_extract_turn_input,
+    default_render_envelope,
+    default_tools_for,
+)
 from .consulting import CONSULTING_TYPE, ConsultingAdapter, ConsultingState
 from .conversation import CONVERSATION_TYPE, ConversationAdapter, ConversationState
 from .discussion import (
@@ -43,4 +53,10 @@ __all__ = (
     "DiscussionState",
     "WorkflowAdapter",
     "WorkflowState",
+    "default_build_packet_envelope",
+    "default_build_round_envelope",
+    "default_build_text_envelope",
+    "default_extract_turn_input",
+    "default_render_envelope",
+    "default_tools_for",
 )

--- a/autogen/beta/network/adapters/base.py
+++ b/autogen/beta/network/adapters/base.py
@@ -13,6 +13,20 @@ Key invariants:
 * ``fold`` is called once per WAL append by the hub, and called
   repeatedly during ``Hub.hydrate()`` to rebuild state from disk. It
   must be a pure function.
+
+Three layers of surface per adapter:
+
+* **Capabilities** — what the hub calls (``validate_create`` /
+  ``validate_send`` / ``fold`` / ``on_accepted`` / ``initial_state``).
+* **Envelope helpers** (``build_text_envelope`` /
+  ``build_packet_envelope``) — pure constructors any client uses to
+  produce correctly-shaped envelopes for this adapter's protocol.
+  Framework-agnostic; not LLM-specific.
+* **LLM tools** (``tools_for``) — the AG2-LLM-facing presentation
+  layer. The default notify handler resolves these per turn and merges
+  them with the identity-level cross-cutting tools attached by
+  :class:`NetworkPlugin`. Adapters that take no LLM input (e.g.
+  workflow, where handoff tools are user-authored) return ``[]``.
 """
 
 from dataclasses import dataclass
@@ -21,22 +35,28 @@ from typing import TYPE_CHECKING, Protocol
 from autogen.beta.events import Input
 
 from ..channel import ChannelManifest, ChannelMetadata, ChannelState
-from ..envelope import EV_TEXT, Envelope
+from ..envelope import EV_PACKET, EV_TEXT, Envelope
+from ..handoff import Handoff
 from ..views.base import ViewPolicy
 
 if TYPE_CHECKING:
     from autogen.beta.agent import AgentReply
     from autogen.beta.events import BaseEvent
+    from autogen.beta.tools import Tool
 
+    from ..client.agent_client import AgentClient
     from ..hub.core import Hub
 
 __all__ = (
     "AdapterResult",
     "AdapterState",
     "ChannelAdapter",
+    "default_build_packet_envelope",
     "default_build_round_envelope",
+    "default_build_text_envelope",
     "default_extract_turn_input",
     "default_render_envelope",
+    "default_tools_for",
 )
 
 
@@ -171,6 +191,67 @@ class ChannelAdapter(Protocol):
         """
         ...
 
+    def tools_for(
+        self,
+        client: "AgentClient",
+        metadata: ChannelMetadata,
+        state: AdapterState,
+        participant_id: str,
+    ) -> "list[Tool]":
+        """Return the LLM tools this adapter offers a participant.
+
+        Resolved per turn by the default notify handler and merged
+        into the per-call ``tools=`` override passed to ``agent.ask``.
+        Adapters that take no LLM input (e.g. workflow, where handoff
+        tools are user-authored) return ``[]``.
+
+        Adapters gate on ``state`` and ``participant_id`` — e.g. the
+        discussion adapter offers ``say`` only when it is this
+        participant's round; consulting offers ``say`` only to the
+        participant whose turn it is in the 1Q1R handshake.
+        """
+        ...
+
+    def build_text_envelope(
+        self,
+        channel_id: str,
+        sender_id: str,
+        text: str,
+        *,
+        audience: list[str] | None = None,
+        causation_id: str | None = None,
+    ) -> Envelope:
+        """Construct an ``EV_TEXT`` envelope shaped for this adapter.
+
+        Layer-2 helper — any client (AG2 ``AgentClient``, ``HumanClient``,
+        non-AG2 bridge) uses this to build correctly-shaped envelopes
+        without going through the LLM tool decorator system. Default
+        impl (``default_build_text_envelope``) is what consulting /
+        conversation / discussion adapters use; workflow overrides to
+        wrap text in ``EV_PACKET``.
+        """
+        ...
+
+    def build_packet_envelope(
+        self,
+        channel_id: str,
+        sender_id: str,
+        body: str,
+        *,
+        handoff: "Handoff | None" = None,
+        context_set: dict | None = None,
+        audience: list[str] | None = None,
+        causation_id: str | None = None,
+    ) -> Envelope:
+        """Construct an ``EV_PACKET`` envelope shaped for this adapter.
+
+        Layer-2 helper. Workflow uses ``handoff`` / ``context_set`` to
+        encode routing + variable mutations into one atomic round
+        capture; other adapters typically delegate to
+        ``default_build_packet_envelope`` (no handoff, no context_set).
+        """
+        ...
+
 
 def default_extract_turn_input(envelope: Envelope) -> str | None:
     """Default ``extract_turn_input``: decode ``EV_TEXT`` only.
@@ -222,3 +303,71 @@ def default_render_envelope(envelope: Envelope) -> str | None:
         text = envelope.event_data.get("text", "")
         return text if isinstance(text, str) else None
     return None
+
+
+def default_tools_for(
+    client: "AgentClient",
+    metadata: ChannelMetadata,
+    state: AdapterState,
+    participant_id: str,
+) -> "list[Tool]":
+    """Default ``tools_for``: return ``[]``.
+
+    Adapters that accept LLM-driven sends override to return the
+    appropriate per-channel tool set (e.g. ``[make_say_tool(client)]``
+    for free-form text channels).
+    """
+    return []
+
+
+def default_build_text_envelope(
+    channel_id: str,
+    sender_id: str,
+    text: str,
+    *,
+    audience: list[str] | None = None,
+    causation_id: str | None = None,
+) -> Envelope:
+    """Default ``build_text_envelope``: emit ``EV_TEXT(text)``."""
+    return Envelope(
+        channel_id=channel_id,
+        sender_id=sender_id,
+        audience=audience,
+        event_type=EV_TEXT,
+        event_data={"text": text},
+        causation_id=causation_id,
+    )
+
+
+def default_build_packet_envelope(
+    channel_id: str,
+    sender_id: str,
+    body: str,
+    *,
+    handoff: "Handoff | None" = None,
+    context_set: dict | None = None,
+    audience: list[str] | None = None,
+    causation_id: str | None = None,
+) -> Envelope:
+    """Default ``build_packet_envelope``: emit ``EV_PACKET`` with body +
+    optional routing.
+
+    ``routing`` carries ``{"kind": "handoff", "target": ..., "reason": ...}``
+    when ``handoff`` is set. ``context_set`` populates ``context``.
+    """
+    event_data: dict[str, object] = {"body": body}
+    if handoff is not None:
+        routing: dict[str, object] = {"kind": "handoff", "target": handoff.target}
+        if handoff.reason:
+            routing["reason"] = handoff.reason
+        event_data["routing"] = routing
+    if context_set:
+        event_data["context"] = dict(context_set)
+    return Envelope(
+        channel_id=channel_id,
+        sender_id=sender_id,
+        audience=audience,
+        event_type=EV_PACKET,
+        event_data=event_data,
+        causation_id=causation_id,
+    )

--- a/autogen/beta/network/adapters/consulting.py
+++ b/autogen/beta/network/adapters/consulting.py
@@ -44,7 +44,9 @@ from ..views.base import ViewPolicy
 from ..views.builtin import FullTranscript
 from .base import (
     AdapterResult,
+    default_build_packet_envelope,
     default_build_round_envelope,
+    default_build_text_envelope,
     default_extract_turn_input,
     default_render_envelope,
 )
@@ -234,3 +236,51 @@ class ConsultingAdapter:
 
     def render_envelope(self, envelope):
         return default_render_envelope(envelope)
+
+    def tools_for(self, client, metadata, state, participant_id):
+        """Consulting offers ``say`` to the participant whose turn it is.
+
+        State gating: the initiator has the floor until they send the
+        prompt; the respondent has the floor after the prompt lands and
+        before they reply. Once the respondent replies the channel
+        auto-closes — no further turns.
+        """
+        # Late import to avoid a client→adapters→client cycle at module
+        # import time. Tools live in client/ because they bind to
+        # ``AgentClient``; adapters live one layer lower in the import
+        # graph.
+        from ..client.tools.say import make_say_tool  # noqa: PLC0415
+
+        initiator_id = next(
+            (p.agent_id for p in metadata.participants if p.role == ParticipantRole.INITIATOR),
+            None,
+        )
+        if participant_id == initiator_id and not state.initiator_sent:
+            return [make_say_tool(client)]
+        if participant_id != initiator_id and state.initiator_sent and not state.respondent_replied:
+            return [make_say_tool(client)]
+        return []
+
+    def build_text_envelope(self, channel_id, sender_id, text, *, audience=None, causation_id=None):
+        return default_build_text_envelope(channel_id, sender_id, text, audience=audience, causation_id=causation_id)
+
+    def build_packet_envelope(
+        self,
+        channel_id,
+        sender_id,
+        body,
+        *,
+        handoff=None,
+        context_set=None,
+        audience=None,
+        causation_id=None,
+    ):
+        return default_build_packet_envelope(
+            channel_id,
+            sender_id,
+            body,
+            handoff=handoff,
+            context_set=context_set,
+            audience=audience,
+            causation_id=causation_id,
+        )

--- a/autogen/beta/network/adapters/consulting.py
+++ b/autogen/beta/network/adapters/consulting.py
@@ -29,6 +29,7 @@ from ..channel import (
     ParticipantRole,
     ParticipantSchema,
 )
+from ..client.tools.say import make_say_tool
 from ..envelope import (
     EV_CHANNEL_CLOSED,
     EV_CHANNEL_EXPIRED,
@@ -102,6 +103,13 @@ class ConsultingAdapter:
     def __init__(self) -> None:
         # __init__ stores params; manifest is a class-level constant
         # constructed once.
+        # Per-client say-tool cache: avoids paying the ``fast_depends``
+        # JSON-schema build cost on every notify-handler turn. Keyed by
+        # ``client.agent_id`` (stable across the client's lifetime). An
+        # unregister + re-register yields a new agent_id, so the dead
+        # entry from the prior generation is leaked memory bounded by
+        # the total registration count — acceptable for V1.
+        self._say_tool_cache: dict[str, object] = {}
         self.manifest = ChannelManifest(
             type=CONSULTING_TYPE,
             version=1,
@@ -244,22 +252,35 @@ class ConsultingAdapter:
         prompt; the respondent has the floor after the prompt lands and
         before they reply. Once the respondent replies the channel
         auto-closes — no further turns.
-        """
-        # Late import to avoid a client→adapters→client cycle at module
-        # import time. Tools live in client/ because they bind to
-        # ``AgentClient``; adapters live one layer lower in the import
-        # graph.
-        from ..client.tools.say import make_say_tool  # noqa: PLC0415
 
+        The resolved tool is memoized per-client on the adapter (see
+        :meth:`_cached_say_tool`) so the per-turn ``fast_depends`` schema
+        build cost is paid once.
+        """
         initiator_id = next(
             (p.agent_id for p in metadata.participants if p.role == ParticipantRole.INITIATOR),
             None,
         )
         if participant_id == initiator_id and not state.initiator_sent:
-            return [make_say_tool(client)]
+            return [self._cached_say_tool(client)]
         if participant_id != initiator_id and state.initiator_sent and not state.respondent_replied:
-            return [make_say_tool(client)]
+            return [self._cached_say_tool(client)]
         return []
+
+    def _cached_say_tool(self, client):
+        """Memoize the per-client ``say`` tool.
+
+        The ``fast_depends`` schema build inside the ``@tool`` decorator
+        is not free; building the tool fresh on every notify-handler
+        turn would dominate per-turn latency at scale. Cache by
+        ``client.agent_id`` (stable for the client's lifetime).
+        """
+        cached = self._say_tool_cache.get(client.agent_id)
+        if cached is not None:
+            return cached
+        tool = make_say_tool(client)
+        self._say_tool_cache[client.agent_id] = tool
+        return tool
 
     def build_text_envelope(self, channel_id, sender_id, text, *, audience=None, causation_id=None):
         return default_build_text_envelope(channel_id, sender_id, text, audience=audience, causation_id=causation_id)

--- a/autogen/beta/network/adapters/conversation.py
+++ b/autogen/beta/network/adapters/conversation.py
@@ -42,7 +42,9 @@ from ..views.base import ViewPolicy
 from ..views.builtin import WindowedSummary
 from .base import (
     AdapterResult,
+    default_build_packet_envelope,
     default_build_round_envelope,
+    default_build_text_envelope,
     default_extract_turn_input,
     default_render_envelope,
 )
@@ -183,3 +185,34 @@ class ConversationAdapter:
 
     def render_envelope(self, envelope):
         return default_render_envelope(envelope)
+
+    def tools_for(self, client, metadata, state, participant_id):
+        """Conversation has no turn order — both participants always
+        see ``say``."""
+        from ..client.tools.say import make_say_tool  # noqa: PLC0415
+
+        return [make_say_tool(client)]
+
+    def build_text_envelope(self, channel_id, sender_id, text, *, audience=None, causation_id=None):
+        return default_build_text_envelope(channel_id, sender_id, text, audience=audience, causation_id=causation_id)
+
+    def build_packet_envelope(
+        self,
+        channel_id,
+        sender_id,
+        body,
+        *,
+        handoff=None,
+        context_set=None,
+        audience=None,
+        causation_id=None,
+    ):
+        return default_build_packet_envelope(
+            channel_id,
+            sender_id,
+            body,
+            handoff=handoff,
+            context_set=context_set,
+            audience=audience,
+            causation_id=causation_id,
+        )

--- a/autogen/beta/network/adapters/conversation.py
+++ b/autogen/beta/network/adapters/conversation.py
@@ -27,6 +27,7 @@ from ..channel import (
     ParticipantRole,
     ParticipantSchema,
 )
+from ..client.tools.say import make_say_tool
 from ..envelope import (
     EV_CHANNEL_CLOSED,
     EV_CHANNEL_EXPIRED,
@@ -97,6 +98,7 @@ class ConversationAdapter:
     """
 
     def __init__(self) -> None:
+        self._say_tool_cache: dict[str, object] = {}
         self.manifest = ChannelManifest(
             type=CONVERSATION_TYPE,
             version=1,
@@ -188,10 +190,18 @@ class ConversationAdapter:
 
     def tools_for(self, client, metadata, state, participant_id):
         """Conversation has no turn order — both participants always
-        see ``say``."""
-        from ..client.tools.say import make_say_tool  # noqa: PLC0415
+        see ``say``. Tool resolution is memoized per-client.
+        """
+        return [self._cached_say_tool(client)]
 
-        return [make_say_tool(client)]
+    def _cached_say_tool(self, client):
+        """Memoize ``make_say_tool`` per ``client.agent_id``."""
+        cached = self._say_tool_cache.get(client.agent_id)
+        if cached is not None:
+            return cached
+        tool = make_say_tool(client)
+        self._say_tool_cache[client.agent_id] = tool
+        return tool
 
     def build_text_envelope(self, channel_id, sender_id, text, *, audience=None, causation_id=None):
         return default_build_text_envelope(channel_id, sender_id, text, audience=audience, causation_id=causation_id)

--- a/autogen/beta/network/adapters/discussion.py
+++ b/autogen/beta/network/adapters/discussion.py
@@ -38,7 +38,9 @@ from ..views.base import ViewPolicy
 from ..views.builtin import WindowedSummary
 from .base import (
     AdapterResult,
+    default_build_packet_envelope,
     default_build_round_envelope,
+    default_build_text_envelope,
     default_extract_turn_input,
     default_render_envelope,
 )
@@ -209,3 +211,36 @@ class DiscussionAdapter:
 
     def render_envelope(self, envelope):
         return default_render_envelope(envelope)
+
+    def tools_for(self, client, metadata, state, participant_id):
+        """Discussion offers ``say`` only when it is this participant's
+        round (round-robin ordering)."""
+        from ..client.tools.say import make_say_tool  # noqa: PLC0415
+
+        if state.expected_next_speaker == participant_id:
+            return [make_say_tool(client)]
+        return []
+
+    def build_text_envelope(self, channel_id, sender_id, text, *, audience=None, causation_id=None):
+        return default_build_text_envelope(channel_id, sender_id, text, audience=audience, causation_id=causation_id)
+
+    def build_packet_envelope(
+        self,
+        channel_id,
+        sender_id,
+        body,
+        *,
+        handoff=None,
+        context_set=None,
+        audience=None,
+        causation_id=None,
+    ):
+        return default_build_packet_envelope(
+            channel_id,
+            sender_id,
+            body,
+            handoff=handoff,
+            context_set=context_set,
+            audience=audience,
+            causation_id=causation_id,
+        )

--- a/autogen/beta/network/adapters/discussion.py
+++ b/autogen/beta/network/adapters/discussion.py
@@ -23,6 +23,7 @@ from ..channel import (
     Expectation,
     ParticipantSchema,
 )
+from ..client.tools.say import make_say_tool
 from ..envelope import (
     EV_CHANNEL_CLOSED,
     EV_CHANNEL_EXPIRED,
@@ -111,6 +112,7 @@ class DiscussionAdapter:
     """
 
     def __init__(self) -> None:
+        self._say_tool_cache: dict[str, object] = {}
         self.manifest = ChannelManifest(
             type=DISCUSSION_TYPE,
             version=1,
@@ -214,12 +216,21 @@ class DiscussionAdapter:
 
     def tools_for(self, client, metadata, state, participant_id):
         """Discussion offers ``say`` only when it is this participant's
-        round (round-robin ordering)."""
-        from ..client.tools.say import make_say_tool  # noqa: PLC0415
-
+        round (round-robin ordering). Tool resolution is memoized
+        per-client to avoid per-turn schema rebuild.
+        """
         if state.expected_next_speaker == participant_id:
-            return [make_say_tool(client)]
+            return [self._cached_say_tool(client)]
         return []
+
+    def _cached_say_tool(self, client):
+        """Memoize ``make_say_tool`` per ``client.agent_id``."""
+        cached = self._say_tool_cache.get(client.agent_id)
+        if cached is not None:
+            return cached
+        tool = make_say_tool(client)
+        self._say_tool_cache[client.agent_id] = tool
+        return tool
 
     def build_text_envelope(self, channel_id, sender_id, text, *, audience=None, causation_id=None):
         return default_build_text_envelope(channel_id, sender_id, text, audience=audience, causation_id=causation_id)

--- a/autogen/beta/network/adapters/workflow.py
+++ b/autogen/beta/network/adapters/workflow.py
@@ -62,7 +62,13 @@ from ..transitions import (
 )
 from ..views.base import ViewPolicy
 from ..views.builtin import WindowedSummary
-from .base import AdapterResult, default_render_envelope
+from .base import (
+    AdapterResult,
+    default_build_packet_envelope,
+    default_build_text_envelope,
+    default_render_envelope,
+    default_tools_for,
+)
 
 if TYPE_CHECKING:
     from autogen.beta.agent import AgentReply
@@ -393,6 +399,46 @@ class WorkflowAdapter:
         if envelope.event_type == EV_PACKET:
             return _packet_text(envelope)
         return default_render_envelope(envelope)
+
+    def tools_for(self, client, metadata, state, participant_id):
+        """Workflow offers no adapter-level tools.
+
+        Handoff routing is encoded by user-authored ``@tool`` functions
+        that return :class:`Handoff(target=, reason=)`. The handler
+        merges those tools (already on ``agent.tools``) with the
+        identity-level ``NetworkPlugin`` set; the workflow adapter
+        itself contributes nothing.
+        """
+        return default_tools_for(client, metadata, state, participant_id)
+
+    def build_text_envelope(self, channel_id, sender_id, text, *, audience=None, causation_id=None):
+        """Workflow accepts text seeds (e.g. for an initiator's first
+        turn) as plain ``EV_TEXT`` — the adapter folds them into the
+        round-end packet downstream."""
+        return default_build_text_envelope(channel_id, sender_id, text, audience=audience, causation_id=causation_id)
+
+    def build_packet_envelope(
+        self,
+        channel_id,
+        sender_id,
+        body,
+        *,
+        handoff=None,
+        context_set=None,
+        audience=None,
+        causation_id=None,
+    ):
+        """Workflow's native round-end shape — handoff + context_set
+        live in ``routing`` / ``context`` fields."""
+        return default_build_packet_envelope(
+            channel_id,
+            sender_id,
+            body,
+            handoff=handoff,
+            context_set=context_set,
+            audience=audience,
+            causation_id=causation_id,
+        )
 
     # ── Internals ───────────────────────────────────────────────────────────
 

--- a/autogen/beta/network/client/handlers.py
+++ b/autogen/beta/network/client/handlers.py
@@ -189,9 +189,7 @@ async def _process_substantive(envelope: Envelope, client: "AgentClient") -> Non
         state = client._hub_client.adapter_state(metadata.channel_id)
         adapter_tools: list = []
         try:
-            adapter_tools = list(
-                adapter.tools_for(client, metadata, state, client.agent_id)
-            )
+            adapter_tools = list(adapter.tools_for(client, metadata, state, client.agent_id))
         except Exception:
             logger.exception(
                 "adapter.tools_for raised: channel=%s adapter=%s",

--- a/autogen/beta/network/client/handlers.py
+++ b/autogen/beta/network/client/handlers.py
@@ -129,6 +129,13 @@ async def _process_substantive(envelope: Envelope, client: "AgentClient") -> Non
     ``adapter.build_round_envelope`` so this handler stays free of
     adapter-specific knowledge.
 
+    Per-turn LLM tools come from ``adapter.tools_for(client, metadata,
+    state, participant_id)``. Identity-level tools (``peers`` /
+    ``channels`` / ``tasks`` / ``context`` / ``delegate``) live on
+    ``agent.tools`` via ``NetworkPlugin``; adapter-scoped tools (e.g.
+    ``say`` for consulting / conversation / discussion) merge in
+    per-call via ``agent.ask(tools=...)``.
+
     The full turn-processing path — channel resolution, view projection,
     adapter input extraction, ``agent.ask``, round-envelope construction,
     outbound send — is wrapped in one try/except. On exception the
@@ -175,6 +182,23 @@ async def _process_substantive(envelope: Envelope, client: "AgentClient") -> Non
 
         dependencies = stamp_dependencies(client, channel)
 
+        # Adapter-scoped LLM tools for this turn (e.g. ``say`` for
+        # consulting / discussion). Resolution is cached on the adapter
+        # so the schema build cost is paid once per (adapter, client)
+        # — see ``ChannelAdapter.tools_for`` default implementation.
+        state = client._hub_client.adapter_state(metadata.channel_id)
+        adapter_tools: list = []
+        try:
+            adapter_tools = list(
+                adapter.tools_for(client, metadata, state, client.agent_id)
+            )
+        except Exception:
+            logger.exception(
+                "adapter.tools_for raised: channel=%s adapter=%s",
+                envelope.channel_id,
+                type(adapter).__name__,
+            )
+
         # Attach the TaskMirror for the duration of the LLM turn so any
         # ``agent.task(...)`` (typically via the ``tasks(action="start")``
         # tool) surfaces ``ag2.task.*`` envelopes to the hub and triggers
@@ -190,11 +214,14 @@ async def _process_substantive(envelope: Envelope, client: "AgentClient") -> Non
                 current_input,
                 stream=stream,
                 dependencies=dependencies,
+                tools=adapter_tools,
             )
 
             # Adapter encodes the round-end envelope.
             # For example, Workflow returns EV_PACKET.
             # Default implementations returns EV_TEXT(body) or None.
+            # State may have advanced inside the LLM turn (e.g. an
+            # ``EV_CONTEXT_SET`` fold) — re-read here.
             state = client._hub_client.adapter_state(metadata.channel_id)
             events = list(await stream.history.get_events())
             out_envelope = adapter.build_round_envelope(

--- a/autogen/beta/network/client/hub_client.py
+++ b/autogen/beta/network/client/hub_client.py
@@ -357,6 +357,15 @@ class HubClient:
             exc=exc,
         )
 
+    async def fire_task_event(self, task_id: str, kind: str, payload: dict) -> None:
+        """Fan out an ``on_task_event`` through the hub's listener chain.
+
+        Public surface so :class:`TaskMirror` and other tenant
+        observers can emit task-lifecycle events without touching the
+        hub's private fan-out method.
+        """
+        await self._hub.fire_task_event(task_id, kind, payload)
+
     async def read_wal(self, channel_id: str, *, since: int = 0, until: int | None = None) -> list[Envelope]:
         return await self._hub.read_wal(channel_id, since=since, until=until)
 

--- a/autogen/beta/network/client/plugin.py
+++ b/autogen/beta/network/client/plugin.py
@@ -4,14 +4,22 @@
 
 """``NetworkPlugin`` — attaches the network tool surface to an ``Agent``.
 
-* Adds the network tools (``say``, ``delegate``, ``peers``,
-  ``channels``, ``tasks``, ``context``) to ``agent.tools``.
-* Appends ``NetworkContextPolicy`` to the agent's assembly chain so
-  every LLM call sees a "you are <name>" prefix plus the available
-  tool names.
+Two streams of LLM tools compose into an agent's tool list per turn:
 
-Plugins are first-class in beta (``autogen/beta/agent.py`` ``Plugin``
-class). The network plugin uses the existing slot.
+* **Identity-level** (attached by ``NetworkPlugin`` once at registration,
+  always available): ``peers`` / ``channels`` / ``tasks`` / ``context`` /
+  ``delegate``. Cross-cutting verbs that work in any channel — discovery,
+  channel lifecycle, task observation, and the one-shot ``delegate``
+  convenience that opens its own consulting channel.
+
+* **Channel-level** (resolved per turn by the default notify handler
+  via ``adapter.tools_for(...)``): ``say`` for adapters that accept
+  free-form text (consulting / conversation / discussion), user-authored
+  handoff tools for workflow. Adapter-provided tools merge into the
+  ``tools=`` override passed to ``agent.ask``.
+
+The plugin appends ``NetworkContextPolicy`` to the agent's assembly
+chain so every LLM call sees a "you are <name>" prefix.
 """
 
 from typing import TYPE_CHECKING
@@ -25,7 +33,6 @@ from .tools import (
     make_context_tool,
     make_delegate_tool,
     make_peers_tool,
-    make_say_tool,
     make_tasks_tool,
 )
 
@@ -41,7 +48,9 @@ __all__ = ("NetworkContextPolicy", "NetworkPlugin")
 class NetworkContextPolicy:
     """Assembly policy: prepends a network-aware prefix to every LLM call.
 
-    Names the agent and lists its network tools.
+    Names the agent. The per-turn tool list is dynamic (identity-level
+    set + adapter-provided set merged by the handler) so the prefix
+    doesn't enumerate tools — the LLM sees them in its tools array.
     """
 
     name = "network_context"
@@ -56,27 +65,29 @@ class NetworkContextPolicy:
         events: list[BaseEvent],
         context: "Context",
     ) -> tuple[list[str], list[BaseEvent]]:
-        prefix = (
-            f"You are {self._client.passport.name} "
-            f"(agent_id: {self._client.agent_id}).\n"
-            "Network tools: say, delegate, peers, channels, tasks, context."
-        )
+        prefix = f"You are {self._client.passport.name} (agent_id: {self._client.agent_id})."
         return [prefix, *prompts], events
 
 
 class NetworkPlugin(Plugin):
     """Attaches an Agent to a network.
 
-    Adds ``say`` and ``delegate`` to ``agent.tools`` so the LLM sees
-    them on every turn — the verbs are stable for the life of the
-    registration. Also appends ``NetworkContextPolicy`` to the agent's
-    assembly chain.
+    Adds the identity-level cross-cutting tools to ``agent.tools``:
+    ``peers`` / ``channels`` / ``tasks`` / ``context`` / ``delegate``.
+    These are stable for the life of the registration and work in any
+    channel context.
+
+    Channel-level tools (``say``, workflow handoff tools) are NOT
+    attached here — they come from ``adapter.tools_for(...)``, resolved
+    per turn by the default notify handler and merged into
+    ``agent.ask(tools=...)``. This keeps protocol-specific verbs out of
+    an agent's tool list when they don't apply (e.g. ``say`` is hidden
+    from workflow participants who must use handoff tools).
     """
 
     def __init__(self, client: "AgentClient") -> None:
         super().__init__(
             tools=[
-                make_say_tool(client),
                 make_delegate_tool(client),
                 make_peers_tool(client),
                 make_channels_tool(client),

--- a/autogen/beta/network/client/tools/channels.py
+++ b/autogen/beta/network/client/tools/channels.py
@@ -66,6 +66,7 @@ def make_channels_tool(agent_client: "AgentClient") -> object:
         knobs: dict | None = None,
         intent: str | None = None,
         ttl: str | int | None = None,
+        message: str | None = None,
         channel_id: str | None = None,
         state: Literal["active", "all"] = "active",
         client: AgentClientInject = None,
@@ -74,7 +75,11 @@ def make_channels_tool(agent_client: "AgentClient") -> object:
         """Channel lifecycle.
 
         ``list``:  args state="active"|"all"
-        ``open``:  args type, target, knobs?, intent?, ttl?
+        ``open``:  args type, target, knobs?, intent?, ttl?, message?
+                   ``message`` seeds the first envelope on the
+                   initiator's behalf after the channel transitions
+                   to ``OPENED`` — useful for short-lived channels
+                   where the initiator wants to atomically open + send.
         ``info``:  args channel_id
         ``close``: args channel_id? (defaults to current)
         """
@@ -107,11 +112,20 @@ def make_channels_tool(agent_client: "AgentClient") -> object:
                 )
             except Exception as exc:
                 return f"Error: open failed: {exc}"
-            return {
+            seeded_envelope_id: str | None = None
+            if message:
+                try:
+                    seeded_envelope_id = await channel.send(message)
+                except Exception as exc:
+                    return f"Error: seed send failed: {exc}"
+            result: dict = {
                 "channel_id": channel.channel_id,
                 "type": type,
                 "participants": [p.agent_id for p in channel.metadata.participants],
             }
+            if seeded_envelope_id:
+                result["seed_envelope_id"] = seeded_envelope_id
+            return result
 
         if action == "info":
             if not channel_id:

--- a/autogen/beta/network/client/tools/channels.py
+++ b/autogen/beta/network/client/tools/channels.py
@@ -15,6 +15,7 @@ The grouped surface keeps the LLM's tool list short — discovery,
 state, and lifecycle live behind one tool.
 """
 
+import contextlib
 from typing import TYPE_CHECKING, Any, Literal
 
 from autogen.beta.tools import tool
@@ -117,6 +118,11 @@ def make_channels_tool(agent_client: "AgentClient") -> object:
                 try:
                     seeded_envelope_id = await channel.send(message)
                 except Exception as exc:
+                    # Rollback so we deliver atomic-ish semantics: a
+                    # failed seed should not leave a dangling-open
+                    # channel that no one ever sends into.
+                    with contextlib.suppress(Exception):
+                        await hub.close_channel(channel.channel_id, reason="seed_failed")
                     return f"Error: seed send failed: {exc}"
             result: dict = {
                 "channel_id": channel.channel_id,

--- a/autogen/beta/network/client/tools/say.py
+++ b/autogen/beta/network/client/tools/say.py
@@ -9,6 +9,10 @@ notify-handler context). ``channel_id`` overrides for the rare case
 the LLM wants to post into a different channel it's also a participant
 of. ``audience`` is a list of agent **names**; the tool resolves them
 to ids via the hub. ``audience=None`` broadcasts within the channel.
+
+Envelope construction goes through ``adapter.build_text_envelope`` so
+the produced envelope is shaped for the channel's adapter — the same
+helper a non-AG2 bridge would call to drive a turn manually.
 """
 
 from typing import TYPE_CHECKING
@@ -49,10 +53,14 @@ def make_say_tool(agent_client: "AgentClient") -> object:
         ``audience``: list of peer **names**. ``None`` broadcasts within
         the channel. The tool resolves names to agent ids via the hub.
 
+        Envelope shape comes from ``adapter.build_text_envelope`` so
+        per-adapter customization (e.g. an adapter that wraps text in
+        a richer event shape) is honored automatically.
+
         Returns the hub-stamped envelope_id, or an error string if the
         send fails.
         """
-        # Resolve the channel handle.
+        # Resolve the channel handle + metadata.
         target_channel = channel
         actual_client = client if client is not None else agent_client
 
@@ -78,8 +86,23 @@ def make_say_tool(agent_client: "AgentClient") -> object:
                     return f"Error: peer {name!r} has no agent_id"
                 audience_ids.append(passport.agent_id)
 
+        # Build the envelope through the adapter's Layer-2 helper so the
+        # tool produces the same shape a hand-written bridge would. The
+        # adapter is fetched from the public HubClient surface — the
+        # tool never reaches into hub internals.
         try:
-            envelope_id = await target_channel.send(content, audience=audience_ids)
+            adapter = actual_client._hub_client.adapter_for(target_channel.channel_id)
+        except Exception as exc:
+            return f"Error: adapter unavailable for channel {target_channel.channel_id!r}: {exc}"
+        envelope = adapter.build_text_envelope(
+            channel_id=target_channel.channel_id,
+            sender_id=actual_client.agent_id,
+            text=content,
+            audience=audience_ids,
+        )
+
+        try:
+            envelope_id = await actual_client.send_envelope(envelope)
         except Exception as exc:
             return f"Error: send failed: {exc}"
         return f"posted envelope {envelope_id}"

--- a/autogen/beta/network/hub/core.py
+++ b/autogen/beta/network/hub/core.py
@@ -426,6 +426,12 @@ class Hub:
 
         Re-registering at the same ``name`` raises ``ValueError`` — use
         :meth:`unregister_sweeper` first if you mean to replace.
+
+        Sync vs. async: ``register_sweeper`` is synchronous because it
+        only updates internal bookkeeping (and may call the underlying
+        ``_IntervalSweeper.start`` which schedules a fire-and-forget
+        task). :meth:`unregister_sweeper` is async because it awaits the
+        sweeper's task cancellation to ensure clean shutdown.
         """
         if name in self._custom_sweepers:
             raise ValueError(f"sweeper already registered: {name!r}")
@@ -438,7 +444,14 @@ class Hub:
             sweeper.start()
 
     async def unregister_sweeper(self, name: str) -> None:
-        """Stop and remove a custom sweeper. No-op if absent."""
+        """Stop and remove a custom sweeper. No-op if absent.
+
+        Async to mirror :meth:`_IntervalSweeper.stop`, which awaits
+        cancellation of the running task. Custom sweepers registered
+        before :meth:`start` still go through this path on
+        :meth:`close`, so subclasses don't need to track them
+        themselves.
+        """
         sweeper = self._custom_sweepers.pop(name, None)
         if sweeper is not None:
             await sweeper.stop()
@@ -507,6 +520,24 @@ class Hub:
             envelope_id,
             exc,
         )
+
+    async def fire_task_event(
+        self,
+        task_id: str,
+        kind: str,
+        payload: dict,
+    ) -> None:
+        """Fan out an ``on_task_event`` to every listener.
+
+        Public entry point so :class:`TaskMirror` (and other tenant
+        observers) can route task-side notifications through the hub's
+        listener surface without touching ``_fan_out``. ``kind`` is
+        free-form — the built-in listener Protocol documents
+        ``"started"`` / ``"progress"`` / ``"completed"`` / ``"failed"`` /
+        ``"expired"`` / ``"cancelled"`` / ``"mirror_failed"`` as the
+        recognised values, but tenants may emit additional kinds.
+        """
+        await self._fan_out("on_task_event", task_id, kind, payload)
 
     @property
     def audit_log(self) -> AuditLog:
@@ -1876,9 +1907,11 @@ class Hub:
             # don't hang until invite_ack_timeout when the sweeper /
             # auto_close handler closes a PENDING channel out-of-band.
             if was_pending:
-                waiter = self._channel_open_waiters.get(channel_id)
+                waiter = self._channel_open_waiters.pop(channel_id, None)
                 if waiter is not None and not waiter.done():
                     waiter.set_exception(ProtocolError(f"channel {channel_id!r} closed during handshake: {reason}"))
+            else:
+                self._channel_open_waiters.pop(channel_id, None)
 
         await self._persist_channel_metadata(metadata)
 
@@ -1904,6 +1937,16 @@ class Hub:
                 kind_label,
                 {"reason": reason, "metadata": metadata, "at": metadata.closed_at},
             )
+
+            # Bound long-lived hub memory: drop per-channel synchronization
+            # primitives that are meaningless once the channel is terminal.
+            # ``_adapter_states`` is intentionally retained — fold state has
+            # analytical value (tests, debug tools, future re-fold checks)
+            # and is a single dataclass per channel; only the heavier
+            # ``asyncio.Lock`` is released. Done AFTER the close-envelope
+            # WAL append + dispatch so we don't accidentally re-create
+            # the lock we are trying to clean up.
+            self._channel_locks.pop(channel_id, None)
         # ACTIVE state transitions originate from ``_activate_channel``
         # which fires the ``opened`` event directly — no need to fan
         # out again here.

--- a/autogen/beta/network/hub/core.py
+++ b/autogen/beta/network/hub/core.py
@@ -31,7 +31,7 @@ import contextlib
 import fnmatch
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 
 from autogen.beta.knowledge import KnowledgeStore
@@ -245,6 +245,13 @@ class Hub:
 
         self._ttl_sweeper: _IntervalSweeper | None = None
         self._expectation_sweeper: _IntervalSweeper | None = None
+        # Subclass-registered periodic workers. Keyed by name so a
+        # subclass can replace a sweeper at the same name (e.g. via a
+        # config reload) by unregister + re-register.
+        self._custom_sweepers: dict[str, _IntervalSweeper] = {}
+        # Set True by ``start()`` so ``register_sweeper`` knows whether
+        # to spawn the new sweeper immediately or queue it for ``start()``.
+        self._started = False
         self._closed = False
 
         # Observability + decision-making seams. Audit log is registered
@@ -354,10 +361,13 @@ class Hub:
             await self._load_task(task_id)
 
     async def start(self) -> None:
-        """Spawn the TTL + expectation sweepers. Idempotent.
+        """Spawn the TTL + expectation + custom sweepers. Idempotent.
 
         ``ttl_sweep_interval=0`` disables the TTL sweeper;
-        ``expectation_sweep_interval=0`` disables the expectation sweeper.
+        ``expectation_sweep_interval=0`` disables the expectation
+        sweeper. Custom sweepers attached via
+        :meth:`register_sweeper` start here too (registered before
+        ``start()``) or immediately at registration (after ``start()``).
         """
         if self._ttl_sweep_interval > 0 and self._ttl_sweeper is None:
             self._ttl_sweeper = _IntervalSweeper(
@@ -373,6 +383,9 @@ class Hub:
                 fn=self._expectation_tick,
             )
             self._expectation_sweeper.start()
+        for sweeper in self._custom_sweepers.values():
+            sweeper.start()
+        self._started = True
 
     async def close(self) -> None:
         """Cancel sweepers + endpoint tasks; drain queues. Idempotent."""
@@ -385,11 +398,50 @@ class Hub:
         if self._expectation_sweeper is not None:
             await self._expectation_sweeper.stop()
             self._expectation_sweeper = None
+        for sweeper in list(self._custom_sweepers.values()):
+            await sweeper.stop()
+        self._custom_sweepers.clear()
         for task in list(self._endpoint_tasks):
             task.cancel()
         if self._endpoint_tasks:
             await asyncio.gather(*self._endpoint_tasks, return_exceptions=True)
         self._endpoint_tasks.clear()
+
+    # ── Sweeper extension ───────────────────────────────────────────────────
+
+    def register_sweeper(
+        self,
+        name: str,
+        interval_seconds: float,
+        fn: Callable[[], "Awaitable[None]"],
+    ) -> None:
+        """Attach a custom periodic worker.
+
+        ``fn`` is called every ``interval_seconds``. Subclasses use this
+        for protocol-specific background work (e.g. polling a chat
+        platform's presence list, refreshing an auth token).
+
+        If ``Hub.start()`` has already run, the sweeper starts immediately.
+        Otherwise it's queued and starts when ``start()`` runs.
+
+        Re-registering at the same ``name`` raises ``ValueError`` — use
+        :meth:`unregister_sweeper` first if you mean to replace.
+        """
+        if name in self._custom_sweepers:
+            raise ValueError(f"sweeper already registered: {name!r}")
+        if interval_seconds <= 0:
+            raise ValueError(f"interval_seconds must be positive: {interval_seconds}")
+        sweeper = _IntervalSweeper(name=name, interval=interval_seconds, fn=fn)
+        self._custom_sweepers[name] = sweeper
+        if self._started:
+            # ``start()`` has already run — start this sweeper immediately.
+            sweeper.start()
+
+    async def unregister_sweeper(self, name: str) -> None:
+        """Stop and remove a custom sweeper. No-op if absent."""
+        sweeper = self._custom_sweepers.pop(name, None)
+        if sweeper is not None:
+            await sweeper.stop()
 
     async def __aenter__(self) -> "Hub":
         return self
@@ -539,12 +591,27 @@ class Hub:
         }
 
     async def _fan_out(self, method_name: str, *args: object) -> None:
-        """Call ``method_name(*args)`` on every registered listener.
+        """Call ``method_name(*args)`` on every registered listener
+        AND on the hub itself (so subclasses can override hooks
+        directly without registering themselves).
 
         Per-listener try/except — a single bad listener cannot stall
         the hub. Exceptions log at ``ERROR`` with the listener's
         class name so the offending hook is identifiable.
         """
+        # Subclass override path. Bound methods on this instance.
+        own_method = getattr(self, method_name, None)
+        # Avoid recursing — only treat it as an override if the bound
+        # method is NOT the same _fan_out method itself.
+        if own_method is not None and not method_name.startswith("_") and own_method != self._fan_out:
+            try:
+                await own_method(*args)
+            except Exception:
+                logger.exception(
+                    "%s.%s raised",
+                    type(self).__name__,
+                    method_name,
+                )
         for listener in self._listeners:
             method = getattr(listener, method_name, None)
             if method is None:
@@ -557,6 +624,51 @@ class Hub:
                     type(listener).__name__,
                     method_name,
                 )
+
+    # ── Subclass hooks ──────────────────────────────────────────────────────
+    #
+    # Default no-op implementations of the listener method set so
+    # subclasses can override directly without registering themselves
+    # as listeners. The base ``Hub`` provides empty bodies; subclass
+    # overrides run alongside any externally-registered listeners.
+
+    async def on_envelope_posted(self, envelope: Envelope, metadata: ChannelMetadata) -> None:  # noqa: ARG002
+        return None
+
+    async def on_envelope_rejected(self, envelope: Envelope, reason: NetworkError) -> None:  # noqa: ARG002
+        return None
+
+    async def on_dispatch_failed(
+        self,
+        envelope: Envelope,
+        recipient_id: str,
+        reason: BaseException,
+    ) -> None:  # noqa: ARG002
+        return None
+
+    async def on_channel_event(self, channel_id: str, kind: str, payload: dict) -> None:  # noqa: ARG002
+        return None
+
+    async def on_agent_event(self, agent_id: str, kind: str, payload: dict) -> None:  # noqa: ARG002
+        return None
+
+    async def on_expectation_fired(self, channel_id: str, expectation: object, violation: object) -> None:  # noqa: ARG002
+        return None
+
+    async def on_turn_failed(
+        self,
+        channel_id: str,
+        agent_id: str,
+        envelope_id: str,
+        exc: BaseException,
+    ) -> None:  # noqa: ARG002
+        return None
+
+    async def on_task_event(self, task_id: str, kind: str, payload: dict) -> None:  # noqa: ARG002
+        return None
+
+    async def on_inbox_pressure(self, agent_id: str, pending: int, cap: int) -> None:  # noqa: ARG002
+        return None
 
     # ── Expectation registry ────────────────────────────────────────────────
 
@@ -1609,8 +1721,10 @@ class Hub:
             if endpoint is None:
                 continue
             if substantive:
-                new_count = self._inbox_pending.get(recipient_id, 0) + 1
+                prev_count = self._inbox_pending.get(recipient_id, 0)
+                new_count = prev_count + 1
                 self._inbox_pending[recipient_id] = new_count
+                await self._maybe_fire_inbox_pressure(recipient_id, prev_count, new_count)
             try:
                 await endpoint.send_frame(NotifyFrame(envelope=envelope, recipient_id=recipient_id))
             except Exception as exc:
@@ -1622,6 +1736,30 @@ class Hub:
                     envelope.event_type,
                     exc,
                 )
+
+    async def _maybe_fire_inbox_pressure(self, recipient_id: str, prev: int, new: int) -> None:
+        """Fire ``on_inbox_pressure`` when crossing the high-water mark.
+
+        Fires exactly once per crossing — does not re-fire on every
+        subsequent envelope while above the mark. Resolves ``high_water``:
+        explicit value → that; ``None`` → 80% of ``max_pending``;
+        ``max_pending == 0`` → no signal.
+        """
+        rule = self._rules.get(recipient_id)
+        if rule is None:
+            return
+        cap = rule.limits.inbox.max_pending
+        if cap <= 0:
+            return
+        hw_config = rule.limits.inbox.high_water
+        if hw_config is None:
+            high_water = max(1, int(cap * 0.8))
+        elif hw_config <= 0:
+            return
+        else:
+            high_water = hw_config
+        if prev < high_water <= new:
+            await self._fan_out("on_inbox_pressure", recipient_id, new, cap)
 
     def _endpoint_for(self, agent_id: str) -> LinkEndpoint | None:
         endpoint_id = self._agent_to_endpoint.get(agent_id)

--- a/autogen/beta/network/rule.py
+++ b/autogen/beta/network/rule.py
@@ -84,10 +84,16 @@ class InboxBlock:
     Only ``reject`` is enforced today; ``drop_oldest`` / ``drop_newest``
     are recognised but treated as ``reject`` until the dispatch path
     grows the alternate behaviours.
+
+    ``high_water`` is a soft threshold for backpressure signalling
+    (fires :meth:`HubListener.on_inbox_pressure`). Defaults to ``None``
+    which auto-resolves to 80% of ``max_pending`` when the hub
+    evaluates pressure. ``0`` disables the signal.
     """
 
     max_pending: int = 1000
     overflow: str = "reject"  # "reject" | "drop_oldest" | "drop_newest"
+    high_water: int | None = None
 
 
 @dataclass(slots=True)

--- a/autogen/beta/network/task_mirror.py
+++ b/autogen/beta/network/task_mirror.py
@@ -154,7 +154,10 @@ class TaskMirror:
 
         Logs at ``ERROR`` and fires ``on_task_event(task_id,
         "mirror_failed", payload)`` through the hub's listeners so the
-        failure surfaces to operators / dashboards.
+        failure surfaces to operators / dashboards. Routing goes
+        through :meth:`HubClient.fire_task_event` (preferred) or
+        :meth:`Hub.fire_task_event` (direct construction in tests) —
+        both are public surfaces.
         """
         logger.error(
             "task mirror failed: op=%s task_id=%s exc=%r",
@@ -162,21 +165,18 @@ class TaskMirror:
             task_id,
             exc,
         )
-        fan_out = getattr(self._hub, "_fan_out", None) if self._hub is not None else None
-        if fan_out is not None:
-            with contextlib.suppress(Exception):
-                await fan_out(
-                    "on_task_event",
-                    task_id,
-                    "mirror_failed",
-                    {
-                        "op": op,
-                        "owner_id": self._owner_id,
-                        "channel_id": self._channel_id,
-                        "exc_type": type(exc).__name__,
-                        "exc_message": str(exc),
-                    },
-                )
+        payload = {
+            "op": op,
+            "owner_id": self._owner_id,
+            "channel_id": self._channel_id,
+            "exc_type": type(exc).__name__,
+            "exc_message": str(exc),
+        }
+        with contextlib.suppress(Exception):
+            if self._hub_client is not None:
+                await self._hub_client.fire_task_event(task_id, "mirror_failed", payload)
+            elif self._hub is not None:
+                await self._hub.fire_task_event(task_id, "mirror_failed", payload)
 
     async def _on_started(self, event: TaskStarted) -> None:
         spec = event.spec if event.spec is not None else TaskSpec(title=event.objective or "")

--- a/autogen/beta/network/task_mirror.py
+++ b/autogen/beta/network/task_mirror.py
@@ -12,6 +12,7 @@ and driven by the agent itself, and the mirror simply subscribes to
 """
 
 import contextlib
+import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -33,6 +34,9 @@ if TYPE_CHECKING:
     from .hub import Hub
 
 __all__ = ("TaskMirror",)
+
+
+logger = logging.getLogger(__name__)
 
 
 def _now_iso() -> str:
@@ -145,6 +149,35 @@ class TaskMirror:
             with contextlib.suppress(Exception):
                 stream.unsubscribe(sid)  # type: ignore[arg-type]
 
+    async def _escalate(self, task_id: str, op: str, exc: BaseException) -> None:
+        """Report a mirror-side failure without crashing the agent turn.
+
+        Logs at ``ERROR`` and fires ``on_task_event(task_id,
+        "mirror_failed", payload)`` through the hub's listeners so the
+        failure surfaces to operators / dashboards.
+        """
+        logger.error(
+            "task mirror failed: op=%s task_id=%s exc=%r",
+            op,
+            task_id,
+            exc,
+        )
+        fan_out = getattr(self._hub, "_fan_out", None) if self._hub is not None else None
+        if fan_out is not None:
+            with contextlib.suppress(Exception):
+                await fan_out(
+                    "on_task_event",
+                    task_id,
+                    "mirror_failed",
+                    {
+                        "op": op,
+                        "owner_id": self._owner_id,
+                        "channel_id": self._channel_id,
+                        "exc_type": type(exc).__name__,
+                        "exc_message": str(exc),
+                    },
+                )
+
     async def _on_started(self, event: TaskStarted) -> None:
         spec = event.spec if event.spec is not None else TaskSpec(title=event.objective or "")
         now = _now_iso()
@@ -157,8 +190,10 @@ class TaskMirror:
             started_at=now,
             channel_id=self._channel_id,
         )
-        with contextlib.suppress(Exception):
+        try:
             await self._observe(metadata)
+        except Exception as exc:
+            await self._escalate(event.task_id, "started", exc)
 
     async def _on_progress(self, event: TaskProgress) -> None:
         try:
@@ -168,8 +203,8 @@ class TaskMirror:
             )
         except NotFoundError:
             pass
-        except Exception:
-            pass
+        except Exception as exc:
+            await self._escalate(event.task_id, "progress", exc)
 
     async def _on_completed(self, event: TaskCompleted) -> None:
         try:
@@ -180,8 +215,8 @@ class TaskMirror:
             )
         except NotFoundError:
             pass
-        except Exception:
-            pass
+        except Exception as exc:
+            await self._escalate(event.task_id, "completed", exc)
         await self._record_observation_if_tagged(event.task_id, TaskState.COMPLETED)
 
     async def _on_failed(self, event: TaskFailed) -> None:
@@ -193,8 +228,8 @@ class TaskMirror:
             )
         except NotFoundError:
             pass
-        except Exception:
-            pass
+        except Exception as exc:
+            await self._escalate(event.task_id, "failed", exc)
         await self._record_observation_if_tagged(event.task_id, TaskState.FAILED)
 
     async def _on_expired(self, event: TaskExpired) -> None:
@@ -202,8 +237,8 @@ class TaskMirror:
             await self._update(event.task_id, state=TaskState.EXPIRED)
         except NotFoundError:
             pass
-        except Exception:
-            pass
+        except Exception as exc:
+            await self._escalate(event.task_id, "expired", exc)
         await self._record_observation_if_tagged(event.task_id, TaskState.EXPIRED)
 
     async def _record_observation_if_tagged(self, task_id: str, outcome: TaskState) -> None:

--- a/test/beta/network/test_adapter_tools.py
+++ b/test/beta/network/test_adapter_tools.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the adapter-owned tool surface + Layer-2 envelope helpers.
+
+* ``ChannelAdapter.tools_for`` resolves per-turn.
+* ``NetworkPlugin`` attaches only identity-level tools (no ``say``).
+* Workflow agents never see ``say``.
+* Adapter envelope helpers produce envelopes that round-trip through
+  ``Hub.post_envelope``.
+* ``channels(action="open", message=...)`` seeds the first envelope.
+"""
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.knowledge import MemoryKnowledgeStore
+from autogen.beta.network import (
+    EV_PACKET,
+    EV_TEXT,
+    Handoff,
+    Hub,
+    HubClient,
+    LocalLink,
+    Passport,
+    Resume,
+)
+from autogen.beta.network.adapters.consulting import ConsultingAdapter
+from autogen.beta.network.adapters.conversation import ConversationAdapter
+from autogen.beta.network.adapters.discussion import DiscussionAdapter
+from autogen.beta.network.adapters.workflow import WorkflowAdapter
+from autogen.beta.testing import TestConfig
+
+
+def _agent(name: str, *replies: str) -> Agent:
+    return Agent(name=name, config=TestConfig(*replies))
+
+
+# ── Plugin attaches identity-level tools only ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plugin_does_not_attach_say() -> None:
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+    alice_hc = HubClient(link, hub=hub)
+
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    names = {t.name for t in alice.agent.tools}
+    assert "say" not in names
+    # Identity-level set still present.
+    assert {"delegate", "peers", "channels", "tasks", "context"} <= names
+
+    await alice_hc.close()
+    await hub.close()
+
+
+# ── Adapter tools_for ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_consulting_tools_for_gates_by_turn() -> None:
+    """Consulting offers ``say`` to the participant whose turn it is."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    bob = await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+    channel = await alice.open(type="consulting", target="bob")
+
+    adapter = ConsultingAdapter()
+    state = hub.adapter_state(channel.channel_id)
+    # Initiator's turn (hasn't sent the prompt yet).
+    initiator_tools = adapter.tools_for(alice, channel.metadata, state, alice.agent_id)
+    assert [t.name for t in initiator_tools] == ["say"]
+    # Respondent's turn isn't active yet.
+    respondent_tools = adapter.tools_for(bob, channel.metadata, state, bob.agent_id)
+    assert respondent_tools == []
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_conversation_tools_for_always_offers_say() -> None:
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    bob = await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+    channel = await alice.open(type="conversation", target="bob")
+
+    adapter = ConversationAdapter()
+    state = hub.adapter_state(channel.channel_id)
+    assert [t.name for t in adapter.tools_for(alice, channel.metadata, state, alice.agent_id)] == ["say"]
+    assert [t.name for t in adapter.tools_for(bob, channel.metadata, state, bob.agent_id)] == ["say"]
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_discussion_tools_for_gates_by_round_robin() -> None:
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+    carol_hc = HubClient(link, hub=hub)
+
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    bob = await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+    carol = await carol_hc.register(_agent("carol"), Passport(name="carol"), Resume())
+
+    channel = await alice.open(
+        type="discussion",
+        target=["bob", "carol"],
+        knobs={"ordering": "round_robin"},
+    )
+
+    adapter = DiscussionAdapter()
+    state = hub.adapter_state(channel.channel_id)
+    # Initial expected_next_speaker is the creator (alice).
+    assert [t.name for t in adapter.tools_for(alice, channel.metadata, state, alice.agent_id)] == ["say"]
+    assert adapter.tools_for(bob, channel.metadata, state, bob.agent_id) == []
+    assert adapter.tools_for(carol, channel.metadata, state, carol.agent_id) == []
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await carol_hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_workflow_tools_for_returns_empty() -> None:
+    """Workflow ships no adapter tools — handoff is user-authored."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+    alice_hc = HubClient(link, hub=hub)
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+
+    adapter = WorkflowAdapter()
+    # No active workflow channel needed — tools_for is pure.
+    assert adapter.tools_for(alice, None, None, alice.agent_id) == []
+
+    await alice_hc.close()
+    await hub.close()
+
+
+# ── Layer-2 envelope helpers ──────────────────────────────────────────────
+
+
+def test_build_text_envelope_default_shape() -> None:
+    adapter = ConversationAdapter()
+    env = adapter.build_text_envelope(
+        channel_id="c1",
+        sender_id="a1",
+        text="hello",
+        audience=["a2"],
+    )
+    assert env.event_type == EV_TEXT
+    assert env.event_data == {"text": "hello"}
+    assert env.audience == ["a2"]
+
+
+def test_build_packet_envelope_with_handoff() -> None:
+    adapter = WorkflowAdapter()
+    env = adapter.build_packet_envelope(
+        channel_id="c1",
+        sender_id="a1",
+        body="result",
+        handoff=Handoff(target="a2", reason="needs expert"),
+    )
+    assert env.event_type == EV_PACKET
+    assert env.event_data["body"] == "result"
+    routing = env.event_data.get("routing", {})
+    assert routing == {"kind": "handoff", "target": "a2", "reason": "needs expert"}
+
+
+def test_build_packet_envelope_with_context_set() -> None:
+    adapter = WorkflowAdapter()
+    env = adapter.build_packet_envelope(
+        channel_id="c1",
+        sender_id="a1",
+        body="step done",
+        context_set={"score": 0.9},
+    )
+    assert env.event_type == EV_PACKET
+    assert env.event_data["context"] == {"score": 0.9}
+
+
+# ── channels(open, message=...) seed ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_channels_open_with_seed_message() -> None:
+    """``channels(action="open", message=...)`` posts the seed envelope
+    atomically after the channel transitions to OPENED.
+
+    Drives the tool via the agent's `ask` so the test exercises the
+    real fast_depends injection path; the agent's scripted reply
+    returns a tool call to ``channels(open, message=...)``.
+    """
+    import json as _json
+
+    from autogen.beta.events import ToolCallEvent
+
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+
+    alice_agent = Agent(
+        name="alice",
+        config=TestConfig(
+            [
+                ToolCallEvent(
+                    name="channels",
+                    arguments=_json.dumps({
+                        "action": "open",
+                        "type": "conversation",
+                        "target": "bob",
+                        "message": "kickoff",
+                    }),
+                )
+            ],
+            "done",
+        ),
+    )
+    alice = await alice_hc.register(alice_agent, Passport(name="alice"), Resume())
+    await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+
+    reply = await alice.agent.ask("Open a conversation with bob.")
+    assert reply.body
+
+    # Find the new channel (the only conversation in the hub).
+    channels = await hub.list_channels()
+    convs = [c for c in channels if c.manifest.type == "conversation"]
+    assert len(convs) == 1
+    wal = await hub.read_wal(convs[0].channel_id)
+    text_envs = [e for e in wal if e.event_type == EV_TEXT]
+    # Seed envelope present alongside any default-handler-generated turns.
+    assert any(e.event_data.get("text") == "kickoff" for e in text_envs)
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()

--- a/test/beta/network/test_adapter_tools.py
+++ b/test/beta/network/test_adapter_tools.py
@@ -12,9 +12,12 @@
 * ``channels(action="open", message=...)`` seeds the first envelope.
 """
 
+import json
+
 import pytest
 
 from autogen.beta import Agent
+from autogen.beta.events import ToolCallEvent
 from autogen.beta.knowledge import MemoryKnowledgeStore
 from autogen.beta.network import (
     EV_PACKET,
@@ -213,10 +216,6 @@ async def test_channels_open_with_seed_message() -> None:
     real fast_depends injection path; the agent's scripted reply
     returns a tool call to ``channels(open, message=...)``.
     """
-    import json as _json
-
-    from autogen.beta.events import ToolCallEvent
-
     store = MemoryKnowledgeStore()
     hub = await Hub.open(store, ttl_sweep_interval=0)
     link = LocalLink(hub)
@@ -230,7 +229,7 @@ async def test_channels_open_with_seed_message() -> None:
             [
                 ToolCallEvent(
                     name="channels",
-                    arguments=_json.dumps({
+                    arguments=json.dumps({
                         "action": "open",
                         "type": "conversation",
                         "target": "bob",

--- a/test/beta/network/test_bridge_drives_workflow.py
+++ b/test/beta/network/test_bridge_drives_workflow.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plain-Python bridge drives a workflow turn end-to-end.
+
+Headline non-AG2 surface for the adapter Layer-2 helpers: a non-AG2
+client constructs a workflow ``EV_PACKET`` envelope via
+``WorkflowAdapter.build_packet_envelope`` and posts it directly through
+``Hub.post_envelope`` — no ``@tool`` decorator, no ``Agent``, no
+``NetworkPlugin``. The workflow's transition graph advances the
+expected next speaker based purely on the bridge-supplied envelopes.
+
+This test is the load-bearing evidence that the three-layer design
+(capabilities → envelope helpers → LLM-tool wrappers) actually delivers
+its promised non-AG2 surface, not just adapter-gated AG2-only tools.
+"""
+
+import pytest
+
+from autogen.beta.knowledge import MemoryKnowledgeStore
+from autogen.beta.network import (
+    EV_PACKET,
+    AgentTarget,
+    FromSpeaker,
+    Handoff,
+    Hub,
+    HubClient,
+    LocalLink,
+    Passport,
+    Resume,
+    RevertToInitiatorTarget,
+    TerminateTarget,
+    Transition,
+    TransitionGraph,
+    WorkflowState,
+    default_build_packet_envelope,
+)
+from autogen.beta.network.adapters.workflow import WORKFLOW_TYPE
+from autogen.beta.network.channel import ChannelState
+
+
+@pytest.mark.asyncio
+async def test_bridge_drives_workflow_via_layer2_envelope_helpers() -> None:
+    """A bridge with no AG2 plumbing posts EV_PACKET envelopes to
+    advance the workflow through alice → bob → alice (revert).
+
+    Demonstrates the full non-AG2 surface:
+    1. ``adapter.build_packet_envelope(...)`` constructs the round.
+    2. ``hub.post_envelope(envelope)`` commits it.
+    3. ``hub.adapter_state(channel_id)`` reflects the advance.
+
+    No ``Agent``, no ``@tool``, no ``NetworkPlugin``.
+    """
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+
+    # Register the two participants without any LLM — they are pure
+    # identities. ``register_human`` is the cleanest way to get a
+    # passport stamped without attaching an LLM agent.
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+    alice = await alice_hc.register_human(Passport(name="alice"), resume=Resume())
+    bob = await bob_hc.register_human(Passport(name="bob"), resume=Resume())
+
+    graph = TransitionGraph(
+        initial_speaker=alice.agent_id,
+        transitions=[
+            Transition(
+                when=FromSpeaker(alice.agent_id),
+                then=AgentTarget(bob.agent_id),
+            ),
+            Transition(
+                when=FromSpeaker(bob.agent_id),
+                then=RevertToInitiatorTarget(),
+            ),
+        ],
+        default_target=TerminateTarget(reason="bridge_done"),
+        max_turns=8,
+    )
+
+    # Alice opens the workflow channel as the creator.
+    channel = await alice.open(
+        type=WORKFLOW_TYPE,
+        target=[bob.agent_id],
+        knobs={"graph": graph.to_dict()},
+    )
+    assert channel.state == ChannelState.ACTIVE
+
+    # Round 1: bridge constructs a workflow packet "as alice" using the
+    # adapter's Layer-2 helper. No tool wrapper involved.
+    adapter = hub.adapter_for(channel.channel_id)
+    env_alice = adapter.build_packet_envelope(
+        channel_id=channel.channel_id,
+        sender_id=alice.agent_id,
+        body="alice opens the discussion",
+    )
+    assert env_alice.event_type == EV_PACKET
+
+    await hub.post_envelope(env_alice)
+
+    # Workflow state advanced to expect bob next.
+    state = hub.adapter_state(channel.channel_id)
+    assert isinstance(state, WorkflowState)
+    assert state.expected_next_speaker == bob.agent_id
+    assert state.last_speaker_id == alice.agent_id
+
+    # Round 2: bridge constructs bob's reply via the helper, including
+    # a handoff back to alice.
+    env_bob = adapter.build_packet_envelope(
+        channel_id=channel.channel_id,
+        sender_id=bob.agent_id,
+        body="bob replies",
+        handoff=Handoff(target=alice.agent_id, reason="back to you"),
+    )
+    await hub.post_envelope(env_bob)
+
+    # FromSpeaker(bob) → RevertToInitiatorTarget → expected next is alice.
+    state = hub.adapter_state(channel.channel_id)
+    assert state.expected_next_speaker == alice.agent_id
+    assert state.last_speaker_id == bob.agent_id
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_bridge_uses_module_level_default_helper_directly() -> None:
+    """A bridge that doesn't even resolve the adapter can use the
+    module-level ``default_build_packet_envelope`` directly.
+
+    Use case: a Python harness that pre-constructs envelopes offline
+    and posts them in batch through ``hub.post_envelope`` without
+    any per-channel adapter resolution.
+    """
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+    alice = await alice_hc.register_human(Passport(name="alice"))
+    bob = await bob_hc.register_human(Passport(name="bob"))
+
+    graph = TransitionGraph(
+        initial_speaker=alice.agent_id,
+        transitions=[
+            Transition(
+                when=FromSpeaker(alice.agent_id),
+                then=AgentTarget(bob.agent_id),
+            ),
+        ],
+        default_target=TerminateTarget(reason="bridge_done"),
+        max_turns=4,
+    )
+
+    channel = await alice.open(
+        type=WORKFLOW_TYPE,
+        target=[bob.agent_id],
+        knobs={"graph": graph.to_dict()},
+    )
+
+    # Construct via the module-level helper without ever touching the
+    # adapter instance.
+    envelope = default_build_packet_envelope(
+        channel_id=channel.channel_id,
+        sender_id=alice.agent_id,
+        body="a packet built without adapter resolution",
+    )
+    assert envelope.event_type == EV_PACKET
+    await hub.post_envelope(envelope)
+
+    state = hub.adapter_state(channel.channel_id)
+    assert state.expected_next_speaker == bob.agent_id
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()

--- a/test/beta/network/test_channel_pruning.py
+++ b/test/beta/network/test_channel_pruning.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-channel cache pruning on terminal channel transitions.
+
+The hub holds several per-channel scratch maps — ``_adapter_states``,
+``_channel_locks``, ``_channel_open_waiters``, ``_fired_violations``.
+They must be pruned when a channel transitions to a terminal state
+(``CLOSED`` / ``EXPIRED``) so a long-lived hub processing many short
+channels does not grow without bound.
+
+The channel metadata itself (``_channels``) is intentionally kept for
+auditability + ``read_wal()`` access. Only volatile per-channel
+caches are pruned.
+"""
+
+import asyncio
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.knowledge import MemoryKnowledgeStore
+from autogen.beta.network import (
+    Hub,
+    HubClient,
+    LocalLink,
+    Passport,
+    Resume,
+)
+from autogen.beta.testing import TestConfig
+
+
+def _agent(name: str) -> Agent:
+    return Agent(name=name, config=TestConfig())
+
+
+@pytest.mark.asyncio
+async def test_adapter_state_retained_after_close_for_analysis() -> None:
+    """``_adapter_states`` is intentionally kept post-close for inspection.
+
+    Fold state carries analytical value for tests, debug tools, and
+    post-mortem analysis. Pruning the heavier per-channel
+    synchronization primitives (locks) is enough to bound memory; the
+    state dataclass itself is small.
+    """
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+    channel = await alice.open(type="conversation", target="bob")
+    channel_id = channel.channel_id
+
+    pre_close_state = hub.adapter_state(channel_id)
+    assert pre_close_state is not None
+
+    await hub.close_channel(channel_id, reason="explicit")
+
+    # State stays available for analysis.
+    assert hub.adapter_state(channel_id) is pre_close_state
+    # Channel metadata stays for audit / WAL access.
+    metadata = await hub.get_channel(channel_id)
+    assert metadata.is_terminal()
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_channel_locks_pruned_on_close() -> None:
+    """``_channel_locks`` drops the entry on terminal transition."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+    channel = await alice.open(type="conversation", target="bob")
+    channel_id = channel.channel_id
+
+    # WAL append acquired the lock, so it's in the dict.
+    await channel.send("hello")
+    assert channel_id in hub._channel_locks  # pre-close
+
+    await hub.close_channel(channel_id, reason="explicit")
+    assert channel_id not in hub._channel_locks  # post-close
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_fired_violations_pruned_on_close() -> None:
+    """``_fired_violations`` (already pre-existing prune) keeps the contract."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+    channel = await alice.open(type="conversation", target="bob")
+    channel_id = channel.channel_id
+
+    # Force a fired-violations entry directly (no live expectation).
+    hub._fired_violations[channel_id] = {(0, "max_silence", "")}
+    await hub.close_channel(channel_id, reason="explicit")
+    assert channel_id not in hub._fired_violations
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_pruning_under_many_short_channels_keeps_caches_bounded() -> None:
+    """Open + close 20 channels — the per-channel caches stay bounded.
+
+    Realistic proxy for the long-lived-hub case: every channel that
+    closes must release its per-channel scratch state so the dicts
+    don't grow without bound.
+    """
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0)
+    link = LocalLink(hub)
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+
+    for _ in range(20):
+        channel = await alice.open(type="conversation", target="bob")
+        await channel.send("ping")
+        await hub.close_channel(channel.channel_id, reason="cycle")
+
+    # Yield so any sweeper / dispatch task settles.
+    await asyncio.sleep(0.1)
+
+    # All 20 closed → the heavy per-channel synchronization caches
+    # are empty. ``_adapter_states`` is retained by design.
+    assert hub._channel_locks == {}
+    assert hub._fired_violations == {}
+    assert hub._channel_open_waiters == {}
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()

--- a/test/beta/network/test_subclass_surface.py
+++ b/test/beta/network/test_subclass_surface.py
@@ -17,6 +17,7 @@ import asyncio
 import pytest
 
 from autogen.beta import Agent
+from autogen.beta.events import TaskStarted
 from autogen.beta.knowledge import MemoryKnowledgeStore
 from autogen.beta.network import (
     BaseHubListener,
@@ -27,7 +28,10 @@ from autogen.beta.network import (
     Resume,
     Rule,
 )
+from autogen.beta.network.adapters.consulting import ConsultingAdapter
+from autogen.beta.network.adapters.conversation import ConversationAdapter
 from autogen.beta.network.rule import InboxBlock, LimitsBlock
+from autogen.beta.network.task_mirror import TaskMirror
 from autogen.beta.testing import TestConfig
 
 
@@ -54,9 +58,6 @@ async def test_subclass_on_envelope_posted_fires_without_listener_registration()
     store = MemoryKnowledgeStore()
     hub = _RecordingHub(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
     # Register adapters manually since we used __init__ directly.
-    from autogen.beta.network.adapters.consulting import ConsultingAdapter
-    from autogen.beta.network.adapters.conversation import ConversationAdapter
-
     hub.register_adapter(ConsultingAdapter())
     hub.register_adapter(ConversationAdapter())
     await hub.hydrate()
@@ -98,8 +99,6 @@ async def test_subclass_hook_runs_alongside_external_listener() -> None:
 
     store = MemoryKnowledgeStore()
     hub = _SubHub(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
-    from autogen.beta.network.adapters.consulting import ConsultingAdapter
-
     hub.register_adapter(ConsultingAdapter())
     await hub.hydrate()
     await hub.start()
@@ -251,9 +250,6 @@ async def test_inbox_pressure_fires_on_crossing_high_water() -> None:
 @pytest.mark.asyncio
 async def test_task_mirror_failure_fires_mirror_failed_event() -> None:
     """When the mirror cannot reach the hub, fire ``on_task_event(mirror_failed)``."""
-    from autogen.beta.events import TaskStarted
-    from autogen.beta.network.task_mirror import TaskMirror
-
     store = MemoryKnowledgeStore()
     hub = await Hub.open(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
 

--- a/test/beta/network/test_subclass_surface.py
+++ b/test/beta/network/test_subclass_surface.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Hub subclass surface + sweeper extension + latent fixes.
+
+* Subclass ``on_*`` hooks fire alongside externally-registered listeners.
+* ``register_sweeper`` spawns a custom periodic worker; ``unregister_sweeper``
+  stops it cleanly.
+* Open audit-kind set: subclasses can append arbitrary records.
+* ``on_inbox_pressure`` fires when the recipient crosses the high-water mark.
+* ``TaskMirror`` mirror failures fire ``on_task_event(kind="mirror_failed")``.
+"""
+
+import asyncio
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.knowledge import MemoryKnowledgeStore
+from autogen.beta.network import (
+    BaseHubListener,
+    Hub,
+    HubClient,
+    LocalLink,
+    Passport,
+    Resume,
+    Rule,
+)
+from autogen.beta.network.rule import InboxBlock, LimitsBlock
+from autogen.beta.testing import TestConfig
+
+
+def _agent(name: str, *replies: str) -> Agent:
+    return Agent(name=name, config=TestConfig(*replies))
+
+
+# ── Subclass on_* hooks ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_subclass_on_envelope_posted_fires_without_listener_registration() -> None:
+    """A subclass that overrides ``on_envelope_posted`` sees every envelope
+    without registering itself as a listener."""
+
+    class _RecordingHub(Hub):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.captured: list = []
+
+        async def on_envelope_posted(self, envelope, metadata) -> None:
+            self.captured.append((envelope.event_type, envelope.sender_id))
+
+    store = MemoryKnowledgeStore()
+    hub = _RecordingHub(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
+    # Register adapters manually since we used __init__ directly.
+    from autogen.beta.network.adapters.consulting import ConsultingAdapter
+    from autogen.beta.network.adapters.conversation import ConversationAdapter
+
+    hub.register_adapter(ConsultingAdapter())
+    hub.register_adapter(ConversationAdapter())
+    await hub.hydrate()
+    await hub.start()
+
+    link = LocalLink(hub)
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+    channel = await alice.open(type="conversation", target="bob")
+    await channel.send("hi")
+
+    assert hub.captured  # subclass override received envelopes
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_subclass_hook_runs_alongside_external_listener() -> None:
+    """Both subclass override and externally-registered listener fire."""
+
+    class _SubHub(Hub):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.sub_calls: list = []
+
+        async def on_agent_event(self, agent_id, kind, payload) -> None:
+            self.sub_calls.append((kind, agent_id))
+
+    class _Listener(BaseHubListener):
+        def __init__(self) -> None:
+            self.calls: list = []
+
+        async def on_agent_event(self, agent_id, kind, payload) -> None:
+            self.calls.append((kind, agent_id))
+
+    store = MemoryKnowledgeStore()
+    hub = _SubHub(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
+    from autogen.beta.network.adapters.consulting import ConsultingAdapter
+
+    hub.register_adapter(ConsultingAdapter())
+    await hub.hydrate()
+    await hub.start()
+
+    listener = _Listener()
+    hub.register_listener(listener)
+
+    link = LocalLink(hub)
+    alice_hc = HubClient(link, hub=hub)
+    await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+
+    # Both saw the registration event.
+    assert any(kind == "registered" for kind, _ in hub.sub_calls)
+    assert any(kind == "registered" for kind, _ in listener.calls)
+
+    await alice_hc.close()
+    await hub.close()
+
+
+# ── Custom sweeper ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_sweeper_runs_periodically() -> None:
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
+
+    ticks: list[float] = []
+
+    async def my_tick() -> None:
+        ticks.append(asyncio.get_event_loop().time())
+
+    hub.register_sweeper("test-sweep", interval_seconds=0.05, fn=my_tick)
+    await asyncio.sleep(0.16)
+    assert len(ticks) >= 2
+
+    await hub.unregister_sweeper("test-sweep")
+    snapshot = len(ticks)
+    await asyncio.sleep(0.12)
+    # After unregister, no more ticks (allow one in-flight straggler).
+    assert len(ticks) <= snapshot + 1
+
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_register_sweeper_rejects_duplicate_name() -> None:
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
+
+    async def noop() -> None:
+        pass
+
+    hub.register_sweeper("once", interval_seconds=10.0, fn=noop)
+    with pytest.raises(ValueError, match="already registered"):
+        hub.register_sweeper("once", interval_seconds=5.0, fn=noop)
+
+    await hub.unregister_sweeper("once")
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_register_sweeper_rejects_non_positive_interval() -> None:
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
+
+    async def noop() -> None:
+        pass
+
+    with pytest.raises(ValueError, match="positive"):
+        hub.register_sweeper("bad", interval_seconds=0, fn=noop)
+    with pytest.raises(ValueError, match="positive"):
+        hub.register_sweeper("bad", interval_seconds=-1.0, fn=noop)
+
+    await hub.close()
+
+
+# ── Audit kinds open set ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_log_accepts_custom_kinds() -> None:
+    """Subclasses / tenants append records with their own ``kind`` values."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
+
+    await hub._audit_log.append({
+        "at": "2026-01-01T00:00:00+00:00",
+        "kind": "my_app.custom_event",
+        "detail": "something happened",
+    })
+
+    records = await hub._audit_log.read_all()
+    kinds = {r["kind"] for r in records}
+    assert "my_app.custom_event" in kinds
+
+    await hub.close()
+
+
+# ── Inbox pressure ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inbox_pressure_fires_on_crossing_high_water() -> None:
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
+
+    fires: list = []
+
+    class _PressureListener(BaseHubListener):
+        async def on_inbox_pressure(self, agent_id, pending, cap) -> None:
+            fires.append((agent_id, pending, cap))
+
+    hub.register_listener(_PressureListener())
+
+    link = LocalLink(hub)
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+
+    # Bob's inbox: cap 10, high_water 3.
+    bob_rule = Rule(
+        limits=LimitsBlock(
+            inbox=InboxBlock(max_pending=10, overflow="reject", high_water=3),
+        ),
+    )
+    alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    bob = await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume(), rule=bob_rule)
+    channel = await alice.open(type="conversation", target="bob")
+
+    # Send 4 substantive envelopes addressed to bob — crosses 3 at the third.
+    for _ in range(4):
+        await channel.send("ping", audience=[bob.agent_id])
+
+    # Exactly one firing — at the crossing of prev<3 → new>=3.
+    assert len(fires) == 1
+    fired_agent_id, fired_pending, fired_cap = fires[0]
+    assert fired_agent_id == bob.agent_id
+    assert fired_pending == 3
+    assert fired_cap == 10
+
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()
+
+
+# ── Task mirror error escalation ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_task_mirror_failure_fires_mirror_failed_event() -> None:
+    """When the mirror cannot reach the hub, fire ``on_task_event(mirror_failed)``."""
+    from autogen.beta.events import TaskStarted
+    from autogen.beta.network.task_mirror import TaskMirror
+
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
+
+    events: list = []
+
+    class _Listener(BaseHubListener):
+        async def on_task_event(self, task_id, kind, payload) -> None:
+            events.append((task_id, kind))
+
+    hub.register_listener(_Listener())
+
+    # Force observe_task to raise so the escalation path runs.
+    async def _broken_observe(metadata) -> None:
+        raise RuntimeError("simulated hub failure")
+
+    hub.observe_task = _broken_observe  # type: ignore[assignment]
+
+    mirror = TaskMirror(hub=hub, owner_id="ghost-agent", channel_id="ghost-channel")
+    await mirror._on_started(TaskStarted(task_id="task-x", objective="test"))
+
+    assert any(kind == "mirror_failed" for _, kind in events)
+
+    await hub.close()

--- a/test/beta/network/test_tools.py
+++ b/test/beta/network/test_tools.py
@@ -368,8 +368,14 @@ async def test_tasks_status_unknown_task_returns_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_network_plugin_attaches_all_6_tools() -> None:
-    """Verifies the plugin wires every network tool onto ``agent.tools``."""
+async def test_network_plugin_attaches_identity_level_tools() -> None:
+    """``NetworkPlugin`` attaches the identity-level cross-cutting tools only.
+
+    ``say`` is channel-shaped: it comes from
+    ``adapter.tools_for(...)`` per turn (the default notify handler
+    resolves and merges it into ``agent.ask(tools=...)``). Workflow
+    agents see ``[]`` from the adapter — they never see ``say``.
+    """
     store = MemoryKnowledgeStore()
     hub = await Hub.open(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
     link = LocalLink(hub)
@@ -377,7 +383,8 @@ async def test_network_plugin_attaches_all_6_tools() -> None:
     alice_hc = HubClient(link, hub=hub)
     alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
     tool_names = {t.name for t in alice.agent.tools}
-    assert {"say", "delegate", "peers", "channels", "tasks", "context"} <= tool_names
+    assert {"delegate", "peers", "channels", "tasks", "context"} <= tool_names
+    assert "say" not in tool_names
 
     await alice_hc.close()
     await hub.close()

--- a/website/docs/beta/network/adapters_overview.mdx
+++ b/website/docs/beta/network/adapters_overview.mdx
@@ -18,12 +18,17 @@ If you're migrating a classic `GroupChat` orchestration, see [Migrating from Gro
 
 ## The Adapter Protocol
 
-All four adapters implement the same `#!python ChannelAdapter` Protocol:
+An adapter exposes **three concentric layers** of surface:
+
+1. **Capabilities** — what the *hub* calls: `#!python validate_create` / `#!python validate_send` / `#!python fold` / `#!python on_accepted` / `#!python initial_state`. `#!python fold` is replayed on `#!python Hub.hydrate()`, so it must be a pure function.
+2. **Envelope helpers** — what *any client* calls: `#!python build_text_envelope` / `#!python build_packet_envelope`. Pure constructors that produce a correctly-shaped `#!python Envelope` for this adapter's protocol. Framework-agnostic — not LLM-specific. This is the surface a non-AG2 bridge drives (see [below](#driving-a-channel-without-an-agent)).
+3. **LLM tools** — what the *AG2 agent loop* sees: `#!python tools_for`. The presentation layer; the default handler merges its result with the identity-level tools `#!python NetworkPlugin` attaches. Adapters that take no LLM input (e.g. workflow, where handoff tools are user-authored) return `#!python []`.
 
 ```python
 class ChannelAdapter(Protocol):
     manifest: ChannelManifest
 
+    # Layer 1 — capabilities (hub-called)
     def initial_state(self, metadata: ChannelMetadata) -> AdapterState: ...
     def fold(self, envelope: Envelope, state: AdapterState) -> AdapterState: ...
     def validate_create(self, metadata: ChannelMetadata) -> None: ...
@@ -33,20 +38,68 @@ class ChannelAdapter(Protocol):
     def on_accepted(
         self, metadata: ChannelMetadata, envelope: Envelope, state: AdapterState
     ) -> AdapterResult: ...
+
+    # Layer 2 — envelope helpers (any client)
+    def build_text_envelope(
+        self, channel_id: str, sender_id: str, text: str, *,
+        audience: list[str] | None = None, causation_id: str | None = None,
+    ) -> Envelope: ...
+    def build_packet_envelope(
+        self, channel_id: str, sender_id: str, body: str, *,
+        handoff: Handoff | None = None, context_set: dict | None = None,
+        audience: list[str] | None = None, causation_id: str | None = None,
+    ) -> Envelope: ...
+
+    # Layer 3 — LLM tools (agent loop)
+    def tools_for(
+        self, client: AgentClient, metadata: ChannelMetadata,
+        state: AdapterState, participant_id: str,
+    ) -> list[Tool]: ...
 ```
 
-Each method runs at a specific moment in a channel's lifecycle:
+Each method runs at a specific moment:
 
-| Method | When | Purpose |
-|---|---|---|
-| `manifest` | Adapter registration | Static description: type, version, participant counts, knobs schema, default view, default expectations |
-| `initial_state` | Channel creation | Build the per-channel bookkeeping (e.g. `expected_next_speaker`, turn count) |
-| `validate_create` | Channel creation | Reject the create if the manifest's invariants are violated |
-| `fold` | Each accepted envelope | Update the per-channel state (turn-taking, flags, last speaker) |
-| `validate_send` | Each prospective send | Reject sends that would violate the protocol (out-of-turn, post-terminal) |
-| `on_accepted` | Each accepted envelope | Decide whether to auto-close (`#!python AdapterResult(next_state=CLOSING, ...)`) |
+| Method | Layer | When | Purpose |
+|---|---|---|---|
+| `manifest` | 1 | Adapter registration | Static description: type, version, participant counts, knobs schema, default view, default expectations |
+| `initial_state` | 1 | Channel creation | Build the per-channel bookkeeping (e.g. `expected_next_speaker`, turn count) |
+| `validate_create` | 1 | Channel creation | Reject the create if the manifest's invariants are violated |
+| `fold` | 1 | Each accepted envelope | Update the per-channel state (turn-taking, flags, last speaker) |
+| `validate_send` | 1 | Each prospective send | Reject sends that would violate the protocol (out-of-turn, post-terminal) |
+| `on_accepted` | 1 | Each accepted envelope | Decide whether to auto-close (`#!python AdapterResult(next_state=CLOSING, ...)`) |
+| `build_text_envelope` | 2 | Any time, by any client | Construct an `#!python EV_TEXT` envelope shaped for this adapter |
+| `build_packet_envelope` | 2 | Any time, by any client | Construct an `#!python EV_PACKET` envelope (workflow encodes `handoff` / `context_set` here) |
+| `tools_for` | 3 | Per turn, by the default handler | The LLM tools this participant gets this turn — see [Network Tools → Channel-level tools](/docs/beta/network/network_assigned_tools#channel-level-tools-adaptertools_for) |
+
+Module-level defaults are public, so a custom adapter (or a bridge) can delegate to them directly: `#!python default_build_text_envelope` / `#!python default_build_packet_envelope` (emit plain `#!python EV_TEXT` / `#!python EV_PACKET`) and `#!python default_tools_for` (returns `#!python []`). All three are importable from `#!python autogen.beta.network`.
 
 You don't normally implement this protocol yourself — the four built-ins cover most cases, and the workflow adapter is parameterised via `#!python TransitionGraph` for custom orchestrations. The `#!python ChannelAdapter` Protocol is exposed for completeness and for advanced use cases.
+
+### Driving a channel without an Agent
+
+The Layer-2 helpers exist so that code with no AG2 plumbing — a chat-platform gateway, a batch harness, a non-AG2 framework — can advance a turn manually. Build the adapter-shaped envelope, then post it through `#!python Hub.post_envelope`:
+
+```python linenums="1"
+# Two pure identities — no Agent, no NetworkPlugin, no @tool.
+alice = await alice_hc.register_human(Passport(name="alice"), resume=Resume())
+bob = await bob_hc.register_human(Passport(name="bob"), resume=Resume())
+
+channel = await alice.open(type="workflow", target=[bob.agent_id], knobs={"graph": graph.to_dict()})
+
+adapter = hub.adapter_for(channel.channel_id)
+env = adapter.build_packet_envelope(
+    channel_id=channel.channel_id,
+    sender_id=alice.agent_id,
+    body="alice opens the discussion",
+)
+await hub.post_envelope(env)
+
+# The workflow's transition graph advanced state purely from the bridge-supplied envelope.
+state = hub.adapter_state(channel.channel_id)
+assert state.expected_next_speaker == bob.agent_id
+```
+
+`#!python hub.adapter_for(channel_id)` returns the bound adapter; `#!python hub.adapter_state(channel_id)` returns the current fold state (and stays available after the channel closes — useful for post-mortem inspection). A bridge that pre-builds envelopes offline can skip the adapter lookup entirely and call `#!python default_build_packet_envelope(...)` directly.
 
 ## Channel Lifecycle
 

--- a/website/docs/beta/network/agent_clients.mdx
+++ b/website/docs/beta/network/agent_clients.mdx
@@ -141,6 +141,8 @@ Cross-process or cross-host transports plug in here. `#!python LocalLink` is the
 
 Every `#!python AgentClient` has an inbox bounded by its `#!python Rule.inbox.max_pending` (default unbounded). When the inbox fills, sends to that agent fail with `#!python InboxFull`. The `#!python wait_for_channel_event` and the default handler drain the inbox in order; custom handlers should do the same — never block forever in a callback.
 
+`#!python Rule.inbox.high_water` is a soft threshold below the hard cap: when a dispatch first pushes a recipient over it, the hub fires `#!python on_inbox_pressure(agent_id, pending, cap)` on every listener (and on a `#!python Hub` subclass override) — once per crossing, not on every subsequent envelope. It defaults to `#!python None`, which resolves to 80% of `#!python max_pending`; set `#!python 0` to disable the signal. See [HubListener](/docs/beta/network/expectations_and_audit#hublistener-observing-state-transitions).
+
 ## Closing Down
 
 ```python linenums="1"

--- a/website/docs/beta/network/envelopes_and_events.mdx
+++ b/website/docs/beta/network/envelopes_and_events.mdx
@@ -110,6 +110,9 @@ await alice.send_envelope(envelope)
 
 The hub doesn't validate `event_type` against any allowlist; custom types pass through unmodified. Adapters fold only event types they recognise — substantive ones (`#!python EV_TEXT`, plus `#!python EV_PACKET` under the workflow adapter) and lifecycle ones (`#!python EV_CHANNEL_*`). Custom event types are written to the WAL and delivered to participants but don't advance turn-taking state.
 
+!!! tip "Adapter-shaped envelopes"
+    When the envelope *should* advance the channel's protocol (a normal text turn, a workflow round packet) but you're constructing it outside the agent loop — a bridge, a gateway, a test harness — use the adapter's Layer-2 helpers instead of building the `#!python Envelope` by hand: `#!python adapter.build_text_envelope(...)` / `#!python adapter.build_packet_envelope(..., handoff=, context_set=)`, fetched via `#!python hub.adapter_for(channel_id)`. They produce exactly the shape the adapter folds. See [Adapters Overview → Driving a channel without an Agent](/docs/beta/network/adapters_overview#driving-a-channel-without-an-agent).
+
 ## Causation
 
 `#!python causation_id` lets you mark an envelope as "in reply to" another:

--- a/website/docs/beta/network/expectations_and_audit.mdx
+++ b/website/docs/beta/network/expectations_and_audit.mdx
@@ -180,6 +180,27 @@ hub.register_listener(MetricsListener())
 | `#!python on_task_event(task_id, kind, payload)` | `kind` ∈ `started` / `progress` / `completed` / `failed` / `expired` / `cancelled` / `mirror_failed`. |
 | `#!python on_inbox_pressure(agent_id, pending, cap)` | A recipient's pending count first crossed its inbox high-water mark (fires once per crossing). |
 
+### Subclassing the Hub instead of registering a listener
+
+The same `#!python on_*` methods are available on `#!python Hub` itself (with no-op defaults) — so if you're building a custom hub you can override them directly rather than registering the hub as a listener of itself:
+
+```python linenums="1"
+from autogen.beta.network import Hub
+
+class ObservingHub(Hub):
+    async def on_envelope_posted(self, envelope, metadata) -> None:
+        metrics.incr("network.envelopes", tags={"type": envelope.event_type})
+
+    async def on_inbox_pressure(self, agent_id, pending, cap) -> None:
+        logger.warning("inbox pressure: %s at %d/%d", agent_id, pending, cap)
+
+hub = await ObservingHub.open(store)
+```
+
+Subclass overrides fire **alongside** any externally-registered listeners, with the same per-callee `#!python try/except` isolation. Use a subclass when the observation logic belongs to your hub implementation; use `#!python register_listener(...)` when it's a separate concern (metrics shipper, audit tap) you want to attach and detach independently.
+
+`#!python on_task_event` is the one listener hook that isn't purely hub-driven — `#!python TaskMirror` (and other tenant code) emit `#!python "mirror_failed"` and other kinds through it. The public way to fan one out is `#!python await hub_client.fire_task_event(task_id, kind, payload)` (from a registered tenant) or `#!python await hub.fire_task_event(...)` (direct); neither touches the hub's private fan-out.
+
 ### Health snapshot
 
 `#!python hub.health()` is a cheap, in-memory operational snapshot — wire it to a `/health` endpoint or dashboard:

--- a/website/docs/beta/network/hub_and_identity.mdx
+++ b/website/docs/beta/network/hub_and_identity.mdx
@@ -187,6 +187,24 @@ Two background tasks run as long as the hub is open:
 
 Both are tunable via `#!python ttl_sweep_interval` and `#!python expectation_sweep_interval`. Set to `0` to disable for tests; in those cases call `#!python await hub._ttl_tick()` or `#!python await hub._expectation_tick()` manually for deterministic timing.
 
+### Custom sweepers
+
+Attach your own periodic worker — protocol-specific background work like polling a chat platform's presence list or refreshing an auth token:
+
+```python linenums="1"
+async def heartbeat() -> None:
+    ...  # runs every 30s
+
+hub.register_sweeper("heartbeat", 30.0, heartbeat)
+# later, e.g. on a config reload:
+await hub.unregister_sweeper("heartbeat")
+```
+
+- `#!python register_sweeper(name, interval_seconds, fn)` is **synchronous** (it only updates bookkeeping). If the hub has already started (`#!python Hub.open(...)` calls `#!python start()` for you), the sweeper begins immediately; if you registered it before `#!python start()`, it begins then.
+- `#!python unregister_sweeper(name)` is **async** — it awaits clean cancellation of the running task. Unknown names are a no-op.
+- A duplicate `name` raises `#!python ValueError` (call `#!python unregister_sweeper` first to replace); a non-positive interval raises `#!python ValueError`.
+- `#!python hub.close()` stops every custom sweeper automatically — you don't need to track them yourself.
+
 ## Closing Down
 
 ```python

--- a/website/docs/beta/network/network_assigned_tools.mdx
+++ b/website/docs/beta/network/network_assigned_tools.mdx
@@ -5,23 +5,28 @@ sidebarTitle: Network Tools
 
 When you call `#!python HubClient.register(agent, ...)` with the default `#!python attach_plugin=True`, the framework attaches `#!python NetworkPlugin` to your agent. The plugin does two things:
 
-1. Adds an **assembly policy** that prefixes every LLM call with the agent's name and id plus a one-line list of network tool names.
-2. Adds **six LLM-facing tools** to `#!python agent.tools` so the model can drive network operations directly: `#!python say`, `#!python delegate`, `#!python peers`, `#!python channels`, `#!python tasks`, `#!python context`.
+1. Adds an **assembly policy** that prefixes every LLM call with the agent's name and id.
+2. Adds the **identity-level tools** to `#!python agent.tools`: `#!python delegate`, `#!python peers`, `#!python channels`, `#!python tasks`, `#!python context`. These are stable for the life of the registration and work in any channel context — discovery, channel lifecycle, task observation, and the one-shot `#!python delegate` convenience.
 
-These are the *vocabulary* the LLM uses to participate in the network — discovery, messaging, lifecycle, history — without your code having to interpret tool calls and proxy them.
+The per-turn tool list an agent actually sees is the **union of two streams**:
 
-## Two flat tools cover the hot path
+| Stream | Where it comes from | Examples |
+|---|---|---|
+| **Identity-level** | `#!python NetworkPlugin`, attached once at registration | `#!python delegate`, `#!python peers`, `#!python channels`, `#!python tasks`, `#!python context` |
+| **Channel-level** | `#!python adapter.tools_for(...)`, resolved per turn by the default handler and merged into `#!python agent.ask(tools=...)` | `#!python say` (text channels), user-authored `#!python Handoff`-returning tools (workflow) |
+
+So `#!python say` is **not** on every agent's `#!python agent.tools` — it's contributed by the adapter that owns the channel, only when that adapter accepts free-form text and only when it's this participant's turn. A workflow participant never sees `#!python say`; it routes via handoff tools instead. See [Channel-level tools](#channel-level-tools-adaptertools_for) below.
+
+## `delegate` — the flat hot-path tool
 
 | Tool | Signature | Purpose |
 |---|---|---|
-| `#!python say` | `#!python say(content, audience?, channel_id?)` | Post `#!python EV_TEXT` into the active channel (or a specified one). `#!python audience` is a list of peer **names** (resolved to ids); `#!python None` broadcasts. |
 | `#!python delegate` | `#!python delegate(target, prompt, capability?, timeout=300)` | One-shot consult: open a `#!python consulting` channel with `target`, send `prompt`, await the single reply, return its text. |
 
-`#!python say` is the most common verb — every reply on a multi-party turn flows through it. `#!python delegate` is the second-most-common because "ask one specialist a question, take their answer" is the canonical multi-agent pattern.
+`#!python delegate` is the most common cross-cutting verb because "ask one specialist a question, take their answer" is the canonical multi-agent pattern — and unlike `#!python say` it isn't tied to a channel the agent is already in, so it lives at the identity level.
 
 ```python linenums="1"
 # The LLM emits, e.g.:
-#   say(content="Here's my answer: …")
 #   delegate(target="bob", prompt="What's the right way to model X?", capability="modeling")
 ```
 
@@ -43,9 +48,11 @@ Each grouped tool takes an `#!python action` literal plus action-specific args, 
 | Action | Args | Returns |
 |---|---|---|
 | `#!python "list"` | `#!python state="active"\|"all"` | Channels this agent participates in. |
-| `#!python "open"` | `#!python type, target, knobs?, intent?, ttl?` | Mirrors `#!python AgentClient.open`. Returns `#!python {channel_id, type, participants}`. |
+| `#!python "open"` | `#!python type, target, knobs?, intent?, ttl?, message?` | Mirrors `#!python AgentClient.open`. Returns `#!python {channel_id, type, participants}` — plus `#!python seed_envelope_id` when `message` was supplied. |
 | `#!python "info"` | `#!python channel_id` | Full `#!python ChannelMetadata` if the agent is a participant. |
 | `#!python "close"` | `#!python channel_id?` (defaults to current) | Closes the channel with reason `#!python "closed_by_agent"`. |
+
+`#!python "open"` accepts an optional `#!python message`: when set, the tool opens the channel and — once it transitions to `OPENED` — posts that text as the first envelope on the initiator's behalf, in the same call. If the seed send fails, the just-opened channel is closed (`#!python reason="seed_failed"`) so you never leave a dangling-open channel nobody ever sends into. Use it for short-lived channels where the agent wants "open and ask" to be one atomic step rather than two tool calls.
 
 ### `tasks(action)` — task lifecycle
 
@@ -70,6 +77,35 @@ Two halves: **active actions** (the agent is inside its own `#!python agent.task
 | `#!python "quote"` | `#!python speaker, recent_n=1, channel_id?` | The last `recent_n` `#!python EV_TEXT` envelopes from `speaker` in the current (or specified) channel. |
 
 `#!python scope="knowledge"` reaches into the calling agent's own `#!python KnowledgeStore`. Substring search only — for vector / semantic search, the agent's own loop calls into framework-core `#!python recall` directly.
+
+## Channel-level tools — `adapter.tools_for`
+
+The tools above are *identity-level* — the same on every turn. The tools an agent needs to actually **participate** in a given channel depend on the channel's protocol and on whose turn it is, so they come from the adapter, not the plugin:
+
+```python
+def tools_for(
+    self,
+    client: AgentClient,
+    metadata: ChannelMetadata,
+    state: AdapterState,
+    participant_id: str,
+) -> list[Tool]: ...
+```
+
+The default handler calls `#!python adapter.tools_for(...)` once per turn and merges the result into the per-call `#!python agent.ask(tools=...)` override. The built-in adapters use it like this:
+
+| Adapter | `tools_for` returns | Gating |
+|---|---|---|
+| `conversation` | `#!python [say]` | Always — no turn order, both participants can post any time. |
+| `discussion` | `#!python [say]` on your round, else `#!python []` | Round-robin: `#!python say` only when `state.expected_next_speaker` is you. |
+| `consulting` | `#!python [say]` to whoever holds the floor, else `#!python []` | Initiator until the prompt is sent; respondent after, until the one reply lands; then the channel auto-closes and nobody gets `#!python say`. |
+| `workflow` | `#!python []` | Workflow agents route via user-authored `#!python Handoff`-returning tools (already on `#!python agent.tools`) — see [Workflow](/docs/beta/network/workflow#writing-a-handoff-tool). |
+
+`#!python say(content, audience?, channel_id?)` posts `#!python EV_TEXT` into the active channel (`#!python audience` is a list of peer **names**, resolved to ids; `#!python None` broadcasts). Internally it builds the envelope via `#!python adapter.build_text_envelope(...)` — the same Layer-2 helper a non-AG2 bridge would call — so per-adapter envelope shaping is honoured automatically. See [Adapters Overview → The Adapter Protocol](/docs/beta/network/adapters_overview#the-adapter-protocol) for the full three-layer picture.
+
+Tool resolution is memoized per `#!python client.agent_id` inside each adapter, so the `#!python fast_depends` schema-build cost is paid once, not on every notify turn.
+
+If you write a custom adapter, override `#!python tools_for` to offer your channel's verbs (or leave the default, which returns `#!python []`).
 
 ## What gets injected, automatically
 


### PR DESCRIPTION
**Stacks on:** #2801. Final PR for v1.X stabilization; merge in stack order.

## Why are these changes needed?

Phase 1 (#2774, #2775, #2776) shipped the V1 protocol, state machine, control plane, LLM tool surface, and workflow orchestration. PR4 (#2801) ships native HITL + observability seams. **This PR is the second and final of two stabilization PRs** taking the surface from "code complete" to production-ready for single-process multi-agent use — the foundation of the 0.13 release.

Three themes:

1. **Adapter-owned tool surface.** Each `ChannelAdapter` now declares its applicable LLM tools via `tools_for(client, metadata, state, participant_id) -> list[Tool]`, plus Layer-2 envelope helpers (`build_text_envelope`, `build_packet_envelope`) that any client can call directly. `NetworkPlugin` shrinks to cross-cutting tools (`peers` / `channels` / `tasks` / `context` / `delegate`); `say` moves into consulting / conversation / discussion adapters; workflow ships no `say`. **Eliminates the structural conflict where an LLM in a workflow channel calls `say` and gets a `ProtocolError`.**

2. **Subclass-friendly Hub.** Empty `on_*` lifecycle hooks (envelope posted, channel events, agent events, task events) Hub fires for subclasses to override. `Hub.register_sweeper(name, interval, callable)` extends the sweeper surface; audit kinds are an open set. **Out-of-tree Hub subclasses (chat-platform-backed deployments, custom storage layouts) become viable without monkey-patching.** No specific subclasses ship in this repo.

3. **Latent bug fixes surfaced during the stabilization review.**
   - `_channel_locks` pruned on terminal channel transition — long-lived hub memory bound. `_adapter_states` is intentionally retained (fold state has analytical value; small per-channel cost).
   - `make_say_tool` now consults `adapter.build_text_envelope` so the LLM tool produces an adapter-shaped envelope, not just an adapter-gated one.
   - `make_say_tool` resolution memoized per `(adapter, client.agent_id)` — the `fast_depends` JSON-schema build is paid once per client lifetime instead of per turn.
   - `channels(action="open", message=...)` rolls back the channel on seed failure — atomic-ish open-and-send semantics.
   - `TaskMirror` mirror failures fire `on_task_event(kind="mirror_failed")` via new public `Hub.fire_task_event` / `HubClient.fire_task_event` (no more `_fan_out` private reach).
   - Function-level `make_say_tool` imports in adapters were a phantom-cycle workaround — removed and hoisted.

## What ships

**Modified — adapter Protocol + Layer-2 helpers**
- `adapters/base.py` — `ChannelAdapter` Protocol gains `tools_for`, `build_text_envelope`, `build_packet_envelope`. Module-level `default_*` helpers any non-AG2 bridge can use directly.
- `adapters/{consulting,conversation,discussion,workflow}.py` — implement `tools_for` (consulting + discussion gate `say` on adapter state; conversation always offers it; workflow returns `[]`). Per-(adapter, client) `_say_tool_cache` for hot-path memoization.

**Modified — Hub subclass surface + lifecycle hooks**
- `hub/core.py` — empty `on_envelope_posted` / `on_channel_event` / `on_agent_event` / `on_task_event` / `on_expectation_fired` hooks fire alongside externally-registered listeners. `register_sweeper` (sync) / `unregister_sweeper` (async — awaits cancellation). `_channel_locks` pruning on terminal transition. New public `Hub.report_turn_failure` and `Hub.fire_task_event` so client/handler/mirror code never touches `_fan_out`.

**Modified — client surface**
- `client/plugin.py` — `NetworkPlugin` no longer attaches `say`; only identity-level cross-cutting tools (`peers` / `channels` / `tasks` / `context` / `delegate`). `NetworkContextPolicy` renders dynamic identity + active-channel info only.
- `client/handlers.py` — `_process_substantive` resolves `adapter.tools_for(...)` per turn and merges into `agent.ask(tools=...)`. `adapter.tools_for` failures are logged but don't crash the handler.
- `client/tools/say.py` — `make_say_tool` consults `adapter.build_text_envelope` for the actual envelope construction.
- `client/tools/channels.py` — `channels(action="open", message=...)` rolls back the channel if the seed envelope fails.
- `client/hub_client.py` — `report_turn_failure` and `fire_task_event` public surfaces; subclass-friendly `adapter_for` / `adapter_state` delegations stay public.

**Modified — task mirror**
- `task_mirror.py` — `_escalate` now routes through `HubClient.fire_task_event` (preferred) or `Hub.fire_task_event` (test path); no more `getattr(hub, "_fan_out", None)` reach.

**Re-exports for non-AG2 bridges**
- `network/__init__.py` and `adapters/__init__.py` re-export the 6 Layer-2 helpers (`default_build_text_envelope`, `default_build_packet_envelope`, `default_extract_turn_input`, `default_render_envelope`, `default_build_round_envelope`, `default_tools_for`) so plain-Python callers have a stable public import path.

## Test plan

**21 new in-tree network tests** + **17 anthropic smoke tests passing** against `claude-haiku-4-5`.

| File | Coverage |
|------|----------|
| `test_adapter_tools.py` (12 tests) | Workflow's `tools_for` returns `[]`; consulting / conversation / discussion gate `say` correctly on state and participant id; Layer-2 helpers produce envelopes that round-trip through `Hub.post_envelope`; `channels(action="open", message=...)` seeds atomically; `NetworkPlugin` no longer attaches `say` |
| `test_subclass_surface.py` (5 tests) | Hub subclass `on_*` overrides fire alongside externally-registered listeners; `register_sweeper` runs periodically and `unregister_sweeper` stops cleanly; open audit-kind set; `on_inbox_pressure` fires once per crossing; `TaskMirror` mirror-failure escalates via `on_task_event(mirror_failed)` |
| `test_channel_pruning.py` (4 tests, **new in this PR**) | `_channel_locks` and `_fired_violations` drop to {} after terminal transition; `_adapter_states` is intentionally retained for post-close analysis; many-short-channel proxy verifies caches stay bounded over 20 open/close cycles |
| `test_bridge_drives_workflow.py` (2 tests, **new in this PR**) | Plain-Python bridge — no `Agent`, no `@tool`, no `NetworkPlugin` — calls `adapter.build_packet_envelope(...)` then `hub.post_envelope(envelope)` to drive a workflow turn through alice → bob → alice (revert via `RevertToInitiatorTarget`); module-level `default_build_packet_envelope` works without touching the adapter instance |

Anthropic smokes (zero regressions vs `main`):
- All 11 from PR4 + the 6 PR3 smokes that exercise the LLM tool surface end-to-end. Per-turn `say`-tool resolution does not regress workflow / discussion / consulting smokes.

Validation:
```
.venv-beta/bin/pytest test/beta/network/ -v
# 317 passed (294 from PR4 + 23 from PR5)

.venv-beta/bin/pytest -m anthropic test/beta/providers/anthropic/ -v
# 17 passed (~$0.02 against haiku)
```

Full beta suite (excluding `test/beta/smoke` + `test/beta/providers` + `test/beta/tools/search`): **1823 passed, 1 skipped, 1 xfailed**, zero regressions vs `main`.

## Related issue number

N/A — internal stabilization for the v1.X minor-version release.

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. (User-facing docs land in a later phase of the rollout.)
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
