### PR TITLE
refactor(beta): replace ToolCallEvent.provider_data with typed Gemini subclass

### DIFF
--- a/autogen/beta/ag_ui/stream.py
+++ b/autogen/beta/ag_ui/stream.py
@@ -350,7 +350,7 @@ def map_agui_messages_to_events(command: AGStreamInput) -> tuple[list[str], list
             continue
 
         if input_buffer:
-            messages.append(events.ModelRequest(list(input_buffer)))
+            messages.append(events.ModelRequest(input_buffer))
             input_buffer.clear()
 
         if m.role in ["system", "developer"]:
@@ -378,7 +378,7 @@ def map_agui_messages_to_events(command: AGStreamInput) -> tuple[list[str], list
                 events.ToolResultsEvent([
                     events.ToolResultEvent(
                         parent_id=m.tool_call_id,
-                        result=ToolResult.ensure_result(m.error or m.content),
+                        result=ToolResult([m.error or m.content]),
                     )
                 ])
             )

--- a/autogen/beta/ag_ui/stream.py
+++ b/autogen/beta/ag_ui/stream.py
@@ -350,7 +350,7 @@ def map_agui_messages_to_events(command: AGStreamInput) -> tuple[list[str], list
             continue
 
         if input_buffer:
-            messages.append(events.ModelRequest(input_buffer))
+            messages.append(events.ModelRequest(list(input_buffer)))
             input_buffer.clear()
 
         if m.role in ["system", "developer"]:
@@ -378,7 +378,7 @@ def map_agui_messages_to_events(command: AGStreamInput) -> tuple[list[str], list
                 events.ToolResultsEvent([
                     events.ToolResultEvent(
                         parent_id=m.tool_call_id,
-                        result=ToolResult([m.error or m.content]),
+                        result=ToolResult.ensure_result(m.error or m.content),
                     )
                 ])
             )

--- a/autogen/beta/config/gemini/events.py
+++ b/autogen/beta/config/gemini/events.py
@@ -15,10 +15,17 @@ from autogen.beta.events import (
     Field,
     Input,
     TextInput,
+    ToolCallEvent,
     ToolResult,
     UrlInput,
 )
 from autogen.beta.tools.builtin.code_execution import CODE_EXECUTION_TOOL_NAME
+
+
+class GeminiToolCallEvent(ToolCallEvent):
+    """Function tool call from Gemini, carries thinking metadata."""
+
+    thought_signature: bytes | None = Field(default=None, repr=False)
 
 
 class GeminiServerToolCallEvent(BuiltinToolCallEvent):

--- a/autogen/beta/config/gemini/gemini_client.py
+++ b/autogen/beta/config/gemini/gemini_client.py
@@ -29,7 +29,7 @@ from autogen.beta.events import (
 from autogen.beta.response import ResponseProto
 from autogen.beta.tools.schemas import ToolSchema
 
-from .events import GeminiServerToolCallEvent, GeminiServerToolResultEvent
+from .events import GeminiServerToolCallEvent, GeminiServerToolResultEvent, GeminiToolCallEvent
 from .mappers import (
     build_system_instruction,
     build_tools,
@@ -147,15 +147,12 @@ class GeminiClient(LLMClient):
                         await context.send(model_msg)
                     elif part.function_call:
                         fc = part.function_call
-                        pdata: dict[str, Any] = {}
-                        if part.thought_signature is not None:
-                            pdata["thought_signature"] = part.thought_signature
                         calls.append(
-                            ToolCallEvent(
+                            GeminiToolCallEvent(
                                 id=fc.id or str(uuid4()),
                                 name=fc.name or "",
                                 arguments=json.dumps(dict(fc.args)) if fc.args else "{}",
-                                provider_data=pdata,
+                                thought_signature=part.thought_signature,
                             )
                         )
                     elif part.executable_code and (call_event := GeminiServerToolCallEvent.from_executable_code(part)):
@@ -223,15 +220,12 @@ class GeminiClient(LLMClient):
                             await context.send(ModelMessageChunk(part.text))
                         elif part.function_call:
                             fc = part.function_call
-                            pdata: dict[str, Any] = {}
-                            if part.thought_signature is not None:
-                                pdata["thought_signature"] = part.thought_signature
                             calls.append(
-                                ToolCallEvent(
+                                GeminiToolCallEvent(
                                     id=fc.id or str(uuid4()),
                                     name=fc.name or "",
                                     arguments=json.dumps(dict(fc.args)) if fc.args else "{}",
-                                    provider_data=pdata,
+                                    thought_signature=part.thought_signature,
                                 )
                             )
                         elif part.executable_code and (

--- a/autogen/beta/config/gemini/mappers.py
+++ b/autogen/beta/config/gemini/mappers.py
@@ -33,7 +33,7 @@ from autogen.beta.tools.builtin.web_search import WEB_SEARCH_TOOL_NAME, WebSearc
 from autogen.beta.tools.final import FunctionToolSchema
 from autogen.beta.tools.schemas import ToolSchema
 
-from .events import GeminiServerToolCallEvent, GeminiServerToolResultEvent
+from .events import GeminiServerToolCallEvent, GeminiServerToolResultEvent, GeminiToolCallEvent
 
 
 def response_proto_to_config(response: ResponseProto | None) -> dict[str, Any]:
@@ -210,8 +210,8 @@ def convert_messages(
                     name=call.name,
                     args=json.loads(call.arguments or "{}"),
                 )
-                if "thought_signature" in call.provider_data:
-                    fc_part.thought_signature = call.provider_data["thought_signature"]
+                if isinstance(call, GeminiToolCallEvent) and call.thought_signature is not None:
+                    fc_part.thought_signature = call.thought_signature
                 parts.append(fc_part)
             if parts:
                 result.append(types.Content(role="model", parts=parts))

--- a/autogen/beta/events/tool_events.py
+++ b/autogen/beta/events/tool_events.py
@@ -68,7 +68,6 @@ class ToolCallEvent(ToolEvent):
     id: str = Field(default_factory=lambda: str(uuid4()))
     name: str = Field(kw_only=False)
     arguments: str = "{}"
-    provider_data: dict[str, Any] = Field(default_factory=dict, compare=False)
 
     _serialized_arguments: dict[str, Any] | None = Field(default=None, init=False, compare=False)
 

--- a/test/beta/config/gemini/test_tool_call_event.py
+++ b/test/beta/config/gemini/test_tool_call_event.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from autogen.beta.config.gemini.events import GeminiToolCallEvent
+from autogen.beta.events._serialization import deserialize_value, serialize_value
+
+
+def test_thought_signature_round_trip() -> None:
+    sig = b"\x12\x34\n\x32\x01\x0c\x39\xd6\xc7\xa3"
+    event = GeminiToolCallEvent(
+        id="call-1",
+        name="get_weather",
+        arguments='{"city": "Paris"}',
+        thought_signature=sig,
+    )
+
+    round_tripped = deserialize_value(serialize_value(event))
+
+    assert isinstance(round_tripped, GeminiToolCallEvent)
+    assert round_tripped.thought_signature == sig
+    assert isinstance(round_tripped.thought_signature, bytes)
+
+
+def test_thought_signature_defaults_to_none() -> None:
+    event = GeminiToolCallEvent(id="call-1", name="get_weather", arguments="{}")
+
+    assert event.thought_signature is None

--- a/test/beta/events/test_serialization.py
+++ b/test/beta/events/test_serialization.py
@@ -74,20 +74,6 @@ class TestBytes:
         payload = [b"\x01", b"\x02"]
         assert _round_trip(payload) == payload
 
-    def test_bytes_inside_event_provider_data(self) -> None:
-        """The original Gemini thought_signature bug — bytes in provider_data."""
-        sig = b"\x12\x34\n\x32\x01\x0c\x39\xd6\xc7\xa3"
-        event = ToolCallEvent(
-            id="call-1",
-            name="get_weather",
-            arguments='{"city": "Paris"}',
-            provider_data={"thought_signature": sig},
-        )
-        round_tripped = _round_trip(event)
-        assert isinstance(round_tripped, ToolCallEvent)
-        assert round_tripped.provider_data["thought_signature"] == sig
-        assert isinstance(round_tripped.provider_data["thought_signature"], bytes)
-
 
 class TestUUID:
     def test_uuid_round_trip(self) -> None:

--- a/test/beta/providers/gemini/test_gemini_integration.py
+++ b/test/beta/providers/gemini/test_gemini_integration.py
@@ -9,6 +9,7 @@ import pytest
 
 from autogen.beta import Agent
 from autogen.beta.config import GeminiConfig
+from autogen.beta.config.gemini.events import GeminiToolCallEvent
 from autogen.beta.streams.redis.serializer import Serializer, deserialize, serialize
 
 
@@ -178,9 +179,6 @@ async def test_thinking_budget_reports_thinking_tokens(gemini_config: GeminiConf
 @pytest.mark.gemini
 @pytest.mark.asyncio()
 async def test_history_round_trip_preserves_thought_signature(gemini_config: GeminiConfig) -> None:
-    """Gemini thinking models stash bytes in ``ToolCallEvent.provider_data``;
-    history persisted through the Redis JSON serializer must replay intact."""
-
     def get_weather(city: str) -> str:
         """Get the current weather for a city."""
         return f"The weather in {city} is sunny and 22°C."
@@ -195,17 +193,16 @@ async def test_history_round_trip_preserves_thought_signature(gemini_config: Gem
     reply1 = await agent.ask("What's the weather in Paris?")
     assert reply1.body is not None
 
-    # Round-trip history through the persistent-stream serializer.
     events = list(await reply1.history.get_events())
     round_tripped = [deserialize(serialize(e, Serializer.JSON), Serializer.JSON) for e in events]
 
     for ev in round_tripped:
-        sig = getattr(ev, "provider_data", {}).get("thought_signature") if hasattr(ev, "provider_data") else None
-        if sig is not None:
-            assert isinstance(sig, bytes), f"thought_signature corrupted to {type(sig).__name__}: {sig!r}"
+        if isinstance(ev, GeminiToolCallEvent) and ev.thought_signature is not None:
+            assert isinstance(ev.thought_signature, bytes), (
+                f"thought_signature corrupted to {type(ev.thought_signature).__name__}: {ev.thought_signature!r}"
+            )
 
     await reply1.history.replace(round_tripped)
 
-    # Replay must not 400 with INVALID_ARGUMENT on the corrupted signature.
     reply2 = await reply1.ask("What about London?")
     assert reply2.body is not None

--- a/test/beta/stream/redis/test_redis_stream.py
+++ b/test/beta/stream/redis/test_redis_stream.py
@@ -393,24 +393,6 @@ class TestRedisStream:
 class TestBinaryRoundTrip:
     """Events carrying binary or provider-SDK fields must round-trip intact."""
 
-    async def test_tool_call_event_with_bytes_provider_data(self, redis_storage, stream_id):
-        """The Gemini thought_signature scenario: bytes nested in provider_data."""
-        storage = redis_storage()
-        sig = b"\x12\x34\n\x32\x01\x0c\x39\xd6\xc7\xa3\x83,t\x95\xa2j\x9c\xb3\xd3"
-
-        original = ToolCallEvent(
-            id="call-1",
-            name="get_weather",
-            arguments='{"city": "Paris"}',
-            provider_data={"thought_signature": sig},
-        )
-        await storage.set_history(stream_id, [original])
-
-        [restored] = list(await storage.get_history(stream_id))
-        assert isinstance(restored, ToolCallEvent)
-        assert restored.provider_data["thought_signature"] == sig
-        assert isinstance(restored.provider_data["thought_signature"], bytes)
-
     async def test_image_input_round_trip(self, redis_storage, stream_id):
         """BinaryInput.data (used by ImageInput/AudioInput/...) carries raw bytes."""
         storage = redis_storage()


### PR DESCRIPTION
## Summary

`ToolCallEvent` carried a `provider_data: dict[str, Any]` field used as a catch-all for provider-specific metadata. In practice the only consumer was Gemini, which stuffed `thought_signature: bytes` into it. The shape was untyped, leaked provider concerns into the base event, and broke round-trip serialization for raw bytes nested inside a `dict[str, Any]` JSON column.

This PR drops `provider_data` from the base event and replaces it with a typed Gemini-only subclass.
