### PR TITLE
fix(fast_depends): route keyword-passed positional_or_keyword params before **kwargs (#1790)

### DIFF
--- a/autogen/fast_depends/core/model.py
+++ b/autogen/fast_depends/core/model.py
@@ -220,6 +220,12 @@ class CallModel(Generic[P, T]):
                 kw[arg] = v
 
         if self.var_keyword_arg is not None:
+            # POSITIONAL_OR_KEYWORD params can be supplied by name; without this
+            # explicit pop they leak into **var_keyword_arg and never reach their
+            # own slot, so the underlying call sees them as missing (#1790).
+            for arg in self.positional_args:
+                if (v := kwargs.pop(arg, Parameter.empty)) is not Parameter.empty:
+                    kw[arg] = v
             kw[self.var_keyword_arg] = kwargs
         else:
             kw.update(kwargs)

--- a/test/fast_depends/sync/test_cast.py
+++ b/test/fast_depends/sync/test_cast.py
@@ -217,3 +217,44 @@ def test_multi_annotated():
         f(1)
 
     assert f(10) == 20
+
+
+def test_var_keyword_with_named_positional_or_keyword_args():
+    """Regression for ag2 issue #1790.
+
+    A function declaring both regular POSITIONAL_OR_KEYWORD parameters and
+    a ``**kwargs`` catch-all must route keyword-supplied values to their
+    own slots, not bundle every keyword argument into ``**kwargs``.
+    """
+
+    @inject
+    def f(arg1: str, arg2: str, **kwargs):
+        return arg1, arg2, kwargs
+
+    arg1, arg2, kwargs = f(arg1="A", arg2="B", extra1="X", extra2="Y")
+    assert arg1 == "A"
+    assert arg2 == "B"
+    assert kwargs == {"extra1": "X", "extra2": "Y"}
+
+
+def test_var_keyword_only_extras():
+    """If only **kwargs is declared, every supplied keyword goes to it."""
+
+    @inject
+    def f(**kwargs):
+        return kwargs
+
+    assert f(a=1, b=2) == {"a": 1, "b": 2}
+
+
+def test_var_keyword_with_positional_call():
+    """POSITIONAL_OR_KEYWORD args supplied positionally still work alongside **kwargs."""
+
+    @inject
+    def f(arg1: str, arg2: str, **kwargs):
+        return arg1, arg2, kwargs
+
+    arg1, arg2, kwargs = f("A", "B", extra="X")
+    assert arg1 == "A"
+    assert arg2 == "B"
+    assert kwargs == {"extra": "X"}


### PR DESCRIPTION
> Supersedes #2788 (closed pending CLA). CLA is now signed; re-raising for review.

## Summary

Fixes #1790.

`autogen/fast_depends/core/model.py::CallModel._solve` only popped declared **keyword-only** parameters from the incoming kwargs dict before assigning the leftover into the function's `**var_keyword_arg` slot. POSITIONAL_OR_KEYWORD parameters — the common case for normal arguments like `arg1: str` — were never popped, so when callers pass them by name they get bundled into `**kwargs` and the wrapped function sees them as missing.

This is the path that `Tool.register_for_llm` goes through. As reported in #1790, any user tool that declares regular args alongside `**kwargs` (e.g. for an open-ended dict of LLM-supplied extras) breaks: the LLM returns JSON like `{"arg1": "...", "arg2": "...", "kwargs": "{...}"}` and the executor raises:

```
ValidationError: 2 validation errors for hello_world_v3
  arg1  Field required ... input_value={'kwargs': {'arg1': '...', 'arg2': '...', ...}}
  arg2  Field required ...
```

The maintainer @Lancetnik noted on the issue that this was fixed in the upstream FastDepends 3.0.0; the vendored copy in `autogen/fast_depends/` did not pick up the equivalent fix.

## Fix

In the `var_keyword_arg` branch, pop `positional_args` from `kwargs` (so they reach their own slot) before assigning the remainder to the catch-all. Functions that declare no `**kwargs` are unaffected — the existing `kw.update(kwargs)` branch is unchanged.

```python
if self.var_keyword_arg is not None:
    # POSITIONAL_OR_KEYWORD params can be supplied by name; without this
    # explicit pop they leak into **var_keyword_arg and never reach their
    # own slot, so the underlying call sees them as missing (#1790).
    for arg in self.positional_args:
        if (v := kwargs.pop(arg, Parameter.empty)) is not Parameter.empty:
            kw[arg] = v
    kw[self.var_keyword_arg] = kwargs
else:
    kw.update(kwargs)
```

## Validation

Added three regression tests in `test/fast_depends/sync/test_cast.py`:

- `test_var_keyword_with_named_positional_or_keyword_args` — the broken case from #1790; passes only with the fix.
- `test_var_keyword_only_extras` — sanity check that a kwargs-only function still routes everything to `**kwargs`.
- `test_var_keyword_with_positional_call` — POSITIONAL_OR_KEYWORD args supplied positionally still work alongside `**kwargs`.

## Test plan

- [x] `pytest test/fast_depends/sync/test_cast.py::test_var_keyword_with_named_positional_or_keyword_args`
- [x] `pytest test/fast_depends/sync/test_cast.py::test_var_keyword_only_extras`
- [x] `pytest test/fast_depends/sync/test_cast.py::test_var_keyword_with_positional_call`
- [x] `pytest test/fast_depends/ test/tools/test_dependency_injection.py test/tools/test_function_utils.py` — 178 passed, 6 skipped
- [x] Verified original repro from #1790 (a function with `arg1`, `arg2`, and annotated `**kwargs`) now returns the correct merged result instead of raising
- [x] `ruff check` and `ruff format --check` clean on changed files

## Notes

The fix mirrors the upstream FastDepends 3.0.0 change Lancetnik mentioned. Scope kept minimal — vendored `autogen.fast_depends` only, no broader sync of vendored vs upstream.
