### PR TITLE
fix(beta/filesystem): pin read/write encoding to UTF-8

### DIFF
--- a/autogen/beta/tools/toolkits/filesystem.py
+++ b/autogen/beta/tools/toolkits/filesystem.py
@@ -95,7 +95,13 @@ class FilesystemToolkit(Toolkit):
             target = _resolve_path(base_dir, path)
             if raw:
                 return base64.b64encode(target.read_bytes()).decode("ascii")
-            return target.read_text()
+            # Pin the encoding so the toolkit produces the same bytes on Linux,
+            # macOS, and Windows. Without it `Path.read_text()` inherits
+            # `locale.getpreferredencoding()`, which is `cp1252` on most
+            # Windows installs and raises `UnicodeDecodeError` on any file
+            # written with non-cp1252 content (most modern source files,
+            # config files, JSON with non-ASCII strings, etc.).
+            return target.read_text(encoding="utf-8")
 
         return _read_file
 
@@ -148,7 +154,12 @@ class FilesystemToolkit(Toolkit):
         ) -> str:
             target = _resolve_path(base_dir, path)
             target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(content)
+            # Encode the payload as UTF-8 so the toolkit round-trips any
+            # text the model writes (smart quotes, emoji, non-Latin scripts,
+            # code with non-ASCII docstrings). The platform-default
+            # encoding is `cp1252` on most Windows machines and silently
+            # raises `UnicodeEncodeError` mid-write.
+            target.write_text(content, encoding="utf-8")
             return f"Successfully wrote {len(content)} characters to {path}"
 
         return _write_file
@@ -179,10 +190,15 @@ class FilesystemToolkit(Toolkit):
             ],
         ) -> str:
             target = _resolve_path(base_dir, path)
-            text = target.read_text()
+            # See _read_file / _write_file: pin UTF-8 so update_file reads
+            # back the exact bytes it (or any other UTF-8 writer) produced,
+            # and writes the modified payload back in the same encoding.
+            # Without this, the read/write pair on Windows would silently
+            # transcode the file into cp1252 every time the model edits it.
+            text = target.read_text(encoding="utf-8")
             if old_content not in text:
                 raise ValueError(f"old_content not found in {path}")
-            target.write_text(text.replace(old_content, new_content, 1))
+            target.write_text(text.replace(old_content, new_content, 1), encoding="utf-8")
             return f"Successfully updated {path}"
 
         return _update_file

--- a/test/beta/tools/test_filesystem.py
+++ b/test/beta/tools/test_filesystem.py
@@ -136,6 +136,80 @@ async def test_write_creates_parent_dirs(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_write_file_encodes_as_utf8(tmp_path: Path) -> None:
+    """The toolkit must write non-ASCII content as UTF-8 regardless of the
+    host's `locale.getpreferredencoding()` (which is `cp1252` on most
+    Windows installs and would silently raise `UnicodeEncodeError` mid-write
+    for any non-cp1252 glyph). Read the bytes back and compare against the
+    UTF-8 encoding directly so the test pins the contract on every platform.
+    """
+    payload = "Café — Beberenice ☕ — 例 — émoji 🚀"
+    toolkit = FilesystemToolkit(base_path=tmp_path)
+
+    config = TestConfig(
+        ToolCallEvent(
+            name="write_file",
+            arguments=json.dumps({"path": "non_ascii.txt", "content": payload}),
+        ),
+        "done",
+    )
+    agent = Agent("", config=config, tools=[toolkit])
+    await agent.ask("write it")
+
+    assert (tmp_path / "non_ascii.txt").read_bytes() == payload.encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_read_file_decodes_as_utf8(tmp_path: Path) -> None:
+    """The toolkit must read files written as UTF-8 regardless of the
+    host's default encoding. On Windows, `Path.read_text()` without an
+    explicit encoding decodes as `cp1252` and raises `UnicodeDecodeError`
+    for any non-cp1252 byte sequence.
+    """
+    payload = "Café — Beberenice ☕ — 例 — émoji 🚀"
+    (tmp_path / "non_ascii.txt").write_bytes(payload.encode("utf-8"))
+
+    toolkit = FilesystemToolkit(base_path=tmp_path)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="read_file",
+                arguments=json.dumps({"path": "./non_ascii.txt"}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[toolkit])
+    await agent.ask("read it")
+
+    tool_result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    assert tool_result_msg.results[0].result.parts[0].content == payload
+
+
+@pytest.mark.asyncio
+async def test_update_file_preserves_utf8(tmp_path: Path) -> None:
+    """`update_file` reads, edits, and rewrites the file. Both endpoints
+    must use UTF-8 so a round-trip preserves non-ASCII byte content.
+    """
+    target = tmp_path / "data.txt"
+    target.write_bytes("Café old Beberenice".encode("utf-8"))
+
+    toolkit = FilesystemToolkit(base_path=tmp_path)
+    config = TestConfig(
+        ToolCallEvent(
+            name="update_file",
+            arguments=json.dumps({"path": "data.txt", "old_content": "old", "new_content": "新"}),
+        ),
+        "done",
+    )
+    agent = Agent("", config=config, tools=[toolkit])
+    await agent.ask("update it")
+
+    assert target.read_bytes() == "Café 新 Beberenice".encode("utf-8")
+
+
+@pytest.mark.asyncio
 async def test_update_file(tmp_path: Path) -> None:
     (tmp_path / "data.txt").write_text("foo bar baz")
 

--- a/test/beta/tools/test_filesystem.py
+++ b/test/beta/tools/test_filesystem.py
@@ -193,7 +193,7 @@ async def test_update_file_preserves_utf8(tmp_path: Path) -> None:
     must use UTF-8 so a round-trip preserves non-ASCII byte content.
     """
     target = tmp_path / "data.txt"
-    target.write_bytes("Café old Beberenice".encode("utf-8"))
+    target.write_bytes("Café old Beberenice".encode())
 
     toolkit = FilesystemToolkit(base_path=tmp_path)
     config = TestConfig(
@@ -206,7 +206,7 @@ async def test_update_file_preserves_utf8(tmp_path: Path) -> None:
     agent = Agent("", config=config, tools=[toolkit])
     await agent.ask("update it")
 
-    assert target.read_bytes() == "Café 新 Beberenice".encode("utf-8")
+    assert target.read_bytes() == "Café 新 Beberenice".encode()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`FilesystemToolkit` exposes `read_file`, `write_file`, and `update_file` tools that the model uses to manipulate user files on disk. All three called `Path.read_text()` / `Path.write_text()` without an explicit encoding, so each operation inherited `locale.getpreferredencoding()` — `cp1252` on most Windows installs:

- `read_file` raised `UnicodeDecodeError` on any file whose bytes weren't valid cp1252 (most modern source files, JSON / YAML with non-ASCII strings, Markdown with smart quotes, anything with emoji or CJK glyphs).
- `write_file` raised `UnicodeEncodeError` on any payload the model generated that wasn't representable in cp1252 (the same set of characters).
- `update_file` did the read and the write in the same call against the platform default, so a round-trip on Windows silently transcoded the file every time the model edited it.

Same class of bug as #1731 / #2814 / #2815, this time on the LLM-facing beta toolkit.

## Fix

Pass `encoding=\"utf-8\"` explicitly at all three call sites so the toolkit produces the same bytes on Linux, macOS, and Windows. No change to the public tool signatures; no new options. Inline comments explain why the kwarg is required so a future refactor doesn't drop it again.

## Test

`test/beta/tools/test_filesystem.py` gets three regression tests that drive the toolkit through `Agent.ask` (per `test/beta/CLAUDE.md`'s public-API guidance) and assert byte-level equality against the explicit UTF-8 encoding of the payload — not against `Path.read_text()`, which would mask the bug on POSIX:

- `test_write_file_encodes_as_utf8`
- `test_read_file_decodes_as_utf8`
- `test_update_file_preserves_utf8` — replaces an ASCII token with a CJK glyph so the read+write pair has to round-trip non-cp1252 content.

`npm test` equivalent: `.venv/bin/python -m pytest test/beta/tools/test_filesystem.py` reports 16 passed.