### PR TITLE
feat(beta/network): named views with [name] prefixes for N-party channels

### DIFF
--- a/autogen/beta/network/__init__.py
+++ b/autogen/beta/network/__init__.py
@@ -193,7 +193,16 @@ from .transport import (
     decode_frame,
     encode_frame,
 )
-from .views import FullTranscript, ViewPolicy, WindowedSummary
+from .views import (
+    EnvelopeRenderer,
+    FullTranscript,
+    NameResolver,
+    NamedTranscript,
+    NamedWindowedSummary,
+    ViewPolicy,
+    WindowedSummary,
+    default_name_resolver,
+)
 
 __all__ = (
     "AGENT_CLIENT_DEP",
@@ -272,6 +281,7 @@ __all__ = (
     "DiscussionAdapter",
     "DiscussionState",
     "Envelope",
+    "EnvelopeRenderer",
     "ErrorFrame",
     "EventFrame",
     "Expectation",
@@ -297,6 +307,9 @@ __all__ = (
     "LocalLinkClient",
     "LocalLinkEndpoint",
     "MaxSilenceEvaluator",
+    "NameResolver",
+    "NamedTranscript",
+    "NamedWindowedSummary",
     "NetworkClient",
     "NetworkContextPolicy",
     "NetworkError",
@@ -355,6 +368,7 @@ __all__ = (
     "default_extract_turn_input",
     "default_handler",
     "default_handlers",
+    "default_name_resolver",
     "default_render_envelope",
     "default_tools_for",
     "encode_frame",

--- a/autogen/beta/network/adapters/discussion.py
+++ b/autogen/beta/network/adapters/discussion.py
@@ -36,7 +36,7 @@ from ..envelope import (
 )
 from ..errors import ProtocolError
 from ..views.base import ViewPolicy
-from ..views.builtin import WindowedSummary
+from ..views.builtin import NamedWindowedSummary
 from .base import (
     AdapterResult,
     default_build_packet_envelope,
@@ -107,8 +107,12 @@ class DiscussionAdapter:
     Knobs: ``{"ordering": "round_robin"}`` (default). Unsupported
     orderings are rejected at create time.
 
-    Default view: :class:`WindowedSummary(recent_n=N*2)` where N =
-    participant count — keeps prompt size bounded at any turn count.
+    Default view: :class:`NamedWindowedSummary(recent_n=N*2)` where
+    N = participant count — keeps prompt size bounded at any turn
+    count AND prefixes each non-self projection line with the
+    sender's name so the LLM can tell its peers apart in a 3+ party
+    chat (the assistant/user role bit alone collapses every "other"
+    into one indistinguishable stream).
     """
 
     def __init__(self) -> None:
@@ -118,7 +122,7 @@ class DiscussionAdapter:
             version=1,
             participants=ParticipantSchema(min=2),
             knobs_schema={"ordering": "str"},
-            default_view_policy=WindowedSummary.name,
+            default_view_policy=NamedWindowedSummary.name,
             expectations=[
                 Expectation(
                     name="turn_within",
@@ -203,7 +207,7 @@ class DiscussionAdapter:
         participant_id: str,
     ) -> ViewPolicy:
         recent_n = max(len(metadata.participants) * 2, 4)
-        return WindowedSummary(recent_n=recent_n)
+        return NamedWindowedSummary(recent_n=recent_n)
 
     def extract_turn_input(self, envelope):
         return default_extract_turn_input(envelope)

--- a/autogen/beta/network/adapters/workflow.py
+++ b/autogen/beta/network/adapters/workflow.py
@@ -61,7 +61,7 @@ from ..transitions import (
     WorkflowGraphError,
 )
 from ..views.base import ViewPolicy
-from ..views.builtin import WindowedSummary
+from ..views.builtin import NamedWindowedSummary
 from .base import (
     AdapterResult,
     default_build_packet_envelope,
@@ -134,8 +134,12 @@ class WorkflowAdapter:
     """Generic orchestrated multi-party channel.
 
     Knobs: ``{"graph": <TransitionGraph.to_dict()>}``. Participants:
-    2+. Default view: :class:`WindowedSummary(recent_n=N*2)` with
-    ``N`` = participant count.
+    2+. Default view: :class:`NamedWindowedSummary(recent_n=N*2)`
+    with ``N`` = participant count — bounded prompt size plus sender
+    labels on non-self projection lines so the orchestrator / next
+    speaker can tell its peers apart in a 3+ party chat (the
+    assistant/user role bit alone collapses every "other" into one
+    indistinguishable stream).
     """
 
     def __init__(self) -> None:
@@ -144,7 +148,7 @@ class WorkflowAdapter:
             version=1,
             participants=ParticipantSchema(min=2),
             knobs_schema={"graph": "TransitionGraph"},
-            default_view_policy=WindowedSummary.name,
+            default_view_policy=NamedWindowedSummary.name,
             expectations=[
                 Expectation(
                     name="turn_within",
@@ -332,7 +336,7 @@ class WorkflowAdapter:
         participant_id: str,
     ) -> ViewPolicy:
         recent_n = max(len(metadata.participants) * 2, 4)
-        return WindowedSummary(recent_n=recent_n)
+        return NamedWindowedSummary(recent_n=recent_n)
 
     def extract_turn_input(self, envelope: Envelope) -> str | None:
         """Decode an inbound substantive envelope into the next

--- a/autogen/beta/network/client/handlers.py
+++ b/autogen/beta/network/client/handlers.py
@@ -166,6 +166,7 @@ async def _process_substantive(envelope: Envelope, client: "AgentClient") -> Non
             participant_id=client.agent_id,
             channel=metadata,
             render_envelope=adapter.render_envelope,
+            name_for=client._hub.name_for,
         )
 
         current_input = adapter.extract_turn_input(envelope)

--- a/autogen/beta/network/hub/core.py
+++ b/autogen/beta/network/hub/core.py
@@ -893,6 +893,20 @@ class Hub:
 
     # ── Discovery (read-side) ────────────────────────────────────────────────
 
+    def name_for(self, agent_id: str, *, default: str | None = None) -> str:
+        """Resolve ``agent_id`` to its registered ``Passport.name``.
+
+        Reads the in-memory passport directory.
+        Returns ``default`` when the id is unknown (or ``agent_id`` itself
+        if ``default`` is ``None``), so callers can use this as a safe
+        ``NameResolver`` for view projection without needing to handle
+        the unregistered / unregistered-mid-turn case.
+        """
+        passport = self._passports.get(agent_id)
+        if passport is not None:
+            return passport.name
+        return default if default is not None else agent_id
+
     async def get_agent(self, name_or_id: str) -> Passport:
         agent_id = self._name_to_id.get(name_or_id, name_or_id)
         passport = self._passports.get(agent_id)

--- a/autogen/beta/network/views/__init__.py
+++ b/autogen/beta/network/views/__init__.py
@@ -11,15 +11,21 @@ is what view policies produce.
 Built-ins: ``FullTranscript`` (verbatim) and ``WindowedSummary``
 (bounded tail + head summary, composes with framework-core
 ``compact.py``). Envelope rendering is supplied per-call by the
-channel's adapter via ``ChannelAdapter.render_envelope``.
+channel's adapter via ``ChannelAdapter.render_envelope``. Sender
+identity is supplied per-call by the handler via a ``NameResolver``
+sourced from the hub's passport directory.
 """
 
-from .base import EnvelopeRenderer, ViewPolicy
-from .builtin import FullTranscript, WindowedSummary
+from .base import EnvelopeRenderer, NameResolver, ViewPolicy, default_name_resolver
+from .builtin import FullTranscript, NamedTranscript, NamedWindowedSummary, WindowedSummary
 
 __all__ = (
     "EnvelopeRenderer",
     "FullTranscript",
+    "NameResolver",
+    "NamedTranscript",
+    "NamedWindowedSummary",
     "ViewPolicy",
     "WindowedSummary",
+    "default_name_resolver",
 )

--- a/autogen/beta/network/views/base.py
+++ b/autogen/beta/network/views/base.py
@@ -21,7 +21,7 @@ from autogen.beta.events import BaseEvent
 from ..channel import ChannelMetadata
 from ..envelope import Envelope
 
-__all__ = ("EnvelopeRenderer", "ViewPolicy")
+__all__ = ("EnvelopeRenderer", "NameResolver", "ViewPolicy", "default_name_resolver")
 
 
 EnvelopeRenderer = Callable[[Envelope], "str | None"]
@@ -29,6 +29,26 @@ EnvelopeRenderer = Callable[[Envelope], "str | None"]
 to skip. Supplied by the channel's adapter via
 ``ChannelAdapter.render_envelope`` so view policies stay
 adapter-neutral."""
+
+
+NameResolver = Callable[[str], str]
+"""Resolve an ``agent_id`` to its human-facing ``Passport.name``.
+
+Supplied by the default handler (sourced from :meth:`Hub.name_for`) so
+view policies can label projection lines without depending on hub
+internals. The resolver is called once per visible envelope. If the id
+is unknown the resolver returns the raw id so projection never fails."""
+
+
+def default_name_resolver(agent_id: str) -> str:
+    """Identity ``NameResolver`` — returns ``agent_id`` verbatim.
+
+    Used by call sites that want to invoke a view policy without
+    plumbing a real hub-backed resolver (tests, headless utilities).
+    Production code paths (the default notify handler) always pass a
+    real resolver backed by the hub's passport directory.
+    """
+    return agent_id
 
 
 class ViewPolicy(Protocol):
@@ -48,8 +68,15 @@ class ViewPolicy(Protocol):
         participant_id: str,
         channel: ChannelMetadata,
         render_envelope: EnvelopeRenderer,
+        name_for: NameResolver = default_name_resolver,
     ) -> list[BaseEvent]:
         """Convert the WAL slice this participant should see into model
-        events. ``render_envelope`` is provided by the channel's
-        adapter so the view stays adapter-neutral."""
+        events.
+
+        ``render_envelope`` is provided by the channel's adapter so the
+        view stays adapter-neutral. ``name_for`` resolves an
+        ``agent_id`` to its human-facing ``Passport.name`` for views
+        that want to label projection lines with the sender — built-in
+        views that don't label simply ignore it.
+        """
         ...

--- a/autogen/beta/network/views/builtin.py
+++ b/autogen/beta/network/views/builtin.py
@@ -5,14 +5,24 @@
 """Built-in ``ViewPolicy`` implementations.
 
 * :class:`FullTranscript` — projects every visible substantive envelope
-  verbatim.
+  verbatim. Used by adapters where the assistant/user role bit already
+  disambiguates speakers (i.e. 2-party).
 * :class:`WindowedSummary` — keeps a bounded tail of recent envelopes
   and replaces older ones with a single :class:`CompactionSummary`
   event (static stat-style summary, no LLM call).
+* :class:`NamedTranscript` — like :class:`FullTranscript` but
+  prefixes each non-self projection line with ``[<sender name>]:``.
+  Necessary in N-party (3+) channels where every non-self envelope
+  would otherwise collapse into one indistinguishable ``user``-role
+  stream.
+* :class:`NamedWindowedSummary` — :class:`WindowedSummary` with the
+  same speaker-name prefix. The default view for the ``discussion``
+  and ``workflow`` adapters.
 
 Policies dispatch envelope rendering through the adapter via the
-``render_envelope`` callable supplied to ``project``, so they stay
-adapter-neutral.
+``render_envelope`` callable supplied to ``project`` and resolve
+sender identity via the ``name_for`` callable supplied by the default
+handler — both keep view policies adapter-neutral and hub-independent.
 """
 
 from autogen.beta.compact import CompactionSummary
@@ -20,9 +30,14 @@ from autogen.beta.events import BaseEvent, ModelMessage, ModelRequest, TextInput
 
 from ..channel import ChannelMetadata
 from ..envelope import Envelope, visible_to
-from .base import EnvelopeRenderer
+from .base import EnvelopeRenderer, NameResolver, default_name_resolver
 
-__all__ = ("FullTranscript", "WindowedSummary")
+__all__ = (
+    "FullTranscript",
+    "NamedTranscript",
+    "NamedWindowedSummary",
+    "WindowedSummary",
+)
 
 
 class FullTranscript:
@@ -36,7 +51,10 @@ class FullTranscript:
     metadata into the prompt prefix instead.
 
     Inbound envelopes (sender != participant) become ``ModelRequest``
-    (a "user turn"); own past envelopes become ``ModelMessage``.
+    (a "user turn"); own past envelopes become ``ModelMessage``. The
+    assistant/user role bit is the speaker disambiguator — sufficient
+    for 2-party channels where there's only one possible "other".
+    Use :class:`NamedTranscript` for N-party channels.
     """
 
     name = "full_transcript"
@@ -48,6 +66,7 @@ class FullTranscript:
         participant_id: str,
         channel: ChannelMetadata,
         render_envelope: EnvelopeRenderer,
+        name_for: NameResolver = default_name_resolver,  # noqa: ARG002
     ) -> list[BaseEvent]:
         events: list[BaseEvent] = []
         for envelope in wal:
@@ -56,10 +75,7 @@ class FullTranscript:
             text = render_envelope(envelope)
             if text is None:
                 continue
-            if envelope.sender_id == participant_id:
-                events.append(ModelMessage(text))
-            else:
-                events.append(ModelRequest([TextInput(text)]))
+            events.append(_to_event(envelope, text, participant_id))
         return events
 
 
@@ -75,7 +91,8 @@ class WindowedSummary:
 
     The summary is a static stat-style line
     (``"Earlier in this channel: N messages from a, b."``) — no LLM
-    call.
+    call. Use :class:`NamedWindowedSummary` for N-party channels where
+    the speaker labels matter.
     """
 
     name = "windowed_summary"
@@ -96,6 +113,7 @@ class WindowedSummary:
         participant_id: str,
         channel: ChannelMetadata,
         render_envelope: EnvelopeRenderer,
+        name_for: NameResolver = default_name_resolver,  # noqa: ARG002
     ) -> list[BaseEvent]:
         visible: list[tuple[Envelope, str]] = []
         for envelope in wal:
@@ -117,13 +135,116 @@ class WindowedSummary:
         return [compaction, *(_to_event(env, txt, participant_id) for env, txt in recent)]
 
 
+class NamedTranscript:
+    """Like :class:`FullTranscript` but prefixes non-self lines with the sender name.
+
+    Used in N-party channels (3+ participants) where the assistant/user
+    role bit alone can't tell the LLM which "other" said which message.
+    Each non-self envelope is projected as
+    ``ModelRequest([TextInput(f"[{sender_name}]: {body}")])`` so the
+    LLM sees a name-prefixed stream instead of an unattributed collapse.
+
+    Self envelopes still project as ``ModelMessage(text)`` — the
+    assistant role already says "I said this," no label needed.
+    """
+
+    name = "named_transcript"
+
+    async def project(
+        self,
+        wal: list[Envelope],
+        *,
+        participant_id: str,
+        channel: ChannelMetadata,
+        render_envelope: EnvelopeRenderer,
+        name_for: NameResolver = default_name_resolver,
+    ) -> list[BaseEvent]:
+        events: list[BaseEvent] = []
+        for envelope in wal:
+            if not visible_to(envelope, participant_id):
+                continue
+            text = render_envelope(envelope)
+            if text is None:
+                continue
+            events.append(_to_named_event(envelope, text, participant_id, name_for))
+        return events
+
+
+class NamedWindowedSummary:
+    """:class:`WindowedSummary` with sender labels on non-self lines.
+
+    The default view for the ``discussion`` and ``workflow`` adapters.
+    Same bounded-tail-plus-compaction behaviour as
+    :class:`WindowedSummary`; non-self projections are prefixed
+    ``[<sender name>]:`` so the manager / next speaker can tell who
+    just spoke. The head :class:`CompactionSummary` for elided
+    envelopes also lists speakers by name rather than by raw id.
+    """
+
+    name = "named_windowed_summary"
+
+    def __init__(self, recent_n: int) -> None:
+        if recent_n < 1:
+            raise ValueError(f"recent_n must be >= 1, got {recent_n}")
+        self._recent_n = recent_n
+
+    @property
+    def recent_n(self) -> int:
+        return self._recent_n
+
+    async def project(
+        self,
+        wal: list[Envelope],
+        *,
+        participant_id: str,
+        channel: ChannelMetadata,
+        render_envelope: EnvelopeRenderer,
+        name_for: NameResolver = default_name_resolver,
+    ) -> list[BaseEvent]:
+        visible: list[tuple[Envelope, str]] = []
+        for envelope in wal:
+            if not visible_to(envelope, participant_id):
+                continue
+            text = render_envelope(envelope)
+            if text is None:
+                continue
+            visible.append((envelope, text))
+
+        if len(visible) <= self._recent_n:
+            return [_to_named_event(env, txt, participant_id, name_for) for env, txt in visible]
+
+        cutoff = len(visible) - self._recent_n
+        older = visible[:cutoff]
+        recent = visible[cutoff:]
+        summary = _summarize_older([env for env, _ in older], name_for=name_for)
+        compaction = CompactionSummary(summary=summary, event_count=len(older))
+        return [
+            compaction,
+            *(_to_named_event(env, txt, participant_id, name_for) for env, txt in recent),
+        ]
+
+
 def _to_event(envelope: Envelope, text: str, participant_id: str) -> BaseEvent:
     if envelope.sender_id == participant_id:
         return ModelMessage(text)
     return ModelRequest([TextInput(text)])
 
 
-def _summarize_older(older: list[Envelope]) -> str:
-    speakers = sorted({e.sender_id for e in older})
+def _to_named_event(
+    envelope: Envelope,
+    text: str,
+    participant_id: str,
+    name_for: NameResolver,
+) -> BaseEvent:
+    if envelope.sender_id == participant_id:
+        return ModelMessage(text)
+    return ModelRequest([TextInput(f"[{name_for(envelope.sender_id)}]: {text}")])
+
+
+def _summarize_older(older: list[Envelope], *, name_for: NameResolver | None = None) -> str:
+    if name_for is None:
+        speakers = sorted({e.sender_id for e in older})
+    else:
+        speakers = sorted({name_for(e.sender_id) for e in older})
     plural = "s" if len(older) != 1 else ""
     return f"Earlier in this channel: {len(older)} message{plural} from {', '.join(speakers)}."

--- a/test/beta/network/test_view_name_resolver.py
+++ b/test/beta/network/test_view_name_resolver.py
@@ -1,0 +1,392 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``NameResolver`` plumbing + the named built-in views.
+
+This PR exposes a ``name_for: NameResolver`` kwarg on
+``ViewPolicy.project`` so views can prefix projections with the
+sender's ``Passport.name`` without depending on hub internals, and
+ships two new built-ins (``NamedTranscript`` and
+``NamedWindowedSummary``) that USE the resolver to prefix non-self
+projection lines with ``[<name>]:``. The default-view for the
+N-party adapters (``discussion``, ``workflow``) swaps to
+``NamedWindowedSummary``; the 2-party adapters (``consulting``,
+``conversation``) keep their unprefixed defaults because the
+assistant/user role bit already disambiguates with only one "other".
+
+These tests pin:
+
+* Foundation: ``Hub.name_for`` + back-compat built-ins accept the new kwarg.
+* Named built-ins prefix non-self projections (own envelopes stay bare).
+* Adapter defaults swap to Named in N-party, stay unprefixed in 2-party.
+* The default notify handler hands a real ``Hub.name_for``-backed
+  resolver into ``view.project`` at turn time.
+"""
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.compact import CompactionSummary
+from autogen.beta.events import ModelMessage, ModelRequest, TextInput
+from autogen.beta.knowledge import MemoryKnowledgeStore
+from autogen.beta.network import (
+    EV_TEXT,
+    Envelope,
+    FullTranscript,
+    Hub,
+    HubClient,
+    LocalLink,
+    NameResolver,
+    NamedTranscript,
+    NamedWindowedSummary,
+    Passport,
+    Resume,
+    WindowedSummary,
+    default_name_resolver,
+)
+from autogen.beta.network.adapters.base import default_render_envelope
+from autogen.beta.network.adapters.consulting import ConsultingAdapter
+from autogen.beta.network.adapters.conversation import ConversationAdapter
+from autogen.beta.network.adapters.discussion import DiscussionAdapter
+from autogen.beta.network.adapters.workflow import WorkflowAdapter
+from autogen.beta.network.channel import (
+    ChannelMetadata,
+    ChannelState,
+    Participant,
+    ParticipantRole,
+)
+from autogen.beta.testing import TestConfig
+
+
+def _two_party_metadata(a_id: str, b_id: str) -> ChannelMetadata:
+    """Synthesize a minimal conversation-style channel for projection tests."""
+    return ChannelMetadata(
+        channel_id="ch-test",
+        manifest=ConversationAdapter().manifest,
+        creator_id=a_id,
+        participants=[
+            Participant(agent_id=a_id, role=ParticipantRole.INITIATOR, order=0, joined_at="now"),
+            Participant(agent_id=b_id, role=ParticipantRole.RESPONDENT, order=1, joined_at="now"),
+        ],
+        state=ChannelState.ACTIVE,
+        created_at="now",
+        expires_at=None,
+        knobs={},
+        labels={},
+        required_acks=None,
+        pending_acks=[],
+    )
+
+
+def _text_envelope(sender: str, audience: str, text: str) -> Envelope:
+    return Envelope(
+        channel_id="ch-test",
+        sender_id=sender,
+        audience=[audience],
+        event_type=EV_TEXT,
+        event_data={"text": text},
+    )
+
+
+def test_default_name_resolver_returns_id_verbatim() -> None:
+    assert default_name_resolver("abc-123") == "abc-123"
+
+
+@pytest.mark.asyncio
+async def test_full_transcript_accepts_name_for_kwarg() -> None:
+    """Back-compat: built-in views accept the new kwarg and behave unchanged."""
+    metadata = _two_party_metadata("alice", "bob")
+    wal = [
+        _text_envelope("alice", "bob", "hi"),
+        _text_envelope("bob", "alice", "hello"),
+    ]
+
+    view = FullTranscript()
+    projection = await view.project(
+        wal,
+        participant_id="bob",
+        channel=metadata,
+        render_envelope=default_render_envelope,
+        name_for=lambda aid: f"Mx-{aid}",
+    )
+
+    # Built-ins ignore name_for today — same shape as without it.
+    assert projection == [
+        ModelRequest([TextInput("hi")]),
+        ModelMessage("hello"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_windowed_summary_accepts_name_for_kwarg() -> None:
+    """``WindowedSummary`` accepts ``name_for`` without behaviour change."""
+    metadata = _two_party_metadata("alice", "bob")
+    wal = [
+        _text_envelope("alice", "bob", "hi"),
+        _text_envelope("bob", "alice", "hello"),
+    ]
+
+    view = WindowedSummary(recent_n=10)
+    projection = await view.project(
+        wal,
+        participant_id="bob",
+        channel=metadata,
+        render_envelope=default_render_envelope,
+        name_for=lambda aid: f"Mx-{aid}",
+    )
+
+    assert projection == [
+        ModelRequest([TextInput("hi")]),
+        ModelMessage("hello"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hub_name_for_resolves_registered_passport_name() -> None:
+    """``Hub.name_for`` returns the ``Passport.name`` for a registered agent."""
+    hub = await Hub.open(
+        MemoryKnowledgeStore(),
+        ttl_sweep_interval=0,
+        expectation_sweep_interval=0,
+    )
+    try:
+        hc = HubClient(LocalLink(hub), hub=hub)
+        try:
+            agent = Agent(name="alice", prompt="x", config=TestConfig([], "ok"))
+            client = await hc.register(agent, Passport(name="alice"), Resume(), attach_plugin=False)
+            assert hub.name_for(client.agent_id) == "alice"
+        finally:
+            await hc.close()
+    finally:
+        await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_hub_name_for_falls_back_for_unknown_id() -> None:
+    """Unknown ids fall back to the id itself (or a supplied default)."""
+    hub = await Hub.open(
+        MemoryKnowledgeStore(),
+        ttl_sweep_interval=0,
+        expectation_sweep_interval=0,
+    )
+    try:
+        assert hub.name_for("does-not-exist") == "does-not-exist"
+        assert hub.name_for("does-not-exist", default="unknown") == "unknown"
+    finally:
+        await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_handler_passes_real_resolver_to_view_project() -> None:
+    """The default notify handler hands a hub-backed ``name_for`` to
+    ``view.project``. Verified by registering a custom view that records
+    what it was called with."""
+
+    seen: dict[str, object] = {}
+
+    class RecordingView:
+        name = "recording"
+
+        async def project(
+            self,
+            wal,  # noqa: ARG002
+            *,
+            participant_id,
+            channel,  # noqa: ARG002
+            render_envelope,  # noqa: ARG002
+            name_for: NameResolver = default_name_resolver,
+        ):
+            seen["name_for_alice_known"] = name_for(participant_id)
+            seen["name_for_unknown"] = name_for("definitely-not-an-agent-id")
+            return []
+
+    # Stand up a hub with a conversation adapter whose default view is
+    # our recorder. We don't need a real LLM turn — just the handler
+    # passing name_for into project. We bypass the agent loop by
+    # directly invoking project the way the handler does.
+    hub = await Hub.open(
+        MemoryKnowledgeStore(),
+        ttl_sweep_interval=0,
+        expectation_sweep_interval=0,
+    )
+    try:
+        hc = HubClient(LocalLink(hub), hub=hub)
+        try:
+            agent = Agent(name="alice", prompt="x", config=TestConfig([], "ok"))
+            client = await hc.register(agent, Passport(name="alice"), Resume(), attach_plugin=False)
+
+            metadata = _two_party_metadata(client.agent_id, "bob")
+            view = RecordingView()
+            await view.project(
+                [],
+                participant_id=client.agent_id,
+                channel=metadata,
+                render_envelope=default_render_envelope,
+                name_for=hub.name_for,
+            )
+
+            assert seen["name_for_alice_known"] == "alice"
+            assert seen["name_for_unknown"] == "definitely-not-an-agent-id"
+        finally:
+            await hc.close()
+    finally:
+        await hub.close()
+
+
+# ── Named views ────────────────────────────────────────────────────────────
+
+
+def _named_resolver(mapping: dict[str, str]) -> NameResolver:
+    """Build a resolver from an id→name dict, falling back to the id."""
+    return lambda aid: mapping.get(aid, aid)
+
+
+@pytest.mark.asyncio
+async def test_named_transcript_prefixes_non_self_envelopes() -> None:
+    """Non-self lines get ``[<name>]:`` prefix; own lines stay bare."""
+    metadata = _two_party_metadata("alice", "bob")
+    wal = [
+        _text_envelope("alice", "bob", "hi bob"),
+        _text_envelope("bob", "alice", "hi alice"),
+        _text_envelope("alice", "bob", "how's it going"),
+    ]
+
+    projection = await NamedTranscript().project(
+        wal,
+        participant_id="bob",
+        channel=metadata,
+        render_envelope=default_render_envelope,
+        name_for=_named_resolver({"alice": "Alice", "bob": "Bob"}),
+    )
+
+    assert projection == [
+        ModelRequest([TextInput("[Alice]: hi bob")]),
+        ModelMessage("hi alice"),
+        ModelRequest([TextInput("[Alice]: how's it going")]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_named_transcript_falls_back_to_raw_id_for_unknown_sender() -> None:
+    """If the resolver returns the raw id, projection still succeeds."""
+    metadata = _two_party_metadata("alice", "bob")
+    wal = [_text_envelope("ghost", "alice", "leftover")]
+
+    projection = await NamedTranscript().project(
+        wal,
+        participant_id="alice",
+        channel=metadata,
+        render_envelope=default_render_envelope,
+        name_for=default_name_resolver,  # identity — returns id verbatim
+    )
+
+    assert projection == [ModelRequest([TextInput("[ghost]: leftover")])]
+
+
+@pytest.mark.asyncio
+async def test_named_windowed_summary_short_history_labels_recents() -> None:
+    """Short history (WAL ≤ recent_n): labels every non-self projection."""
+    metadata = _two_party_metadata("alice", "bob")
+    wal = [
+        _text_envelope("alice", "bob", "hi"),
+        _text_envelope("bob", "alice", "hello"),
+    ]
+
+    projection = await NamedWindowedSummary(recent_n=10).project(
+        wal,
+        participant_id="bob",
+        channel=metadata,
+        render_envelope=default_render_envelope,
+        name_for=_named_resolver({"alice": "Alice", "bob": "Bob"}),
+    )
+
+    assert projection == [
+        ModelRequest([TextInput("[Alice]: hi")]),
+        ModelMessage("hello"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_named_windowed_summary_long_history_summarises_with_names() -> None:
+    """When WAL > recent_n, the head compaction lists speakers by name."""
+    metadata = _two_party_metadata("alice", "bob")
+    wal = [_text_envelope("alice", "bob", f"msg {i}") for i in range(8)]
+
+    projection = await NamedWindowedSummary(recent_n=3).project(
+        wal,
+        participant_id="bob",
+        channel=metadata,
+        render_envelope=default_render_envelope,
+        name_for=_named_resolver({"alice": "Alice"}),
+    )
+
+    head = projection[0]
+    assert isinstance(head, CompactionSummary)
+    assert head.event_count == 5
+    # Speakers list uses the resolved name, not the raw id.
+    assert "Alice" in head.summary
+    assert "alice" not in head.summary
+    # Tail entries are prefixed with the sender name.
+    assert projection[1:] == [
+        ModelRequest([TextInput("[Alice]: msg 5")]),
+        ModelRequest([TextInput("[Alice]: msg 6")]),
+        ModelRequest([TextInput("[Alice]: msg 7")]),
+    ]
+
+
+# ── Adapter default-view swap (N-party only) ───────────────────────────────
+
+
+def _three_party_metadata(adapter, ids: list[str]) -> ChannelMetadata:
+    """Build minimal metadata for an N-party adapter."""
+    return ChannelMetadata(
+        channel_id="ch-n",
+        manifest=adapter.manifest,
+        creator_id=ids[0],
+        participants=[
+            Participant(agent_id=a, role=ParticipantRole.PARTICIPANT, order=i, joined_at="now")
+            for i, a in enumerate(ids)
+        ],
+        state=ChannelState.ACTIVE,
+        created_at="now",
+        expires_at=None,
+        knobs={},
+        labels={},
+        required_acks=None,
+        pending_acks=[],
+    )
+
+
+def test_workflow_default_view_is_named() -> None:
+    """N-party workflow adapter defaults to NamedWindowedSummary."""
+    adapter = WorkflowAdapter()
+    metadata = _three_party_metadata(adapter, ["a", "b", "c"])
+    view = adapter.default_view_policy(metadata, participant_id="a")
+    assert isinstance(view, NamedWindowedSummary)
+
+
+def test_discussion_default_view_is_named() -> None:
+    """N-party discussion adapter defaults to NamedWindowedSummary."""
+    adapter = DiscussionAdapter()
+    metadata = _three_party_metadata(adapter, ["a", "b", "c"])
+    view = adapter.default_view_policy(metadata, participant_id="a")
+    assert isinstance(view, NamedWindowedSummary)
+
+
+def test_consulting_default_view_unchanged() -> None:
+    """2-party consulting adapter keeps unprefixed FullTranscript."""
+    adapter = ConsultingAdapter()
+    metadata = _three_party_metadata(adapter, ["a", "b"])  # 2 participants
+    view = adapter.default_view_policy(metadata, participant_id="a")
+    assert isinstance(view, FullTranscript)
+
+
+def test_conversation_default_view_unchanged() -> None:
+    """2-party conversation adapter keeps unprefixed WindowedSummary."""
+    adapter = ConversationAdapter()
+    metadata = _three_party_metadata(adapter, ["a", "b"])  # 2 participants
+    view = adapter.default_view_policy(metadata, participant_id="a")
+    assert isinstance(view, WindowedSummary)
+    # And NOT the named variant (subclass guard).
+    assert not isinstance(view, NamedWindowedSummary)

--- a/website/docs/beta/network/views_and_skills.mdx
+++ b/website/docs/beta/network/views_and_skills.mdx
@@ -12,28 +12,42 @@ Two LLM-facing concerns:
 
 `#!python ViewPolicy` is a `#!python Protocol`:
 
-```python
+```python linenums="1"
 class ViewPolicy(Protocol):
     name: ClassVar[str]
     async def project(
         self,
-        history: list[Envelope],
+        wal: list[Envelope],
         *,
         participant_id: str,
         channel: ChannelMetadata,
+        render_envelope: EnvelopeRenderer,
+        name_for: NameResolver = default_name_resolver,
     ) -> list[BaseEvent]: ...
 ```
 
 It takes the WAL up to the current envelope and returns a list of `#!python BaseEvent`s that the framework feeds into the LLM turn as pre-populated stream history. Adapters declare a default; tenants can override per-channel.
 
+Two callables are supplied per call so view policies stay adapter-neutral and identity-aware without depending on hub internals:
+
+- `#!python render_envelope: Callable[[Envelope], str | None]` — comes from the channel's `#!python ChannelAdapter.render_envelope`. Lets a view ask "what's the LLM-visible text for this envelope?" without knowing the channel type's envelope shape.
+- `#!python name_for: Callable[[str], str]` — comes from `#!python Hub.name_for`. Lets a view resolve an `#!python agent_id` to its registered `#!python Passport.name` for projection lines that need a speaker label. Falls back to the raw id when the sender is unknown so projection never fails.
+
 ## Built-in Views
 
-| View | Behaviour |
-|---|---|
-| `#!python FullTranscript()` | Every `#!python EV_TEXT` / `#!python EV_HANDOFF` envelope, in order, no filtering beyond audience. Used by `#!python consulting`. |
-| `#!python WindowedSummary(recent_n=N)` | The last `N` text envelopes. If the WAL is longer, prepends a `#!python CompactionSummary` placeholder with a count of the elided turns. Used by `#!python conversation`, `#!python discussion`, `#!python workflow`. |
+| View | Behaviour | Default for |
+|---|---|---|
+| `#!python FullTranscript()` | Every visible envelope, in order, no filtering beyond audience. Non-self envelopes become bare `#!python ModelRequest`s. | `#!python consulting` (2-party) |
+| `#!python WindowedSummary(recent_n=N)` | The last `N` visible envelopes. If the WAL is longer, prepends a `#!python CompactionSummary` placeholder with a count of the elided turns. Non-self envelopes become bare `#!python ModelRequest`s. | `#!python conversation` (2-party) |
+| `#!python NamedTranscript()` | Like `#!python FullTranscript`, but each non-self envelope is prefixed with `#!python [<sender name>]:` so the LLM can tell its peers apart. Resolves names via the supplied `#!python NameResolver`. | — |
+| `#!python NamedWindowedSummary(recent_n=N)` | Like `#!python WindowedSummary`, but with the same `#!python [<sender name>]:` labelling on non-self lines and on the head `#!python CompactionSummary`'s speakers list. | `#!python discussion`, `#!python workflow` (N-party) |
 
-Both honour audience: an envelope addressed only to `[bob]` doesn't appear in `carol`'s projection.
+All four views honour audience: an envelope addressed only to `[bob]` doesn't appear in `carol`'s projection.
+
+!!! tip "Why two flavours?"
+    In a **2-party** channel, the assistant/user role bit already disambiguates speakers — the LLM sees its own past as `#!python role: "assistant"` and the only other party as `#!python role: "user"`. Labels would be redundant.
+
+    In a **3+ party** channel (discussion, workflow), every non-self envelope collapses into the same `#!python role: "user"` stream. Without a sender label the LLM can't tell which peer said which message. The `#!python Named*` variants put `#!python [<sender name>]:` on each non-self line so the orchestrator / next speaker can route accurately. This is the default for N-party adapters precisely because the role bit alone isn't enough.
 
 ```python linenums="1"
 from autogen.beta.network import FullTranscript, WindowedSummary
@@ -62,24 +76,45 @@ Implement the protocol, give it a unique `name`, and pass to the policy resolver
 
 ```python linenums="1"
 from typing import ClassVar
-from autogen.beta.events import BaseEvent, ModelMessage, ModelRequest
-from autogen.beta.network import Envelope, EV_TEXT, ChannelMetadata, ViewPolicy
+from autogen.beta.events import BaseEvent, ModelMessage, ModelRequest, TextInput
+from autogen.beta.network import (
+    ChannelMetadata,
+    EV_TEXT,
+    Envelope,
+    EnvelopeRenderer,
+    NameResolver,
+    ViewPolicy,
+    default_name_resolver,
+)
 
 
 class FromOneOnly(ViewPolicy):
-    """Show only envelopes from a single named sender."""
+    """Show only envelopes from a single named sender, prefixed with their name."""
     name: ClassVar[str] = "from_one_only"
 
     def __init__(self, sender_id: str) -> None:
         self.sender_id = sender_id
 
-    async def project(self, history, *, participant_id, channel):
+    async def project(
+        self,
+        wal: list[Envelope],
+        *,
+        participant_id: str,
+        channel: ChannelMetadata,
+        render_envelope: EnvelopeRenderer,
+        name_for: NameResolver = default_name_resolver,
+    ) -> list[BaseEvent]:
         out: list[BaseEvent] = []
-        for env in history:
+        for env in wal:
             if env.event_type != EV_TEXT or env.sender_id != self.sender_id:
                 continue
-            text = env.event_data.get("text", "")
-            out.append(ModelMessage(text) if env.sender_id == participant_id else ModelRequest(text))
+            text = render_envelope(env) or ""
+            if env.sender_id == participant_id:
+                out.append(ModelMessage(text))
+            else:
+                # Use name_for to label so the LLM knows who said it.
+                label = name_for(env.sender_id)
+                out.append(ModelRequest([TextInput(f"[{label}]: {text}")]))
         return out
 ```
 


### PR DESCRIPTION
## Why are these changes needed?

Fix the structural speaker-attribution bug in N-party channels (`discussion`, `workflow`). The existing built-in views (`FullTranscript`, `WindowedSummary`) project every non-self envelope as a bare `ModelRequest` with no sender
label, so other agents' LLM see a flat `role: "user"` stream with no way to tell which agents said what.

This PR:

1. **Foundation:** adds a `NameResolver = Callable[[str], str]` callable    alongside the existing `EnvelopeRenderer` on `ViewPolicy.project()`. The  default notify handler sources it from a new public `Hub.name_for(...)` method and hands it to every projection. Views can label without depending on hub internals.
2. **Built-ins:** adds `NamedTranscript` and `NamedWindowedSummary` that USE the resolver to prefix non-self projection lines with `[<sender name>]:`.
3. **Defaults:** swaps `DiscussionAdapter` and `WorkflowAdapter` from `WindowedSummary` to `NamedWindowedSummary`. Two-party adapters (`consulting`, `conversation`) are unchanged — the assistant/user role bit already disambiguates when there's only one possible "other."

Currently:

In a 2-party adapter, an agent's projected history looks like:

```
assistant: ...own past turns...
user: ...the other party's turn...
```

The role helps the LLM differentiate between them and the other agent.

In a 3+ party adapter (one manager + multiple specialists) the projection becomes:

```
assistant: ...own past turns...
user: <researcher's reply>
user: <critic's reply>
user: <synthesizer's reply>
```

And that makes it challenging for the LLM to see multiple agents and identify them.

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
