### PR TITLE
feat(beta/network): Add ability for tool to indicate the Finish for WorkflowAdapter

### DIFF
--- a/autogen/beta/network/__init__.py
+++ b/autogen/beta/network/__init__.py
@@ -89,7 +89,7 @@ from .errors import (
     NotFoundError,
     ProtocolError,
 )
-from .handoff import Handoff
+from .handoff import Finish, Handoff
 from .hub import (
     AUDIT_KIND_AGENT_REGISTERED,
     AUDIT_KIND_AGENT_UNREGISTERED,
@@ -277,6 +277,7 @@ __all__ = (
     "Expectation",
     "ExpectationContext",
     "ExpectationEvaluator",
+    "Finish",
     "Frame",
     "FromSpeaker",
     "FullTranscript",

--- a/autogen/beta/network/adapters/workflow.py
+++ b/autogen/beta/network/adapters/workflow.py
@@ -53,7 +53,7 @@ from ..envelope import (
     Envelope,
 )
 from ..errors import ProtocolError
-from ..handoff import Handoff
+from ..handoff import Finish, Handoff
 from ..transitions import (
     ToolCalled,
     TransitionDecision,
@@ -239,18 +239,26 @@ class WorkflowAdapter:
         )
 
         # Routing resolution.
-        # If the packet carries a pre-resolved ``routing.target`` (set
-        # by the framework when a tool returned a typed ``Handoff``),
-        # trust it directly — dynamic Handoff supersedes graph rules.
-        # Otherwise run ``select_next`` so static rules (``ToolCalled``,
-        # ``ContextEquals``, ``FromSpeaker``) decide.
+        # ``kind: "finish"`` short-circuits to termination — a tool
+        # that returned ``Finish`` is the most explicit intent the
+        # agent can express. ``kind: "handoff"`` with a pre-resolved
+        # ``routing.target`` (from a typed ``Handoff`` return) trusts
+        # the tool's pick directly. Otherwise run ``select_next`` so
+        # static rules (``ToolCalled``, ``ContextEquals``,
+        # ``FromSpeaker``) decide.
+        finish_reason: str | None = None
         pre_resolved = None
         if envelope.event_type == EV_PACKET:
             routing = envelope.event_data.get("routing", {}) or {}
-            if routing.get("kind") == "handoff":
+            if routing.get("kind") == "finish":
+                finish_reason = routing.get("reason") or "finished"
+            elif routing.get("kind") == "handoff":
                 pre_resolved = routing.get("target")
 
-        if pre_resolved:
+        if finish_reason is not None:
+            new_state.expected_next_speaker = None
+            new_state.pending_close_reason = finish_reason
+        elif pre_resolved:
             new_state.expected_next_speaker = pre_resolved
             new_state.pending_close_reason = ""
         else:
@@ -529,11 +537,15 @@ def _resolve_routing(
     order (which mirrors the LLM's left-to-right tool-call order).
     For each call, in priority:
 
-    1. Dynamic ``Handoff`` — does the corresponding
+    1. Dynamic ``Finish`` — does the corresponding
+       ``ToolResultEvent`` carry a ``Finish`` instance? If so, the
+       call ends the channel; ``reason``/``summary`` ride on the
+       packet's routing field.
+    2. Dynamic ``Handoff`` — does the corresponding
        ``ToolResultEvent`` carry a ``Handoff`` instance? If so, the
        call's name + Handoff's ``target``/``reason`` becomes the
        routing.
-    2. Static ``ToolCalled`` match — does the call's name match a
+    3. Static ``ToolCalled`` match — does the call's name match a
        graph rule? If so, the call's name becomes the routing tool;
        ``select_next`` resolves the target at fold time.
 
@@ -558,6 +570,14 @@ def _resolve_routing(
 
     for call in calls:
         result_event = results_by_parent.get(call.id)
+        finish = _extract_finish(result_event) if result_event else None
+        if finish is not None:
+            return {
+                "kind": "finish",
+                "tool": call.name,
+                "reason": finish.reason,
+                "summary": finish.summary,
+            }
         handoff = _extract_handoff(result_event) if result_event else None
         if handoff is not None:
             target = name_to_id.get(handoff.target, handoff.target)
@@ -584,6 +604,17 @@ def _extract_handoff(result_event: ToolResultEvent) -> Handoff | None:
         return None
     for part in result.parts:
         if isinstance(part, DataInput) and isinstance(part.data, Handoff):
+            return part.data
+    return None
+
+
+def _extract_finish(result_event: ToolResultEvent) -> Finish | None:
+    """Look for a ``Finish`` instance in a tool result's parts."""
+    result = result_event.result
+    if result is None or not result.parts:
+        return None
+    for part in result.parts:
+        if isinstance(part, DataInput) and isinstance(part.data, Finish):
             return part.data
     return None
 

--- a/autogen/beta/network/handoff.py
+++ b/autogen/beta/network/handoff.py
@@ -2,23 +2,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""``Handoff`` — typed return value for dynamic routing tools.
+"""Typed routing-intent returns: ``Handoff`` (redirect) / ``Finish`` (terminate).
 
 A tool that needs to decide its target at runtime (load balancing,
 state-driven dispatch, conditional pick) returns ``Handoff`` instead
-of a string. The framework reads it from the agent's local
+of a string. A tool that wants to end the channel cleanly returns
+``Finish``. The framework reads either from the agent's local
 ``ToolResultEvent`` stream and treats it as the packet's routing
 intent.
 
-``target`` is the participant's ``Passport.name`` — *not* a raw
-``agent_id``. The framework resolves name → id at packet-finalize
-using the hub's name directory, so tool code stays decoupled from
-runtime IDs and portable across channels.
+For ``Handoff``, ``target`` is the participant's ``Passport.name`` —
+*not* a raw ``agent_id``. The framework resolves name → id at
+packet-finalize using the hub's name directory, so tool code stays
+decoupled from runtime IDs and portable across channels.
 """
 
 from dataclasses import dataclass
 
-__all__ = ("Handoff",)
+__all__ = ("Finish", "Handoff")
 
 
 @dataclass(slots=True)
@@ -43,3 +44,28 @@ class Handoff:
 
     target: str
     reason: str = ""
+
+
+@dataclass(slots=True)
+class Finish:
+    """Routing intent returned by a tool that ends the channel cleanly.
+
+    Example::
+
+        from autogen.beta.network import Finish
+
+
+        @coord_agent.tool
+        def finish(summary: str) -> Finish:
+            return Finish(summary=summary)
+
+    When the framework finds a ``Finish`` on a ``ToolResultEvent`` it
+    closes the channel — equivalent to a ``TerminateTarget`` rule
+    firing, but driven by the tool's runtime decision rather than a
+    static graph transition. ``reason`` populates
+    ``ChannelMetadata.close_reason``; ``summary`` rides on the
+    packet's ``routing.summary`` field for callers / observability.
+    """
+
+    summary: str = ""
+    reason: str = "finished"

--- a/test/beta/network/test_packet_routing.py
+++ b/test/beta/network/test_packet_routing.py
@@ -15,6 +15,7 @@ import json
 from autogen.beta.events import DataInput, ToolCallEvent, ToolResult, ToolResultEvent
 from autogen.beta.network import (
     AgentTarget,
+    Finish,
     Handoff,
     TerminateTarget,
     ToolCalled,
@@ -198,3 +199,63 @@ class TestResolveRouting:
         routing = _resolve_routing(events, graph, name_to_id={"alice": "agent-id-alice"})
         # No calls at all → text routing.
         assert routing == {"kind": "text"}
+
+    def test_dynamic_finish_terminates(self) -> None:
+        """A ToolResultEvent carrying a Finish dataclass produces
+        routing with ``kind: "finish"`` so fold can close the channel."""
+        graph = _graph("delegate_a")
+        events = [
+            _call("finish", call_id="c1"),
+            _result("c1", name="finish", value=Finish(summary="all done", reason="done")),
+        ]
+        routing = _resolve_routing(events, graph, name_to_id={})
+        assert routing == {
+            "kind": "finish",
+            "tool": "finish",
+            "reason": "done",
+            "summary": "all done",
+        }
+
+    def test_finish_default_reason_propagates(self) -> None:
+        """Finish() with no args still produces a valid termination routing."""
+        graph = _graph("delegate_a")
+        events = [
+            _call("finish", call_id="c1"),
+            _result("c1", name="finish", value=Finish()),
+        ]
+        routing = _resolve_routing(events, graph, name_to_id={})
+        assert routing == {
+            "kind": "finish",
+            "tool": "finish",
+            "reason": "finished",
+            "summary": "",
+        }
+
+    def test_finish_beats_handoff_in_same_emission(self) -> None:
+        """If a single tool somehow returns Finish, it beats a later
+        Handoff from another call — first-emitted-wins extends to
+        Finish."""
+        graph = _graph("delegate_a")
+        events = [
+            _call("finish", call_id="c1"),
+            _result("c1", name="finish", value=Finish(reason="early")),
+            _call("delegate_a", call_id="c2"),
+            _result("c2", name="delegate_a", value=Handoff(target="alice")),
+        ]
+        routing = _resolve_routing(events, graph, name_to_id={"alice": "agent-id-alice"})
+        assert routing["kind"] == "finish"
+        assert routing["tool"] == "finish"
+
+    def test_handoff_before_finish_still_first_wins(self) -> None:
+        """First emission still wins — a Handoff that fires before a
+        later Finish takes precedence."""
+        graph = _graph("delegate_a")
+        events = [
+            _call("delegate_a", call_id="c1"),
+            _result("c1", name="delegate_a", value=Handoff(target="alice")),
+            _call("finish", call_id="c2"),
+            _result("c2", name="finish", value=Finish(reason="late")),
+        ]
+        routing = _resolve_routing(events, graph, name_to_id={"alice": "agent-id-alice"})
+        assert routing["kind"] == "handoff"
+        assert routing["target"] == "agent-id-alice"

--- a/test/beta/network/test_workflow.py
+++ b/test/beta/network/test_workflow.py
@@ -468,6 +468,120 @@ async def test_workflow_swarm_with_tool_handoff_and_revert() -> None:
 
 
 @pytest.mark.asyncio
+async def test_workflow_finish_routing_closes_channel() -> None:
+    """A ``Finish`` typed return surfaces on the packet as
+    ``routing.kind == "finish"``; ``fold`` then sets the next speaker
+    to ``None`` and ``on_accepted`` closes the channel using the
+    finish's ``reason`` as the close reason."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
+    link = LocalLink(hub)
+
+    a_hc = HubClient(link, hub=hub)
+    b_hc = HubClient(link, hub=hub)
+    alice = await a_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    bob = await b_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+
+    graph = TransitionGraph(
+        initial_speaker=alice.agent_id,
+        transitions=[
+            Transition(when=FromSpeaker(alice.agent_id), then=AgentTarget(bob.agent_id)),
+            Transition(when=FromSpeaker(bob.agent_id), then=AgentTarget(alice.agent_id)),
+        ],
+        default_target=TerminateTarget(reason="default"),
+        max_turns=10,
+    )
+    channel = await alice.open(
+        type=WORKFLOW_TYPE,
+        target=[bob.agent_id],
+        knobs={"graph": graph.to_dict()},
+    )
+
+    # Alice emits a finish-routed packet — the typed-return payload as
+    # the framework would construct it from a ``Finish`` instance.
+    finish_env = Envelope(
+        channel_id=channel.channel_id,
+        sender_id=alice.agent_id,
+        audience=None,
+        event_type=EV_PACKET,
+        event_data={
+            "routing": {
+                "kind": "finish",
+                "tool": "finish",
+                "reason": "all_done",
+                "summary": "covered the agenda",
+            },
+            "context_updates": {"set": {}, "delete": []},
+            "body": "",
+        },
+    )
+    await hub.post_envelope(finish_env)
+
+    # State should reflect termination intent: no next speaker, reason
+    # propagated from Finish.
+    state = hub._adapter_states[channel.channel_id]
+    assert state.expected_next_speaker is None
+    assert state.pending_close_reason == "all_done"
+
+    # Channel itself should be closed with the finish reason.
+    refreshed = await hub.get_channel(channel.channel_id)
+    assert refreshed.state == ChannelState.CLOSED
+    assert refreshed.close_reason == "all_done"
+
+    await a_hc.close()
+    await b_hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
+async def test_workflow_finish_default_reason_uses_finished() -> None:
+    """``Finish()`` with no args (or empty reason) folds to the
+    ``"finished"`` default close reason."""
+    store = MemoryKnowledgeStore()
+    hub = await Hub.open(store, ttl_sweep_interval=0, expectation_sweep_interval=0)
+    link = LocalLink(hub)
+
+    a_hc = HubClient(link, hub=hub)
+    b_hc = HubClient(link, hub=hub)
+    alice = await a_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+    bob = await b_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+
+    graph = TransitionGraph(
+        initial_speaker=alice.agent_id,
+        transitions=[Transition(when=Always(), then=AgentTarget(bob.agent_id))],
+        default_target=TerminateTarget(reason="default"),
+        max_turns=5,
+    )
+    channel = await alice.open(
+        type=WORKFLOW_TYPE,
+        target=[bob.agent_id],
+        knobs={"graph": graph.to_dict()},
+    )
+
+    # routing.reason missing entirely — fold should fall back to "finished".
+    finish_env = Envelope(
+        channel_id=channel.channel_id,
+        sender_id=alice.agent_id,
+        audience=None,
+        event_type=EV_PACKET,
+        event_data={
+            "routing": {"kind": "finish", "tool": "finish"},
+            "context_updates": {"set": {}, "delete": []},
+            "body": "",
+        },
+    )
+    await hub.post_envelope(finish_env)
+
+    refreshed = await hub.get_channel(channel.channel_id)
+    assert refreshed.state == ChannelState.CLOSED
+    assert refreshed.close_reason == "finished"
+
+    await a_hc.close()
+    await b_hc.close()
+    await hub.close()
+
+
+@pytest.mark.asyncio
 async def test_workflow_manager_as_initiator_auto_pattern() -> None:
     """AutoPattern equivalent: manager is initiator + RevertToInitiator default.
 

--- a/website/docs/beta/network/workflow.mdx
+++ b/website/docs/beta/network/workflow.mdx
@@ -166,6 +166,27 @@ async def transfer_to_eng(reason: str = "") -> Handoff:
 
 The workflow adapter consumes the `#!python Handoff` from the agent's local-stream `#!python ToolResultEvent` at round-end and routes the next speaker — no separate `#!python ToolCalled` evaluation is needed because the typed return supersedes the graph match. The matching `#!python ToolCalled` rule in the graph remains useful as documentation and as a fallback if you ever want to re-route the same tool name to a different target.
 
+### Ending a workflow with `Finish`
+
+A tool can also end the channel cleanly by returning a typed `#!python Finish(summary="...", reason="...")`. The framework reads it from the agent's `#!python ToolResultEvent` and closes the channel — same effect as a `#!python TerminateTarget` rule firing, but the decision is made by the tool at runtime rather than by a static graph transition:
+
+```python linenums="1" hl_lines="1 2 3"
+@coord.tool
+async def finish(summary: str) -> Finish:
+    """Wrap up — no further handoffs needed."""
+    return Finish(summary=summary)
+```
+
+`#!python reason` (default `#!python "finished"`) lands on `#!python ChannelMetadata.close_reason`; `#!python summary` rides on the packet's `#!python routing.summary` field for callers and observability. With `#!python Finish`, you no longer need a `#!python Rule(when=ToolCalled("finish"), then=TerminateTarget())` glue rule — the typed return is enough.
+
+!!! tip "Handoff vs Finish — which to use?"
+    Both are typed returns the framework reads from `#!python ToolResultEvent`. They're mutually exclusive intents:
+
+    - `#!python Handoff(target="alice", reason="...")` — redirect: the channel continues; `alice` speaks next.
+    - `#!python Finish(summary="...", reason="...")` — terminate: the channel closes; no further turns.
+
+    First emission wins. If a tool emits both in the same round (unusual), the first event in stream order takes precedence.
+
 ## Context-Driven Transitions
 
 Most non-trivial group-chat orchestrations in classic AG2 routed on context variables — `#!python OnContextCondition`, `#!python StringContextCondition`, `#!python ExpressionContextCondition`. The beta equivalent is a tool that emits `#!python EV_CONTEXT_SET` and a transition whose `#!python when` is `#!python ContextEquals(key, value)`. The mutation primitive lives on the [Context Variables](/docs/beta/network/context_variables) page; this section is about *using* context to decide who speaks next.


### PR DESCRIPTION
## Why are these changes needed?

Add `Finish(summary="", reason="finished")` — a typed routing-intent return value that parallels `Handoff` and lets a tool end a workflow channel cleanly.

Without it, terminating a workflow requires a glue rule like `Rule(when=ToolCalled("finish"), then=TerminateTarget())` in every `TransitionGraph`. With it, a tool just returns `Finish(...)` and the framework closes the channel — the routing protocol carries the intent end-to-end.

`Handoff` already exists for runtime *redirect* decisions: a tool returns `Handoff(target="alice")` and the framework reads it from `ToolResultEvent`, stamps the packet's `routing.target`, and `fold` routes the next turn to alice. Termination has no equivalent path today — it must be encoded as a static `TerminateTarget` rule that fires on a `ToolCalled` match. That works, but it splits the same intent across two places (the tool + the graph), and the static rule can't carry a runtime-generated `summary`.

`Finish` closes that gap. Same pickup mechanism as `Handoff` (typed return on a `ToolResultEvent`), same first-emit-wins precedence, same end-of-round consumption by `_resolve_routing`. The packet's `routing.kind` is now one of three values — `"text"` / `"handoff"` / `"finish"` — and `fold` short-circuits on the third.

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
