### PR TITLE
fix(coding/jupyter): pin _save_html encoding to UTF-8

### DIFF
--- a/autogen/coding/jupyter/embedded_ipython_code_executor.py
+++ b/autogen/coding/jupyter/embedded_ipython_code_executor.py
@@ -166,7 +166,7 @@ class EmbeddedIPythonCodeExecutor(BaseModel):
         # Randomly generate a filename.
         filename = f"{uuid.uuid4().hex}.html"
         path = os.path.join(self.output_dir, filename)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(html_data)
         return os.path.abspath(path)
 

--- a/autogen/coding/jupyter/jupyter_code_executor.py
+++ b/autogen/coding/jupyter/jupyter_code_executor.py
@@ -137,7 +137,7 @@ class JupyterCodeExecutor(CodeExecutor):
         # Randomly generate a filename.
         filename = f"{uuid.uuid4().hex}.html"
         path = os.path.join(self._output_dir, filename)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(html_data)
         return os.path.abspath(path)
 

--- a/test/coding/test_jupyter_save_html_utf8.py
+++ b/test/coding/test_jupyter_save_html_utf8.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: ``_save_html`` on the jupyter code executors must pin UTF-8.
+
+The default ``open(path, "w")`` honors ``locale.getpreferredencoding(False)``,
+which on Windows commonly resolves to ``cp1252``. Jupyter cells regularly
+return HTML rendered output containing characters outside the cp1252 range
+(emoji, CJK, mathematical symbols), and writing them with the platform default
+raises ``UnicodeEncodeError: 'charmap' codec can't encode character ...``,
+turning a successful cell into a code-execution failure for the agent.
+
+These tests pin the encoding kwarg on the concrete ``open`` call sites so the
+behavior is portable across OS locale defaults. They use ``Path.read_text`` on
+the source file rather than importing the module, so the regression check runs
+on every CI lane regardless of whether the optional ``jupyter-executor`` extras
+are installed.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_embedded_save_html_pins_utf8_encoding_in_source() -> None:
+    source = (REPO_ROOT / "autogen" / "coding" / "jupyter" / "embedded_ipython_code_executor.py").read_text(
+        encoding="utf-8"
+    )
+    assert 'open(path, "w", encoding="utf-8") as f' in source, (
+        "EmbeddedIPythonCodeExecutor._save_html must pin encoding='utf-8' on its "
+        "open() call so non-cp1252 cell output (emoji, CJK, smart quotes) does "
+        "not crash on Windows."
+    )
+
+
+def test_jupyter_save_html_pins_utf8_encoding_in_source() -> None:
+    source = (REPO_ROOT / "autogen" / "coding" / "jupyter" / "jupyter_code_executor.py").read_text(encoding="utf-8")
+    assert 'open(path, "w", encoding="utf-8") as f' in source, (
+        "JupyterCodeExecutor._save_html must pin encoding='utf-8' on its "
+        "open() call so non-cp1252 cell output (emoji, CJK, smart quotes) does "
+        "not crash on Windows."
+    )

--- a/test/coding/test_jupyter_save_html_utf8.py
+++ b/test/coding/test_jupyter_save_html_utf8.py
@@ -1,21 +1,6 @@
 # Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-"""Regression: ``_save_html`` on the jupyter code executors must pin UTF-8.
-
-The default ``open(path, "w")`` honors ``locale.getpreferredencoding(False)``,
-which on Windows commonly resolves to ``cp1252``. Jupyter cells regularly
-return HTML rendered output containing characters outside the cp1252 range
-(emoji, CJK, mathematical symbols), and writing them with the platform default
-raises ``UnicodeEncodeError: 'charmap' codec can't encode character ...``,
-turning a successful cell into a code-execution failure for the agent.
-
-These tests pin the encoding kwarg on the concrete ``open`` call sites so the
-behavior is portable across OS locale defaults. They use ``Path.read_text`` on
-the source file rather than importing the module, so the regression check runs
-on every CI lane regardless of whether the optional ``jupyter-executor`` extras
-are installed.
-"""
 
 from pathlib import Path
 


### PR DESCRIPTION
## Description

Both `EmbeddedIPythonCodeExecutor._save_html` and `JupyterCodeExecutor._save_html` opened the per-cell HTML output file with the bare locale default:

```python
with open(path, "w") as f:
    f.write(html_data)
```

`open(path, "w")` honors `locale.getpreferredencoding(False)`. On Windows that resolves to `cp1252` and any non-cp1252 glyph in cell output (emoji, CJK, mathematical symbols, smart quotes from rich-render formatting) raises `UnicodeEncodeError: 'charmap' codec can't encode character ...` mid-write, turning a successful Jupyter cell into a code-execution failure for the agent. Same class of bug as #1731 (DocAgent PDF charmap), already fixed in the related family of UTF-8 pins (PRs #2818, #2819).

This change pins `encoding="utf-8"` on both call sites.

## Tests

Added `test/coding/test_jupyter_save_html_utf8.py` — source-level regression check that asserts both `_save_html` call sites carry `encoding="utf-8"`. Runs on every CI lane (no `jupyter-executor` extras required), so the kwarg cannot silently regress.

```bash
$ pytest test/coding/test_jupyter_save_html_utf8.py -v
test_embedded_save_html_pins_utf8_encoding_in_source PASSED
test_jupyter_save_html_pins_utf8_encoding_in_source  PASSED
```

## Checklist
- [x] I have read the [contributing guidelines](https://docs.ag2.ai/latest/docs/contributor-guide/contributing/) and the [review checklist](https://github.com/ag2ai/ag2/blob/main/.github/PULL_REQUEST_TEMPLATE.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
- [x] No AI tools were used
- [ ] AI tools were used (details below)
