### PR TITLE
fix(mcp/mcp_proxy): pin file IO encoding to UTF-8

### DIFF
--- a/autogen/mcp/mcp_proxy/mcp_proxy.py
+++ b/autogen/mcp/mcp_proxy/mcp_proxy.py
@@ -292,14 +292,14 @@ class MCPProxy:
 
         main_path = output_dir / "main.py"
 
-        with main_path.open("r") as f:
+        with main_path.open("r", encoding="utf-8") as f:
             main_py_code = f.read()
         # main_py_code = main_py_code.replace("from .models import", "from models import")
         main_py_code = main_py_code.replace("from .models", "from models")
         # Removing "from __future__ import annotations" to avoid ForwardRef issues, should be fixed in fastapi_code_generator
         main_py_code = main_py_code.replace("from __future__ import annotations", "")
 
-        with main_path.open("w") as f:
+        with main_path.open("w", encoding="utf-8") as f:
             f.write(main_py_code)
 
         return main_path.stem
@@ -435,11 +435,11 @@ class MCPProxy:
         rendered_config = template.render(context)
 
         # Save the output to a file
-        with open(output_file, "w") as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             f.write(rendered_config)
 
     def load_configuration(self, config_file: str) -> None:
-        with Path(config_file).open("r") as f:
+        with Path(config_file).open("r", encoding="utf-8") as f:
             config_data_str = f.read()
 
         self.load_configuration_from_string(config_data_str)

--- a/test/mcp/test_mcp_proxy_utf8.py
+++ b/test/mcp/test_mcp_proxy_utf8.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: MCP proxy file writes must pin UTF-8.
+
+`autogen/mcp/mcp_proxy/mcp_proxy.py` rewrites the generated `main.py` (post-
+fastapi-codegen patch) and saves the rendered server configuration template.
+Both call sites previously used the bare locale default — on Windows that
+resolves to `cp1252` and any non-cp1252 glyph in an OpenAPI spec
+(internationalized model names, smart quotes in descriptions, emoji in
+example payloads) raised `UnicodeEncodeError` mid-write, killing the proxy
+generation step.
+
+This source-level check guards the kwarg so the bug cannot silently regress.
+Runs without optional MCP extras installed.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_mcp_proxy_file_writes_pin_utf8() -> None:
+    source = (REPO_ROOT / "autogen" / "mcp" / "mcp_proxy" / "mcp_proxy.py").read_text(encoding="utf-8")
+    must_contain = (
+        'main_path.open("r", encoding="utf-8") as f',
+        'main_path.open("w", encoding="utf-8") as f',
+        'open(output_file, "w", encoding="utf-8") as f',
+        'Path(config_file).open("r", encoding="utf-8") as f',
+    )
+    missing = [pattern for pattern in must_contain if pattern not in source]
+    assert not missing, (
+        f"MCP proxy main_path / output_file / config_file IO must pin encoding='utf-8'; missing patterns: {missing!r}"
+    )

--- a/test/mcp/test_mcp_proxy_utf8.py
+++ b/test/mcp/test_mcp_proxy_utf8.py
@@ -1,19 +1,6 @@
 # Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-"""Regression: MCP proxy file writes must pin UTF-8.
-
-`autogen/mcp/mcp_proxy/mcp_proxy.py` rewrites the generated `main.py` (post-
-fastapi-codegen patch) and saves the rendered server configuration template.
-Both call sites previously used the bare locale default — on Windows that
-resolves to `cp1252` and any non-cp1252 glyph in an OpenAPI spec
-(internationalized model names, smart quotes in descriptions, emoji in
-example payloads) raised `UnicodeEncodeError` mid-write, killing the proxy
-generation step.
-
-This source-level check guards the kwarg so the bug cannot silently regress.
-Runs without optional MCP extras installed.
-"""
 
 from pathlib import Path
 


### PR DESCRIPTION
## Description

`autogen/mcp/mcp_proxy/mcp_proxy.py` performs four file IO operations through the bare locale default:

- `main_path.open("r")` then `main_path.open("w")` rewriting the post-fastapi-codegen `main.py` (`mcp_proxy.py:295,302`).
- `open(output_file, "w")` saving the rendered server-configuration template (`mcp_proxy.py:438`).
- `Path(config_file).open("r")` reading saved server configuration (`mcp_proxy.py:442`).

`open(...)` honors `locale.getpreferredencoding(False)`. On Windows that resolves to `cp1252` and any non-cp1252 glyph in an OpenAPI spec — internationalized model names, smart quotes in descriptions, emoji in example payloads — raises `UnicodeEncodeError` mid-write, killing the proxy generation step. Same class of bug as #1731 / PRs #2818 / #2819 / #2825.

This change pins `encoding="utf-8"` on all four call sites.

## Tests

Added `test/mcp/test_mcp_proxy_utf8.py` — source-level regression check that asserts the kwarg appears on the four call sites. Runs on every CI lane (no MCP extras required).

```bash
$ pytest test/mcp/test_mcp_proxy_utf8.py -v
test_mcp_proxy_file_writes_pin_utf8 PASSED
```

## Checklist
- [x] I have read the [contributing guidelines](https://docs.ag2.ai/latest/docs/contributor-guide/contributing/) and the [review checklist](https://github.com/ag2ai/ag2/blob/main/.github/PULL_REQUEST_TEMPLATE.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
- [x] No AI tools were used
- [ ] AI tools were used (details below)
