### PR TITLE
fix(environments): pin PythonEnvironment._write_to_file encoding to UTF-8

### DIFF
--- a/autogen/environments/python_environment.py
+++ b/autogen/environments/python_environment.py
@@ -87,7 +87,13 @@ class PythonEnvironment(ABC):
             script_path: Path to the file to write.
             content: Content to write to the file.
         """
-        with open(script_path, "w") as f:
+        # Pin UTF-8 so any non-ASCII glyph in agent-supplied script content
+        # (string literals, comments, docstrings, identifiers) round-trips on
+        # platforms whose locale.getpreferredencoding() is not UTF-8 (cp1252
+        # on default Windows installs). Without it `open(path, "w")` raises
+        # UnicodeEncodeError mid-write on the first non-cp1252 character,
+        # turning a successful agent code-gen into a runtime failure.
+        with open(script_path, "w", encoding="utf-8") as f:
             f.write(content)
 
     # Utility method for subclasses to wrap (for async support)

--- a/test/environments/__init__.py
+++ b/test/environments/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/environments/test_python_environment_utf8.py
+++ b/test/environments/test_python_environment_utf8.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: PythonEnvironment._write_to_file must pin UTF-8.
+
+Agent-generated scripts routinely embed non-ASCII content — string literals
+in CJK / emoji / smart quotes from copy-pasted documentation, identifiers
+under PEP 3131. When `open(path, "w")` runs on a host whose
+`locale.getpreferredencoding(False)` is not UTF-8 (e.g. cp1252 on a default
+Windows install), the first non-cp1252 character raises
+`UnicodeEncodeError` mid-write. The script is then partially written, the
+subprocess runs an invalid file, and the agent sees a syntax error or
+truncated output instead of the intended behavior.
+
+Pinning `encoding="utf-8"` on the open call removes the OS-locale
+dependency entirely. This source-level guard prevents the kwarg from
+silently regressing.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_python_environment_write_to_file_pins_utf8() -> None:
+    source = (REPO_ROOT / "autogen" / "environments" / "python_environment.py").read_text(encoding="utf-8")
+    assert 'open(script_path, "w", encoding="utf-8") as f' in source, (
+        "PythonEnvironment._write_to_file must pin encoding='utf-8' on its "
+        "open() call so non-cp1252 script content (CJK string literals, emoji, "
+        "smart quotes, PEP 3131 identifiers) does not crash on Windows."
+    )

--- a/test/environments/test_python_environment_utf8.py
+++ b/test/environments/test_python_environment_utf8.py
@@ -1,21 +1,6 @@
 # Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-"""Regression: PythonEnvironment._write_to_file must pin UTF-8.
-
-Agent-generated scripts routinely embed non-ASCII content — string literals
-in CJK / emoji / smart quotes from copy-pasted documentation, identifiers
-under PEP 3131. When `open(path, "w")` runs on a host whose
-`locale.getpreferredencoding(False)` is not UTF-8 (e.g. cp1252 on a default
-Windows install), the first non-cp1252 character raises
-`UnicodeEncodeError` mid-write. The script is then partially written, the
-subprocess runs an invalid file, and the agent sees a syntax error or
-truncated output instead of the intended behavior.
-
-Pinning `encoding="utf-8"` on the open call removes the OS-locale
-dependency entirely. This source-level guard prevents the kwarg from
-silently regressing.
-"""
 
 from pathlib import Path
 


### PR DESCRIPTION
## Description

`PythonEnvironment._write_to_file` (`autogen/environments/python_environment.py:90`) is the shared helper every concrete `PythonEnvironment` subclass uses to land an agent-generated script on disk before invoking `subprocess`. The bare `open(script_path, "w")` inherits `locale.getpreferredencoding(False)` — cp1252 on default Windows installs — so the first non-cp1252 character (CJK string literal, emoji, smart quote from copy-pasted documentation, PEP 3131 identifier) raises `UnicodeEncodeError` mid-write. The script is then partially written, the subprocess runs an invalid file, and the agent sees a syntax error or truncated output instead of the intended behavior. Same class of bug as #1731 / PRs #2818 / #2819 / #2825 / #2826.

This change pins `encoding="utf-8"`.

## Tests

Added `test/environments/test_python_environment_utf8.py` — source-level regression check that asserts the kwarg appears on the call site. Runs on every CI lane.

```bash
$ pytest test/environments/test_python_environment_utf8.py -v
test_python_environment_write_to_file_pins_utf8 PASSED
```

## Checklist
- [x] I have read the [contributing guidelines](https://docs.ag2.ai/latest/docs/contributor-guide/contributing/) and the [review checklist](https://github.com/ag2ai/ag2/blob/main/.github/PULL_REQUEST_TEMPLATE.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
- [x] No AI tools were used
- [ ] AI tools were used (details below)
