### PR TITLE
fix: use serializable LLM guardrail response schema

### DIFF
--- a/autogen/agentchat/group/guardrails.py
+++ b/autogen/agentchat/group/guardrails.py
@@ -62,7 +62,7 @@ class LLMGuardrail(Guardrail):
             raise ValueError("LLMConfig is required.")
 
         self.llm_config = llm_config.deepcopy()
-        setattr(self.llm_config, "response_format", GuardrailResult)
+        setattr(self.llm_config, "response_format", GuardrailCheckResult)
         self.client = OpenAIWrapper(**self.llm_config.model_dump())
 
         self.check_prompt = f"""You are a guardrail that checks if a condition is met in the conversation you are given.
@@ -145,12 +145,17 @@ class RegexGuardrail(Guardrail):
         return GuardrailResult(activated=False, justification="No match found in the context.", guardrail=self)
 
 
-class GuardrailResult(BaseModel):
-    """Represents the outcome of a guardrail check."""
+class GuardrailCheckResult(BaseModel):
+    """LLM-facing JSON schema for a guardrail check."""
 
     activated: bool
-    guardrail: Guardrail
     justification: str = Field(default="No justification provided")
+
+
+class GuardrailResult(GuardrailCheckResult):
+    """Represents the outcome of a guardrail check."""
+
+    guardrail: Guardrail
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -174,6 +179,7 @@ class GuardrailResult(BaseModel):
         """
         try:
             data = json.loads(text)
-            return GuardrailResult(**data, guardrail=guardrail)
+            parsed = GuardrailCheckResult.model_validate(data)
+            return GuardrailResult(**parsed.model_dump(), guardrail=guardrail)
         except (json.JSONDecodeError, ValueError) as e:
             raise ValueError(f"Failed to parse GuardrailResult from text: {text}") from e

--- a/test/agentchat/group/test_guardrails.py
+++ b/test/agentchat/group/test_guardrails.py
@@ -8,7 +8,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from autogen.agentchat.group.guardrails import Guardrail, GuardrailResult, LLMGuardrail, RegexGuardrail
+from autogen.agentchat.group.guardrails import (
+    Guardrail,
+    GuardrailCheckResult,
+    GuardrailResult,
+    LLMGuardrail,
+    RegexGuardrail,
+)
 from autogen.agentchat.group.targets.transition_target import TransitionTarget
 
 
@@ -219,8 +225,22 @@ class TestLLMGuardrail:
                 name="test_llm_guardrail", condition="test condition", target=mock_target, llm_config=mock_llm_config
             )
 
-            # Verify that response_format was set to GuardrailResult
+            assert mock_llm_config.response_format is GuardrailCheckResult
             mock_llm_config.deepcopy.assert_called_once()
+
+    def test_check_response_format_is_json_schema_compatible(self) -> None:
+        """The LLM-facing response format must not include runtime Guardrail objects."""
+        schema = GuardrailCheckResult.model_json_schema()
+
+        assert schema["properties"] == {
+            "activated": {"title": "Activated", "type": "boolean"},
+            "justification": {
+                "default": "No justification provided",
+                "title": "Justification",
+                "type": "string",
+            },
+        }
+        assert schema["required"] == ["activated"]
 
 
 class TestRegexGuardrail:


### PR DESCRIPTION
## Summary

- use a JSON-schema-compatible `GuardrailCheckResult` as the LLM-facing `response_format`
- keep `GuardrailResult` as the runtime result object that carries the originating `Guardrail`
- validate parsed LLM JSON through the serializable schema before attaching the runtime guardrail
- add regression coverage for the response schema used by `LLMGuardrail`

Fixes #2334.

## Context

`LLMGuardrail` was passing `GuardrailResult` to `llm_config.response_format`, but `GuardrailResult` includes a runtime `Guardrail` object. Pydantic cannot generate a JSON schema for that arbitrary field, so clients that consume `response_format` can fail while preparing structured output.

This keeps the runtime return shape unchanged while exposing only the LLM-produced fields in the structured-output schema.

## Validation

- `.venv/bin/python -m pytest test/agentchat/group/test_guardrails.py -q` -> 25 passed
- `.venv/bin/python -m pytest test/agentchat/group/test_safeguards.py -q` -> 23 passed
- `.venv/bin/python -m ruff check autogen/agentchat/group/guardrails.py test/agentchat/group/test_guardrails.py` -> passed
- `.venv/bin/python -m ruff format --check autogen/agentchat/group/guardrails.py test/agentchat/group/test_guardrails.py` -> passed
- `git diff --check` -> passed
