### PR TITLE
fix(beta/middleware): emit AG2 version on TelemetryMiddleware instrumentation scope

### DIFF
--- a/autogen/beta/middleware/builtin/telemetry.py
+++ b/autogen/beta/middleware/builtin/telemetry.py
@@ -25,6 +25,7 @@ from autogen.beta.middleware.base import (
     ToolExecution,
     ToolResultType,
 )
+from autogen.version import __version__
 
 try:
     from opentelemetry import trace
@@ -43,7 +44,7 @@ _INSTRUMENTING_MODULE = "opentelemetry.instrumentation.ag2.beta"
 
 def _get_tracer(tracer_provider: TracerProvider | None = None) -> trace.Tracer:
     provider = tracer_provider or trace.get_tracer_provider()
-    return provider.get_tracer(_INSTRUMENTING_MODULE, schema_url=_SCHEMA_URL)
+    return provider.get_tracer(_INSTRUMENTING_MODULE, instrumenting_library_version=__version__, schema_url=_SCHEMA_URL)
 
 
 class TelemetryMiddleware(MiddlewareFactory):


### PR DESCRIPTION
## Summary

Passes `instrumenting_library_version=__version__` to `provider.get_tracer()` in `TelemetryMiddleware` so that OpenTelemetry traces carry the AG2 framework version in the instrumentation scope metadata.

Previously the tracer was created without a version, which left the `telemetry.sdk.version` (instrumentation scope version) blank in trace backends like Jaeger, Honeycomb, and OTEL Collector exporters.

## Changes

- `autogen/beta/middleware/builtin/telemetry.py`: add `from autogen.version import __version__` import and pass `instrumenting_library_version=__version__` to `get_tracer()`

## Test plan

- [ ] Existing telemetry tests pass
- [ ] Manually verify trace backend shows `ag2` version in instrumentation scope

🤖 Generated with [Claude Code](https://claude.ai/claude-code)