### PR TITLE
fix(beta/middleware): emit gen_ai.output.messages when model returns tool calls

### DIFF
--- a/autogen/beta/middleware/builtin/telemetry.py
+++ b/autogen/beta/middleware/builtin/telemetry.py
@@ -194,7 +194,7 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
             if usage.thinking_tokens:
                 span.set_attribute("gen_ai.usage.thinking_tokens", int(usage.thinking_tokens))
 
-            if self._capture_content and response.message:
+            if self._capture_content and (response.message or response.tool_calls):
                 span.set_attribute("gen_ai.output.messages", json.dumps([response.to_api()]))
 
             return response


### PR DESCRIPTION
## Summary

`gen_ai.output.messages` was silently dropped from `chat` spans whenever the model responded with tool calls only (no text content), because the guard was `response.message` — which is `None` when the LLM issues tool calls without any accompanying text.

`ModelResponse.to_api()` already serialises both `content` and `tool_calls` correctly. The fix is a one-character guard change: `response.message or response.tool_calls`.

**Impact:** Traces for tool-calling turns (e.g. `ex02_single_tool.py`, `ex04_parallel_tools.py`) now include the full model output — which tool(s) the model requested, with what arguments — directly on the `chat` span. Previously you could only infer this from child `execute_tool` spans.

## Changes

- `autogen/beta/middleware/builtin/telemetry.py` `on_llm_call`: guard changed from `response.message` to `response.message or response.tool_calls`

## Test plan

- [ ] Existing telemetry tests pass
- [ ] Manually verify a tool-calling trace in Jaeger/Honeycomb now shows `gen_ai.output.messages` on the `chat` span

Related: part of the P1 items in `AG2_TELEMETRY_TASKS.md` (reconstructing & evaluating the agentic workflow).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)