### PR TITLE
fix(beta/middleware): record full conversation history in gen_ai.input.messages

### DIFF
--- a/autogen/beta/middleware/builtin/telemetry.py
+++ b/autogen/beta/middleware/builtin/telemetry.py
@@ -15,6 +15,7 @@ from autogen.beta.events import (
     TextInput,
     ToolCallEvent,
     ToolResultEvent,
+    ToolResultsEvent,
 )
 from autogen.beta.middleware.base import (
     AgentTurn,
@@ -39,6 +40,34 @@ from autogen.beta.events import ToolErrorEvent
 
 _SCHEMA_URL = "https://opentelemetry.io/schemas/1.11.0"
 _INSTRUMENTING_MODULE = "opentelemetry.instrumentation.ag2.beta"
+
+
+def _build_input_messages(events: Sequence[BaseEvent]) -> list[dict[str, object]]:
+    """Serialize the full conversation history into OpenAI-compatible message dicts.
+
+    Includes user messages (ModelRequest), prior assistant turns (ModelResponse with
+    optional tool_calls), and tool results (ToolResultsEvent) so the span carries the
+    complete prompt that was sent to the model, not just the current user message.
+    Binary inputs (images, audio, documents) are omitted — they cannot be stored as
+    string span attributes.
+    """
+    result: list[dict[str, object]] = []
+    for event in events:
+        if isinstance(event, ModelRequest):
+            for inp in event.parts:
+                if isinstance(inp, TextInput):
+                    result.append(inp.to_api())
+        elif isinstance(event, ModelResponse):
+            result.append(event.to_api())
+        elif isinstance(event, ToolResultsEvent):
+            for r in event.results:
+                text_parts = [p.content for p in r.result.parts if isinstance(p, TextInput)]
+                result.append({
+                    "role": "tool",
+                    "tool_call_id": r.parent_id,
+                    "content": "\n".join(text_parts),
+                })
+    return result
 
 
 def _get_tracer(tracer_provider: TracerProvider | None = None) -> trace.Tracer:
@@ -152,14 +181,7 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
                 span.set_attribute("gen_ai.request.model", self._model_name)
 
             if self._capture_content:
-                input_messages = json.dumps([
-                    inp.to_api()
-                    for event in events
-                    if isinstance(event, ModelRequest)
-                    for inp in event.parts
-                    if isinstance(inp, TextInput)
-                ])
-                span.set_attribute("gen_ai.input.messages", input_messages)
+                span.set_attribute("gen_ai.input.messages", json.dumps(_build_input_messages(events)))
 
             try:
                 response = await call_next(events, context)


### PR DESCRIPTION
## Summary

`gen_ai.input.messages` on `chat` spans only recorded the current user message (TextInput parts of the latest `ModelRequest`). On tool-calling turns this means the span omits:

- Prior assistant turns (`ModelResponse`), including embedded tool calls
- Tool results fed back to the model (`ToolResultsEvent` → `ToolResultEvent`)

The consequence: you can't see what the model actually received, can't explain its output, and can't replay the call for evaluation.

## Changes

- `autogen/beta/middleware/builtin/telemetry.py`: add `_build_input_messages()` helper that walks the full event sequence (user messages, assistant turns, tool results) and serialises each in OpenAI-compatible format. Binary inputs are intentionally skipped — they cannot be stored as string span attributes.

## Example: before vs after on a tool-calling turn

**Before** (`gen_ai.input.messages`):
```json
[{"content": "What's the weather in Paris?", "role": "user"}]
```

**After**:
```json
[
  {"content": "What's the weather in Paris?", "role": "user"},
  {"content": null, "role": "assistant", "tool_calls": [{"id": "call_abc", "type": "function", "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"}}]},
  {"role": "tool", "tool_call_id": "call_abc", "content": "15°C, partly cloudy"}
]
```

## Test plan

- [ ] Existing telemetry tests pass
- [ ] Verify `ex02_single_tool.py` / `ex04_parallel_tools.py` traces now show the full conversation history on `chat` spans

Related: P1 item in `AG2_TELEMETRY_TASKS.md` — "gen_ai.input.messages is not the prompt the model received".

🤖 Generated with [Claude Code](https://claude.ai/claude-code)