### PR TITLE
fix: count Responses image costs per output item

### DIFF
--- a/autogen/oai/openai_responses.py
+++ b/autogen/oai/openai_responses.py
@@ -225,12 +225,8 @@ class OpenAIResponsesClient:
     def _add_image_cost(self, response: "Response") -> None:
         """Add image cost to self._image_costs when an image is generated"""
         for output in response.output:
-            if (
-                isinstance(output, ImageGenerationCall)
-                and hasattr(response.output[0], "model_extra")
-                and response.output[0].model_extra
-            ):
-                extra_fields = output.model_extra
+            if isinstance(output, ImageGenerationCall) and hasattr(output, "model_extra"):
+                extra_fields = output.model_extra or {}
 
                 image_cost, image_error = calculate_openai_image_cost(
                     model="gpt-image-1",

--- a/test/oai/test_responses_client.py
+++ b/test/oai/test_responses_client.py
@@ -480,15 +480,14 @@ def test_add_image_cost_defaults(mocked_openai_client):
     mock_call = MagicMock(spec=ImageGenerationCall)
     mock_call.model_extra = {}  # Empty dict
 
-    # Note: Due to the bug in line 193, empty dict is falsy so no cost will be added
     output = [mock_call]
     resp = _FakeResponse(output=output)
 
     # Process the response
     client._add_image_cost(resp)
 
-    # Empty model_extra dict is falsy, so the condition fails and no cost is added
-    assert client.image_costs == 0
+    # Empty model_extra dict should still use the Responses image defaults.
+    assert client.image_costs == 0.25
 
 
 def test_total_cost_includes_image_costs(mocked_openai_client):
@@ -530,13 +529,13 @@ def test_image_costs_persist_across_calls(mocked_openai_client):
     assert client.image_costs == 0.011 + 0.042
 
 
-def test_add_image_cost_bug_demonstration(mocked_openai_client):
-    """Demonstrate the bug in _add_image_cost where it checks output[0] instead of current item."""
+def test_add_image_cost_uses_each_image_item_model_extra(mocked_openai_client):
+    """Test _add_image_cost reads model_extra from each image output item."""
     client = OpenAIResponsesClient(mocked_openai_client)
 
-    # Create two mocks: first with model_extra (required by bug), second with model_extra
+    # Create two image outputs with different size/quality metadata.
     mock_call1 = MagicMock(spec=ImageGenerationCall)
-    mock_call1.model_extra = {"size": "1024x1024", "quality": "high"}  # Need this due to bug
+    mock_call1.model_extra = {"size": "1024x1024", "quality": "high"}
 
     mock_call2 = MagicMock(spec=ImageGenerationCall)
     mock_call2.model_extra = {"size": "1024x1024", "quality": "low"}
@@ -547,7 +546,6 @@ def test_add_image_cost_bug_demonstration(mocked_openai_client):
     # Process the response
     client._add_image_cost(resp)
 
-    # Due to the bug checking output[0], both images will be processed
     # First: 1024x1024 high = 0.167, Second: 1024x1024 low = 0.011
     assert client.image_costs == 0.167 + 0.011
 
@@ -588,9 +586,8 @@ def test_add_image_cost_with_non_image_first(mocked_openai_client):
     # Process the response
     client._add_image_cost(resp)
 
-    # The bug will try to check output[0].model_extra on a dict, which will fail
-    # So no image cost will be added
-    assert client.image_costs == 0
+    # Non-image output items should not prevent later image outputs from being counted.
+    assert client.image_costs == 0.011
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Update `OpenAIResponsesClient._add_image_cost` to inspect each image output item instead of checking `response.output[0]` while iterating.
- Preserve default Responses image cost behavior when `model_extra` is present but empty.
- Update existing image-cost tests for empty metadata, multiple image outputs, and non-image output items before image output items.

## Root cause

The loop over `response.output` gated image-cost calculation on the first response item. If the first output was not an image output with metadata, later image generation outputs were skipped and their costs were not counted.

## Validation

- `AUTOGEN_USE_DOCKER=0 OPENAI_API_KEY=test uv run pytest test/oai/test_responses_client.py -k 'image_cost' -q`
- `AUTOGEN_USE_DOCKER=0 OPENAI_API_KEY=test uv run pytest test/oai/test_responses_client.py -q`
- `uv run ruff check autogen/oai/openai_responses.py test/oai/test_responses_client.py`
- `uv run ruff format --check autogen/oai/openai_responses.py test/oai/test_responses_client.py`
- `git diff --check`

## AI assistance

Prepared with AI assistance and manually reviewed before submission.