### PR TITLE
feat(beta/telemetry): stamp agent_id and workflow state on invoke_agent spans

### DIFF
--- a/autogen/beta/middleware/builtin/telemetry.py
+++ b/autogen/beta/middleware/builtin/telemetry.py
@@ -36,6 +36,7 @@ except ImportError as _err:
     ) from _err
 
 from autogen.beta.events import ToolErrorEvent
+from autogen.beta.network.policies import AGENT_CLIENT_DEP, CHANNEL_STATE_DEP
 
 _SCHEMA_URL = "https://opentelemetry.io/schemas/1.11.0"
 _INSTRUMENTING_MODULE = "opentelemetry.instrumentation.ag2.beta"
@@ -122,6 +123,30 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
                 span.set_attribute("gen_ai.provider.name", self._provider_name)
             if self._model_name:
                 span.set_attribute("gen_ai.request.model", self._model_name)
+
+            # Network identity: stamp the agent's ID when running inside a
+            # hub channel (AGENT_CLIENT_DEP is set by stamp_dependencies).
+            agent_client = context.dependencies.get(AGENT_CLIENT_DEP)
+            if agent_client is not None:
+                agent_id = getattr(agent_client, "agent_id", None)
+                if agent_id:
+                    span.set_attribute("ag2.network.agent_id", agent_id)
+
+            # Workflow state: stamp per-turn routing info when the channel
+            # adapter exposes it (WorkflowState / DiscussionState). Uses
+            # getattr so this stays adapter-agnostic without importing
+            # concrete state types into the middleware layer.
+            channel_state = context.dependencies.get(CHANNEL_STATE_DEP)
+            if channel_state is not None:
+                next_speaker = getattr(channel_state, "expected_next_speaker", None)
+                if next_speaker:
+                    span.set_attribute("ag2.workflow.next_speaker", next_speaker)
+                turn_count = getattr(channel_state, "turn_count", None)
+                if turn_count is not None:
+                    span.set_attribute("ag2.workflow.turn_number", turn_count)
+                context_vars = getattr(channel_state, "context_vars", None)
+                if context_vars and self._capture_content:
+                    span.set_attribute("ag2.workflow.context_vars", json.dumps(context_vars))
 
             try:
                 response = await call_next(event, context)


### PR DESCRIPTION
## Summary

Extends `TelemetryMiddleware.on_turn` to stamp two more dependency values from `context.dependencies` onto the `invoke_agent` span, giving AI engineers richer per-turn context in Jaeger / Zipkin / OTLP backends.

### New span attributes

| Attribute | Source | Condition |
|---|---|---|
| `ag2.network.agent_id` | `AGENT_CLIENT_DEP` → `agent_client.agent_id` | When running inside a hub channel |
| `ag2.workflow.next_speaker` | `CHANNEL_STATE_DEP` → `expected_next_speaker` | When state has this field (WorkflowState, DiscussionState) |
| `ag2.workflow.turn_number` | `CHANNEL_STATE_DEP` → `turn_count` | When state has this field (WorkflowState) |
| `ag2.workflow.context_vars` | `CHANNEL_STATE_DEP` → `context_vars` | When state has this field AND `capture_content=True` |

### Design

**`getattr` for state fields** — rather than importing `WorkflowState`/`DiscussionState` into the middleware layer (which would create a cross-package dependency), the code uses `getattr(channel_state, "expected_next_speaker", None)`. This keeps the middleware agnostic of concrete adapter state types and means any future adapter that exposes these fields gets the attributes automatically.

**No-op outside network** — both dependency keys (`AGENT_CLIENT_DEP`, `CHANNEL_STATE_DEP`) are only stamped into `context.dependencies` by `handlers.stamp_dependencies`, which runs inside hub-channel LLM turns. Agents running standalone (no hub) produce no change in behaviour.

## Related

- Follows #2836 (W3C traceparent propagation through envelopes, which also extends `on_turn`)
- Both PRs are independent and can be merged in any order

## Test plan

- [ ] Unit: construct a `Context` with `AGENT_CLIENT_DEP` → mock `agent_id`; verify `ag2.network.agent_id` attribute on span
- [ ] Unit: construct a `Context` with `CHANNEL_STATE_DEP` → mock object with `expected_next_speaker="alice"`, `turn_count=3`, `context_vars={"k":"v"}`; verify all three workflow attrs
- [ ] Unit: empty `context.dependencies` → span has no `ag2.network.*` or `ag2.workflow.*` attrs (standalone agent)
- [ ] Integration: workflow channel with two agents + OTLP exporter → confirm `ag2.workflow.next_speaker` advances across turns

🤖 Generated with [Claude Code](https://claude.ai/claude-code)