### PR TITLE
feat(beta/telemetry): emit gen_ai.request.temperature/top_p/max_tokens on chat spans

### DIFF
--- a/autogen/beta/middleware/builtin/telemetry.py
+++ b/autogen/beta/middleware/builtin/telemetry.py
@@ -57,6 +57,9 @@ class TelemetryMiddleware(MiddlewareFactory):
         agent_name: Agent name for span attributes. If not set, defaults to "unknown".
         provider_name: LLM provider name (e.g. "openai", "anthropic").
         model_name: Model name (e.g. "gpt-4o-mini").
+        temperature: Sampling temperature emitted as ``gen_ai.request.temperature``.
+        top_p: Top-p sampling value emitted as ``gen_ai.request.top_p``.
+        max_tokens: Max tokens value emitted as ``gen_ai.request.max_tokens``.
     """
 
     def __init__(
@@ -67,12 +70,18 @@ class TelemetryMiddleware(MiddlewareFactory):
         agent_name: str | None = None,
         provider_name: str | None = None,
         model_name: str | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        max_tokens: int | None = None,
     ) -> None:
         self._tracer = _get_tracer(tracer_provider)
         self._capture_content = capture_content
         self._agent_name = agent_name or "unknown"
         self._provider_name = provider_name
         self._model_name = model_name
+        self._temperature = temperature
+        self._top_p = top_p
+        self._max_tokens = max_tokens
 
     def __call__(self, event: BaseEvent, context: Context) -> BaseMiddleware:
         return _TelemetryMiddlewareInstance(
@@ -83,6 +92,9 @@ class TelemetryMiddleware(MiddlewareFactory):
             agent_name=self._agent_name,
             provider_name=self._provider_name,
             model_name=self._model_name,
+            temperature=self._temperature,
+            top_p=self._top_p,
+            max_tokens=self._max_tokens,
         )
 
 
@@ -97,6 +109,9 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
         agent_name: str,
         provider_name: str | None,
         model_name: str | None,
+        temperature: float | None,
+        top_p: float | None,
+        max_tokens: int | None,
     ) -> None:
         super().__init__(event, context)
         self._tracer = tracer
@@ -104,6 +119,9 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
         self._agent_name = agent_name
         self._provider_name = provider_name
         self._model_name = model_name
+        self._temperature = temperature
+        self._top_p = top_p
+        self._max_tokens = max_tokens
 
     async def on_turn(
         self,
@@ -150,6 +168,13 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
                 span.set_attribute("gen_ai.provider.name", self._provider_name)
             if self._model_name:
                 span.set_attribute("gen_ai.request.model", self._model_name)
+
+            if self._temperature is not None:
+                span.set_attribute("gen_ai.request.temperature", self._temperature)
+            if self._top_p is not None:
+                span.set_attribute("gen_ai.request.top_p", self._top_p)
+            if self._max_tokens is not None:
+                span.set_attribute("gen_ai.request.max_tokens", self._max_tokens)
 
             if self._capture_content:
                 input_messages = json.dumps([

--- a/test/beta/middleware/telemetry/test_telemetry.py
+++ b/test/beta/middleware/telemetry/test_telemetry.py
@@ -498,3 +498,51 @@ async def test_thinking_tokens_omitted_when_zero(otel_setup):
     spans = exporter.get_finished_spans()
     llm_span = next(s for s in spans if s.attributes.get("ag2.span.type") == "llm")
     assert "gen_ai.usage.thinking_tokens" not in llm_span.attributes
+
+
+@pytest.mark.asyncio()
+async def test_request_params_on_llm_span(otel_setup):
+    """temperature, top_p, and max_tokens appear as gen_ai.request.* on the chat span."""
+    exporter, provider = otel_setup
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(ModelResponse(ModelMessage("Hi!"))),
+        middleware=[
+            TelemetryMiddleware(
+                tracer_provider=provider,
+                agent_name="assistant",
+                temperature=0.7,
+                top_p=0.9,
+                max_tokens=512,
+            )
+        ],
+    )
+
+    await agent.ask("Hello")
+
+    spans = exporter.get_finished_spans()
+    llm_span = next(s for s in spans if s.attributes.get("ag2.span.type") == "llm")
+    assert llm_span.attributes["gen_ai.request.temperature"] == pytest.approx(0.7)
+    assert llm_span.attributes["gen_ai.request.top_p"] == pytest.approx(0.9)
+    assert llm_span.attributes["gen_ai.request.max_tokens"] == 512
+
+
+@pytest.mark.asyncio()
+async def test_request_params_absent_when_not_set(otel_setup):
+    """When temperature/top_p/max_tokens are not passed, no span attributes are emitted."""
+    exporter, provider = otel_setup
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(ModelResponse(ModelMessage("Hi!"))),
+        middleware=[TelemetryMiddleware(tracer_provider=provider, agent_name="assistant")],
+    )
+
+    await agent.ask("Hello")
+
+    spans = exporter.get_finished_spans()
+    llm_span = next(s for s in spans if s.attributes.get("ag2.span.type") == "llm")
+    assert "gen_ai.request.temperature" not in llm_span.attributes
+    assert "gen_ai.request.top_p" not in llm_span.attributes
+    assert "gen_ai.request.max_tokens" not in llm_span.attributes


### PR DESCRIPTION
## Summary

- Adds `temperature`, `top_p`, and `max_tokens` constructor parameters to `TelemetryMiddleware`
- Emits `gen_ai.request.temperature`, `gen_ai.request.top_p`, and `gen_ai.request.max_tokens` on the `chat` span per OpenTelemetry GenAI Semantic Conventions
- Follows the same pattern as the existing `model_name` / `provider_name` params — callers supply values at middleware construction time

## Why not auto-detect from the LLM call?

The model config (temperature, max_tokens, etc.) is encapsulated inside the `LLMClient` concrete implementation and not accessible via the `LLMClient` Protocol or `ConversationContext`. Supplying them at `TelemetryMiddleware` construction time is consistent with how `model_name` and `provider_name` already work, avoids private API access, and keeps the middleware layer decoupled from provider internals.

## Usage

```python
from autogen.beta.middleware.builtin import TelemetryMiddleware

middleware = TelemetryMiddleware(
    provider_name="openai",
    model_name="gpt-4o-mini",
    temperature=0.7,
    max_tokens=4096,
)
```

## Test plan

- [ ] Construct `TelemetryMiddleware` with `temperature`, `top_p`, `max_tokens`
- [ ] Verify the `chat` span contains `gen_ai.request.temperature`, `gen_ai.request.top_p`, `gen_ai.request.max_tokens`
- [ ] Verify omitting these params produces no span attributes (no noise)
- [ ] Pre-commit passes (ruff, mypy, typos) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)