### PR TITLE
feat(beta/middleware): ConditionalMiddleware for condition-gated hook execution

### DIFF
--- a/autogen/beta/middleware/__init__.py
+++ b/autogen/beta/middleware/__init__.py
@@ -13,6 +13,7 @@ from .base import (
     ToolResultType,
 )
 from .builtin import (
+    ConditionalMiddleware,
     HistoryLimiter,
     LoggingMiddleware,
     RetryMiddleware,
@@ -24,6 +25,7 @@ from .builtin import (
 __all__ = (
     "AgentTurn",
     "BaseMiddleware",
+    "ConditionalMiddleware",
     "HistoryLimiter",
     "HumanInputHook",
     "LLMCall",

--- a/autogen/beta/middleware/builtin/__init__.py
+++ b/autogen/beta/middleware/builtin/__init__.py
@@ -4,6 +4,7 @@
 
 from autogen.beta.exceptions import missing_optional_dependency
 
+from .conditional import ConditionalMiddleware
 from .history_limiter import HistoryLimiter
 from .llm_retry import RetryMiddleware
 from .logging import LoggingMiddleware
@@ -16,6 +17,7 @@ except ImportError as e:
     TelemetryMiddleware = missing_optional_dependency("TelemetryMiddleware", "tracing", e)
 
 __all__ = (
+    "ConditionalMiddleware",
     "HistoryLimiter",
     "LoggingMiddleware",
     "RetryMiddleware",

--- a/autogen/beta/middleware/builtin/conditional.py
+++ b/autogen/beta/middleware/builtin/conditional.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Sequence
+
+from autogen.beta.annotations import Context
+from autogen.beta.events import BaseEvent, HumanInputRequest, HumanMessage, ModelResponse, ToolCallEvent
+from autogen.beta.events.conditions import Condition
+from autogen.beta.middleware.base import (
+    AgentTurn,
+    BaseMiddleware,
+    HumanInputHook,
+    LLMCall,
+    MiddlewareFactory,
+    ToolExecution,
+    ToolResultType,
+)
+
+
+class ConditionalMiddleware(MiddlewareFactory):
+    """Activates an inner middleware only when a Condition matches the relevant event.
+
+    Each hook checks the condition against its event independently:
+
+    - ``on_turn``: condition evaluated against the turn-triggering event.
+    - ``on_tool_execution``: condition evaluated against the :class:`ToolCallEvent`.
+    - ``on_llm_call``: condition evaluated against the initial turn event.
+    - ``on_human_input``: condition evaluated against the :class:`HumanInputRequest`.
+
+    If the condition is not satisfied the hook short-circuits — ``call_next`` is
+    invoked directly and the inner middleware layer is transparent for that hook.
+
+    Args:
+        condition: A :class:`~autogen.beta.events.conditions.Condition` instance.
+            Build one from event-field DSL expressions
+            (e.g. ``ToolCallEvent.name == "execute_code"``) or compose with
+            ``&``, ``|``, ``~``.
+        middleware: The :class:`MiddlewareFactory` to activate when the condition
+            matches.
+
+    Example::
+
+        from autogen.beta.events import ToolCallEvent
+        from autogen.beta.middleware import ConditionalMiddleware, Middleware
+        from autogen.beta.middleware.builtin.tools import approval_required
+
+        agent = Agent(
+            "assistant",
+            ...,
+            middleware=[
+                ConditionalMiddleware(
+                    condition=ToolCallEvent.name == "execute_code",
+                    middleware=Middleware(approval_required),
+                )
+            ],
+        )
+    """
+
+    def __init__(self, condition: Condition, middleware: MiddlewareFactory) -> None:
+        self._condition = condition
+        self._middleware = middleware
+
+    def __call__(self, event: BaseEvent, context: Context) -> BaseMiddleware:
+        return _ConditionalMiddlewareInstance(
+            event,
+            context,
+            condition=self._condition,
+            inner=self._middleware(event, context),
+        )
+
+
+class _ConditionalMiddlewareInstance(BaseMiddleware):
+    def __init__(
+        self,
+        event: BaseEvent,
+        context: Context,
+        *,
+        condition: Condition,
+        inner: BaseMiddleware,
+    ) -> None:
+        super().__init__(event, context)
+        self._condition = condition
+        self._inner = inner
+
+    async def on_turn(
+        self,
+        call_next: AgentTurn,
+        event: BaseEvent,
+        context: Context,
+    ) -> ModelResponse:
+        if not self._condition(event):
+            return await call_next(event, context)
+        return await self._inner.on_turn(call_next, event, context)
+
+    async def on_llm_call(
+        self,
+        call_next: LLMCall,
+        events: Sequence[BaseEvent],
+        context: Context,
+    ) -> ModelResponse:
+        if not self._condition(self.initial_event):
+            return await call_next(events, context)
+        return await self._inner.on_llm_call(call_next, events, context)
+
+    async def on_tool_execution(
+        self,
+        call_next: ToolExecution,
+        event: ToolCallEvent,
+        context: Context,
+    ) -> ToolResultType:
+        if not self._condition(event):
+            return await call_next(event, context)
+        return await self._inner.on_tool_execution(call_next, event, context)
+
+    async def on_human_input(
+        self,
+        call_next: HumanInputHook,
+        event: HumanInputRequest,
+        context: Context,
+    ) -> HumanMessage:
+        if not self._condition(event):
+            return await call_next(event, context)
+        return await self._inner.on_human_input(call_next, event, context)

--- a/test/beta/middleware/test_conditional_middleware.py
+++ b/test/beta/middleware/test_conditional_middleware.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Sequence
+from unittest.mock import MagicMock
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.annotations import Context
+from autogen.beta.events import BaseEvent, ModelMessage, ModelResponse, ToolCallEvent, ToolCallsEvent
+from autogen.beta.events.conditions import TypeCondition
+from autogen.beta.middleware import BaseMiddleware, ConditionalMiddleware, Middleware, ToolExecution
+from autogen.beta.middleware.base import AgentTurn, LLMCall, ToolResultType
+from autogen.beta.testing import TestConfig
+from autogen.beta.tools import tool
+
+
+class _TrackingMiddleware(BaseMiddleware):
+    """Records which hooks were invoked."""
+
+    def __init__(self, event: BaseEvent, context: Context, *, tracker: MagicMock) -> None:
+        super().__init__(event, context)
+        self._tracker = tracker
+
+    async def on_turn(self, call_next: AgentTurn, event: BaseEvent, context: Context) -> ModelResponse:
+        self._tracker.on_turn()
+        return await call_next(event, context)
+
+    async def on_llm_call(self, call_next: LLMCall, events: Sequence[BaseEvent], context: Context) -> ModelResponse:
+        self._tracker.on_llm_call()
+        return await call_next(events, context)
+
+    async def on_tool_execution(
+        self, call_next: ToolExecution, event: ToolCallEvent, context: Context
+    ) -> ToolResultType:
+        self._tracker.on_tool_execution()
+        return await call_next(event, context)
+
+
+def _tracking_factory(tracker: MagicMock) -> Middleware:
+    return Middleware(_TrackingMiddleware, tracker=tracker)
+
+
+@pytest.mark.asyncio()
+async def test_condition_match_activates_inner_on_turn():
+    tracker = MagicMock()
+    agent = Agent(
+        "assistant",
+        config=TestConfig(ModelResponse(ModelMessage("Hello!"))),
+        middleware=[
+            ConditionalMiddleware(
+                condition=TypeCondition(ModelMessage),  # always False — turn event is not ModelMessage
+                middleware=_tracking_factory(tracker),
+            )
+        ],
+    )
+
+    await agent.ask("Hi")
+
+    tracker.on_turn.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_tool_condition_gates_only_matching_tool():
+    tracker = MagicMock()
+
+    @tool
+    def greet(name: str) -> str:
+        """Greet someone."""
+        return f"Hello {name}"
+
+    @tool
+    def farewell(name: str) -> str:
+        """Say goodbye."""
+        return f"Goodbye {name}"
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(
+            ModelResponse(
+                tool_calls=ToolCallsEvent(
+                    calls=[
+                        ToolCallEvent(id="c1", name="greet", arguments='{"name": "World"}'),
+                        ToolCallEvent(id="c2", name="farewell", arguments='{"name": "World"}'),
+                    ]
+                ),
+            ),
+            ModelResponse(ModelMessage("Done")),
+        ),
+        tools=[greet, farewell],
+        middleware=[
+            ConditionalMiddleware(
+                condition=ToolCallEvent.name == "greet",
+                middleware=_tracking_factory(tracker),
+            )
+        ],
+    )
+
+    await agent.ask("Go")
+
+    # Only the "greet" tool call should have triggered on_tool_execution
+    assert tracker.on_tool_execution.call_count == 1
+
+
+@pytest.mark.asyncio()
+async def test_condition_no_match_passes_through():
+    """When condition never matches, inner middleware is fully transparent."""
+    tracker = MagicMock()
+
+    @tool
+    def noop() -> str:
+        """Does nothing."""
+        return "ok"
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(
+            ModelResponse(
+                tool_calls=ToolCallsEvent(calls=[ToolCallEvent(id="c1", name="noop", arguments="{}")]),
+            ),
+            ModelResponse(ModelMessage("Done")),
+        ),
+        tools=[noop],
+        middleware=[
+            ConditionalMiddleware(
+                condition=ToolCallEvent.name == "nonexistent_tool",
+                middleware=_tracking_factory(tracker),
+            )
+        ],
+    )
+
+    await agent.ask("Go")
+
+    tracker.on_tool_execution.assert_not_called()
+    # Turn still completes successfully
+    tracker.on_turn.assert_not_called()  # turn event is HumanMessage, not the condition type
+
+
+@pytest.mark.asyncio()
+async def test_condition_match_on_tool_name():
+    """Positive case: condition matches the exact tool name."""
+    tracker = MagicMock()
+
+    @tool
+    def calculate(x: int, y: int) -> int:
+        """Add two numbers."""
+        return x + y
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(
+            ModelResponse(
+                tool_calls=ToolCallsEvent(
+                    calls=[ToolCallEvent(id="c1", name="calculate", arguments='{"x": 1, "y": 2}')]
+                ),
+            ),
+            ModelResponse(ModelMessage("Result: 3")),
+        ),
+        tools=[calculate],
+        middleware=[
+            ConditionalMiddleware(
+                condition=ToolCallEvent.name == "calculate",
+                middleware=_tracking_factory(tracker),
+            )
+        ],
+    )
+
+    await agent.ask("What is 1 + 2?")
+
+    tracker.on_tool_execution.assert_called_once()
+
+
+@pytest.mark.asyncio()
+async def test_conditional_middleware_composable_with_other_middleware():
+    """ConditionalMiddleware stacks correctly with other middleware."""
+    outer_tracker = MagicMock()
+    inner_tracker = MagicMock()
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(ModelResponse(ModelMessage("Hi!"))),
+        middleware=[
+            Middleware(_TrackingMiddleware, tracker=outer_tracker),
+            ConditionalMiddleware(
+                condition=TypeCondition(ModelMessage),  # won't match HumanMessage turn event
+                middleware=_tracking_factory(inner_tracker),
+            ),
+        ],
+    )
+
+    await agent.ask("Hello")
+
+    # Outer middleware runs on every turn
+    outer_tracker.on_turn.assert_called_once()
+    # Inner conditional middleware did not match
+    inner_tracker.on_turn.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_export_from_top_level_middleware_package():
+    """ConditionalMiddleware is importable from autogen.beta.middleware."""
+    from autogen.beta.middleware import ConditionalMiddleware as Conditional
+
+    assert Conditional is ConditionalMiddleware

--- a/website/docs/beta/middleware.mdx
+++ b/website/docs/beta/middleware.mdx
@@ -337,7 +337,7 @@ agent = Agent(
 
 ## Built-In Middleware
 
-AG2 Beta currently includes four built-in middleware in `autogen.beta.middleware`:
+AG2 Beta currently includes the following built-in middleware in `autogen.beta.middleware`:
 
 ### `LoggingMiddleware`
 
@@ -398,6 +398,55 @@ It uses a character-based estimate controlled by `chars_per_token`.
 
 Use it when you need lightweight context budgeting without depending on a model-specific tokenizer.
 
+### `ConditionalMiddleware`
+
+```python linenums="1"
+from autogen.beta import Agent
+from autogen.beta.events import ToolCallEvent
+from autogen.beta.middleware import ConditionalMiddleware, Middleware
+from autogen.beta.middleware.builtin import approval_required
+
+agent = Agent(
+    "assistant",
+    ...,
+    middleware=[
+        ConditionalMiddleware(
+            condition=ToolCallEvent.name == "execute_code",
+            middleware=Middleware(approval_required),
+        )
+    ],
+)
+```
+
+Wraps another middleware and activates it only when a `Condition` matches the relevant event.
+Each hook is gated independently:
+
+- `on_turn` — condition evaluated against the turn-triggering event.
+- `on_tool_execution` — condition evaluated against the `ToolCallEvent`.
+- `on_llm_call` — condition evaluated against the initial turn event.
+- `on_human_input` — condition evaluated against the `HumanInputRequest`.
+
+When the condition is not satisfied the hook short-circuits — `call_next` is invoked directly and the inner middleware layer is transparent for that hook.
+
+**Building conditions** — use the field DSL on event classes:
+
+```python linenums="1"
+from autogen.beta.events import ToolCallEvent
+from autogen.beta.events.conditions import TypeCondition
+
+# Match a specific tool by name
+ToolCallEvent.name == "execute_code"
+
+# Match any tool whose name starts with "search_" (using a custom Condition)
+# Compose with & (and), | (or), ~ (not)
+cond_a & cond_b   # both must match
+cond_a | cond_b   # either must match
+~cond_a           # must NOT match
+TypeCondition(SomeEventClass)  # event must be an instance of the given type
+```
+
+Use `ConditionalMiddleware` when you want a middleware to apply selectively — for example, requiring human approval only for a specific tool, or adding tracing only when a particular event type arrives.
+
 ## Choosing the Right Hook
 
 If you are unsure where a behavior belongs, use this rule of thumb:
@@ -407,5 +456,7 @@ If you are unsure where a behavior belongs, use this rule of thumb:
 - Use `on_tool_execution()` when the behavior is about tool safety, auditing, or result shaping across tools (or when branching on `event.name` is acceptable).
     - Use **tool-scoped** `middleware=[...]` on `@tool` / `Agent.tool` / `Toolkit.tool` when the behavior applies only to that tool’s definition; see [Tool middleware](/docs/beta/tools/tool_middleware){.internal-link}.
 - Use `on_human_input()` when the behavior is about intercepting, logging, or transforming human-in-the-loop requests and responses.
+
+Use `ConditionalMiddleware` to wrap any of the above when the behavior should apply selectively based on which event arrives.
 
 For related runtime customization patterns, see [Tools](/docs/beta/tools/tools), [Tool middleware](/docs/beta/tools/tool_middleware), [Prompt Management](../system_prompts), and [Events Streaming](../advanced/stream).


### PR DESCRIPTION
## Summary

Closes #2781.

Adds `ConditionalMiddleware` — a `MiddlewareFactory` wrapper that activates an inner middleware only when a `Condition` matches the relevant event. When the condition is not satisfied, `call_next` is invoked directly and the inner middleware is fully transparent for that hook.

- `on_turn`: condition evaluated against the turn-triggering event
- `on_tool_execution`: condition evaluated against the `ToolCallEvent`
- `on_llm_call`: condition evaluated against the initial turn event
- `on_human_input`: condition evaluated against the `HumanInputRequest`

Uses the existing `Condition` algebra from `autogen.beta.events.conditions` (including the field DSL, `&`/`|`/`~` combinators).

**Example:**
```python
from autogen.beta.events import ToolCallEvent
from autogen.beta.middleware import ConditionalMiddleware, Middleware

agent = Agent(
    "assistant",
    ...,
    middleware=[
        ConditionalMiddleware(
            condition=ToolCallEvent.name == "execute_code",
            middleware=Middleware(ApprovalMiddleware),
        )
    ],
)
```

## Test plan

- [x] `test_condition_match_activates_inner_on_turn` — non-matching type condition skips `on_turn`
- [x] `test_tool_condition_gates_only_matching_tool` — two tool calls, condition matches one; inner `on_tool_execution` fires once
- [x] `test_condition_no_match_passes_through` — no condition match, turn completes without inner middleware
- [x] `test_condition_match_on_tool_name` — positive case: matching tool name activates inner
- [x] `test_conditional_middleware_composable_with_other_middleware` — stacks correctly alongside other middleware
- [x] `test_export_from_top_level_middleware_package` — importable from `autogen.beta.middleware`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)