### PR TITLE
feat(beta): add AgentReply.usage and AgentReply.total_usage() for first-class token tracking

### DIFF
--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -48,6 +48,7 @@ from .events import (
     ModelRequest,
     ModelResponse,
     ToolResultsEvent,
+    Usage,
 )
 from .events.conditions import Condition
 from .events.lifecycle import (
@@ -236,6 +237,23 @@ class AgentReply(Generic[TResult, TAgent]):
     @property
     def history(self) -> History:
         return self.context.stream.history
+
+    @property
+    def usage(self) -> Usage:
+        """Token usage from the final model call in this turn."""
+        return self.response.usage
+
+    async def total_usage(self) -> Usage:
+        """Accumulated token usage across all model calls in this turn.
+
+        Useful when a turn involves multiple LLM calls (e.g. tool-use loops),
+        where :attr:`usage` only reflects the last call.
+        """
+        total = Usage()
+        for event in await self.history.get_events():
+            if isinstance(event, ModelResponse):
+                total = total + event.usage
+        return total
 
     @overload
     async def ask(

--- a/autogen/beta/events/types.py
+++ b/autogen/beta/events/types.py
@@ -32,6 +32,23 @@ class Usage:
             self.thinking_tokens,
         ))
 
+    def __add__(self, other: "Usage") -> "Usage":
+        """Return a new Usage with all fields summed. None + None stays None; None + N = N."""
+
+        def _sum(a: float | None, b: float | None) -> float | None:
+            if a is None and b is None:
+                return None
+            return (a or 0.0) + (b or 0.0)
+
+        return Usage(
+            prompt_tokens=_sum(self.prompt_tokens, other.prompt_tokens),
+            completion_tokens=_sum(self.completion_tokens, other.completion_tokens),
+            total_tokens=_sum(self.total_tokens, other.total_tokens),
+            cache_read_input_tokens=_sum(self.cache_read_input_tokens, other.cache_read_input_tokens),
+            cache_creation_input_tokens=_sum(self.cache_creation_input_tokens, other.cache_creation_input_tokens),
+            thinking_tokens=_sum(self.thinking_tokens, other.thinking_tokens),
+        )
+
 
 class ModelEvent(BaseEvent):
     """Base class for all model-related events."""

--- a/test/beta/agent/test_usage.py
+++ b/test/beta/agent/test_usage.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for AgentReply.usage / AgentReply.total_usage() and Usage.__add__."""
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.events import (
+    ModelMessage,
+    ModelResponse,
+    ToolCallEvent,
+    ToolCallsEvent,
+    Usage,
+)
+from autogen.beta.testing import TestConfig
+from autogen.beta.tools import tool
+
+# ---------------------------------------------------------------------------
+# Usage.__add__
+# ---------------------------------------------------------------------------
+
+
+def test_usage_add_both_populated() -> None:
+    a = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    b = Usage(prompt_tokens=3, completion_tokens=2, total_tokens=5)
+    c = a + b
+    assert c.prompt_tokens == 13
+    assert c.completion_tokens == 7
+    assert c.total_tokens == 20
+
+
+def test_usage_add_none_stays_none_when_both_none() -> None:
+    a = Usage(prompt_tokens=None)
+    b = Usage(prompt_tokens=None)
+    assert (a + b).prompt_tokens is None
+
+
+def test_usage_add_none_plus_value() -> None:
+    a = Usage(prompt_tokens=None)
+    b = Usage(prompt_tokens=7)
+    assert (a + b).prompt_tokens == 7
+    assert (b + a).prompt_tokens == 7
+
+
+def test_usage_add_cache_tokens() -> None:
+    a = Usage(cache_read_input_tokens=100, cache_creation_input_tokens=50)
+    b = Usage(cache_read_input_tokens=20, cache_creation_input_tokens=10)
+    c = a + b
+    assert c.cache_read_input_tokens == 120
+    assert c.cache_creation_input_tokens == 60
+
+
+# ---------------------------------------------------------------------------
+# AgentReply.usage — single turn, no tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reply_usage_single_turn() -> None:
+    agent = Agent(
+        "assistant",
+        config=TestConfig(
+            ModelResponse(
+                message=ModelMessage("Hi!"),
+                usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            )
+        ),
+    )
+    reply = await agent.ask("Hello")
+    assert reply.usage.prompt_tokens == 10
+    assert reply.usage.completion_tokens == 5
+    assert reply.usage.total_tokens == 15
+
+
+@pytest.mark.asyncio
+async def test_reply_usage_no_usage_info() -> None:
+    agent = Agent(
+        "assistant",
+        config=TestConfig(ModelResponse(message=ModelMessage("Hi!"))),
+    )
+    reply = await agent.ask("Hello")
+    # Usage is always a Usage object (never None); empty when provider omits it
+    assert isinstance(reply.usage, Usage)
+    assert not reply.usage
+
+
+# ---------------------------------------------------------------------------
+# AgentReply.total_usage — accumulates across tool-calling loops
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_total_usage_accumulates_across_tool_calls() -> None:
+    @tool
+    async def add(a: int, b: int) -> int:
+        """Return a + b."""
+        return a + b
+
+    # Two LLM calls: first returns a tool call, second returns final reply
+    agent = Agent(
+        "assistant",
+        config=TestConfig(
+            ModelResponse(
+                tool_calls=ToolCallsEvent(calls=[ToolCallEvent(name="add", arguments='{"a": 1, "b": 2}')]),
+                usage=Usage(prompt_tokens=8, completion_tokens=3, total_tokens=11),
+            ),
+            ModelResponse(
+                message=ModelMessage("The answer is 3."),
+                usage=Usage(prompt_tokens=20, completion_tokens=6, total_tokens=26),
+            ),
+        ),
+        tools=[add],
+    )
+    reply = await agent.ask("What is 1 + 2?")
+
+    # .usage is only the final call
+    assert reply.usage.prompt_tokens == 20
+
+    # .total_usage() sums both calls
+    total = await reply.total_usage()
+    assert total.prompt_tokens == 28
+    assert total.completion_tokens == 9
+    assert total.total_tokens == 37
+
+
+@pytest.mark.asyncio
+async def test_total_usage_single_turn_matches_usage() -> None:
+    agent = Agent(
+        "assistant",
+        config=TestConfig(
+            ModelResponse(
+                message=ModelMessage("Hi!"),
+                usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            )
+        ),
+    )
+    reply = await agent.ask("Hello")
+    total = await reply.total_usage()
+    # Single LLM call: total_usage == usage
+    assert total.prompt_tokens == reply.usage.prompt_tokens
+    assert total.completion_tokens == reply.usage.completion_tokens
+    assert total.total_tokens == reply.usage.total_tokens


### PR DESCRIPTION
## Summary

Addresses the P1 roadmap item **"First-class Usage tracking"**.

### Changes

**`Usage.__add__`** (`autogen/beta/events/types.py`)
- Enables summing two `Usage` objects: `None + None` stays `None`; `None + N = N`
- Makes it possible to accumulate usage across multiple LLM calls with a simple `total + event.usage` fold

**`AgentReply.usage`** (synchronous property)
- Returns `self.response.usage` — the `Usage` from the final `ModelResponse` in the turn
- Immediately accessible on every `reply = await agent.ask(...)` call

**`AgentReply.total_usage()`** (async method)
- Iterates the turn's full event history and sums `Usage` across all `ModelResponse` events
- Covers tool-use loops where the final `ModelResponse` only reflects the last call:

```python
reply = await agent.ask("What is 1 + 2?")

# Token usage from the final LLM call only
print(reply.usage.prompt_tokens)

# Total tokens across all LLM calls in the turn (includes tool loop calls)
total = await reply.total_usage()
print(total.prompt_tokens)
```

### Before / After

Before this PR:
```python
reply = await agent.ask("...")
# No way to get token usage without subscribing to stream events
```

After:
```python
reply = await agent.ask("...")
print(reply.usage)                   # final call's Usage
total = await reply.total_usage()    # all calls summed
```

## Test plan

- [x] `test_usage_add_both_populated` — basic addition
- [x] `test_usage_add_none_stays_none_when_both_none` — None semantics
- [x] `test_usage_add_none_plus_value` — None + value = value (commutative)
- [x] `test_usage_add_cache_tokens` — cache_read + cache_creation fields
- [x] `test_reply_usage_single_turn` — `.usage` reflects the model's reported tokens
- [x] `test_reply_usage_no_usage_info` — empty `Usage()` when provider omits it
- [x] `test_total_usage_accumulates_across_tool_calls` — tool loop produces correct aggregate
- [x] `test_total_usage_single_turn_matches_usage` — single turn: both methods agree

All 8 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)