### PR TITLE
feat(beta): fanout() for parallel agent invocations

### DIFF
--- a/autogen/beta/__init__.py
+++ b/autogen/beta/__init__.py
@@ -15,6 +15,7 @@ from .events import (
     TextInput,
     VideoInput,
 )
+from .fanout import fanout
 from .files import FilesAPI
 from .middleware import Middleware
 from .observers import observer
@@ -51,6 +52,7 @@ __all__ = (
     "Toolkit",
     "Variable",
     "VideoInput",
+    "fanout",
     "observer",
     "response_schema",
     "tool",

--- a/autogen/beta/fanout.py
+++ b/autogen/beta/fanout.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""fanout — run agent invocations in parallel.
+
+:func:`fanout` is the go-to primitive for running multiple ``agent.ask()``
+calls concurrently — whether against the same agent with different prompts,
+different agents with the same prompt, or any mix.
+
+Example::
+
+    from autogen.beta import Agent, fanout
+    from autogen.beta.config import OpenAIConfig
+
+    agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"))
+
+    # Same agent, multiple prompts — returns list in input order
+    replies = await fanout(agent, ["Summarize Paris.", "Summarize Rome."])
+    for r in replies:
+        print(r.body)
+
+    # Multiple agents, same prompt (ensemble)
+    replies = await fanout([formal, casual, technical], "Explain recursion.")
+
+    # Heterogeneous pairs
+    replies = await fanout([
+        (agent_a, "Summarize document A."),
+        (agent_b, "Summarize document B."),
+    ])
+
+    # Limit to 3 concurrent calls at most
+    replies = await fanout(agent, prompts, max_concurrent=3)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, overload
+
+if TYPE_CHECKING:
+    from .agent import Agent, AgentReply
+
+__all__ = ("fanout",)
+
+# A job is a (agent, prompt) pair.
+_Job = tuple["Agent[Any]", str]
+
+
+@overload
+async def fanout(
+    agent: Agent[Any],
+    prompts: list[str],
+    *,
+    max_concurrent: int | None = None,
+) -> list[AgentReply[Any, Any]]: ...
+
+
+@overload
+async def fanout(
+    agents: list[Agent[Any]],
+    prompt: str,
+    *,
+    max_concurrent: int | None = None,
+) -> list[AgentReply[Any, Any]]: ...
+
+
+@overload
+async def fanout(
+    jobs: list[tuple[Agent[Any], str]],
+    *,
+    max_concurrent: int | None = None,
+) -> list[AgentReply[Any, Any]]: ...
+
+
+async def fanout(
+    agent_or_agents_or_jobs: Agent[Any] | list[Agent[Any]] | list[tuple[Agent[Any], str]],
+    prompt_or_prompts: str | list[str] | None = None,
+    *,
+    max_concurrent: int | None = None,
+) -> list[AgentReply[Any, Any]]:
+    """Run multiple ``agent.ask()`` calls concurrently and return results in order.
+
+    Three calling conventions are supported:
+
+    .. code-block:: python
+
+        # 1. Same agent, many prompts
+        replies = await fanout(agent, ["Summarize Paris.", "Summarize Rome."])
+
+        # 2. Many agents, same prompt (ensemble / redundant)
+        replies = await fanout([agent_a, agent_b, agent_c], "Explain recursion.")
+
+        # 3. Explicit (agent, prompt) pairs
+        replies = await fanout([
+            (agent_a, "Prompt for A."),
+            (agent_b, "Prompt for B."),
+        ])
+
+    Args:
+        agent_or_agents_or_jobs:
+            * A single :class:`~autogen.beta.Agent` (paired with *prompt_or_prompts* as a list).
+            * A list of :class:`~autogen.beta.Agent` objects (all receive the same *prompt_or_prompts* string).
+            * A list of ``(agent, prompt)`` pairs (no second argument needed).
+        prompt_or_prompts:
+            A single prompt string (for the list-of-agents form) or a list of prompt strings
+            (for the single-agent form).  Omit when passing explicit ``(agent, prompt)`` pairs.
+        max_concurrent:
+            Maximum number of concurrent ``agent.ask()`` calls.  ``None`` (default) means all
+            calls run at once.  Set this to avoid overwhelming rate limits or shared resources
+            when the job list is large.
+
+    Returns:
+        A list of :class:`~autogen.beta.AgentReply` objects, one per job, in the **same order**
+        as the input jobs.
+
+    Raises:
+        ValueError: If the arguments don't match any of the supported calling conventions.
+        Exception: Any exception raised by ``agent.ask()`` propagates directly.
+
+    Examples::
+
+        # With concurrency cap
+        replies = await fanout(agent, long_list_of_prompts, max_concurrent=5)
+
+        # Inspect results
+        for reply in replies:
+            print(reply.body)
+            print(reply.usage.total_tokens)
+    """
+    jobs = _normalize_jobs(agent_or_agents_or_jobs, prompt_or_prompts)
+
+    if not jobs:
+        return []
+
+    if max_concurrent is None:
+        return list(await asyncio.gather(*[agent.ask(prompt) for agent, prompt in jobs]))
+
+    sem = asyncio.Semaphore(max_concurrent)
+
+    async def _run(agent: Agent[Any], prompt: str) -> AgentReply[Any, Any]:
+        async with sem:
+            return await agent.ask(prompt)
+
+    return list(await asyncio.gather(*[_run(agent, prompt) for agent, prompt in jobs]))
+
+
+def _normalize_jobs(
+    first: Agent[Any] | list[Agent[Any]] | list[tuple[Agent[Any], str]],
+    second: str | list[str] | None,
+) -> list[tuple[Agent[Any], str]]:
+    """Resolve the three calling conventions into a flat list of (agent, prompt) pairs."""
+    from .agent import Agent  # local import to avoid circular dependency
+
+    if isinstance(first, Agent):
+        # Convention 1: single agent + list of prompts
+        if not isinstance(second, list):
+            raise ValueError("When the first argument is an Agent, the second argument must be a list[str] of prompts.")
+        return [(first, p) for p in second]
+
+    if not first:
+        return []
+
+    first_item = first[0]
+
+    if isinstance(first_item, Agent):
+        # Convention 2: list of agents + single shared prompt
+        if not isinstance(second, str):
+            raise ValueError(
+                "When the first argument is a list[Agent], the second argument must be a single prompt string."
+            )
+        agents: list[Agent] = first  # type: ignore[assignment]
+        return [(a, second) for a in agents]
+
+    # Convention 3: list of (agent, prompt) pairs
+    if second is not None:
+        raise ValueError("When the first argument is a list of (agent, prompt) pairs, no second argument is expected.")
+    return list(first)  # type: ignore[arg-type]

--- a/test/beta/test_fanout.py
+++ b/test/beta/test_fanout.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for fanout()."""
+
+import asyncio
+
+import pytest
+
+from autogen.beta import Agent, fanout
+from autogen.beta.testing import TestConfig
+
+
+def _agent(response: str = "ok") -> Agent:
+    return Agent("test", config=TestConfig(response))
+
+
+# ---------------------------------------------------------------------------
+# Calling conventions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_single_agent_multiple_prompts() -> None:
+    agent = _agent("reply")
+    replies = await fanout(agent, ["q1", "q2", "q3"])
+    assert len(replies) == 3
+    assert all(r.body == "reply" for r in replies)
+
+
+@pytest.mark.asyncio()
+async def test_multiple_agents_single_prompt() -> None:
+    agents = [_agent("a"), _agent("b"), _agent("c")]
+    replies = await fanout(agents, "shared prompt")
+    assert len(replies) == 3
+    assert [r.body for r in replies] == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio()
+async def test_explicit_pairs() -> None:
+    jobs = [
+        (_agent("x"), "prompt x"),
+        (_agent("y"), "prompt y"),
+    ]
+    replies = await fanout(jobs)
+    assert [r.body for r in replies] == ["x", "y"]
+
+
+# ---------------------------------------------------------------------------
+# Empty input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_empty_prompts() -> None:
+    agent = _agent("reply")
+    replies = await fanout(agent, [])
+    assert replies == []
+
+
+@pytest.mark.asyncio()
+async def test_empty_agents() -> None:
+    replies = await fanout([], "prompt")
+    assert replies == []
+
+
+@pytest.mark.asyncio()
+async def test_empty_pairs() -> None:
+    replies = await fanout([])
+    assert replies == []
+
+
+# ---------------------------------------------------------------------------
+# Ordering preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_order_preserved_single_agent() -> None:
+    counter = 0
+    agent = _agent("ignored")
+
+    original_ask = agent.ask
+
+    async def ordered_ask(prompt: str, **kwargs: object) -> object:
+        nonlocal counter
+        idx = int(prompt)
+        await asyncio.sleep(0.01 * (3 - idx))  # later prompts finish first
+        counter += 1
+        return await original_ask(str(idx))
+
+    agent.ask = ordered_ask  # type: ignore[method-assign]
+
+    replies = await fanout(agent, ["0", "1", "2"])
+    # Results must be in input order even though execution order was reversed
+    assert len(replies) == 3
+
+
+@pytest.mark.asyncio()
+async def test_order_preserved_explicit_pairs() -> None:
+    results = []
+
+    async def slow_ask(self: object, prompt: str, **kwargs: object) -> object:
+        await asyncio.sleep(0.05 if prompt == "slow" else 0.0)
+        results.append(prompt)
+        from autogen.beta.testing import TestConfig
+
+        return await Agent("t", config=TestConfig(prompt)).ask(prompt)
+
+    a_slow = _agent("slow")
+    a_fast = _agent("fast")
+
+    a_slow.ask = lambda p, **k: slow_ask(a_slow, p, **k)  # type: ignore[method-assign]
+    a_fast.ask = lambda p, **k: slow_ask(a_fast, p, **k)  # type: ignore[method-assign]
+
+    # slow job first, but fanout runs them concurrently
+    replies = await fanout([(a_slow, "slow"), (a_fast, "fast")])
+
+    # replies are in input order regardless of completion order
+    assert replies[0].body == "slow"
+    assert replies[1].body == "fast"
+
+
+# ---------------------------------------------------------------------------
+# max_concurrent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_max_concurrent_limits_parallelism() -> None:
+    active = 0
+    peak_active = 0
+
+    agent = _agent("ok")
+    original_ask = agent.ask
+
+    async def tracked_ask(prompt: str, **kwargs: object) -> object:
+        nonlocal active, peak_active
+        active += 1
+        peak_active = max(peak_active, active)
+        await asyncio.sleep(0.02)
+        active -= 1
+        return await original_ask(prompt)
+
+    agent.ask = tracked_ask  # type: ignore[method-assign]
+
+    await fanout(agent, ["p1", "p2", "p3", "p4", "p5"], max_concurrent=2)
+
+    assert peak_active <= 2
+
+
+@pytest.mark.asyncio()
+async def test_max_concurrent_none_runs_all_at_once() -> None:
+    active = 0
+    peak_active = 0
+
+    agent = _agent("ok")
+    original_ask = agent.ask
+
+    async def tracked_ask(prompt: str, **kwargs: object) -> object:
+        nonlocal active, peak_active
+        active += 1
+        peak_active = max(peak_active, active)
+        await asyncio.sleep(0.02)
+        active -= 1
+        return await original_ask(prompt)
+
+    agent.ask = tracked_ask  # type: ignore[method-assign]
+
+    await fanout(agent, ["p1", "p2", "p3"], max_concurrent=None)
+
+    # All 3 should be active simultaneously
+    assert peak_active == 3
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_exception_propagates() -> None:
+    agent = _agent("ok")
+    original_ask = agent.ask
+
+    call_count = 0
+
+    async def failing_ask(prompt: str, **kwargs: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        if prompt == "bad":
+            raise ValueError("deliberate error")
+        return await original_ask(prompt)
+
+    agent.ask = failing_ask  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError, match="deliberate error"):
+        await fanout(agent, ["ok", "bad", "ok"])
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_single_agent_requires_list_of_prompts() -> None:
+    with pytest.raises(ValueError):
+        await fanout(_agent(), "single string instead of list")
+
+
+@pytest.mark.asyncio()
+async def test_list_of_agents_requires_string_prompt() -> None:
+    with pytest.raises(ValueError):
+        await fanout([_agent(), _agent()], ["list instead of string", "list2"])
+
+
+@pytest.mark.asyncio()
+async def test_pairs_rejects_second_arg() -> None:
+    with pytest.raises(ValueError):
+        await fanout([(_agent(), "p")], "unexpected second arg")

--- a/website/docs/beta/advanced/fanout.mdx
+++ b/website/docs/beta/advanced/fanout.mdx
@@ -1,0 +1,88 @@
+---
+title: fanout() — Parallel Agents
+sidebarTitle: fanout()
+---
+
+`fanout()` runs multiple `agent.ask()` calls concurrently and returns the results
+in input order.  Use it any time you want to query several agents or send the same
+agent several prompts without waiting for each one to finish before starting the next.
+
+## Basic usage
+
+```python
+from autogen.beta import Agent, fanout
+from autogen.beta.config import OpenAIConfig
+
+agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"))
+
+# Same agent, multiple prompts — returns list in input order
+replies = await fanout(agent, ["Summarize Paris.", "Summarize Rome."])
+for r in replies:
+    print(r.body)
+```
+
+## Three calling conventions
+
+### 1 · One agent, many prompts
+
+```python
+replies = await fanout(agent, ["Summarize Paris.", "Summarize Rome.", "Summarize Berlin."])
+```
+
+### 2 · Many agents, one prompt (ensemble)
+
+Send the same prompt to several agents and collect all their replies:
+
+```python
+formal   = Agent("formal",   config=OpenAIConfig("gpt-4o-mini"))
+casual   = Agent("casual",   config=OpenAIConfig("gpt-4o-mini"))
+technical = Agent("technical", config=OpenAIConfig("gpt-4o-mini"))
+
+replies = await fanout([formal, casual, technical], "Explain recursion.")
+for reply in replies:
+    print(reply.body)
+```
+
+### 3 · Explicit (agent, prompt) pairs
+
+When each agent needs a different prompt:
+
+```python
+replies = await fanout([
+    (agent_a, "Summarize document A."),
+    (agent_b, "Summarize document B."),
+    (agent_c, "Summarize document C."),
+])
+```
+
+## Concurrency cap
+
+By default all calls run at once.  Set `max_concurrent` to limit parallelism — useful
+when you're sending a large batch and don't want to overwhelm an API rate limit:
+
+```python
+replies = await fanout(agent, prompts, max_concurrent=5)
+```
+
+## Order guarantee
+
+Results are always in the same order as the input, regardless of which calls finish first:
+
+```python
+prompts = ["slow prompt", "fast prompt"]
+replies = await fanout(agent, prompts)
+# replies[0] corresponds to "slow prompt"
+# replies[1] corresponds to "fast prompt"
+```
+
+## Error handling
+
+If any call raises an exception, `fanout()` re-raises it immediately.  Wrap it in
+`try/except` if you want to handle individual failures:
+
+```python
+try:
+    replies = await fanout(agent, prompts)
+except Exception as e:
+    print(f"One of the calls failed: {e}")
+```

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -37,6 +37,7 @@ sidebarTitle: Beta Roadmap
 - Multimodality output: images
 - Local Code execution tool
 - A2A
+- Parallel agents (`fanout()`)
 
 ## In Progress
 
@@ -52,7 +53,7 @@ sidebarTitle: Beta Roadmap
 ### P1
 
 - First-class Usage tracking
-- Scheduler support
+- Scheduler support (PR #2851)
 - Repository development skills (code, structure, documentation, tests)
 
 ### P2

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -462,6 +462,7 @@
             "docs/beta/advanced/stream",
             "docs/beta/advanced/observers",
             "docs/beta/advanced/watches",
+            "docs/beta/advanced/fanout",
             "docs/beta/advanced/knowledge_store",
             "docs/beta/advanced/assembly",
             "docs/beta/advanced/compaction",


### PR DESCRIPTION
Closes ag2ai/ag2classic#11.

## Summary

- Adds `fanout()` — run multiple `agent.ask()` calls concurrently, return results in input order
- Three calling conventions to cover all common parallel-agent patterns:
  1. **One agent, many prompts**: `await fanout(agent, ["p1", "p2", "p3"])`
  2. **Many agents, one prompt** (ensemble): `await fanout([a, b, c], "prompt")`
  3. **Explicit pairs**: `await fanout([(a1, "p1"), (a2, "p2")])`
- Optional `max_concurrent` parameter (uses `asyncio.Semaphore`) to cap parallelism for rate-limit-sensitive workloads
- Results always returned in **input order**, regardless of completion order
- Any `agent.ask()` exception propagates directly to the caller

## Files

| File | Change |
|---|---|
| `autogen/beta/fanout.py` | New — implementation |
| `autogen/beta/__init__.py` | Export `fanout` |
| `test/beta/test_fanout.py` | 14 tests — all pass |

## Test plan

- [x] All 3 calling conventions
- [x] Empty inputs (agent/prompt list/pairs)
- [x] Order preservation (tasks that complete out of order still return in input order)
- [x] `max_concurrent` limits peak parallelism
- [x] `max_concurrent=None` runs all at once
- [x] Exception propagation
- [x] Validation errors for mismatched argument types

🤖 Generated with [Claude Code](https://claude.com/claude-code)