### PR TITLE
feat(beta): DeferredToolkit + MemoryToolkit (P2 roadmap items)

### DIFF
--- a/autogen/beta/tools/__init__.py
+++ b/autogen/beta/tools/__init__.py
@@ -24,7 +24,7 @@ from .final import Toolkit, tool
 from .search import DuckDuckSearchTool, ExaToolkit, PerplexitySearchToolkit, TavilySearchTool
 from .shell import LocalShellTool
 from .skills import SkillSearchToolkit, SkillsToolkit
-from .toolkits import FilesystemToolkit, MCPServer, MCPServerConfig, MCPStdioServerConfig
+from .toolkits import FilesystemToolkit, MCPServer, MCPServerConfig, MCPStdioServerConfig, MemoryToolkit
 
 __all__ = (
     "CodeExecutionTool",
@@ -40,6 +40,7 @@ __all__ = (
     "MCPServerTool",
     "MCPStdioServerConfig",
     "MemoryTool",
+    "MemoryToolkit",
     "NetworkPolicy",
     "PerplexitySearchToolkit",
     "SandboxCodeTool",

--- a/autogen/beta/tools/__init__.py
+++ b/autogen/beta/tools/__init__.py
@@ -24,12 +24,20 @@ from .final import Toolkit, tool
 from .search import DuckDuckSearchTool, ExaToolkit, PerplexitySearchToolkit, TavilySearchTool
 from .shell import LocalShellTool
 from .skills import SkillSearchToolkit, SkillsToolkit
-from .toolkits import FilesystemToolkit, MCPServer, MCPServerConfig, MCPStdioServerConfig, MemoryToolkit
+from .toolkits import (
+    DeferredToolkit,
+    FilesystemToolkit,
+    MCPServer,
+    MCPServerConfig,
+    MCPStdioServerConfig,
+    MemoryToolkit,
+)
 
 __all__ = (
     "CodeExecutionTool",
     "ContainerAutoEnvironment",
     "ContainerReferenceEnvironment",
+    "DeferredToolkit",
     "DuckDuckSearchTool",
     "ExaToolkit",
     "FilesystemToolkit",

--- a/autogen/beta/tools/toolkits/__init__.py
+++ b/autogen/beta/tools/toolkits/__init__.py
@@ -4,10 +4,12 @@
 
 from .filesystem import FilesystemToolkit
 from .mcp_server import MCPServer, MCPServerConfig, MCPStdioServerConfig
+from .memory import MemoryToolkit
 
 __all__ = (
     "FilesystemToolkit",
     "MCPServer",
     "MCPServerConfig",
     "MCPStdioServerConfig",
+    "MemoryToolkit",
 )

--- a/autogen/beta/tools/toolkits/__init__.py
+++ b/autogen/beta/tools/toolkits/__init__.py
@@ -2,11 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from .deferred import DeferredToolkit
 from .filesystem import FilesystemToolkit
 from .mcp_server import MCPServer, MCPServerConfig, MCPStdioServerConfig
 from .memory import MemoryToolkit
 
 __all__ = (
+    "DeferredToolkit",
     "FilesystemToolkit",
     "MCPServer",
     "MCPServerConfig",

--- a/autogen/beta/tools/toolkits/deferred.py
+++ b/autogen/beta/tools/toolkits/deferred.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeferredToolkit — expose a large tool catalog through two meta-tools.
+
+When an agent has hundreds of tools, loading every schema upfront wastes
+tokens.  ``DeferredToolkit`` hides the catalog behind two meta-tools:
+
+* **search_tools(query)** — keyword-search the catalog and return matching
+  tool names with descriptions and parameter schemas.
+* **use_tool(name, arguments)** — invoke any catalog entry by name, passing
+  arguments as a JSON object string.
+
+The agent spends no tokens on schemas it never needs; it discovers and invokes
+tools on demand.
+
+Example::
+
+    from autogen.beta import Agent
+    from autogen.beta.tools import DeferredToolkit, FilesystemToolkit, MemoryToolkit
+    from autogen.beta.config import OpenAIConfig
+
+    # Wrap a large set of tools in a DeferredToolkit
+    deferred = DeferredToolkit(
+        *FilesystemToolkit().tools,  # 5 tools
+        *MemoryToolkit().tools,  # 4 tools
+    )
+
+    # The agent only sees 2 tools: search_tools + use_tool
+    agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"), tools=[deferred])
+
+    reply = await agent.ask("Find all Python files under /tmp and remember the count.")
+    # Agent will: search_tools("filesystem") → find_files schema
+    #             use_tool("find_files", '{"pattern": "**/*.py", "path": "/tmp"}')
+    #             search_tools("memory") → remember schema
+    #             use_tool("remember", '{"content": "42 Python files", "key": "py-count"}')
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable
+from typing import Annotated, Any
+
+from pydantic import Field
+
+from autogen.beta.middleware import ToolMiddleware
+from autogen.beta.tools.final import Toolkit, tool
+from autogen.beta.tools.final.function_tool import FunctionTool
+
+__all__ = ("DeferredToolkit",)
+
+
+class _CatalogEntry:
+    """Metadata + callable for one deferred tool."""
+
+    __slots__ = ("name", "description", "parameters_schema", "_call")
+
+    def __init__(self, ft: FunctionTool) -> None:
+        self.name: str = ft.name
+        self.description: str = ft.schema.function.description
+        self.parameters_schema: dict[str, Any] = ft.schema.function.parameters or {}
+        self._call: Callable[..., Any] = ft.model.call
+
+    async def invoke(self, **kwargs: Any) -> str:
+        import asyncio
+
+        result = self._call(**kwargs)
+        if asyncio.iscoroutine(result):
+            result = await result
+        return str(result)
+
+    def summary(self) -> str:
+        """One-line description for search results."""
+        return f"[{self.name}] {self.description}"
+
+    def full_description(self) -> str:
+        """Name + description + parameter schema (for agent reference)."""
+        schema_str = json.dumps(self.parameters_schema, indent=2)
+        return f"Tool: {self.name}\nDescription: {self.description}\nParameters:\n{schema_str}"
+
+
+class DeferredToolkit(Toolkit):
+    """Toolkit that exposes a large tool catalog via search + dispatch meta-tools.
+
+    The agent only sees two tools:
+
+    * ``search_tools(query, max_results?)`` — keyword-search tool names and
+      descriptions; returns names, descriptions, and parameter schemas.
+    * ``use_tool(name, arguments?)`` — invoke a catalog tool by name;
+      *arguments* is a JSON object string (``'{}'`` if no params needed).
+
+    This keeps the per-call token cost proportional to what the agent
+    actually uses, not the total catalog size.
+
+    Args:
+        *tools:
+            :class:`~autogen.beta.tools.final.FunctionTool` instances (or
+            callables) to add to the hidden catalog.
+        middleware:
+            Tool-level middleware applied to the two meta-tools.
+
+    Example::
+
+        deferred = DeferredToolkit(
+            *FilesystemToolkit().tools,
+            *MemoryToolkit().tools,
+        )
+        agent = Agent("assistant", config=config, tools=[deferred])
+    """
+
+    __slots__ = ("_catalog",)
+
+    def __init__(
+        self,
+        *tools: FunctionTool | Callable[..., Any],
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> None:
+        self._catalog: dict[str, _CatalogEntry] = {}
+        for t in tools:
+            ft = t if isinstance(t, FunctionTool) else FunctionTool.ensure_tool(t)
+            assert isinstance(ft, FunctionTool)
+            self._catalog[ft.name] = _CatalogEntry(ft)
+
+        super().__init__(
+            self._search_tools_fn(middleware=middleware),
+            self._use_tool_fn(middleware=middleware),
+            name="deferred_toolkit",
+            middleware=(),
+        )
+
+    # ------------------------------------------------------------------
+    # Meta-tools
+    # ------------------------------------------------------------------
+
+    def _search_tools_fn(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        catalog = self._catalog
+
+        @tool(
+            name="search_tools",
+            description=(
+                "Search available tools by keyword. Returns matching tool names, "
+                "descriptions, and parameter schemas. Call this before use_tool "
+                "if you are not sure which tool to use or what arguments it expects."
+            ),
+            middleware=middleware,
+        )
+        def _search_tools(
+            query: Annotated[str, Field(description="Search query — matched against tool names and descriptions.")],
+            max_results: Annotated[
+                int,
+                Field(description="Maximum number of results to return.", ge=1, le=50),
+            ] = 5,
+        ) -> str:
+            q = query.lower()
+            hits = [entry for entry in catalog.values() if q in entry.name.lower() or q in entry.description.lower()]
+            if not hits:
+                all_names = ", ".join(sorted(catalog))
+                return f"No tools matched '{query}'. Available tools: {all_names}"
+            hits = hits[:max_results]
+            lines = [f"Found {len(hits)} tool(s) matching '{query}':\n"]
+            for entry in hits:
+                lines.append(entry.full_description())
+                lines.append("")
+            return "\n".join(lines)
+
+        return _search_tools
+
+    def _use_tool_fn(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        catalog = self._catalog
+
+        @tool(
+            name="use_tool",
+            description=(
+                "Invoke a tool from the catalog by name. "
+                "Pass arguments as a JSON object string, e.g. "
+                '\'{"path": "src/", "pattern": "**/*.py"}\'. '
+                "Use search_tools() first if you are unsure of the tool name or its parameters."
+            ),
+            middleware=middleware,
+        )
+        async def _use_tool(
+            name: Annotated[str, Field(description="Name of the tool to invoke.")],
+            arguments: Annotated[
+                str,
+                Field(
+                    description="JSON object of arguments to pass to the tool. Use '{}' for tools with no required params."
+                ),
+            ] = "{}",
+        ) -> str:
+            entry = catalog.get(name)
+            if entry is None:
+                known = ", ".join(sorted(catalog))
+                return f"Tool '{name}' not found in catalog. Available tools: {known}"
+            try:
+                kwargs = json.loads(arguments)
+            except json.JSONDecodeError as exc:
+                return f"Invalid JSON in arguments: {exc}"
+            if not isinstance(kwargs, dict):
+                return "arguments must be a JSON object (dict), not a list or primitive."
+            try:
+                return await entry.invoke(**kwargs)
+            except TypeError as exc:
+                return f"Wrong arguments for '{name}': {exc}"
+            except Exception as exc:
+                return f"Tool '{name}' raised an error: {exc}"
+
+        return _use_tool
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def catalog_names(self) -> tuple[str, ...]:
+        """Sorted names of all tools in the catalog."""
+        return tuple(sorted(self._catalog))
+
+    def add_to_catalog(self, *tools: FunctionTool | Callable[..., Any]) -> None:
+        """Add more tools to the catalog after construction."""
+        for t in tools:
+            ft = t if isinstance(t, FunctionTool) else FunctionTool.ensure_tool(t)
+            assert isinstance(ft, FunctionTool)
+            self._catalog[ft.name] = _CatalogEntry(ft)

--- a/autogen/beta/tools/toolkits/memory.py
+++ b/autogen/beta/tools/toolkits/memory.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""MemoryToolkit — provider-agnostic memory tools for AG2 Beta agents.
+
+Gives an agent four tools: remember, recall, forget, and list_memories.
+Memories are stored either in-process (default) or persisted to an SQLite
+database when a *storage_path* is supplied.
+
+Example::
+
+    from autogen.beta import Agent
+    from autogen.beta.tools import MemoryToolkit
+    from autogen.beta.config import OpenAIConfig
+
+    memory = MemoryToolkit()
+    agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"), tools=[memory])
+    # The agent can now call remember/recall/forget/list_memories autonomously.
+
+SQLite persistence::
+
+    memory = MemoryToolkit(storage_path="/tmp/agent-memory.db")
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import Field
+
+from autogen.beta.middleware import ToolMiddleware
+from autogen.beta.tools.final import Toolkit, tool
+from autogen.beta.tools.final.function_tool import FunctionTool
+
+__all__ = ("MemoryToolkit",)
+
+
+# ---------------------------------------------------------------------------
+# Storage backends
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryStore:
+    """Simple dict-backed in-process memory store."""
+
+    def __init__(self) -> None:
+        # key → (content, created_at)
+        self._store: dict[str, tuple[str, float]] = {}
+
+    def store(self, key: str, content: str) -> None:
+        self._store[key] = (content, time.time())
+
+    def retrieve(self, key: str) -> tuple[str, float] | None:
+        return self._store.get(key)
+
+    def search(self, query: str, max_results: int) -> list[tuple[str, str, float]]:
+        q = query.lower()
+        hits = [(k, content, ts) for k, (content, ts) in self._store.items() if q in content.lower() or q in k.lower()]
+        hits.sort(key=lambda x: x[2], reverse=True)
+        return hits[:max_results]
+
+    def delete(self, key: str) -> bool:
+        return self._store.pop(key, None) is not None
+
+    def list_all(self) -> list[tuple[str, str, float]]:
+        return [
+            (k, content, ts) for k, (content, ts) in sorted(self._store.items(), key=lambda x: x[1][1], reverse=True)
+        ]
+
+
+class _SQLiteStore:
+    """SQLite-backed persistent memory store."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        con = sqlite3.connect(self._path, check_same_thread=False)
+        con.execute("PRAGMA journal_mode=WAL")
+        return con
+
+    def _init_db(self) -> None:
+        with self._connect() as con:
+            con.execute(
+                "CREATE TABLE IF NOT EXISTS memories "
+                "(key TEXT PRIMARY KEY, content TEXT NOT NULL, created_at REAL NOT NULL)"
+            )
+
+    def store(self, key: str, content: str) -> None:
+        with self._connect() as con:
+            con.execute(
+                "INSERT OR REPLACE INTO memories (key, content, created_at) VALUES (?, ?, ?)",
+                (key, content, time.time()),
+            )
+
+    def retrieve(self, key: str) -> tuple[str, float] | None:
+        with self._connect() as con:
+            row = con.execute("SELECT content, created_at FROM memories WHERE key = ?", (key,)).fetchone()
+        return (row[0], row[1]) if row else None
+
+    def search(self, query: str, max_results: int) -> list[tuple[str, str, float]]:
+        q = f"%{query}%"
+        with self._connect() as con:
+            rows = con.execute(
+                "SELECT key, content, created_at FROM memories "
+                "WHERE content LIKE ? OR key LIKE ? "
+                "ORDER BY created_at DESC LIMIT ?",
+                (q, q, max_results),
+            ).fetchall()
+        return [(r[0], r[1], r[2]) for r in rows]
+
+    def delete(self, key: str) -> bool:
+        with self._connect() as con:
+            cur = con.execute("DELETE FROM memories WHERE key = ?", (key,))
+        return cur.rowcount > 0
+
+    def list_all(self) -> list[tuple[str, str, float]]:
+        with self._connect() as con:
+            rows = con.execute("SELECT key, content, created_at FROM memories ORDER BY created_at DESC").fetchall()
+        return [(r[0], r[1], r[2]) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Toolkit
+# ---------------------------------------------------------------------------
+
+
+class MemoryToolkit(Toolkit):
+    """Toolkit that gives an agent tools to store and recall memories.
+
+    Memories persist within a session (in-memory backend, default) or across
+    sessions (SQLite backend, when *storage_path* is set).
+
+    Args:
+        storage_path:
+            Path to the SQLite database file.  When ``None`` (default)
+            memories are kept in-process and lost when the session ends.
+        middleware:
+            Optional tool-level middleware applied to every memory tool.
+
+    Example::
+
+        from autogen.beta import Agent
+        from autogen.beta.tools import MemoryToolkit
+        from autogen.beta.config import OpenAIConfig
+
+        # Session-scoped (in-memory)
+        memory = MemoryToolkit()
+
+        # Persistent across sessions
+        memory = MemoryToolkit(storage_path="~/.my-agent/memories.db")
+
+        agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"), tools=[memory])
+    """
+
+    __slots__ = ("_store",)
+
+    def __init__(
+        self,
+        storage_path: str | Path | None = None,
+        *,
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> None:
+        if storage_path is None:
+            self._store: _InMemoryStore | _SQLiteStore = _InMemoryStore()
+        else:
+            self._store = _SQLiteStore(Path(storage_path).expanduser().resolve())
+
+        super().__init__(
+            self._remember_tool(middleware=middleware),
+            self._recall_tool(middleware=middleware),
+            self._forget_tool(middleware=middleware),
+            self._list_memories_tool(middleware=middleware),
+            name="memory_toolkit",
+            middleware=(),
+        )
+
+    # ------------------------------------------------------------------
+    # Tool factories
+    # ------------------------------------------------------------------
+
+    def _remember_tool(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        store = self._store
+
+        @tool(
+            name="remember",
+            description=(
+                "Store a piece of information in memory for later retrieval. "
+                "Supply an optional key to give the memory a name; if omitted "
+                "a unique key is generated. Returns the key used."
+            ),
+            middleware=middleware,
+        )
+        def _remember(
+            content: Annotated[str, Field(description="The information to remember.")],
+            key: Annotated[
+                str,
+                Field(description="Optional name for this memory. Generated automatically if empty."),
+            ] = "",
+        ) -> str:
+            mem_key = key.strip() or f"mem-{uuid.uuid4().hex[:8]}"
+            store.store(mem_key, content)
+            return f"Stored memory '{mem_key}'."
+
+        return _remember
+
+    def _recall_tool(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        store = self._store
+
+        @tool(
+            name="recall",
+            description=(
+                "Search stored memories for entries that match a query. "
+                "Returns the best matching memories (up to max_results)."
+            ),
+            middleware=middleware,
+        )
+        def _recall(
+            query: Annotated[str, Field(description="Search query — matches against memory content and keys.")],
+            max_results: Annotated[
+                int,
+                Field(description="Maximum number of memories to return.", ge=1, le=50),
+            ] = 5,
+        ) -> str:
+            hits = store.search(query, max_results)
+            if not hits:
+                return f"No memories found matching '{query}'."
+            lines = [f"Found {len(hits)} memory(ies) matching '{query}':\n"]
+            for key, content, ts in hits:
+                created = time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
+                lines.append(f"[{key}] ({created})\n{content}\n")
+            return "\n".join(lines)
+
+        return _recall
+
+    def _forget_tool(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        store = self._store
+
+        @tool(
+            name="forget",
+            description="Delete a stored memory by its key.",
+            middleware=middleware,
+        )
+        def _forget(
+            key: Annotated[str, Field(description="The key of the memory to delete.")],
+        ) -> str:
+            if store.delete(key):
+                return f"Deleted memory '{key}'."
+            return f"No memory found with key '{key}'."
+
+        return _forget
+
+    def _list_memories_tool(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        store = self._store
+
+        @tool(
+            name="list_memories",
+            description="List all stored memories, most recent first.",
+            middleware=middleware,
+        )
+        def _list_memories() -> str:
+            entries = store.list_all()
+            if not entries:
+                return "No memories stored."
+            lines = [f"{len(entries)} stored memory(ies):\n"]
+            for key, content, ts in entries:
+                created = time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
+                preview = content[:80] + ("..." if len(content) > 80 else "")
+                lines.append(f"[{key}] ({created}) {preview}")
+            return "\n".join(lines)
+
+        return _list_memories

--- a/test/beta/test_deferred_toolkit.py
+++ b/test/beta/test_deferred_toolkit.py
@@ -1,0 +1,309 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for DeferredToolkit."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from autogen.beta import Agent, Context
+from autogen.beta.events import ToolCallEvent, ToolResultsEvent
+from autogen.beta.testing import TestConfig, TrackingConfig
+from autogen.beta.tools import DeferredToolkit, MemoryToolkit
+from autogen.beta.tools.final import tool
+from autogen.beta.tools.toolkits.deferred import _CatalogEntry
+
+# ---------------------------------------------------------------------------
+# Helpers — simple catalog tools for tests
+# ---------------------------------------------------------------------------
+
+
+@tool(name="add", description="Add two integers and return the sum.")
+def _add(a: int, b: int) -> int:
+    return a + b
+
+
+@tool(name="greet", description="Return a greeting for a given name.")
+def _greet(name: str) -> str:
+    return f"Hello, {name}!"
+
+
+@tool(name="ping", description="Return pong. No parameters needed.")
+def _ping() -> str:
+    return "pong"
+
+
+# ---------------------------------------------------------------------------
+# _CatalogEntry
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_entry_metadata() -> None:
+    entry = _CatalogEntry(_add)
+    assert entry.name == "add"
+    assert "Add two integers" in entry.description
+
+
+def test_catalog_entry_summary() -> None:
+    entry = _CatalogEntry(_greet)
+    assert "[greet]" in entry.summary()
+    assert "greeting" in entry.summary()
+
+
+def test_catalog_entry_full_description_contains_schema() -> None:
+    desc = _CatalogEntry(_add).full_description()
+    assert "add" in desc
+    assert "parameters" in desc.lower()
+
+
+@pytest.mark.asyncio
+async def test_catalog_entry_invoke_sync() -> None:
+    entry = _CatalogEntry(_add)
+    result = await entry.invoke(a=3, b=4)
+    assert result == "7"
+
+
+@pytest.mark.asyncio
+async def test_catalog_entry_invoke_no_args() -> None:
+    entry = _CatalogEntry(_ping)
+    result = await entry.invoke()
+    assert result == "pong"
+
+
+# ---------------------------------------------------------------------------
+# DeferredToolkit construction
+# ---------------------------------------------------------------------------
+
+
+def test_only_two_tools_exposed() -> None:
+    dt = DeferredToolkit(_add, _greet, _ping)
+    assert set(dt._tools.keys()) == {"search_tools", "use_tool"}
+
+
+def test_catalog_names() -> None:
+    dt = DeferredToolkit(_add, _greet, _ping)
+    assert dt.catalog_names == ("add", "greet", "ping")
+
+
+def test_toolkit_name() -> None:
+    assert DeferredToolkit().name == "deferred_toolkit"
+
+
+def test_empty_catalog() -> None:
+    dt = DeferredToolkit()
+    assert dt.catalog_names == ()
+
+
+def test_add_to_catalog() -> None:
+    dt = DeferredToolkit(_add)
+    assert "greet" not in dt.catalog_names
+    dt.add_to_catalog(_greet)
+    assert "greet" in dt.catalog_names
+
+
+def test_from_toolkit_tools() -> None:
+    """Accept tools from another toolkit's .tools property."""
+    memory = MemoryToolkit()
+    dt = DeferredToolkit(*memory.tools)
+    assert set(dt.catalog_names) == {"remember", "recall", "forget", "list_memories"}
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schemas(async_mock: AsyncMock) -> None:
+    dt = DeferredToolkit(_add, _greet)
+    schemas = list(await dt.schemas(Context(async_mock)))
+    names = {s.function.name for s in schemas}
+    assert names == {"search_tools", "use_tool"}
+
+
+# ---------------------------------------------------------------------------
+# search_tools via agent call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_finds_matching_tool() -> None:
+    dt = DeferredToolkit(_add, _greet, _ping)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="search_tools",
+                arguments=json.dumps({"query": "greeting", "max_results": 5}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("find tools")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "greet" in result_text
+    assert "greeting" in result_text
+
+
+@pytest.mark.asyncio
+async def test_search_no_match_lists_all() -> None:
+    dt = DeferredToolkit(_add, _ping)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="search_tools",
+                arguments=json.dumps({"query": "zucchini"}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("find tools")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "No tools matched" in result_text
+    assert "add" in result_text
+    assert "ping" in result_text
+
+
+# ---------------------------------------------------------------------------
+# use_tool via agent call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_use_tool_invokes_sync_function() -> None:
+    dt = DeferredToolkit(_add)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "add", "arguments": '{"a": 10, "b": 32}'}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("add numbers")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "42" in result_text
+
+
+@pytest.mark.asyncio
+async def test_use_tool_no_args() -> None:
+    dt = DeferredToolkit(_ping)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "ping"}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("ping")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "pong" in result_text
+
+
+@pytest.mark.asyncio
+async def test_use_tool_unknown_name() -> None:
+    dt = DeferredToolkit(_ping)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "ghost_tool"}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("use unknown tool")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "not found" in result_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_use_tool_bad_json_arguments() -> None:
+    dt = DeferredToolkit(_add)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "add", "arguments": "not json {{{"}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("use with bad args")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "Invalid JSON" in result_text
+
+
+@pytest.mark.asyncio
+async def test_use_tool_wrong_arguments() -> None:
+    dt = DeferredToolkit(_add)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "add", "arguments": '{"x": 1, "y": 2}'}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("use with wrong args")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "Wrong arguments" in result_text or "error" in result_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_use_memory_toolkit_tool_via_deferred() -> None:
+    """End-to-end: use MemoryToolkit tools through DeferredToolkit."""
+    memory = MemoryToolkit()
+    dt = DeferredToolkit(*memory.tools)
+    memory._store.store("sky", "The sky is blue.")
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "recall", "arguments": '{"query": "sky"}'}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("recall sky memory")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "sky" in result_text
+    assert "The sky is blue." in result_text

--- a/test/beta/test_memory_toolkit.py
+++ b/test/beta/test_memory_toolkit.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for MemoryToolkit."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from autogen.beta import Agent, Context
+from autogen.beta.events import ToolCallEvent, ToolResultsEvent
+from autogen.beta.testing import TestConfig, TrackingConfig
+from autogen.beta.tools import MemoryToolkit
+from autogen.beta.tools.toolkits.memory import _InMemoryStore, _SQLiteStore
+
+# ---------------------------------------------------------------------------
+# _InMemoryStore — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryStore:
+    def test_store_and_retrieve(self) -> None:
+        s = _InMemoryStore()
+        s.store("k1", "hello world")
+        entry = s.retrieve("k1")
+        assert entry is not None
+        content, _ts = entry
+        assert content == "hello world"
+
+    def test_retrieve_missing_key(self) -> None:
+        s = _InMemoryStore()
+        assert s.retrieve("ghost") is None
+
+    def test_search_finds_content(self) -> None:
+        s = _InMemoryStore()
+        s.store("a", "Paris is the capital of France")
+        s.store("b", "Berlin is the capital of Germany")
+        hits = s.search("Paris", 10)
+        assert len(hits) == 1
+        assert hits[0][0] == "a"
+
+    def test_search_finds_key(self) -> None:
+        s = _InMemoryStore()
+        s.store("special-key", "some content")
+        hits = s.search("special-key", 10)
+        assert any(h[0] == "special-key" for h in hits)
+
+    def test_search_case_insensitive(self) -> None:
+        s = _InMemoryStore()
+        s.store("k", "Python is great")
+        assert s.search("python", 5)
+        assert s.search("PYTHON", 5)
+
+    def test_search_respects_max_results(self) -> None:
+        s = _InMemoryStore()
+        for i in range(10):
+            s.store(f"item-{i}", f"item number {i}")
+        hits = s.search("item", 3)
+        assert len(hits) <= 3
+
+    def test_delete_existing(self) -> None:
+        s = _InMemoryStore()
+        s.store("temp", "gone soon")
+        assert s.delete("temp") is True
+        assert s.retrieve("temp") is None
+
+    def test_delete_nonexistent(self) -> None:
+        s = _InMemoryStore()
+        assert s.delete("ghost") is False
+
+    def test_overwrite(self) -> None:
+        s = _InMemoryStore()
+        s.store("k", "original")
+        s.store("k", "updated")
+        content, _ = s.retrieve("k")  # type: ignore[misc]
+        assert content == "updated"
+
+    def test_list_all_empty(self) -> None:
+        s = _InMemoryStore()
+        assert s.list_all() == []
+
+    def test_list_all_returns_all_entries(self) -> None:
+        s = _InMemoryStore()
+        s.store("a", "alpha")
+        s.store("b", "beta")
+        all_entries = s.list_all()
+        keys = {e[0] for e in all_entries}
+        assert keys == {"a", "b"}
+
+    def test_independent_instances(self) -> None:
+        s1 = _InMemoryStore()
+        s2 = _InMemoryStore()
+        s1.store("shared-key", "only in s1")
+        assert s2.search("only in s1", 5) == []
+
+
+# ---------------------------------------------------------------------------
+# _SQLiteStore — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSQLiteStore:
+    def test_store_and_retrieve(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "test.db")
+        s.store("k1", "hello sqlite")
+        content, _ = s.retrieve("k1")  # type: ignore[misc]
+        assert content == "hello sqlite"
+
+    def test_retrieve_missing(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "test.db")
+        assert s.retrieve("ghost") is None
+
+    def test_persistence_across_instances(self, tmp_path: Path) -> None:
+        db = tmp_path / "persist.db"
+        _SQLiteStore(db).store("durable", "survived restart")
+        content, _ = _SQLiteStore(db).retrieve("durable")  # type: ignore[misc]
+        assert content == "survived restart"
+
+    def test_search(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "search.db")
+        s.store("a", "unique searchable text")
+        hits = s.search("unique searchable", 5)
+        assert len(hits) == 1
+        assert hits[0][0] == "a"
+
+    def test_delete(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "del.db")
+        s.store("gone", "byebye")
+        assert s.delete("gone") is True
+        assert s.retrieve("gone") is None
+
+    def test_delete_nonexistent(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "del2.db")
+        assert s.delete("ghost") is False
+
+    def test_list_all(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "list.db")
+        s.store("x", "ex")
+        s.store("y", "why")
+        keys = {e[0] for e in s.list_all()}
+        assert keys == {"x", "y"}
+
+    def test_delete_persists_across_instances(self, tmp_path: Path) -> None:
+        db = tmp_path / "forgetter.db"
+        _SQLiteStore(db).store("gone", "will be deleted")
+        _SQLiteStore(db).delete("gone")
+        assert _SQLiteStore(db).retrieve("gone") is None
+
+
+# ---------------------------------------------------------------------------
+# MemoryToolkit schemas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_toolkit_schemas(async_mock: AsyncMock) -> None:
+    toolkit = MemoryToolkit()
+    schemas = list(await toolkit.schemas(Context(async_mock)))
+    names = {s.function.name for s in schemas}
+    assert names == {"remember", "recall", "forget", "list_memories"}
+
+
+def test_toolkit_name() -> None:
+    assert MemoryToolkit().name == "memory_toolkit"
+
+
+def test_toolkit_tools_dict() -> None:
+    m = MemoryToolkit()
+    assert set(m._tools.keys()) == {"remember", "recall", "forget", "list_memories"}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: agent invokes remember, then recall
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_remember_call() -> None:
+    toolkit = MemoryToolkit()
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="remember",
+                arguments=json.dumps({"content": "The sky is blue.", "key": "sky"}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[toolkit])
+    await agent.ask("remember something")
+
+    # Second mock call receives the tool result
+    tool_result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = tool_result_msg.results[0].result.parts[0].content
+    assert "sky" in result_text
+
+
+@pytest.mark.asyncio
+async def test_agent_recall_call() -> None:
+    toolkit = MemoryToolkit()
+    toolkit._store.store("sky", "The sky is blue.")
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="recall",
+                arguments=json.dumps({"query": "sky", "max_results": 3}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[toolkit])
+    await agent.ask("recall something")
+
+    tool_result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = tool_result_msg.results[0].result.parts[0].content
+    assert "sky" in result_text
+    assert "The sky is blue." in result_text

--- a/website/docs/beta/advanced/deferred_toolkit.mdx
+++ b/website/docs/beta/advanced/deferred_toolkit.mdx
@@ -1,0 +1,93 @@
+---
+title: DeferredToolkit
+sidebarTitle: DeferredToolkit
+---
+
+When an agent has dozens of tools, every tool schema goes into every LLM call —
+consuming thousands of tokens even for tools the agent never uses.
+
+`DeferredToolkit` hides a large tool catalog behind exactly **two** meta-tools:
+
+| Tool | What the agent does |
+|---|---|
+| `search_tools(query)` | Keyword-search the catalog. Returns matching tool names, descriptions, and parameter schemas. |
+| `use_tool(name, arguments)` | Invoke any catalog tool by name. `arguments` is a JSON object string. |
+
+The agent discovers what it needs and pays no token cost for the rest.
+
+## Basic usage
+
+```python
+from autogen.beta import Agent
+from autogen.beta.tools import DeferredToolkit, FilesystemToolkit, MemoryToolkit
+from autogen.beta.config import OpenAIConfig
+
+# Wrap many tools in a DeferredToolkit
+deferred = DeferredToolkit(
+    *FilesystemToolkit().tools,   # 5 tools
+    *MemoryToolkit().tools,       # 4 tools
+    # ...more tools
+)
+
+# Agent only sees 2 tools: search_tools + use_tool
+agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"), tools=[deferred])
+
+reply = await agent.ask("Find Python files under /tmp and remember the count.")
+```
+
+The agent's flow:
+1. `search_tools("filesystem")` → gets `find_files` schema
+2. `use_tool("find_files", '{"pattern": "**/*.py", "path": "/tmp"}')` → gets list
+3. `search_tools("memory")` → gets `remember` schema
+4. `use_tool("remember", '{"content": "42 files", "key": "py-count"}')` → stored
+
+## Selective wrapping
+
+You can combine deferred and direct tools.  Give the agent its most-common tools
+directly and defer the long tail:
+
+```python
+from autogen.beta.tools import DeferredToolkit, FilesystemToolkit, MemoryToolkit, tool
+
+@tool
+def fetch_weather(city: str) -> str:
+    """Get current weather for a city."""
+    ...
+
+# fetch_weather is used often — register it directly for zero overhead
+# The 9 filesystem+memory tools are deferred
+agent = Agent(
+    "assistant",
+    config=OpenAIConfig("gpt-4o-mini"),
+    tools=[
+        fetch_weather,
+        DeferredToolkit(*FilesystemToolkit().tools, *MemoryToolkit().tools),
+    ],
+)
+```
+
+## Adding tools after construction
+
+```python
+deferred = DeferredToolkit(*core_tools)
+deferred.add_to_catalog(*extra_tools)  # add more later
+```
+
+## Inspecting the catalog
+
+```python
+deferred = DeferredToolkit(*my_tools)
+print(deferred.catalog_names)  # ('find_files', 'forget', 'list_memories', ...)
+```
+
+## Trade-offs
+
+| | Direct tools | DeferredToolkit |
+|---|---|---|
+| **Token cost** | All schemas, every call | Only 2 schemas |
+| **Agent flexibility** | Immediate access | Must discover first |
+| **Best for** | ≤10 tools | Large catalogs |
+
+For small tool sets, direct registration is simpler and has zero overhead.
+Use `DeferredToolkit` when your catalog grows large enough that the schema tokens
+become a meaningful cost.

--- a/website/docs/beta/advanced/memory_toolkit.mdx
+++ b/website/docs/beta/advanced/memory_toolkit.mdx
@@ -1,0 +1,92 @@
+---
+title: MemoryToolkit
+sidebarTitle: MemoryToolkit
+---
+
+`MemoryToolkit` gives an agent four tools — `remember`, `recall`, `forget`, and
+`list_memories` — so it can autonomously store and retrieve information across a
+conversation or across sessions.
+
+## Basic usage
+
+```python
+from autogen.beta import Agent
+from autogen.beta.tools import MemoryToolkit
+from autogen.beta.config import OpenAIConfig
+
+memory = MemoryToolkit()
+agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"), tools=[memory])
+
+reply = await agent.ask("Remember that our primary database host is db.prod.example.com")
+```
+
+The agent will call `remember` autonomously.  On a later turn:
+
+```python
+reply = await agent.ask("What is the database host?")
+# The agent calls recall("database host") and uses the stored memory in its answer.
+```
+
+## Tools the agent gets
+
+| Tool | What it does |
+|---|---|
+| `remember(content, key?)` | Store a piece of information. An optional key names the memory; if omitted, a unique key is generated. |
+| `recall(query, max_results?)` | Keyword search across stored memories. Returns the best matches. |
+| `forget(key)` | Delete a memory by its key. |
+| `list_memories()` | List all stored memories, most recent first. |
+
+## Backends
+
+### Session-scoped (in-memory, default)
+
+```python
+memory = MemoryToolkit()
+```
+
+Memories live in-process.  They are fast but are discarded when the session ends.
+
+### Persistent (SQLite)
+
+```python
+memory = MemoryToolkit(storage_path="~/.my-agent/memories.db")
+```
+
+Memories survive process restarts.  The SQLite file is created automatically.
+Use `~` to expand to the user's home directory.
+
+## Picking individual tools
+
+Pass tools from the toolkit selectively if you only want some of them:
+
+```python
+fs = MemoryToolkit()
+agent = Agent(
+    "assistant",
+    config=OpenAIConfig("gpt-4o-mini"),
+    tools=[
+        fs._remember_tool(),
+        fs._recall_tool(),
+    ],
+)
+```
+
+## Example: persistent research assistant
+
+```python
+from autogen.beta import Agent
+from autogen.beta.tools import MemoryToolkit
+from autogen.beta.config import OpenAIConfig
+
+memory = MemoryToolkit(storage_path="~/.research-agent/memories.db")
+agent = Agent(
+    "researcher",
+    config=OpenAIConfig("gpt-4o"),
+    tools=[memory],
+    system_prompt=(
+        "You are a research assistant. When you learn something important, "
+        "use remember() to store it. Use recall() to find relevant facts "
+        "before answering questions."
+    ),
+)
+```

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -37,6 +37,7 @@ sidebarTitle: Beta Roadmap
 - Multimodality output: images
 - Local Code execution tool
 - A2A
+- Builtin Memory toolkit (`MemoryToolkit`)
 
 ## In Progress
 
@@ -60,7 +61,7 @@ sidebarTitle: Beta Roadmap
 - A2UI Plugin
 - NLIP
 - Deferred tools (Tool Search Tool)
-- Builtin Memory toolkit
+- Builtin Memory toolkit (done — `MemoryToolkit` in PR #2853)
 
 ### P3
 

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -38,6 +38,7 @@ sidebarTitle: Beta Roadmap
 - Local Code execution tool
 - A2A
 - Builtin Memory toolkit (`MemoryToolkit`)
+- Deferred tools — Tool Search Tool (`DeferredToolkit`)
 
 ## In Progress
 
@@ -60,7 +61,7 @@ sidebarTitle: Beta Roadmap
 
 - A2UI Plugin
 - NLIP
-- Deferred tools (Tool Search Tool)
+- Deferred tools (Tool Search Tool) (done — `DeferredToolkit` in PR #2854)
 - Builtin Memory toolkit (done — `MemoryToolkit` in PR #2853)
 
 ### P3

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -463,6 +463,7 @@
             "docs/beta/advanced/observers",
             "docs/beta/advanced/watches",
             "docs/beta/advanced/knowledge_store",
+            "docs/beta/advanced/memory_toolkit",
             "docs/beta/advanced/assembly",
             "docs/beta/advanced/compaction",
             "docs/beta/advanced/aggregation"

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -464,6 +464,7 @@
             "docs/beta/advanced/watches",
             "docs/beta/advanced/knowledge_store",
             "docs/beta/advanced/memory_toolkit",
+            "docs/beta/advanced/deferred_toolkit",
             "docs/beta/advanced/assembly",
             "docs/beta/advanced/compaction",
             "docs/beta/advanced/aggregation"


### PR DESCRIPTION
Two P2 roadmap items in one PR:

## 1. `MemoryToolkit` — Builtin Memory toolkit

Gives an agent four tools: `remember`, `recall`, `forget`, `list_memories`.
Two backends: in-process dict (default) or SQLite for cross-session persistence.
No external dependencies.

```python
memory = MemoryToolkit()                         # session-scoped
memory = MemoryToolkit(storage_path="mem.db")    # persistent
agent = Agent("assistant", config=config, tools=[memory])
```

## 2. `DeferredToolkit` — Deferred tools / Tool Search Tool

Hides a large tool catalog behind two meta-tools (`search_tools` + `use_tool`),
so the agent only pays token cost for schemas it actually needs.

```python
deferred = DeferredToolkit(*FilesystemToolkit().tools, *MemoryToolkit().tools)
# Agent sees 2 tools instead of 9 — discovers on demand via search_tools/use_tool
```

## Files

| File | Change |
|---|---|
| `autogen/beta/tools/toolkits/memory.py` | New — `MemoryToolkit` |
| `autogen/beta/tools/toolkits/deferred.py` | New — `DeferredToolkit` |
| `autogen/beta/tools/toolkits/__init__.py` | Export both |
| `autogen/beta/tools/__init__.py` | Export both |
| `test/beta/test_memory_toolkit.py` | 25 tests — all pass |
| `test/beta/test_deferred_toolkit.py` | 20 tests — all pass |
| `website/docs/beta/advanced/memory_toolkit.mdx` | Docs page |
| `website/docs/beta/advanced/deferred_toolkit.mdx` | Docs page |

🤖 Generated with [Claude Code](https://claude.com/claude-code)