### PR TITLE
feat(beta): DynamicAgentToolkit — orchestrators that spawn specialist sub-agents at runtime

### DIFF
--- a/autogen/beta/__init__.py
+++ b/autogen/beta/__init__.py
@@ -6,6 +6,7 @@ from fast_depends import Depends
 
 from .agent import Agent, AgentReply, KnowledgeConfig, TaskConfig
 from .annotations import Context, Inject, Variable
+from .background import BackgroundTask, run_in_background
 from .events import (
     AudioInput,
     BinaryInput,
@@ -29,6 +30,7 @@ __all__ = (
     "AgentReply",
     "AgentSpec",
     "AudioInput",
+    "BackgroundTask",
     "BinaryInput",
     "Context",
     "DataInput",
@@ -53,5 +55,6 @@ __all__ = (
     "VideoInput",
     "observer",
     "response_schema",
+    "run_in_background",
     "tool",
 )

--- a/autogen/beta/background.py
+++ b/autogen/beta/background.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Background agent tasks — non-blocking :meth:`~autogen.beta.Agent.ask` invocations.
+
+:func:`run_in_background` starts an agent call without blocking the caller.
+It returns a :class:`BackgroundTask` immediately.  Await the task to collect
+the :class:`~autogen.beta.AgentReply` when the agent finishes.
+
+Example::
+
+    import asyncio
+    from autogen.beta import Agent
+    from autogen.beta.background import run_in_background
+    from autogen.beta.config import OpenAIConfig
+
+
+    async def main():
+        agent = Agent("analyst", config=OpenAIConfig("gpt-4o-mini"))
+
+        # Start without blocking
+        task = run_in_background(agent, "Summarise the Q1 results.")
+
+        # Do other awaitable work concurrently
+        await asyncio.sleep(0)
+
+        # Collect the result when ready
+        reply = await task
+        print(await reply.content())
+
+
+    asyncio.run(main())
+
+To run *many* agents in parallel and collect all results at once, use
+:func:`~autogen.beta.fanout` instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from .agent import Agent, AgentReply
+
+__all__ = ("BackgroundTask", "run_in_background")
+
+_T = TypeVar("_T")
+
+
+class BackgroundTask(Generic[_T]):
+    """A handle for an :meth:`~autogen.beta.Agent.ask` call running concurrently.
+
+    Wraps an :class:`asyncio.Task`.  Await it to get the
+    :class:`~autogen.beta.AgentReply` when the agent finishes.
+
+    Example::
+
+        task = run_in_background(agent, "Long analysis…")
+
+        # Continue doing other async work…
+        await asyncio.sleep(0)
+
+        # Collect result (waits until the agent finishes if still running)
+        reply = await task
+
+    Args:
+        task:
+            An :class:`asyncio.Task` wrapping :meth:`~autogen.beta.Agent.ask`.
+    """
+
+    __slots__ = ("_task",)
+
+    def __init__(self, task: asyncio.Task[AgentReply[_T, Any]]) -> None:
+        self._task = task
+
+    # ------------------------------------------------------------------
+    # Task control
+    # ------------------------------------------------------------------
+
+    def cancel(self, msg: str | None = None) -> bool:
+        """Request cancellation of the background agent call.
+
+        Returns ``True`` if the task was successfully requested to cancel,
+        ``False`` if it is already done.
+        """
+        return self._task.cancel(msg)  # type: ignore[call-arg]
+
+    # ------------------------------------------------------------------
+    # Status inspection
+    # ------------------------------------------------------------------
+
+    def done(self) -> bool:
+        """Return ``True`` if the agent has finished (successfully or not)."""
+        return self._task.done()
+
+    def cancelled(self) -> bool:
+        """Return ``True`` if the task was cancelled via :meth:`cancel`."""
+        return self._task.cancelled()
+
+    def result(self) -> AgentReply[_T, Any]:
+        """Return the :class:`~autogen.beta.AgentReply`.
+
+        Raises :exc:`asyncio.InvalidStateError` if the task is not yet done,
+        :exc:`asyncio.CancelledError` if it was cancelled, or propagates any
+        exception raised by the agent call.
+        """
+        return self._task.result()
+
+    def exception(self) -> BaseException | None:
+        """Return the exception raised by the agent call, or ``None`` on success.
+
+        Raises :exc:`asyncio.InvalidStateError` if not done, or
+        :exc:`asyncio.CancelledError` if it was cancelled.
+        """
+        return self._task.exception()
+
+    # ------------------------------------------------------------------
+    # Awaitable
+    # ------------------------------------------------------------------
+
+    def __await__(self):  # type: ignore[override]
+        return self._task.__await__()
+
+
+def run_in_background(
+    agent: Agent[_T],
+    *msg: Any,
+    **kwargs: Any,
+) -> BackgroundTask[_T]:
+    """Start an :meth:`~autogen.beta.Agent.ask` call as a background asyncio task.
+
+    Returns a :class:`BackgroundTask` immediately.  The agent runs concurrently
+    with the caller — you can do other async work, then ``await`` the task to
+    collect the result.
+
+    Must be called from an async context (a running asyncio event loop).
+
+    Example::
+
+        task = run_in_background(agent, "Analyse the data.")
+        other_result = await other_coroutine()
+        reply = await task  # waits until agent finishes
+
+    Args:
+        agent:
+            The :class:`~autogen.beta.Agent` to invoke.
+        *msg:
+            Positional arguments forwarded verbatim to
+            :meth:`~autogen.beta.Agent.ask`.
+        **kwargs:
+            Keyword arguments forwarded verbatim to
+            :meth:`~autogen.beta.Agent.ask`.
+
+    Returns:
+        A :class:`BackgroundTask` wrapping the underlying asyncio task.
+
+    Raises:
+        RuntimeError: If called outside a running event loop.
+    """
+    task: asyncio.Task[Any] = asyncio.create_task(agent.ask(*msg, **kwargs))
+    return BackgroundTask(task)

--- a/autogen/beta/tools/__init__.py
+++ b/autogen/beta/tools/__init__.py
@@ -24,7 +24,7 @@ from .final import Toolkit, tool
 from .search import DuckDuckSearchTool, ExaToolkit, PerplexitySearchToolkit, TavilySearchTool
 from .shell import LocalShellTool
 from .skills import SkillSearchToolkit, SkillsToolkit
-from .toolkits import FilesystemToolkit, MCPServer, MCPServerConfig, MCPStdioServerConfig
+from .toolkits import FilesystemToolkit, MCPServer, MCPServerConfig, MCPStdioServerConfig, MemoryToolkit
 
 __all__ = (
     "CodeExecutionTool",
@@ -40,6 +40,7 @@ __all__ = (
     "MCPServerTool",
     "MCPStdioServerConfig",
     "MemoryTool",
+    "MemoryToolkit",
     "NetworkPolicy",
     "PerplexitySearchToolkit",
     "SandboxCodeTool",

--- a/autogen/beta/tools/__init__.py
+++ b/autogen/beta/tools/__init__.py
@@ -24,12 +24,20 @@ from .final import Toolkit, tool
 from .search import DuckDuckSearchTool, ExaToolkit, PerplexitySearchToolkit, TavilySearchTool
 from .shell import LocalShellTool
 from .skills import SkillSearchToolkit, SkillsToolkit
-from .toolkits import FilesystemToolkit, MCPServer, MCPServerConfig, MCPStdioServerConfig, MemoryToolkit
+from .toolkits import (
+    DeferredToolkit,
+    FilesystemToolkit,
+    MCPServer,
+    MCPServerConfig,
+    MCPStdioServerConfig,
+    MemoryToolkit,
+)
 
 __all__ = (
     "CodeExecutionTool",
     "ContainerAutoEnvironment",
     "ContainerReferenceEnvironment",
+    "DeferredToolkit",
     "DuckDuckSearchTool",
     "ExaToolkit",
     "FilesystemToolkit",

--- a/autogen/beta/tools/__init__.py
+++ b/autogen/beta/tools/__init__.py
@@ -26,6 +26,7 @@ from .shell import LocalShellTool
 from .skills import SkillSearchToolkit, SkillsToolkit
 from .toolkits import (
     DeferredToolkit,
+    DynamicAgentToolkit,
     FilesystemToolkit,
     MCPServer,
     MCPServerConfig,
@@ -39,6 +40,7 @@ __all__ = (
     "ContainerReferenceEnvironment",
     "DeferredToolkit",
     "DuckDuckSearchTool",
+    "DynamicAgentToolkit",
     "ExaToolkit",
     "FilesystemToolkit",
     "ImageGenerationTool",

--- a/autogen/beta/tools/toolkits/__init__.py
+++ b/autogen/beta/tools/toolkits/__init__.py
@@ -3,12 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .deferred import DeferredToolkit
+from .dynamic_agent import DynamicAgentToolkit
 from .filesystem import FilesystemToolkit
 from .mcp_server import MCPServer, MCPServerConfig, MCPStdioServerConfig
 from .memory import MemoryToolkit
 
 __all__ = (
     "DeferredToolkit",
+    "DynamicAgentToolkit",
     "FilesystemToolkit",
     "MCPServer",
     "MCPServerConfig",

--- a/autogen/beta/tools/toolkits/__init__.py
+++ b/autogen/beta/tools/toolkits/__init__.py
@@ -4,10 +4,12 @@
 
 from .filesystem import FilesystemToolkit
 from .mcp_server import MCPServer, MCPServerConfig, MCPStdioServerConfig
+from .memory import MemoryToolkit
 
 __all__ = (
     "FilesystemToolkit",
     "MCPServer",
     "MCPServerConfig",
     "MCPStdioServerConfig",
+    "MemoryToolkit",
 )

--- a/autogen/beta/tools/toolkits/__init__.py
+++ b/autogen/beta/tools/toolkits/__init__.py
@@ -2,11 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from .deferred import DeferredToolkit
 from .filesystem import FilesystemToolkit
 from .mcp_server import MCPServer, MCPServerConfig, MCPStdioServerConfig
 from .memory import MemoryToolkit
 
 __all__ = (
+    "DeferredToolkit",
     "FilesystemToolkit",
     "MCPServer",
     "MCPServerConfig",

--- a/autogen/beta/tools/toolkits/deferred.py
+++ b/autogen/beta/tools/toolkits/deferred.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeferredToolkit — expose a large tool catalog through two meta-tools.
+
+When an agent has hundreds of tools, loading every schema upfront wastes
+tokens.  ``DeferredToolkit`` hides the catalog behind two meta-tools:
+
+* **search_tools(query)** — keyword-search the catalog and return matching
+  tool names with descriptions and parameter schemas.
+* **use_tool(name, arguments)** — invoke any catalog entry by name, passing
+  arguments as a JSON object string.
+
+The agent spends no tokens on schemas it never needs; it discovers and invokes
+tools on demand.
+
+Example::
+
+    from autogen.beta import Agent
+    from autogen.beta.tools import DeferredToolkit, FilesystemToolkit, MemoryToolkit
+    from autogen.beta.config import OpenAIConfig
+
+    # Wrap a large set of tools in a DeferredToolkit
+    deferred = DeferredToolkit(
+        *FilesystemToolkit().tools,  # 5 tools
+        *MemoryToolkit().tools,  # 4 tools
+    )
+
+    # The agent only sees 2 tools: search_tools + use_tool
+    agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"), tools=[deferred])
+
+    reply = await agent.ask("Find all Python files under /tmp and remember the count.")
+    # Agent will: search_tools("filesystem") → find_files schema
+    #             use_tool("find_files", '{"pattern": "**/*.py", "path": "/tmp"}')
+    #             search_tools("memory") → remember schema
+    #             use_tool("remember", '{"content": "42 Python files", "key": "py-count"}')
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable
+from typing import Annotated, Any
+
+from pydantic import Field
+
+from autogen.beta.middleware import ToolMiddleware
+from autogen.beta.tools.final import Toolkit, tool
+from autogen.beta.tools.final.function_tool import FunctionTool
+
+__all__ = ("DeferredToolkit",)
+
+
+class _CatalogEntry:
+    """Metadata + callable for one deferred tool."""
+
+    __slots__ = ("name", "description", "parameters_schema", "_call")
+
+    def __init__(self, ft: FunctionTool) -> None:
+        self.name: str = ft.name
+        self.description: str = ft.schema.function.description
+        self.parameters_schema: dict[str, Any] = ft.schema.function.parameters or {}
+        self._call: Callable[..., Any] = ft.model.call
+
+    async def invoke(self, **kwargs: Any) -> str:
+        import asyncio
+
+        result = self._call(**kwargs)
+        if asyncio.iscoroutine(result):
+            result = await result
+        return str(result)
+
+    def summary(self) -> str:
+        """One-line description for search results."""
+        return f"[{self.name}] {self.description}"
+
+    def full_description(self) -> str:
+        """Name + description + parameter schema (for agent reference)."""
+        schema_str = json.dumps(self.parameters_schema, indent=2)
+        return f"Tool: {self.name}\nDescription: {self.description}\nParameters:\n{schema_str}"
+
+
+class DeferredToolkit(Toolkit):
+    """Toolkit that exposes a large tool catalog via search + dispatch meta-tools.
+
+    The agent only sees two tools:
+
+    * ``search_tools(query, max_results?)`` — keyword-search tool names and
+      descriptions; returns names, descriptions, and parameter schemas.
+    * ``use_tool(name, arguments?)`` — invoke a catalog tool by name;
+      *arguments* is a JSON object string (``'{}'`` if no params needed).
+
+    This keeps the per-call token cost proportional to what the agent
+    actually uses, not the total catalog size.
+
+    Args:
+        *tools:
+            :class:`~autogen.beta.tools.final.FunctionTool` instances (or
+            callables) to add to the hidden catalog.
+        middleware:
+            Tool-level middleware applied to the two meta-tools.
+
+    Example::
+
+        deferred = DeferredToolkit(
+            *FilesystemToolkit().tools,
+            *MemoryToolkit().tools,
+        )
+        agent = Agent("assistant", config=config, tools=[deferred])
+    """
+
+    __slots__ = ("_catalog",)
+
+    def __init__(
+        self,
+        *tools: FunctionTool | Callable[..., Any],
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> None:
+        self._catalog: dict[str, _CatalogEntry] = {}
+        for t in tools:
+            ft = t if isinstance(t, FunctionTool) else FunctionTool.ensure_tool(t)
+            assert isinstance(ft, FunctionTool)
+            self._catalog[ft.name] = _CatalogEntry(ft)
+
+        super().__init__(
+            self._search_tools_fn(middleware=middleware),
+            self._use_tool_fn(middleware=middleware),
+            name="deferred_toolkit",
+            middleware=(),
+        )
+
+    # ------------------------------------------------------------------
+    # Meta-tools
+    # ------------------------------------------------------------------
+
+    def _search_tools_fn(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        catalog = self._catalog
+
+        @tool(
+            name="search_tools",
+            description=(
+                "Search available tools by keyword. Returns matching tool names, "
+                "descriptions, and parameter schemas. Call this before use_tool "
+                "if you are not sure which tool to use or what arguments it expects."
+            ),
+            middleware=middleware,
+        )
+        def _search_tools(
+            query: Annotated[str, Field(description="Search query — matched against tool names and descriptions.")],
+            max_results: Annotated[
+                int,
+                Field(description="Maximum number of results to return.", ge=1, le=50),
+            ] = 5,
+        ) -> str:
+            q = query.lower()
+            hits = [entry for entry in catalog.values() if q in entry.name.lower() or q in entry.description.lower()]
+            if not hits:
+                all_names = ", ".join(sorted(catalog))
+                return f"No tools matched '{query}'. Available tools: {all_names}"
+            hits = hits[:max_results]
+            lines = [f"Found {len(hits)} tool(s) matching '{query}':\n"]
+            for entry in hits:
+                lines.append(entry.full_description())
+                lines.append("")
+            return "\n".join(lines)
+
+        return _search_tools
+
+    def _use_tool_fn(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        catalog = self._catalog
+
+        @tool(
+            name="use_tool",
+            description=(
+                "Invoke a tool from the catalog by name. "
+                "Pass arguments as a JSON object string, e.g. "
+                '\'{"path": "src/", "pattern": "**/*.py"}\'. '
+                "Use search_tools() first if you are unsure of the tool name or its parameters."
+            ),
+            middleware=middleware,
+        )
+        async def _use_tool(
+            name: Annotated[str, Field(description="Name of the tool to invoke.")],
+            arguments: Annotated[
+                str,
+                Field(
+                    description="JSON object of arguments to pass to the tool. Use '{}' for tools with no required params."
+                ),
+            ] = "{}",
+        ) -> str:
+            entry = catalog.get(name)
+            if entry is None:
+                known = ", ".join(sorted(catalog))
+                return f"Tool '{name}' not found in catalog. Available tools: {known}"
+            try:
+                kwargs = json.loads(arguments)
+            except json.JSONDecodeError as exc:
+                return f"Invalid JSON in arguments: {exc}"
+            if not isinstance(kwargs, dict):
+                return "arguments must be a JSON object (dict), not a list or primitive."
+            try:
+                return await entry.invoke(**kwargs)
+            except TypeError as exc:
+                return f"Wrong arguments for '{name}': {exc}"
+            except Exception as exc:
+                return f"Tool '{name}' raised an error: {exc}"
+
+        return _use_tool
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def catalog_names(self) -> tuple[str, ...]:
+        """Sorted names of all tools in the catalog."""
+        return tuple(sorted(self._catalog))
+
+    def add_to_catalog(self, *tools: FunctionTool | Callable[..., Any]) -> None:
+        """Add more tools to the catalog after construction."""
+        for t in tools:
+            ft = t if isinstance(t, FunctionTool) else FunctionTool.ensure_tool(t)
+            assert isinstance(ft, FunctionTool)
+            self._catalog[ft.name] = _CatalogEntry(ft)

--- a/autogen/beta/tools/toolkits/dynamic_agent.py
+++ b/autogen/beta/tools/toolkits/dynamic_agent.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""DynamicAgentToolkit — let an orchestrator agent spawn specialist sub-agents on demand.
+
+An orchestrating agent equipped with this toolkit can call ``ask_specialist``
+to create a one-shot specialist agent, delegate a task to it, and receive its
+reply — all inside a single tool call.
+
+Example::
+
+    from autogen.beta import Agent
+    from autogen.beta.tools import DynamicAgentToolkit
+    from autogen.beta.config import OpenAIConfig
+
+    config = OpenAIConfig("gpt-4o-mini")
+    coordinator = Agent(
+        "coordinator",
+        config=config,
+        prompt=(
+            "You are a coordinator. Break complex requests into specialist tasks "
+            "and delegate each part using ask_specialist."
+        ),
+        tools=[DynamicAgentToolkit(config=config)],
+    )
+
+    reply = await coordinator.ask("Research and summarise the history of the internet.")
+
+The coordinator will autonomously call ``ask_specialist`` to spawn an ephemeral
+researcher agent, collect its reply, and return a synthesised answer.
+
+Sharing tools with specialists::
+
+    from autogen.beta.tools import DynamicAgentToolkit, FilesystemToolkit
+
+    fs = FilesystemToolkit()
+    toolkit = DynamicAgentToolkit(config=config, tools=[fs])
+
+    # Any specialist spawned by the orchestrator inherits the filesystem tools.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Annotated, Any
+
+from pydantic import Field
+
+from autogen.beta.tools.final import Toolkit, tool
+from autogen.beta.tools.final.function_tool import FunctionTool
+
+if TYPE_CHECKING:
+    from autogen.beta.config.config import ModelConfig
+    from autogen.beta.tools.final import Tool
+
+__all__ = ("DynamicAgentToolkit",)
+
+
+class DynamicAgentToolkit(Toolkit):
+    """Toolkit that lets an agent spawn specialist sub-agents on demand.
+
+    Adds a single ``ask_specialist`` tool.  When the orchestrating agent calls
+    it, an ephemeral :class:`~autogen.beta.Agent` is created with the given
+    role, asked the given task, and its reply is returned as a string.
+
+    Args:
+        config:
+            The :class:`~autogen.beta.config.ModelConfig` used for every
+            spawned specialist.  Typically the same config as the orchestrator.
+        tools:
+            Tools to equip every spawned specialist with.  Defaults to none.
+
+    Example::
+
+        config = OpenAIConfig("gpt-4o-mini")
+        orchestrator = Agent(
+            "orchestrator",
+            config=config,
+            tools=[DynamicAgentToolkit(config=config)],
+        )
+    """
+
+    __slots__ = ("_config", "_shared_tools")
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        tools: Iterable[Tool] = (),
+    ) -> None:
+        self._config = config
+        self._shared_tools: list[Any] = list(tools)
+
+        super().__init__(
+            self._ask_specialist_tool(),
+            name="dynamic_agent_toolkit",
+        )
+
+    # ------------------------------------------------------------------
+    # Tool factory
+    # ------------------------------------------------------------------
+
+    def _ask_specialist_tool(self) -> FunctionTool:
+        config = self._config
+        shared_tools = self._shared_tools
+
+        @tool(
+            name="ask_specialist",
+            description=(
+                "Spawn a temporary specialist agent with a custom role and delegate "
+                "a task to it. Returns the specialist's reply as plain text. "
+                "Use this to break complex requests into focused subtasks handled "
+                "by purpose-built agents."
+            ),
+        )
+        async def ask_specialist(
+            role: Annotated[
+                str,
+                Field(
+                    description=(
+                        "System-prompt that defines the specialist's persona and expertise, "
+                        "e.g. 'You are an expert data analyst specialised in time-series data.'"
+                    )
+                ),
+            ],
+            task: Annotated[
+                str,
+                Field(description="The task or question to delegate to the specialist."),
+            ],
+            name: Annotated[
+                str,
+                Field(description="Optional name for the specialist agent (used in logs)."),
+            ] = "specialist",
+        ) -> str:
+            # Late import avoids the tools → agent → tools circular dependency.
+            from autogen.beta.agent import Agent
+
+            agent = Agent(name=name, prompt=role, config=config, tools=shared_tools)
+            reply = await agent.ask(task)
+            content = await reply.content()
+            return content or ""
+
+        return ask_specialist  # type: ignore[return-value]

--- a/autogen/beta/tools/toolkits/memory.py
+++ b/autogen/beta/tools/toolkits/memory.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""MemoryToolkit — provider-agnostic memory tools for AG2 Beta agents.
+
+Gives an agent four tools: remember, recall, forget, and list_memories.
+Memories are stored either in-process (default) or persisted to an SQLite
+database when a *storage_path* is supplied.
+
+Example::
+
+    from autogen.beta import Agent
+    from autogen.beta.tools import MemoryToolkit
+    from autogen.beta.config import OpenAIConfig
+
+    memory = MemoryToolkit()
+    agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"), tools=[memory])
+    # The agent can now call remember/recall/forget/list_memories autonomously.
+
+SQLite persistence::
+
+    memory = MemoryToolkit(storage_path="/tmp/agent-memory.db")
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import Field
+
+from autogen.beta.middleware import ToolMiddleware
+from autogen.beta.tools.final import Toolkit, tool
+from autogen.beta.tools.final.function_tool import FunctionTool
+
+__all__ = ("MemoryToolkit",)
+
+
+# ---------------------------------------------------------------------------
+# Storage backends
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryStore:
+    """Simple dict-backed in-process memory store."""
+
+    def __init__(self) -> None:
+        # key → (content, created_at)
+        self._store: dict[str, tuple[str, float]] = {}
+
+    def store(self, key: str, content: str) -> None:
+        self._store[key] = (content, time.time())
+
+    def retrieve(self, key: str) -> tuple[str, float] | None:
+        return self._store.get(key)
+
+    def search(self, query: str, max_results: int) -> list[tuple[str, str, float]]:
+        q = query.lower()
+        hits = [(k, content, ts) for k, (content, ts) in self._store.items() if q in content.lower() or q in k.lower()]
+        hits.sort(key=lambda x: x[2], reverse=True)
+        return hits[:max_results]
+
+    def delete(self, key: str) -> bool:
+        return self._store.pop(key, None) is not None
+
+    def list_all(self) -> list[tuple[str, str, float]]:
+        return [
+            (k, content, ts) for k, (content, ts) in sorted(self._store.items(), key=lambda x: x[1][1], reverse=True)
+        ]
+
+
+class _SQLiteStore:
+    """SQLite-backed persistent memory store."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        con = sqlite3.connect(self._path, check_same_thread=False)
+        con.execute("PRAGMA journal_mode=WAL")
+        return con
+
+    def _init_db(self) -> None:
+        with self._connect() as con:
+            con.execute(
+                "CREATE TABLE IF NOT EXISTS memories "
+                "(key TEXT PRIMARY KEY, content TEXT NOT NULL, created_at REAL NOT NULL)"
+            )
+
+    def store(self, key: str, content: str) -> None:
+        with self._connect() as con:
+            con.execute(
+                "INSERT OR REPLACE INTO memories (key, content, created_at) VALUES (?, ?, ?)",
+                (key, content, time.time()),
+            )
+
+    def retrieve(self, key: str) -> tuple[str, float] | None:
+        with self._connect() as con:
+            row = con.execute("SELECT content, created_at FROM memories WHERE key = ?", (key,)).fetchone()
+        return (row[0], row[1]) if row else None
+
+    def search(self, query: str, max_results: int) -> list[tuple[str, str, float]]:
+        q = f"%{query}%"
+        with self._connect() as con:
+            rows = con.execute(
+                "SELECT key, content, created_at FROM memories "
+                "WHERE content LIKE ? OR key LIKE ? "
+                "ORDER BY created_at DESC LIMIT ?",
+                (q, q, max_results),
+            ).fetchall()
+        return [(r[0], r[1], r[2]) for r in rows]
+
+    def delete(self, key: str) -> bool:
+        with self._connect() as con:
+            cur = con.execute("DELETE FROM memories WHERE key = ?", (key,))
+        return cur.rowcount > 0
+
+    def list_all(self) -> list[tuple[str, str, float]]:
+        with self._connect() as con:
+            rows = con.execute("SELECT key, content, created_at FROM memories ORDER BY created_at DESC").fetchall()
+        return [(r[0], r[1], r[2]) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Toolkit
+# ---------------------------------------------------------------------------
+
+
+class MemoryToolkit(Toolkit):
+    """Toolkit that gives an agent tools to store and recall memories.
+
+    Memories persist within a session (in-memory backend, default) or across
+    sessions (SQLite backend, when *storage_path* is set).
+
+    Args:
+        storage_path:
+            Path to the SQLite database file.  When ``None`` (default)
+            memories are kept in-process and lost when the session ends.
+        middleware:
+            Optional tool-level middleware applied to every memory tool.
+
+    Example::
+
+        from autogen.beta import Agent
+        from autogen.beta.tools import MemoryToolkit
+        from autogen.beta.config import OpenAIConfig
+
+        # Session-scoped (in-memory)
+        memory = MemoryToolkit()
+
+        # Persistent across sessions
+        memory = MemoryToolkit(storage_path="~/.my-agent/memories.db")
+
+        agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"), tools=[memory])
+    """
+
+    __slots__ = ("_store",)
+
+    def __init__(
+        self,
+        storage_path: str | Path | None = None,
+        *,
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> None:
+        if storage_path is None:
+            self._store: _InMemoryStore | _SQLiteStore = _InMemoryStore()
+        else:
+            self._store = _SQLiteStore(Path(storage_path).expanduser().resolve())
+
+        super().__init__(
+            self._remember_tool(middleware=middleware),
+            self._recall_tool(middleware=middleware),
+            self._forget_tool(middleware=middleware),
+            self._list_memories_tool(middleware=middleware),
+            name="memory_toolkit",
+            middleware=(),
+        )
+
+    # ------------------------------------------------------------------
+    # Tool factories
+    # ------------------------------------------------------------------
+
+    def _remember_tool(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        store = self._store
+
+        @tool(
+            name="remember",
+            description=(
+                "Store a piece of information in memory for later retrieval. "
+                "Supply an optional key to give the memory a name; if omitted "
+                "a unique key is generated. Returns the key used."
+            ),
+            middleware=middleware,
+        )
+        def _remember(
+            content: Annotated[str, Field(description="The information to remember.")],
+            key: Annotated[
+                str,
+                Field(description="Optional name for this memory. Generated automatically if empty."),
+            ] = "",
+        ) -> str:
+            mem_key = key.strip() or f"mem-{uuid.uuid4().hex[:8]}"
+            store.store(mem_key, content)
+            return f"Stored memory '{mem_key}'."
+
+        return _remember
+
+    def _recall_tool(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        store = self._store
+
+        @tool(
+            name="recall",
+            description=(
+                "Search stored memories for entries that match a query. "
+                "Returns the best matching memories (up to max_results)."
+            ),
+            middleware=middleware,
+        )
+        def _recall(
+            query: Annotated[str, Field(description="Search query — matches against memory content and keys.")],
+            max_results: Annotated[
+                int,
+                Field(description="Maximum number of memories to return.", ge=1, le=50),
+            ] = 5,
+        ) -> str:
+            hits = store.search(query, max_results)
+            if not hits:
+                return f"No memories found matching '{query}'."
+            lines = [f"Found {len(hits)} memory(ies) matching '{query}':\n"]
+            for key, content, ts in hits:
+                created = time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
+                lines.append(f"[{key}] ({created})\n{content}\n")
+            return "\n".join(lines)
+
+        return _recall
+
+    def _forget_tool(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        store = self._store
+
+        @tool(
+            name="forget",
+            description="Delete a stored memory by its key.",
+            middleware=middleware,
+        )
+        def _forget(
+            key: Annotated[str, Field(description="The key of the memory to delete.")],
+        ) -> str:
+            if store.delete(key):
+                return f"Deleted memory '{key}'."
+            return f"No memory found with key '{key}'."
+
+        return _forget
+
+    def _list_memories_tool(self, *, middleware: Iterable[ToolMiddleware] = ()) -> FunctionTool:
+        store = self._store
+
+        @tool(
+            name="list_memories",
+            description="List all stored memories, most recent first.",
+            middleware=middleware,
+        )
+        def _list_memories() -> str:
+            entries = store.list_all()
+            if not entries:
+                return "No memories stored."
+            lines = [f"{len(entries)} stored memory(ies):\n"]
+            for key, content, ts in entries:
+                created = time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
+                preview = content[:80] + ("..." if len(content) > 80 else "")
+                lines.append(f"[{key}] ({created}) {preview}")
+            return "\n".join(lines)
+
+        return _list_memories

--- a/skills/docs-writer/SKILL.md
+++ b/skills/docs-writer/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: docs-writer
+description: AG2 documentation conventions — MDX format, frontmatter, admonitions, code blocks, and how to update the roadmap.
+version: 1.0.0
+license: Apache-2.0
+---
+
+# Docs Writer
+
+Guidelines for writing and updating AG2 documentation under `website/docs/beta/`.
+
+## File format
+
+Docs are MDX files rendered by [Mintlify](https://mintlify.com). Every file starts with YAML frontmatter:
+
+```mdx
+---
+title: My Feature
+sidebarTitle: My Feature        # optional — if different from title
+---
+
+# My Feature
+
+Content here.
+```
+
+`title` is the `<title>` tag in the browser. `sidebarTitle` appears in the left navigation.
+
+## Code blocks
+
+Always add `linenums="1"` to production code examples:
+
+````mdx
+```python linenums="1"
+from autogen.beta import Agent
+
+agent = Agent("assistant", config=config)
+```
+````
+
+Use ` ```bash ` for shell commands (no `linenums`). Use ` ```python linenums="1" ` for all Python examples.
+
+To highlight specific lines, add `hl_lines="2 3"` after the language:
+
+````mdx
+```python linenums="1" hl_lines="2 3"
+from autogen.beta import Agent
+from autogen.beta.config import OpenAIConfig   # (1)!
+
+agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"))
+```
+````
+
+## Inline code
+
+Use single backticks for inline code: `` `agent.ask()` ``, `` `MemoryToolkit` ``.
+
+When inlining Python syntax that should be rendered with syntax highlighting in Mintlify, prefix with `#!python`:
+
+```mdx
+Pass `#!python read_only=True` to restrict the toolkit to read operations.
+```
+
+## Admonitions
+
+Admonitions use `!!!`:
+
+```mdx
+!!! tip
+    Short helpful note here.
+
+!!! note
+    An important note.
+
+!!! warning
+    A warning the reader must not miss.
+```
+
+## External links
+
+Always add `{.external-link target="_blank"}` to external URLs:
+
+```mdx
+[Mintlify](https://mintlify.com){.external-link target="_blank"}
+```
+
+## Tables
+
+Use pipe syntax with a header-separator row:
+
+```mdx
+| Tool | Description |
+| :--- | :--- |
+| `read_file` | Read the contents of a file. |
+| `write_file` | Create or overwrite a file. |
+```
+
+Left-align columns with `:---`.
+
+## Docstrings
+
+Python docstrings in `autogen.beta` use plain reStructuredText (not Google style):
+
+```python
+def fanout(agents, prompts, *, max_concurrent=None):
+    """Run agent.ask() calls in parallel and return results in input order.
+
+    Args:
+        agents: A single :class:`Agent`, a list of agents, or a list of
+            ``(agent, prompt)`` pairs.
+        prompts: Depends on *agents* — see calling conventions.
+        max_concurrent: Maximum number of concurrent agent calls.
+            ``None`` means unlimited.
+
+    Returns:
+        A list of :class:`AgentReply` in the same order as the inputs.
+
+    Raises:
+        ValueError: If the argument combination is invalid.
+    """
+```
+
+Rules:
+- First line: one-sentence summary ending in a period.
+- Blank line before Args / Returns / Raises.
+- Wrap at 88 characters.
+- Only document public APIs; private helpers (`_foo`) need no docstring.
+
+## Updating the navigation
+
+`website/mint-json-template.json.jinja` controls the sidebar. To add a new page, find the relevant `"group"` and add the path (without `.mdx`) to its `"pages"` array:
+
+```json
+{
+  "group": "Advanced",
+  "pages": [
+    "docs/beta/advanced/fanout",
+    "docs/beta/advanced/scheduler",
+    "docs/beta/advanced/my-new-feature"
+  ]
+}
+```
+
+## Updating the roadmap
+
+`website/docs/beta/roadmap.mdx` has three sections: **Completed**, **In Progress**, and **Future Priorities**.
+
+When shipping a feature:
+1. Remove the item from **In Progress** or the relevant **P-level** block.
+2. Add it to **Completed** with a short name matching the existing style.

--- a/skills/python-code/SKILL.md
+++ b/skills/python-code/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: python-code
+description: AG2 Python coding conventions — type annotations, async patterns, tool authoring, and style rules for the autogen.beta package.
+version: 1.0.0
+license: Apache-2.0
+---
+
+# Python Code
+
+Guidelines for writing Python code in the AG2 `autogen.beta` package. Follow every rule here unless the user explicitly overrides one.
+
+## Type annotations
+
+Always annotate every function signature — parameters and return type:
+
+```python
+def resolve(name: str, default: int = 0) -> int | None:
+    ...
+```
+
+Use `from __future__ import annotations` at the top of every module to enable forward references without quoting them:
+
+```python
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .agent import Agent
+```
+
+Prefer `X | Y` unions (PEP 604) over `Optional[X]` or `Union[X, Y]`. Use `X | None` for optional values.
+
+## Async
+
+Use `async def` / `await` for all I/O-bound operations. Never block the event loop with synchronous I/O inside an `async` context.
+
+When bridging sync and async, use `asyncio.iscoroutine()` to detect coroutines at runtime rather than assuming:
+
+```python
+result = fn(**kwargs)
+if asyncio.iscoroutine(result):
+    result = await result
+```
+
+## Pydantic
+
+Use `pydantic` for data models (not `dataclasses`) when the model needs JSON serialization, validation, or schema export.
+
+Use `model_config = ConfigDict(frozen=True)` for value objects that must be immutable.
+
+Never call `.model_dump()` on a plain `dict` — check first or use `isinstance`.
+
+## Tool authoring
+
+Use the `@tool` decorator from `autogen.beta.tools.final`:
+
+```python
+from typing import Annotated
+from pydantic import Field
+from autogen.beta.tools.final import tool
+
+@tool(
+    name="find_files",
+    description="Search for files matching a glob pattern.",
+)
+def find_files(
+    pattern: Annotated[str, Field(description="Glob pattern, e.g. '**/*.py'.")],
+    path: Annotated[str, Field(description="Root directory to search.")] = ".",
+) -> list[str]:
+    ...
+```
+
+Rules:
+- Every parameter must be `Annotated[<type>, Field(description="...")]`.
+- The description on `@tool` must be a full English sentence ending in a period. It appears verbatim in the LLM's tool schema.
+- Prefer returning `str` or a `pydantic` model — LLMs handle these best.
+- Sync functions are automatically wrapped for async use; `async def` is fine too.
+
+## Toolkit authoring
+
+Extend `Toolkit` from `autogen.beta.tools.final`:
+
+```python
+from autogen.beta.tools.final import Toolkit
+
+class MyToolkit(Toolkit):
+    __slots__ = ("_state",)
+
+    def __init__(self, *, middleware=()) -> None:
+        self._state = ...
+        super().__init__(
+            self._tool_a(),
+            self._tool_b(),
+            name="my_toolkit",
+            middleware=(),  # always pass empty tuple; per-tool middleware goes on tools
+        )
+
+    def _tool_a(self) -> FunctionTool:
+        state = self._state
+
+        @tool(name="tool_a", description="Does A.")
+        def _impl(...) -> str:
+            ...
+        return _impl
+```
+
+Use `__slots__` on every toolkit class to avoid accidental attribute leakage.
+
+## Style
+
+- Run `ruff check --fix` and `ruff format` before committing.
+- Run `mypy autogen/beta/` to catch type errors.
+- Line length: 120 characters (`ruff` default in this repo).
+- No `Any` unless unavoidable — prefer `object` or a proper union.
+- No bare `except:` — always catch a specific exception type.
+- No commented-out code; no `TODO` comments in production paths.
+- Use `__all__` to declare public API in every `__init__.py`.
+
+## Imports
+
+Order: stdlib → third-party → local (each separated by a blank line). `ruff` enforces this automatically.
+
+Relative imports inside `autogen.beta` are fine for intra-package references.
+
+## Error handling
+
+Raise descriptive exceptions. The repo defines custom exception types in `autogen.beta.exceptions` — use them instead of generic `ValueError` / `RuntimeError` when a matching one exists.
+
+## Copyright header
+
+Every new `.py` file must start with:
+
+```python
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+```
+
+## Tests
+
+Every new public symbol must have tests. See the `test-scaffold` skill for test patterns.

--- a/skills/repo-structure/SKILL.md
+++ b/skills/repo-structure/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: repo-structure
+description: AG2 repository layout — where to add new code, tests, and docs; module conventions; PR workflow.
+version: 1.0.0
+license: Apache-2.0
+---
+
+# Repo Structure
+
+Reference guide for navigating and extending the `ag2ai/ag2` monorepo.
+
+## Top-level layout
+
+```
+ag2/
+├── autogen/beta/          # New beta package (this is the primary development surface)
+├── autogen/               # Legacy autogen package (not covered here)
+├── test/beta/             # Tests for autogen.beta
+├── website/docs/beta/     # Documentation for autogen.beta (MDX + Mintlify)
+├── skills/                # Bundled repository-development skills (this directory)
+├── pyproject.toml         # Project metadata and dependencies
+└── .pre-commit-config.yaml
+```
+
+## autogen/beta package layout
+
+```
+autogen/beta/
+├── __init__.py            # Top-level exports: Agent, Context, fanout, ...
+├── agent.py               # Agent class + AgentReply
+├── config.py              # LLM provider configs (OpenAIConfig, AnthropicConfig, ...)
+├── exceptions.py          # Custom exception hierarchy
+├── fanout.py              # fanout() for parallel agent invocations
+├── middleware/            # Middleware system
+│   ├── __init__.py
+│   ├── builtin/           # Built-in middlewares (Telemetry, Prometheus, Conditional, ...)
+│   └── ...
+├── scheduler.py           # AgentScheduler (cron/interval/delay)
+├── tools/                 # Tools and toolkits
+│   ├── __init__.py        # Public tool exports
+│   ├── builtin/           # Built-in (provider-side) tools
+│   ├── final/             # @tool decorator, Toolkit base, FunctionTool
+│   ├── skills/            # SkillsToolkit, SkillSearchToolkit, LocalRuntime
+│   └── toolkits/          # FilesystemToolkit, MemoryToolkit, DeferredToolkit, MCPServer
+└── ...
+```
+
+## Where to add new code
+
+| What you're adding | Where it goes |
+| :--- | :--- |
+| New LLM provider config | `autogen/beta/config.py` or a new config module |
+| New middleware | `autogen/beta/middleware/builtin/<name>.py`; export from `middleware/builtin/__init__.py` and `middleware/__init__.py` |
+| New toolkit | `autogen/beta/tools/toolkits/<name>.py`; export from `toolkits/__init__.py` and `tools/__init__.py` |
+| New built-in provider tool | `autogen/beta/tools/builtin/<name>.py`; export from `tools/builtin/__init__.py` |
+| New top-level feature | `autogen/beta/<name>.py`; export from `autogen/beta/__init__.py` |
+
+## Tests
+
+Test files mirror the source layout under `test/beta/`:
+
+```
+test/beta/
+├── conftest.py            # Shared fixtures: context, async_mock
+├── test_agent.py
+├── test_fanout.py
+├── tools/
+│   ├── test_local_skills.py
+│   └── test_skill_search.py
+└── ...
+```
+
+Rules:
+- One test file per source module.
+- File name: `test_<source_module_name>.py`.
+- Fixtures defined in `conftest.py` are available everywhere.
+
+## Documentation
+
+Docs live at `website/docs/beta/`. See the `docs-writer` skill for MDX conventions.
+
+```
+website/docs/beta/
+├── roadmap.mdx            # Completed / In Progress / Future Priorities
+├── agents.mdx             # Agent, AgentReply
+├── tools/
+│   ├── common_toolkits.mdx
+│   └── ...
+└── advanced/
+    ├── fanout.mdx
+    ├── scheduler.mdx
+    └── ...
+```
+
+Nav is declared in `website/mint-json-template.json.jinja`. Add a new page to the appropriate `group.pages` array there.
+
+## PR workflow
+
+1. Branch from `main` with a descriptive name: `feat/beta-<feature>`, `fix/beta-<bug>`, `docs/beta-<topic>`.
+2. Commit with the prefix `feat(beta):`, `fix(beta):`, `docs(beta):`, etc.
+3. Pre-commit hooks run automatically: `ruff`, `mypy`, `typos`, `codespell`, license headers.
+4. Open PR against `main`; the CI matrix tests Python 3.10 / 3.11 / 3.12 on Ubuntu and macOS.
+5. Never force-push to `main`. Never merge your own PR.
+
+## Roadmap
+
+`website/docs/beta/roadmap.mdx` tracks what's done, in progress, and planned. When shipping a feature:
+1. Move it from **In Progress** or the relevant **P-level** block into **Completed**.
+2. If it was a P2 item listed as "(done — ...)", update the note with the real PR number.

--- a/skills/test-scaffold/SKILL.md
+++ b/skills/test-scaffold/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: test-scaffold
+description: AG2 test patterns — pytest fixtures, async tests, toolkit schema tests, and end-to-end tool call verification.
+version: 1.0.0
+license: Apache-2.0
+---
+
+# Test Scaffold
+
+Patterns and conventions for writing tests in `test/beta/`.
+
+## File structure
+
+```
+test/beta/
+├── conftest.py        # Shared fixtures
+├── test_<module>.py   # One file per source module
+└── tools/
+    └── test_<toolkit>.py
+```
+
+Every test file must start with the AG2 copyright header:
+
+```python
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+```
+
+## Shared fixtures
+
+Available everywhere via `conftest.py`:
+
+| Fixture | Type | Description |
+| :--- | :--- | :--- |
+| `context` | `Context` | A minimal `Context` for schema / tool registration tests |
+| `async_mock` | factory | Returns a coroutine-returning mock — use for patching async callables |
+
+Import them by name in your test function signature — pytest injects them automatically.
+
+## Async tests
+
+Mark async tests with `@pytest.mark.asyncio`:
+
+```python
+import pytest
+
+@pytest.mark.asyncio
+async def test_my_async_feature(context) -> None:
+    result = await some_async_call()
+    assert result == expected
+```
+
+## Testing a toolkit's schemas
+
+Call `await toolkit.schemas(context)` to get the tool schemas and assert their structure:
+
+```python
+@pytest.mark.asyncio
+async def test_toolkit_exposes_expected_tools(context) -> None:
+    toolkit = MyToolkit()
+
+    schemas = await toolkit.schemas(context)
+
+    names = {s.function.name for s in schemas}
+    assert names == {"tool_a", "tool_b"}
+```
+
+For detailed schema assertions use `dirty_equals.IsPartialDict`:
+
+```python
+from dirty_equals import IsPartialDict
+
+@pytest.mark.asyncio
+async def test_tool_schema_shape(context) -> None:
+    [schema] = await my_tool.schemas(context)
+
+    assert asdict(schema) == {
+        "type": "function",
+        "function": IsPartialDict({
+            "name": "my_tool",
+            "parameters": IsPartialDict({
+                "properties": IsPartialDict({
+                    "query": IsPartialDict({"type": "string"}),
+                }),
+                "required": ["query"],
+            }),
+        }),
+    }
+```
+
+## End-to-end tool call tests
+
+Use `TrackingConfig` and `ToolCallEvent` to verify the agent actually invokes a tool:
+
+```python
+from autogen.beta.config import TrackingConfig
+from autogen.beta.events import ToolCallEvent
+
+@pytest.mark.asyncio
+async def test_agent_calls_my_tool() -> None:
+    config = TrackingConfig()
+    agent = Agent("assistant", config=config, tools=[my_toolkit])
+
+    await agent.ask("Do the thing.")
+
+    tool_calls = [e for e in config.events if isinstance(e, ToolCallEvent)]
+    assert any(e.name == "my_tool" for e in tool_calls)
+```
+
+`TrackingConfig` records every event without making real LLM calls — it replies with a scripted tool call + result sequence.
+
+## Testing storage-backed classes
+
+Test persistence classes (`_SQLiteStore`, etc.) directly without routing through the full agent:
+
+```python
+import tempfile
+from pathlib import Path
+
+def test_sqlite_store_roundtrip() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = _SQLiteStore(Path(tmpdir) / "test.db")
+
+        store.store("key", "value")
+        content, _ = store.retrieve("key")
+
+        assert content == "value"
+```
+
+Always use `tmp_path` (pytest fixture) or `tempfile.TemporaryDirectory` for files — never hardcode `/tmp`.
+
+## Parametrized tests
+
+Parametrize when the same assertion applies across several inputs:
+
+```python
+@pytest.mark.parametrize("bad_name", ["", "Has Spaces", "CamelCase", "has/slash"])
+def test_reject_bad_names(bad_name) -> None:
+    with pytest.raises((ValueError, InvalidSkillNameError)):
+        validate_name(bad_name)
+```
+
+## Generating a test scaffold
+
+Use the `scaffold` script to generate a starter test file for a module:
+
+```bash
+python skills/test-scaffold/scripts/scaffold.py autogen.beta.tools.toolkits.memory
+```
+
+This reads the module's public symbols and emits a `test_memory.py` template with one empty test per public class/function.

--- a/skills/test-scaffold/scripts/scaffold.py
+++ b/skills/test-scaffold/scripts/scaffold.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Generate a pytest test-file scaffold for an autogen.beta module.
+
+Usage::
+
+    python scaffold.py autogen.beta.tools.toolkits.memory
+    python scaffold.py autogen.beta.exceptions --out test/beta/test_exceptions.py
+
+The script imports the target module, collects its public symbols (classes and
+functions listed in ``__all__`` or without a leading underscore), and emits a
+starter test file with one empty test stub per symbol.
+
+The output is printed to stdout by default so you can review it before writing
+it anywhere.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+_HEADER = dedent("""\
+    # Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+    #
+    # SPDX-License-Identifier: Apache-2.0
+
+    import pytest
+
+    # ---------------------------------------------------------------------------
+    # Auto-generated test scaffold — fill in each test body.
+    # Run:  pytest {test_path}
+    # ---------------------------------------------------------------------------
+""")
+
+_ASYNC_STUB = dedent("""\
+    @pytest.mark.asyncio
+    async def test_{name}() -> None:
+        # TODO: test {symbol}
+        ...
+
+""")
+
+_SYNC_STUB = dedent("""\
+    def test_{name}() -> None:
+        # TODO: test {symbol}
+        ...
+
+""")
+
+
+def _snake(name: str) -> str:
+    """CamelCase → snake_case."""
+    import re
+
+    s = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", name)
+    s = re.sub(r"([a-z\d])([A-Z])", r"\1_\2", s)
+    return s.lower()
+
+
+def _is_async(obj: object) -> bool:
+    return inspect.iscoroutinefunction(obj) or (
+        isinstance(obj, type) and any(inspect.iscoroutinefunction(m) for _, m in inspect.getmembers(obj))
+    )
+
+
+def collect_symbols(module_name: str) -> list[tuple[str, object]]:
+    mod = importlib.import_module(module_name)
+    if hasattr(mod, "__all__"):
+        names = list(mod.__all__)
+    else:
+        names = [n for n in dir(mod) if not n.startswith("_")]
+
+    symbols = []
+    for name in names:
+        obj = getattr(mod, name, None)
+        if obj is None:
+            continue
+        if inspect.isclass(obj) or inspect.isfunction(obj) or inspect.iscoroutinefunction(obj):
+            symbols.append((name, obj))
+    return symbols
+
+
+def generate(module_name: str) -> str:
+    symbols = collect_symbols(module_name)
+    if not symbols:
+        print(f"No public symbols found in {module_name!r}.", file=sys.stderr)
+        sys.exit(1)
+
+    parts: list[str] = []
+
+    # Derive a test file path for the header comment
+    test_path = "test/beta/test_" + module_name.rsplit(".", 1)[-1] + ".py"
+    parts.append(_HEADER.format(test_path=test_path))
+    parts.append(f"# Source module: {module_name}\n\n")
+
+    for name, obj in symbols:
+        slug = _snake(name)
+        template = _ASYNC_STUB if _is_async(obj) else _SYNC_STUB
+        parts.append(template.format(name=slug, symbol=name))
+
+    return "".join(parts)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("module", help="Dotted module path, e.g. autogen.beta.exceptions")
+    parser.add_argument("--out", metavar="FILE", help="Write output to this file instead of stdout")
+    args = parser.parse_args()
+
+    code = generate(args.module)
+
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(code, encoding="utf-8")
+        print(f"Wrote {out}")
+    else:
+        sys.stdout.write(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/beta/test_background.py
+++ b/test/beta/test_background.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for autogen.beta.background — BackgroundTask and run_in_background."""
+
+import asyncio
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.background import BackgroundTask, run_in_background
+from autogen.beta.testing import TestConfig
+
+# ---------------------------------------------------------------------------
+# BackgroundTask — unit tests using plain asyncio coroutines
+# ---------------------------------------------------------------------------
+
+
+class TestBackgroundTask:
+    async def _make(self, coro) -> BackgroundTask:  # type: ignore[type-arg]
+        task: asyncio.Task = asyncio.create_task(coro)
+        return BackgroundTask(task)
+
+    @pytest.mark.asyncio
+    async def test_done_before_and_after(self) -> None:
+        async def _noop() -> str:
+            return "hi"
+
+        bt = await self._make(_noop())
+        assert not bt.done()
+        await bt
+        assert bt.done()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_after_cancel(self) -> None:
+        gate = asyncio.Event()
+
+        async def _wait() -> None:
+            await gate.wait()
+
+        bt = await self._make(_wait())
+        assert not bt.cancelled()
+        bt.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await bt
+        assert bt.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_cancel_returns_false_when_done(self) -> None:
+        async def _noop() -> str:
+            return "done"
+
+        bt = await self._make(_noop())
+        await bt
+        assert not bt.cancel()
+
+    @pytest.mark.asyncio
+    async def test_result_after_completion(self) -> None:
+        async def _answer() -> int:
+            return 42
+
+        bt = await self._make(_answer())
+        await bt
+        assert bt.result() == 42
+
+    @pytest.mark.asyncio
+    async def test_result_raises_when_not_done(self) -> None:
+        gate = asyncio.Event()
+
+        async def _wait() -> None:
+            await gate.wait()
+
+        bt = await self._make(_wait())
+        with pytest.raises(asyncio.InvalidStateError):
+            bt.result()
+        bt.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await bt
+
+    @pytest.mark.asyncio
+    async def test_exception_on_success_is_none(self) -> None:
+        async def _ok() -> str:
+            return "fine"
+
+        bt = await self._make(_ok())
+        await bt
+        assert bt.exception() is None
+
+    @pytest.mark.asyncio
+    async def test_exception_propagates(self) -> None:
+        async def _boom() -> None:
+            raise ValueError("oops")
+
+        bt = await self._make(_boom())
+        with pytest.raises(ValueError, match="oops"):
+            await bt
+        exc = bt.exception()
+        assert isinstance(exc, ValueError)
+
+    @pytest.mark.asyncio
+    async def test_exception_raises_when_not_done(self) -> None:
+        gate = asyncio.Event()
+
+        async def _wait() -> None:
+            await gate.wait()
+
+        bt = await self._make(_wait())
+        with pytest.raises(asyncio.InvalidStateError):
+            bt.exception()
+        bt.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await bt
+
+    @pytest.mark.asyncio
+    async def test_await_returns_task_result(self) -> None:
+        async def _val() -> str:
+            return "value"
+
+        bt = await self._make(_val())
+        result = await bt
+        assert result == "value"
+
+
+# ---------------------------------------------------------------------------
+# run_in_background — integration tests with TestConfig + Agent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestRunInBackground:
+    async def test_returns_background_task_immediately(self) -> None:
+        config = TestConfig("summary complete")
+        agent = Agent("analyst", config=config)
+
+        task = run_in_background(agent, "Summarise.")
+        assert isinstance(task, BackgroundTask)
+
+    async def test_agent_reply_accessible_after_await(self) -> None:
+        config = TestConfig("summary complete")
+        agent = Agent("analyst", config=config)
+
+        task = run_in_background(agent, "Summarise.")
+        reply = await task
+        text = await reply.content()
+        assert text == "summary complete"
+
+    async def test_not_done_before_yield(self) -> None:
+        config = TestConfig("done")
+        agent = Agent("worker", config=config)
+
+        task = run_in_background(agent, "Go.")
+        assert not task.done()
+        await task
+        assert task.done()
+
+    async def test_two_tasks_run_concurrently(self) -> None:
+        config_a = TestConfig("alpha")
+        config_b = TestConfig("beta")
+        agent_a = Agent("alpha", config=config_a)
+        agent_b = Agent("beta", config=config_b)
+
+        task_a = run_in_background(agent_a, "Task A.")
+        task_b = run_in_background(agent_b, "Task B.")
+
+        replies = await asyncio.gather(task_a, task_b)
+        texts = [await r.content() for r in replies]
+        assert "alpha" in texts
+        assert "beta" in texts
+
+    async def test_kwargs_forwarded_to_ask(self) -> None:
+        from autogen.beta.stream import MemoryStream
+
+        config = TestConfig("ok")
+        agent = Agent("streamer", config=config)
+        stream = MemoryStream()
+
+        task = run_in_background(agent, "Hello.", stream=stream)
+        await task
+
+        history = await stream.history.storage.get_history(stream.id)
+        assert len(history) > 0
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_all_exports() -> None:
+    from autogen.beta import background
+
+    assert "BackgroundTask" in background.__all__
+    assert "run_in_background" in background.__all__

--- a/test/beta/test_deferred_toolkit.py
+++ b/test/beta/test_deferred_toolkit.py
@@ -1,0 +1,309 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for DeferredToolkit."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from autogen.beta import Agent, Context
+from autogen.beta.events import ToolCallEvent, ToolResultsEvent
+from autogen.beta.testing import TestConfig, TrackingConfig
+from autogen.beta.tools import DeferredToolkit, MemoryToolkit
+from autogen.beta.tools.final import tool
+from autogen.beta.tools.toolkits.deferred import _CatalogEntry
+
+# ---------------------------------------------------------------------------
+# Helpers — simple catalog tools for tests
+# ---------------------------------------------------------------------------
+
+
+@tool(name="add", description="Add two integers and return the sum.")
+def _add(a: int, b: int) -> int:
+    return a + b
+
+
+@tool(name="greet", description="Return a greeting for a given name.")
+def _greet(name: str) -> str:
+    return f"Hello, {name}!"
+
+
+@tool(name="ping", description="Return pong. No parameters needed.")
+def _ping() -> str:
+    return "pong"
+
+
+# ---------------------------------------------------------------------------
+# _CatalogEntry
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_entry_metadata() -> None:
+    entry = _CatalogEntry(_add)
+    assert entry.name == "add"
+    assert "Add two integers" in entry.description
+
+
+def test_catalog_entry_summary() -> None:
+    entry = _CatalogEntry(_greet)
+    assert "[greet]" in entry.summary()
+    assert "greeting" in entry.summary()
+
+
+def test_catalog_entry_full_description_contains_schema() -> None:
+    desc = _CatalogEntry(_add).full_description()
+    assert "add" in desc
+    assert "parameters" in desc.lower()
+
+
+@pytest.mark.asyncio
+async def test_catalog_entry_invoke_sync() -> None:
+    entry = _CatalogEntry(_add)
+    result = await entry.invoke(a=3, b=4)
+    assert result == "7"
+
+
+@pytest.mark.asyncio
+async def test_catalog_entry_invoke_no_args() -> None:
+    entry = _CatalogEntry(_ping)
+    result = await entry.invoke()
+    assert result == "pong"
+
+
+# ---------------------------------------------------------------------------
+# DeferredToolkit construction
+# ---------------------------------------------------------------------------
+
+
+def test_only_two_tools_exposed() -> None:
+    dt = DeferredToolkit(_add, _greet, _ping)
+    assert set(dt._tools.keys()) == {"search_tools", "use_tool"}
+
+
+def test_catalog_names() -> None:
+    dt = DeferredToolkit(_add, _greet, _ping)
+    assert dt.catalog_names == ("add", "greet", "ping")
+
+
+def test_toolkit_name() -> None:
+    assert DeferredToolkit().name == "deferred_toolkit"
+
+
+def test_empty_catalog() -> None:
+    dt = DeferredToolkit()
+    assert dt.catalog_names == ()
+
+
+def test_add_to_catalog() -> None:
+    dt = DeferredToolkit(_add)
+    assert "greet" not in dt.catalog_names
+    dt.add_to_catalog(_greet)
+    assert "greet" in dt.catalog_names
+
+
+def test_from_toolkit_tools() -> None:
+    """Accept tools from another toolkit's .tools property."""
+    memory = MemoryToolkit()
+    dt = DeferredToolkit(*memory.tools)
+    assert set(dt.catalog_names) == {"remember", "recall", "forget", "list_memories"}
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schemas(async_mock: AsyncMock) -> None:
+    dt = DeferredToolkit(_add, _greet)
+    schemas = list(await dt.schemas(Context(async_mock)))
+    names = {s.function.name for s in schemas}
+    assert names == {"search_tools", "use_tool"}
+
+
+# ---------------------------------------------------------------------------
+# search_tools via agent call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_finds_matching_tool() -> None:
+    dt = DeferredToolkit(_add, _greet, _ping)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="search_tools",
+                arguments=json.dumps({"query": "greeting", "max_results": 5}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("find tools")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "greet" in result_text
+    assert "greeting" in result_text
+
+
+@pytest.mark.asyncio
+async def test_search_no_match_lists_all() -> None:
+    dt = DeferredToolkit(_add, _ping)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="search_tools",
+                arguments=json.dumps({"query": "zucchini"}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("find tools")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "No tools matched" in result_text
+    assert "add" in result_text
+    assert "ping" in result_text
+
+
+# ---------------------------------------------------------------------------
+# use_tool via agent call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_use_tool_invokes_sync_function() -> None:
+    dt = DeferredToolkit(_add)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "add", "arguments": '{"a": 10, "b": 32}'}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("add numbers")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "42" in result_text
+
+
+@pytest.mark.asyncio
+async def test_use_tool_no_args() -> None:
+    dt = DeferredToolkit(_ping)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "ping"}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("ping")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "pong" in result_text
+
+
+@pytest.mark.asyncio
+async def test_use_tool_unknown_name() -> None:
+    dt = DeferredToolkit(_ping)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "ghost_tool"}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("use unknown tool")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "not found" in result_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_use_tool_bad_json_arguments() -> None:
+    dt = DeferredToolkit(_add)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "add", "arguments": "not json {{{"}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("use with bad args")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "Invalid JSON" in result_text
+
+
+@pytest.mark.asyncio
+async def test_use_tool_wrong_arguments() -> None:
+    dt = DeferredToolkit(_add)
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "add", "arguments": '{"x": 1, "y": 2}'}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("use with wrong args")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "Wrong arguments" in result_text or "error" in result_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_use_memory_toolkit_tool_via_deferred() -> None:
+    """End-to-end: use MemoryToolkit tools through DeferredToolkit."""
+    memory = MemoryToolkit()
+    dt = DeferredToolkit(*memory.tools)
+    memory._store.store("sky", "The sky is blue.")
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="use_tool",
+                arguments=json.dumps({"name": "recall", "arguments": '{"query": "sky"}'}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[dt])
+    await agent.ask("recall sky memory")
+
+    result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = result_msg.results[0].result.parts[0].content
+    assert "sky" in result_text
+    assert "The sky is blue." in result_text

--- a/test/beta/test_memory_toolkit.py
+++ b/test/beta/test_memory_toolkit.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for MemoryToolkit."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from autogen.beta import Agent, Context
+from autogen.beta.events import ToolCallEvent, ToolResultsEvent
+from autogen.beta.testing import TestConfig, TrackingConfig
+from autogen.beta.tools import MemoryToolkit
+from autogen.beta.tools.toolkits.memory import _InMemoryStore, _SQLiteStore
+
+# ---------------------------------------------------------------------------
+# _InMemoryStore — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryStore:
+    def test_store_and_retrieve(self) -> None:
+        s = _InMemoryStore()
+        s.store("k1", "hello world")
+        entry = s.retrieve("k1")
+        assert entry is not None
+        content, _ts = entry
+        assert content == "hello world"
+
+    def test_retrieve_missing_key(self) -> None:
+        s = _InMemoryStore()
+        assert s.retrieve("ghost") is None
+
+    def test_search_finds_content(self) -> None:
+        s = _InMemoryStore()
+        s.store("a", "Paris is the capital of France")
+        s.store("b", "Berlin is the capital of Germany")
+        hits = s.search("Paris", 10)
+        assert len(hits) == 1
+        assert hits[0][0] == "a"
+
+    def test_search_finds_key(self) -> None:
+        s = _InMemoryStore()
+        s.store("special-key", "some content")
+        hits = s.search("special-key", 10)
+        assert any(h[0] == "special-key" for h in hits)
+
+    def test_search_case_insensitive(self) -> None:
+        s = _InMemoryStore()
+        s.store("k", "Python is great")
+        assert s.search("python", 5)
+        assert s.search("PYTHON", 5)
+
+    def test_search_respects_max_results(self) -> None:
+        s = _InMemoryStore()
+        for i in range(10):
+            s.store(f"item-{i}", f"item number {i}")
+        hits = s.search("item", 3)
+        assert len(hits) <= 3
+
+    def test_delete_existing(self) -> None:
+        s = _InMemoryStore()
+        s.store("temp", "gone soon")
+        assert s.delete("temp") is True
+        assert s.retrieve("temp") is None
+
+    def test_delete_nonexistent(self) -> None:
+        s = _InMemoryStore()
+        assert s.delete("ghost") is False
+
+    def test_overwrite(self) -> None:
+        s = _InMemoryStore()
+        s.store("k", "original")
+        s.store("k", "updated")
+        content, _ = s.retrieve("k")  # type: ignore[misc]
+        assert content == "updated"
+
+    def test_list_all_empty(self) -> None:
+        s = _InMemoryStore()
+        assert s.list_all() == []
+
+    def test_list_all_returns_all_entries(self) -> None:
+        s = _InMemoryStore()
+        s.store("a", "alpha")
+        s.store("b", "beta")
+        all_entries = s.list_all()
+        keys = {e[0] for e in all_entries}
+        assert keys == {"a", "b"}
+
+    def test_independent_instances(self) -> None:
+        s1 = _InMemoryStore()
+        s2 = _InMemoryStore()
+        s1.store("shared-key", "only in s1")
+        assert s2.search("only in s1", 5) == []
+
+
+# ---------------------------------------------------------------------------
+# _SQLiteStore — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSQLiteStore:
+    def test_store_and_retrieve(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "test.db")
+        s.store("k1", "hello sqlite")
+        content, _ = s.retrieve("k1")  # type: ignore[misc]
+        assert content == "hello sqlite"
+
+    def test_retrieve_missing(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "test.db")
+        assert s.retrieve("ghost") is None
+
+    def test_persistence_across_instances(self, tmp_path: Path) -> None:
+        db = tmp_path / "persist.db"
+        _SQLiteStore(db).store("durable", "survived restart")
+        content, _ = _SQLiteStore(db).retrieve("durable")  # type: ignore[misc]
+        assert content == "survived restart"
+
+    def test_search(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "search.db")
+        s.store("a", "unique searchable text")
+        hits = s.search("unique searchable", 5)
+        assert len(hits) == 1
+        assert hits[0][0] == "a"
+
+    def test_delete(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "del.db")
+        s.store("gone", "byebye")
+        assert s.delete("gone") is True
+        assert s.retrieve("gone") is None
+
+    def test_delete_nonexistent(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "del2.db")
+        assert s.delete("ghost") is False
+
+    def test_list_all(self, tmp_path: Path) -> None:
+        s = _SQLiteStore(tmp_path / "list.db")
+        s.store("x", "ex")
+        s.store("y", "why")
+        keys = {e[0] for e in s.list_all()}
+        assert keys == {"x", "y"}
+
+    def test_delete_persists_across_instances(self, tmp_path: Path) -> None:
+        db = tmp_path / "forgetter.db"
+        _SQLiteStore(db).store("gone", "will be deleted")
+        _SQLiteStore(db).delete("gone")
+        assert _SQLiteStore(db).retrieve("gone") is None
+
+
+# ---------------------------------------------------------------------------
+# MemoryToolkit schemas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_toolkit_schemas(async_mock: AsyncMock) -> None:
+    toolkit = MemoryToolkit()
+    schemas = list(await toolkit.schemas(Context(async_mock)))
+    names = {s.function.name for s in schemas}
+    assert names == {"remember", "recall", "forget", "list_memories"}
+
+
+def test_toolkit_name() -> None:
+    assert MemoryToolkit().name == "memory_toolkit"
+
+
+def test_toolkit_tools_dict() -> None:
+    m = MemoryToolkit()
+    assert set(m._tools.keys()) == {"remember", "recall", "forget", "list_memories"}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: agent invokes remember, then recall
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_remember_call() -> None:
+    toolkit = MemoryToolkit()
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="remember",
+                arguments=json.dumps({"content": "The sky is blue.", "key": "sky"}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[toolkit])
+    await agent.ask("remember something")
+
+    # Second mock call receives the tool result
+    tool_result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = tool_result_msg.results[0].result.parts[0].content
+    assert "sky" in result_text
+
+
+@pytest.mark.asyncio
+async def test_agent_recall_call() -> None:
+    toolkit = MemoryToolkit()
+    toolkit._store.store("sky", "The sky is blue.")
+
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(
+                name="recall",
+                arguments=json.dumps({"query": "sky", "max_results": 3}),
+            ),
+            "done",
+        )
+    )
+    agent = Agent("", config=tracking, tools=[toolkit])
+    await agent.ask("recall something")
+
+    tool_result_msg: ToolResultsEvent = tracking.mock.call_args_list[1][0][0]
+    result_text = tool_result_msg.results[0].result.parts[0].content
+    assert "sky" in result_text
+    assert "The sky is blue." in result_text

--- a/test/beta/tools/test_bundled_skills.py
+++ b/test/beta/tools/test_bundled_skills.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the bundled repository-development skills in skills/."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from autogen.beta.tools.skills.local_skills.loader import SkillLoader
+
+# Bundled skills live at <repo_root>/skills/
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+
+EXPECTED_SKILLS = {"python-code", "repo-structure", "docs-writer", "test-scaffold"}
+
+
+@pytest.fixture
+def loader() -> SkillLoader:
+    return SkillLoader(SKILLS_DIR)
+
+
+def test_skills_directory_exists() -> None:
+    assert SKILLS_DIR.is_dir(), f"Expected .agents/skills/ at {SKILLS_DIR}"
+
+
+def test_all_expected_skills_present(loader: SkillLoader) -> None:
+    names = {s.name for s in loader.discover()}
+    assert EXPECTED_SKILLS.issubset(names), f"Missing skills: {EXPECTED_SKILLS - names}"
+
+
+@pytest.mark.parametrize("skill_name", sorted(EXPECTED_SKILLS))
+def test_skill_is_valid(skill_name: str, loader: SkillLoader) -> None:
+    skills = {s.name: s for s in loader.discover()}
+    meta = skills[skill_name]
+
+    assert meta.name == skill_name
+    assert meta.description, f"{skill_name}: description must not be empty"
+    assert len(meta.description) <= 1024, f"{skill_name}: description too long"
+    assert meta.path.is_dir()
+    assert (meta.path / "SKILL.md").is_file()
+
+
+@pytest.mark.parametrize("skill_name", sorted(EXPECTED_SKILLS))
+def test_skill_loadable(skill_name: str, loader: SkillLoader) -> None:
+    content = loader.load(skill_name)
+
+    assert content.startswith("---"), f"{skill_name}: SKILL.md must start with frontmatter"
+    assert len(content) > 100, f"{skill_name}: SKILL.md content seems too short"
+
+
+def test_python_code_skill_content(loader: SkillLoader) -> None:
+    content = loader.load("python-code")
+
+    assert "@tool" in content
+    assert "type annotation" in content.lower() or "Type annotation" in content
+
+
+def test_repo_structure_skill_content(loader: SkillLoader) -> None:
+    content = loader.load("repo-structure")
+
+    assert "autogen/beta/" in content
+    assert "test/beta/" in content
+
+
+def test_docs_writer_skill_content(loader: SkillLoader) -> None:
+    content = loader.load("docs-writer")
+
+    assert "frontmatter" in content.lower() or "YAML" in content
+    assert "linenums" in content
+
+
+def test_test_scaffold_skill_content(loader: SkillLoader) -> None:
+    content = loader.load("test-scaffold")
+
+    assert "pytest" in content
+    assert "asyncio" in content
+
+
+def test_test_scaffold_has_scripts(loader: SkillLoader) -> None:
+    skills = {s.name: s for s in loader.discover()}
+    meta = skills["test-scaffold"]
+
+    assert meta.has_scripts, "test-scaffold must have a scripts/ directory"
+    scaffold_script = meta.path / "scripts" / "scaffold.py"
+    assert scaffold_script.is_file()
+
+
+def test_scaffold_script_runs(loader: SkillLoader) -> None:
+    script = loader.get_path("test-scaffold") / "scripts" / "scaffold.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "autogen.beta.exceptions"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+
+    assert result.returncode == 0, f"scaffold.py failed:\n{result.stderr}"
+    assert "def test_" in result.stdout
+
+
+def test_scaffold_script_unknown_module_exits_nonzero(loader: SkillLoader) -> None:
+    script = loader.get_path("test-scaffold") / "scripts" / "scaffold.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "this.module.does.not.exist"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+
+    assert result.returncode != 0
+
+
+def test_skills_discoverable_via_default_runtime_from_repo_root() -> None:
+    """SkillsToolkit() from repo root should find bundled skills automatically."""
+    from autogen.beta.tools.skills import LocalRuntime
+
+    runtime = LocalRuntime(dir=str(SKILLS_DIR))
+    names = {m.name for m in runtime.discover()}
+
+    assert EXPECTED_SKILLS.issubset(names)

--- a/test/beta/tools/test_dynamic_agent_toolkit.py
+++ b/test/beta/tools/test_dynamic_agent_toolkit.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for DynamicAgentToolkit — spawn specialist sub-agents on demand."""
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.events import ModelMessage, ModelResponse, ToolCallEvent
+from autogen.beta.testing import TestConfig
+from autogen.beta.tools import DynamicAgentToolkit
+from autogen.beta.tools.final import Toolkit
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _specialist_config(reply: str) -> TestConfig:
+    """Config that makes the specialist agent return *reply*."""
+    return TestConfig(reply)
+
+
+# ---------------------------------------------------------------------------
+# Schema and structure
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicAgentToolkitStructure:
+    def test_is_toolkit(self) -> None:
+        config = TestConfig("ok")
+        t = DynamicAgentToolkit(config=config)
+        assert isinstance(t, Toolkit)
+
+    def test_has_ask_specialist_tool(self) -> None:
+        config = TestConfig("ok")
+        t = DynamicAgentToolkit(config=config)
+        names = {tool.name for tool in t.tools}
+        assert "ask_specialist" in names
+
+    def test_exactly_one_tool(self) -> None:
+        config = TestConfig("ok")
+        t = DynamicAgentToolkit(config=config)
+        assert len(t.tools) == 1
+
+
+# ---------------------------------------------------------------------------
+# ask_specialist — functional tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAskSpecialist:
+    async def test_specialist_reply_returned(self) -> None:
+        """The orchestrator receives the specialist's reply as a string."""
+        specialist_config = _specialist_config("42 is the answer.")
+        orchestrator_config = TestConfig(
+            ToolCallEvent(
+                name="ask_specialist",
+                arguments='{"role":"You are a philosopher.","task":"What is the answer?"}',
+            ),
+            ModelResponse(ModelMessage("The specialist says: 42 is the answer.")),
+        )
+
+        toolkit = DynamicAgentToolkit(config=specialist_config)
+        orchestrator = Agent("orchestrator", config=orchestrator_config, tools=[toolkit])
+        reply = await orchestrator.ask("Delegate to specialist.")
+        text = await reply.content()
+        assert text is not None
+        assert "42" in text
+
+    async def test_custom_specialist_name(self) -> None:
+        """The name parameter is accepted without error."""
+        specialist_config = _specialist_config("analysis done")
+        orchestrator_config = TestConfig(
+            ToolCallEvent(
+                name="ask_specialist",
+                arguments='{"role":"analyst","task":"crunch numbers","name":"data-analyst"}',
+            ),
+            ModelResponse(ModelMessage("done")),
+        )
+
+        toolkit = DynamicAgentToolkit(config=specialist_config)
+        orchestrator = Agent("orchestrator", config=orchestrator_config, tools=[toolkit])
+        reply = await orchestrator.ask("Analyse.")
+        assert await reply.content() is not None
+
+    async def test_specialist_empty_reply_returns_empty_string(self) -> None:
+        """If the specialist returns None/empty content, an empty string is returned."""
+        specialist_config = TestConfig("")
+        orchestrator_config = TestConfig(
+            ToolCallEvent(
+                name="ask_specialist",
+                arguments='{"role":"silent","task":"say nothing"}',
+            ),
+            ModelResponse(ModelMessage("ok")),
+        )
+
+        toolkit = DynamicAgentToolkit(config=specialist_config)
+        orchestrator = Agent("orchestrator", config=orchestrator_config, tools=[toolkit])
+        reply = await orchestrator.ask("go")
+        assert await reply.content() is not None
+
+
+# ---------------------------------------------------------------------------
+# Shared tools propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSharedTools:
+    async def test_shared_tools_forwarded_to_specialist(self) -> None:
+        """Tools passed to DynamicAgentToolkit are available to the specialist."""
+        from autogen.beta.tools import tool as make_tool
+
+        calls: list[str] = []
+
+        @make_tool
+        def recorder(msg: str) -> str:
+            """Record a call."""
+            calls.append(msg)
+            return "recorded"
+
+        # Specialist calls recorder, then replies
+        specialist_config = TestConfig(
+            ToolCallEvent(name="recorder", arguments='{"msg":"hello from specialist"}'),
+            ModelResponse(ModelMessage("done")),
+        )
+        orchestrator_config = TestConfig(
+            ToolCallEvent(
+                name="ask_specialist",
+                arguments='{"role":"recorder agent","task":"record something"}',
+            ),
+            ModelResponse(ModelMessage("delegated")),
+        )
+
+        toolkit = DynamicAgentToolkit(config=specialist_config, tools=[recorder])
+        orchestrator = Agent("orchestrator", config=orchestrator_config, tools=[toolkit])
+        await orchestrator.ask("Go.")
+
+        assert "hello from specialist" in calls
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_importable_from_tools() -> None:
+    from autogen.beta.tools import DynamicAgentToolkit as D
+
+    assert D is DynamicAgentToolkit
+
+
+def test_all_export() -> None:
+    from autogen.beta.tools import toolkits
+
+    assert "DynamicAgentToolkit" in toolkits.__all__

--- a/website/docs/beta/advanced/background.mdx
+++ b/website/docs/beta/advanced/background.mdx
@@ -1,0 +1,100 @@
+---
+title: Background Agents
+sidebarTitle: Background Agents
+---
+
+`run_in_background` starts an agent call without blocking the caller.
+It returns a `BackgroundTask` immediately — you can do other async work,
+then `await` the task to collect the `AgentReply` when the agent finishes.
+
+## Basic usage
+
+```python linenums="1"
+import asyncio
+from autogen.beta import Agent, run_in_background
+from autogen.beta.config import OpenAIConfig
+
+async def main():
+    agent = Agent("analyst", config=OpenAIConfig("gpt-4o-mini"))
+
+    # Starts without blocking — returns immediately
+    task = run_in_background(agent, "Summarise the Q1 results.")
+
+    # Do other work concurrently
+    await asyncio.sleep(0)
+
+    # Collect the result when ready
+    reply = await task
+    print(await reply.content())
+
+asyncio.run(main())
+```
+
+## Running many agents concurrently
+
+Use `asyncio.gather` to start and collect multiple background tasks at once:
+
+```python linenums="1"
+import asyncio
+from autogen.beta import Agent, run_in_background
+from autogen.beta.config import OpenAIConfig
+
+async def main():
+    config = OpenAIConfig("gpt-4o-mini")
+    agents = [Agent(f"agent-{i}", config=config) for i in range(5)]
+
+    tasks = [run_in_background(a, "Analyse your slice of the data.") for a in agents]
+    replies = await asyncio.gather(*tasks)
+
+    for reply in replies:
+        print(await reply.content())
+
+asyncio.run(main())
+```
+
+!!! tip
+    For a simpler parallel fan-out pattern where all agents receive the **same**
+    message, see [`fanout`](/docs/beta/advanced/fanout).
+
+## Task control
+
+`BackgroundTask` exposes the same control surface as `asyncio.Task`:
+
+```python linenums="1"
+task = run_in_background(agent, "Long analysis…")
+
+# Check whether it has finished (non-blocking)
+if task.done():
+    reply = task.result()
+
+# Cancel mid-flight
+task.cancel()
+
+# Inspect an exception after the task finished with an error
+exc = task.exception()
+```
+
+| Method | Returns |
+|---|---|
+| `done()` | `True` once the agent finishes (or errors/cancels) |
+| `cancelled()` | `True` if the task was cancelled via `cancel()` |
+| `cancel(msg=None)` | Requests cancellation; returns `True` if the request was sent |
+| `result()` | The `AgentReply`, or raises if not done / cancelled / errored |
+| `exception()` | The exception raised, or `None` on success |
+
+## Error handling
+
+Exceptions raised inside `agent.ask` propagate when you `await` the task:
+
+```python linenums="1"
+task = run_in_background(agent, "Problematic prompt.")
+try:
+    reply = await task
+except Exception as exc:
+    print(f"Agent failed: {exc}")
+```
+
+## Requirements
+
+`run_in_background` must be called from an async context — it uses
+`asyncio.create_task` internally, which requires a running event loop.

--- a/website/docs/beta/advanced/deferred_toolkit.mdx
+++ b/website/docs/beta/advanced/deferred_toolkit.mdx
@@ -1,0 +1,93 @@
+---
+title: DeferredToolkit
+sidebarTitle: DeferredToolkit
+---
+
+When an agent has dozens of tools, every tool schema goes into every LLM call —
+consuming thousands of tokens even for tools the agent never uses.
+
+`DeferredToolkit` hides a large tool catalog behind exactly **two** meta-tools:
+
+| Tool | What the agent does |
+|---|---|
+| `search_tools(query)` | Keyword-search the catalog. Returns matching tool names, descriptions, and parameter schemas. |
+| `use_tool(name, arguments)` | Invoke any catalog tool by name. `arguments` is a JSON object string. |
+
+The agent discovers what it needs and pays no token cost for the rest.
+
+## Basic usage
+
+```python
+from autogen.beta import Agent
+from autogen.beta.tools import DeferredToolkit, FilesystemToolkit, MemoryToolkit
+from autogen.beta.config import OpenAIConfig
+
+# Wrap many tools in a DeferredToolkit
+deferred = DeferredToolkit(
+    *FilesystemToolkit().tools,   # 5 tools
+    *MemoryToolkit().tools,       # 4 tools
+    # ...more tools
+)
+
+# Agent only sees 2 tools: search_tools + use_tool
+agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"), tools=[deferred])
+
+reply = await agent.ask("Find Python files under /tmp and remember the count.")
+```
+
+The agent's flow:
+1. `search_tools("filesystem")` → gets `find_files` schema
+2. `use_tool("find_files", '{"pattern": "**/*.py", "path": "/tmp"}')` → gets list
+3. `search_tools("memory")` → gets `remember` schema
+4. `use_tool("remember", '{"content": "42 files", "key": "py-count"}')` → stored
+
+## Selective wrapping
+
+You can combine deferred and direct tools.  Give the agent its most-common tools
+directly and defer the long tail:
+
+```python
+from autogen.beta.tools import DeferredToolkit, FilesystemToolkit, MemoryToolkit, tool
+
+@tool
+def fetch_weather(city: str) -> str:
+    """Get current weather for a city."""
+    ...
+
+# fetch_weather is used often — register it directly for zero overhead
+# The 9 filesystem+memory tools are deferred
+agent = Agent(
+    "assistant",
+    config=OpenAIConfig("gpt-4o-mini"),
+    tools=[
+        fetch_weather,
+        DeferredToolkit(*FilesystemToolkit().tools, *MemoryToolkit().tools),
+    ],
+)
+```
+
+## Adding tools after construction
+
+```python
+deferred = DeferredToolkit(*core_tools)
+deferred.add_to_catalog(*extra_tools)  # add more later
+```
+
+## Inspecting the catalog
+
+```python
+deferred = DeferredToolkit(*my_tools)
+print(deferred.catalog_names)  # ('find_files', 'forget', 'list_memories', ...)
+```
+
+## Trade-offs
+
+| | Direct tools | DeferredToolkit |
+|---|---|---|
+| **Token cost** | All schemas, every call | Only 2 schemas |
+| **Agent flexibility** | Immediate access | Must discover first |
+| **Best for** | ≤10 tools | Large catalogs |
+
+For small tool sets, direct registration is simpler and has zero overhead.
+Use `DeferredToolkit` when your catalog grows large enough that the schema tokens
+become a meaningful cost.

--- a/website/docs/beta/advanced/dynamic_agents.mdx
+++ b/website/docs/beta/advanced/dynamic_agents.mdx
@@ -1,0 +1,95 @@
+---
+title: Dynamic Agents
+sidebarTitle: Dynamic Agents
+---
+
+`DynamicAgentToolkit` gives an orchestrating agent the ability to spawn specialist
+sub-agents on demand — at runtime, inside a single tool call.
+
+The orchestrator calls `ask_specialist`, describes the role it needs, hands off a
+task, and receives the specialist's reply as a string.  No specialist agents need to
+be pre-configured; they are created, used, and discarded by the toolkit.
+
+## Basic usage
+
+```python linenums="1"
+import asyncio
+from autogen.beta import Agent
+from autogen.beta.tools import DynamicAgentToolkit
+from autogen.beta.config import OpenAIConfig
+
+async def main():
+    config = OpenAIConfig("gpt-4o-mini")
+
+    coordinator = Agent(
+        "coordinator",
+        config=config,
+        prompt=(
+            "You are a coordinator. Break complex requests into focused subtasks "
+            "and delegate each one to a specialist using ask_specialist."
+        ),
+        tools=[DynamicAgentToolkit(config=config)],
+    )
+
+    reply = await coordinator.ask(
+        "Research and summarise the history of the internet, then write a short essay."
+    )
+    print(await reply.content())
+
+asyncio.run(main())
+```
+
+The coordinator will autonomously call `ask_specialist` to create a researcher agent,
+collect the research, then call it again to create a writer agent to draft the essay.
+
+## The ask_specialist tool
+
+| Parameter | Type | Description |
+|---|---|---|
+| `role` | `str` | System prompt that defines the specialist's persona and expertise |
+| `task` | `str` | The task or question to delegate |
+| `name` | `str` | Optional agent name for logging (default `"specialist"`) |
+
+Each call creates a fresh, independent agent.  The specialist's conversation is
+isolated — it does not share history with the orchestrator or other specialists.
+
+## Sharing tools with specialists
+
+Pass tools to `DynamicAgentToolkit` to equip every spawned specialist:
+
+```python linenums="1"
+from autogen.beta.tools import DynamicAgentToolkit, FilesystemToolkit
+
+fs = FilesystemToolkit()
+
+coordinator = Agent(
+    "coordinator",
+    config=config,
+    prompt="You coordinate file-aware specialists.",
+    tools=[DynamicAgentToolkit(config=config, tools=[fs])],
+)
+```
+
+Any specialist the coordinator spawns will have access to `FilesystemToolkit`'s tools.
+
+## Combining with DeferredToolkit
+
+Equip specialists with a deferred catalog so they can discover their own tools:
+
+```python linenums="1"
+from autogen.beta.tools import DeferredToolkit, DynamicAgentToolkit, FilesystemToolkit, MemoryToolkit
+
+catalog = DeferredToolkit(*FilesystemToolkit().tools, *MemoryToolkit().tools)
+toolkit = DynamicAgentToolkit(config=config, tools=[catalog])
+
+coordinator = Agent("coordinator", config=config, tools=[toolkit])
+```
+
+## When to use it
+
+| Pattern | Use |
+|---|---|
+| Orchestrator delegates to specialists described at runtime | `DynamicAgentToolkit` |
+| Fixed set of agents running in parallel | [`fanout`](/docs/beta/advanced/fanout) |
+| Orchestrator fires an agent call without blocking | [`run_in_background`](/docs/beta/advanced/background) |
+| Agent delegates to another agent with a known spec | `AgentSpec.to_agent()` + `agent.ask()` |

--- a/website/docs/beta/advanced/memory_toolkit.mdx
+++ b/website/docs/beta/advanced/memory_toolkit.mdx
@@ -1,0 +1,92 @@
+---
+title: MemoryToolkit
+sidebarTitle: MemoryToolkit
+---
+
+`MemoryToolkit` gives an agent four tools — `remember`, `recall`, `forget`, and
+`list_memories` — so it can autonomously store and retrieve information across a
+conversation or across sessions.
+
+## Basic usage
+
+```python
+from autogen.beta import Agent
+from autogen.beta.tools import MemoryToolkit
+from autogen.beta.config import OpenAIConfig
+
+memory = MemoryToolkit()
+agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"), tools=[memory])
+
+reply = await agent.ask("Remember that our primary database host is db.prod.example.com")
+```
+
+The agent will call `remember` autonomously.  On a later turn:
+
+```python
+reply = await agent.ask("What is the database host?")
+# The agent calls recall("database host") and uses the stored memory in its answer.
+```
+
+## Tools the agent gets
+
+| Tool | What it does |
+|---|---|
+| `remember(content, key?)` | Store a piece of information. An optional key names the memory; if omitted, a unique key is generated. |
+| `recall(query, max_results?)` | Keyword search across stored memories. Returns the best matches. |
+| `forget(key)` | Delete a memory by its key. |
+| `list_memories()` | List all stored memories, most recent first. |
+
+## Backends
+
+### Session-scoped (in-memory, default)
+
+```python
+memory = MemoryToolkit()
+```
+
+Memories live in-process.  They are fast but are discarded when the session ends.
+
+### Persistent (SQLite)
+
+```python
+memory = MemoryToolkit(storage_path="~/.my-agent/memories.db")
+```
+
+Memories survive process restarts.  The SQLite file is created automatically.
+Use `~` to expand to the user's home directory.
+
+## Picking individual tools
+
+Pass tools from the toolkit selectively if you only want some of them:
+
+```python
+fs = MemoryToolkit()
+agent = Agent(
+    "assistant",
+    config=OpenAIConfig("gpt-4o-mini"),
+    tools=[
+        fs._remember_tool(),
+        fs._recall_tool(),
+    ],
+)
+```
+
+## Example: persistent research assistant
+
+```python
+from autogen.beta import Agent
+from autogen.beta.tools import MemoryToolkit
+from autogen.beta.config import OpenAIConfig
+
+memory = MemoryToolkit(storage_path="~/.research-agent/memories.db")
+agent = Agent(
+    "researcher",
+    config=OpenAIConfig("gpt-4o"),
+    tools=[memory],
+    system_prompt=(
+        "You are a research assistant. When you learn something important, "
+        "use remember() to store it. Use recall() to find relevant facts "
+        "before answering questions."
+    ),
+)
+```

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -39,6 +39,7 @@ sidebarTitle: Beta Roadmap
 - A2A
 - Builtin Memory toolkit (`MemoryToolkit`)
 - Deferred tools — Tool Search Tool (`DeferredToolkit`)
+- Repository development skills (code, structure, documentation, tests)
 
 ## In Progress
 
@@ -55,7 +56,6 @@ sidebarTitle: Beta Roadmap
 
 - First-class Usage tracking
 - Scheduler support
-- Repository development skills (code, structure, documentation, tests)
 
 ### P2
 

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -37,6 +37,7 @@ sidebarTitle: Beta Roadmap
 - Multimodality output: images
 - Local Code execution tool
 - A2A
+- Builtin Memory toolkit (`MemoryToolkit`)
 
 ## In Progress
 
@@ -60,7 +61,7 @@ sidebarTitle: Beta Roadmap
 - A2UI Plugin
 - NLIP
 - Deferred tools (Tool Search Tool)
-- Builtin Memory toolkit
+- Builtin Memory toolkit (done — `MemoryToolkit` in PR #2853)
 
 ### P3
 

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -41,10 +41,10 @@ sidebarTitle: Beta Roadmap
 - Deferred tools — Tool Search Tool (`DeferredToolkit`)
 - Repository development skills (code, structure, documentation, tests)
 - Background agents (`BackgroundTask`, `run_in_background`)
+- Messages aggregation (`ConversationSummaryAggregate`, `WorkingMemoryAggregate`)
 
 ## In Progress
 
-- Messages aggregation
 - Dynamic agents
 - Prometheus metrics
 - Multi-Agent Network supports multimodality
@@ -61,8 +61,8 @@ sidebarTitle: Beta Roadmap
 
 - A2UI Plugin
 - NLIP
-- Deferred tools (Tool Search Tool) (done — `DeferredToolkit` in PR #2854)
-- Builtin Memory toolkit (done — `MemoryToolkit` in PR #2853)
+- Deferred tools (Tool Search Tool)
+- Builtin Memory toolkit
 
 ### P3
 

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -42,10 +42,9 @@ sidebarTitle: Beta Roadmap
 - Repository development skills (code, structure, documentation, tests)
 - Background agents (`BackgroundTask`, `run_in_background`)
 - Messages aggregation (`ConversationSummaryAggregate`, `WorkingMemoryAggregate`)
+- Dynamic agents (`DynamicAgentToolkit` — orchestrators that spawn specialist sub-agents at runtime)
 
 ## In Progress
-
-- Dynamic agents
 - Prometheus metrics
 - Multi-Agent Network supports multimodality
 - Multi-Agent Network supports streaming

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -40,13 +40,13 @@ sidebarTitle: Beta Roadmap
 - Builtin Memory toolkit (`MemoryToolkit`)
 - Deferred tools — Tool Search Tool (`DeferredToolkit`)
 - Repository development skills (code, structure, documentation, tests)
+- Background agents (`BackgroundTask`, `run_in_background`)
 
 ## In Progress
 
 - Messages aggregation
 - Dynamic agents
 - Prometheus metrics
-- Background agents
 - Multi-Agent Network supports multimodality
 - Multi-Agent Network supports streaming
 

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -38,6 +38,7 @@ sidebarTitle: Beta Roadmap
 - Local Code execution tool
 - A2A
 - Builtin Memory toolkit (`MemoryToolkit`)
+- Deferred tools — Tool Search Tool (`DeferredToolkit`)
 
 ## In Progress
 
@@ -60,7 +61,7 @@ sidebarTitle: Beta Roadmap
 
 - A2UI Plugin
 - NLIP
-- Deferred tools (Tool Search Tool)
+- Deferred tools (Tool Search Tool) (done — `DeferredToolkit` in PR #2854)
 - Builtin Memory toolkit (done — `MemoryToolkit` in PR #2853)
 
 ### P3

--- a/website/docs/beta/tools/common_toolkits.mdx
+++ b/website/docs/beta/tools/common_toolkits.mdx
@@ -169,6 +169,35 @@ Available tools:
 | `load_skill` | Fetch the full `SKILL.md` content for a specific skill |
 | `run_skill_script` | Execute a `.py` or `.sh` script from a skill's `scripts/` directory |
 
+### Bundled repository-development skills
+
+AG2 ships four skills that help agents work on Python repositories. They live in `skills/` at the repo root.
+
+| Skill | Description |
+| :--- | :--- |
+| `python-code` | AG2 Python coding conventions — type annotations, async patterns, `@tool` authoring |
+| `repo-structure` | Repository layout, where to add new code/tests/docs, PR workflow |
+| `docs-writer` | MDX format, admonitions, code blocks, docstring style, roadmap updates |
+| `test-scaffold` | pytest fixtures, async tests, `TrackingConfig` end-to-end verification |
+
+The `test-scaffold` skill also includes a `scripts/scaffold.py` utility that generates an empty test file from a module's public API:
+
+```bash
+python skills/test-scaffold/scripts/scaffold.py autogen.beta.tools.toolkits.memory
+```
+
+Load the bundled skills by pointing `LocalRuntime` at the `skills/` directory:
+
+```python linenums="1"
+from autogen.beta.tools import SkillsToolkit
+from autogen.beta.tools.skills import LocalRuntime
+
+# Load bundled AG2 development skills alongside user-installed skills
+skills = SkillsToolkit(
+    runtime=LocalRuntime("~/.agents/skills", extra_paths=["./skills"])
+)
+```
+
 ---
 
 ## SkillSearchToolkit

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -463,6 +463,7 @@
             "docs/beta/advanced/observers",
             "docs/beta/advanced/watches",
             "docs/beta/advanced/knowledge_store",
+            "docs/beta/advanced/memory_toolkit",
             "docs/beta/advanced/assembly",
             "docs/beta/advanced/compaction",
             "docs/beta/advanced/aggregation"

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -464,6 +464,7 @@
             "docs/beta/advanced/watches",
             "docs/beta/advanced/knowledge_store",
             "docs/beta/advanced/memory_toolkit",
+            "docs/beta/advanced/deferred_toolkit",
             "docs/beta/advanced/assembly",
             "docs/beta/advanced/compaction",
             "docs/beta/advanced/aggregation"

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -467,7 +467,8 @@
             "docs/beta/advanced/deferred_toolkit",
             "docs/beta/advanced/assembly",
             "docs/beta/advanced/compaction",
-            "docs/beta/advanced/aggregation"
+            "docs/beta/advanced/aggregation",
+            "docs/beta/advanced/background"
           ]
         },
         {

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -468,7 +468,8 @@
             "docs/beta/advanced/assembly",
             "docs/beta/advanced/compaction",
             "docs/beta/advanced/aggregation",
-            "docs/beta/advanced/background"
+            "docs/beta/advanced/background",
+            "docs/beta/advanced/dynamic_agents"
           ]
         },
         {


### PR DESCRIPTION
## Summary

- Adds `DynamicAgentToolkit` to `autogen.beta.tools`
- Single `ask_specialist` tool: orchestrator describes a role + task → ephemeral specialist `Agent` is created, asked, and its reply returned as a string
- Optional `tools` param equips every spawned specialist with shared tools (e.g. `FilesystemToolkit`, `DeferredToolkit`)
- Closes the "Dynamic agents" roadmap item: CaptainAgent-style orchestration now available as a standard toolkit

## Test plan

- [ ] `uv run pytest test/beta/tools/test_dynamic_agent_toolkit.py -q` — 9 tests pass
- [ ] `DynamicAgentToolkit` importable from `autogen.beta.tools`
- [ ] Orchestrator calls `ask_specialist` → specialist runs → reply returned
- [ ] `tools=[recorder]` forwarded to specialist and invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)