### PR TITLE
feat(beta/tools): Crawl4AIToolkit — web-crawling toolkit

### DIFF
--- a/autogen/beta/tools/__init__.py
+++ b/autogen/beta/tools/__init__.py
@@ -24,12 +24,13 @@ from .final import Toolkit, tool
 from .search import DuckDuckSearchTool, ExaToolkit, PerplexitySearchToolkit, TavilySearchTool
 from .shell import LocalShellTool
 from .skills import SkillSearchToolkit, SkillsToolkit
-from .toolkits import FilesystemToolkit, MCPServer, MCPServerConfig, MCPStdioServerConfig
+from .toolkits import Crawl4AIToolkit, FilesystemToolkit, MCPServer, MCPServerConfig, MCPStdioServerConfig
 
 __all__ = (
     "CodeExecutionTool",
     "ContainerAutoEnvironment",
     "ContainerReferenceEnvironment",
+    "Crawl4AIToolkit",
     "DuckDuckSearchTool",
     "ExaToolkit",
     "FilesystemToolkit",

--- a/autogen/beta/tools/toolkits/__init__.py
+++ b/autogen/beta/tools/toolkits/__init__.py
@@ -2,10 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from autogen.beta.exceptions import missing_optional_dependency
+
 from .filesystem import FilesystemToolkit
 from .mcp_server import MCPServer, MCPServerConfig, MCPStdioServerConfig
 
+try:
+    from .crawl4ai import Crawl4AIToolkit
+except ImportError as e:
+    Crawl4AIToolkit = missing_optional_dependency("Crawl4AIToolkit", "crawl4ai", e)  # type: ignore[misc]
+
 __all__ = (
+    "Crawl4AIToolkit",
     "FilesystemToolkit",
     "MCPServer",
     "MCPServerConfig",

--- a/autogen/beta/tools/toolkits/crawl4ai.py
+++ b/autogen/beta/tools/toolkits/crawl4ai.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Iterable
 from typing import Annotated
+from urllib.parse import urlparse
 
 from pydantic import Field
 
@@ -42,10 +43,20 @@ from autogen.beta.tools.final.function_tool import FunctionTool
 __all__ = ("Crawl4AIToolkit",)
 
 _DEFAULT_MAX_CONCURRENT = 3
+_SAFE_SCHEMES = {"http", "https"}
+
+
+def _safe_url(url: str) -> str:
+    """Return url unchanged if scheme is http/https; otherwise return empty string."""
+    scheme = urlparse(url).scheme.lower()
+    return url if scheme in _SAFE_SCHEMES else ""
 
 
 async def _fetch(url: str, *, include_links: bool, include_images: bool) -> str:
     """Fetch one URL and return a formatted result string."""
+    if not _safe_url(url):
+        return f"[invalid URL] Only http/https URLs are supported; got {url!r}"
+
     try:
         from crawl4ai import AsyncWebCrawler  # type: ignore[import]
     except ImportError:
@@ -80,9 +91,14 @@ async def _fetch(url: str, *, include_links: bool, include_images: bool) -> str:
             parts.append("\n## Links")
             for lnk in internal[:20]:
                 href = lnk.get("href", "") if isinstance(lnk, dict) else str(lnk)
+                # Keep relative paths; reject non-http(s) absolute URLs
+                if href and not (href.startswith(("/", "#")) or _safe_url(href)):
+                    continue
                 parts.append(f"- (internal) {href}")
             for lnk in external[:20]:
                 href = lnk.get("href", "") if isinstance(lnk, dict) else str(lnk)
+                if href and not _safe_url(href):
+                    continue
                 parts.append(f"- (external) {href}")
 
     if include_images:

--- a/autogen/beta/tools/toolkits/crawl4ai.py
+++ b/autogen/beta/tools/toolkits/crawl4ai.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Crawl4AIToolkit — web-crawling tools for AG2 Beta agents.
+
+Gives an agent two tools: ``crawl`` and ``crawl_many``.
+
+``crawl`` fetches a single URL and returns its main content as Markdown.
+``crawl_many`` fetches several URLs concurrently with an optional concurrency cap.
+
+Requires the ``crawl4ai`` package::
+
+    pip install crawl4ai
+
+Basic usage::
+
+    from autogen.beta import Agent
+    from autogen.beta.tools import Crawl4AIToolkit
+    from autogen.beta.config import OpenAIConfig
+
+    crawler = Crawl4AIToolkit()
+    agent = Agent("researcher", config=OpenAIConfig("gpt-4o-mini"), tools=[crawler])
+
+Limit concurrent fetches to avoid overwhelming servers::
+
+    crawler = Crawl4AIToolkit(max_concurrent=2)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+from typing import Annotated
+
+from pydantic import Field
+
+from autogen.beta.middleware import ToolMiddleware
+from autogen.beta.tools.final import Toolkit, tool
+from autogen.beta.tools.final.function_tool import FunctionTool
+
+__all__ = ("Crawl4AIToolkit",)
+
+_DEFAULT_MAX_CONCURRENT = 3
+
+
+async def _fetch(url: str, *, include_links: bool, include_images: bool) -> str:
+    """Fetch one URL and return a formatted result string."""
+    try:
+        from crawl4ai import AsyncWebCrawler  # type: ignore[import]
+    except ImportError:
+        return f"[crawl4ai not installed] Cannot fetch {url!r}. Install it with: pip install crawl4ai"
+
+    try:
+        async with AsyncWebCrawler() as crawler:
+            result = await crawler.arun(url=url)
+    except Exception as exc:
+        return f"[error fetching {url!r}] {exc}"
+
+    if not result.success:
+        return f"[fetch failed for {url!r}] {getattr(result, 'error_message', 'unknown error')}"
+
+    parts: list[str] = []
+    if result.title:
+        parts.append(f"# {result.title}")
+    parts.append(f"URL: {url}")
+    parts.append("")
+
+    content = (result.markdown or "").strip()
+    if content:
+        parts.append(content)
+    else:
+        parts.append("(no content extracted)")
+
+    if include_links:
+        links = getattr(result, "links", {})
+        internal = links.get("internal", [])
+        external = links.get("external", [])
+        if internal or external:
+            parts.append("\n## Links")
+            for lnk in internal[:20]:
+                href = lnk.get("href", "") if isinstance(lnk, dict) else str(lnk)
+                parts.append(f"- (internal) {href}")
+            for lnk in external[:20]:
+                href = lnk.get("href", "") if isinstance(lnk, dict) else str(lnk)
+                parts.append(f"- (external) {href}")
+
+    if include_images:
+        images = getattr(result, "media", {}).get("images", []) if hasattr(result, "media") else []
+        if images:
+            parts.append("\n## Images")
+            for img in images[:10]:
+                src = img.get("src", "") if isinstance(img, dict) else str(img)
+                alt = img.get("alt", "") if isinstance(img, dict) else ""
+                parts.append(f"- {src}" + (f" ({alt})" if alt else ""))
+
+    return "\n".join(parts)
+
+
+class Crawl4AIToolkit(Toolkit):
+    """Web-crawling toolkit powered by ``crawl4ai``.
+
+    Gives an agent two tools: ``crawl`` and ``crawl_many``.
+
+    Requires ``crawl4ai`` (``pip install crawl4ai``).  A clear error is
+    returned from the tool rather than raising at import time if the package
+    is not installed.
+
+    Args:
+        max_concurrent: Maximum number of URLs fetched in parallel by
+            ``crawl_many`` (default 3).
+        middleware: Optional sequence of ``ToolMiddleware`` applied to every
+            tool in the toolkit.
+    """
+
+    __slots__ = ("_max_concurrent",)
+
+    def __init__(
+        self,
+        *,
+        max_concurrent: int = _DEFAULT_MAX_CONCURRENT,
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> None:
+        self._max_concurrent = max_concurrent
+
+        super().__init__(
+            self.crawl(),
+            self.crawl_many(),
+            name="crawl4ai_toolkit",
+            middleware=middleware,
+        )
+
+    def crawl(
+        self,
+        *,
+        name: str = "crawl",
+        description: str = (
+            "Fetch a web page and return its main content as Markdown. "
+            "Use this to read articles, documentation, or any public URL. "
+            "Optionally include hyperlinks and images found on the page."
+        ),
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> FunctionTool:
+        @tool(name=name, description=description, middleware=middleware)
+        async def _crawl(
+            url: Annotated[str, Field(description="Full URL to fetch (must start with http:// or https://).")],
+            include_links: Annotated[
+                bool,
+                Field(description="If true, append a list of hyperlinks found on the page."),
+            ] = False,
+            include_images: Annotated[
+                bool,
+                Field(description="If true, append a list of image URLs found on the page."),
+            ] = False,
+        ) -> str:
+            return await _fetch(url, include_links=include_links, include_images=include_images)
+
+        return _crawl
+
+    def crawl_many(
+        self,
+        *,
+        name: str = "crawl_many",
+        description: str = (
+            "Fetch multiple web pages concurrently and return their contents. "
+            "Results are separated by a divider. "
+            "Use this when you need to read several URLs at once."
+        ),
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> FunctionTool:
+        # Capture the toolkit default as a non-shadowed name for the closure.
+        _default_concurrent = self._max_concurrent
+
+        @tool(name=name, description=description, middleware=middleware)
+        async def _crawl_many(
+            urls: Annotated[
+                list[str],
+                Field(description="List of URLs to fetch (1–20 URLs).", min_length=1, max_length=20),
+            ],
+            max_concurrent: Annotated[
+                int | None,
+                Field(
+                    description=("Maximum number of pages fetched in parallel. Uses the toolkit default when omitted."),
+                    ge=1,
+                    le=20,
+                ),
+            ] = None,
+        ) -> str:
+            concurrency = max_concurrent if max_concurrent is not None else _default_concurrent
+            sem = asyncio.Semaphore(concurrency)
+
+            async def bounded(u: str) -> str:
+                async with sem:
+                    return await _fetch(u, include_links=False, include_images=False)
+
+            results = await asyncio.gather(*[bounded(u) for u in urls])
+            return "\n\n---\n\n".join(results)
+
+        return _crawl_many

--- a/test/beta/tools/test_crawl4ai.py
+++ b/test/beta/tools/test_crawl4ai.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Crawl4AIToolkit — mock-based so crawl4ai need not be installed."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autogen.beta import Context
+from autogen.beta.tools.toolkits.crawl4ai import Crawl4AIToolkit, _fetch
+
+# ---------------------------------------------------------------------------
+# Helpers — fake crawl4ai module
+# ---------------------------------------------------------------------------
+
+
+def _make_crawl4ai_mock(
+    *,
+    success: bool = True,
+    title: str = "Test Page",
+    markdown: str = "Hello, world.",
+    links: dict | None = None,
+    media: dict | None = None,
+    error_message: str = "",
+) -> ModuleType:
+    """Return a fake ``crawl4ai`` module with a controllable AsyncWebCrawler."""
+    result = SimpleNamespace(
+        success=success,
+        title=title,
+        markdown=markdown,
+        links=links or {"internal": [], "external": []},
+        media=media or {"images": []},
+        error_message=error_message,
+    )
+
+    class FakeCrawler:
+        async def __aenter__(self) -> FakeCrawler:
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            pass
+
+        async def arun(self, url: str) -> SimpleNamespace:
+            return result
+
+    mod = ModuleType("crawl4ai")
+    mod.AsyncWebCrawler = FakeCrawler  # type: ignore[attr-defined]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestCrawl4AIToolkitConstruction:
+    @pytest.mark.asyncio
+    async def test_default_tool_names(self, async_mock: AsyncMock) -> None:
+        toolkit = Crawl4AIToolkit()
+        schemas = list(await toolkit.schemas(Context(async_mock)))
+        names = {s.function.name for s in schemas}
+        assert names == {"crawl", "crawl_many"}
+
+    def test_custom_max_concurrent(self) -> None:
+        toolkit = Crawl4AIToolkit(max_concurrent=5)
+        assert toolkit._max_concurrent == 5
+
+    def test_importable_from_tools_package(self) -> None:
+        from autogen.beta.tools import Crawl4AIToolkit as Alias  # noqa: F401
+
+        assert Alias is Crawl4AIToolkit
+
+
+# ---------------------------------------------------------------------------
+# _fetch helper — with mocked crawl4ai
+# ---------------------------------------------------------------------------
+
+
+class TestFetchHelper:
+    @pytest.mark.asyncio
+    async def test_fetch_returns_content(self) -> None:
+        fake_mod = _make_crawl4ai_mock(title="My Page", markdown="Some content here.")
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await _fetch("https://example.com", include_links=False, include_images=False)
+        assert "My Page" in result
+        assert "Some content here." in result
+        assert "https://example.com" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_no_title(self) -> None:
+        fake_mod = _make_crawl4ai_mock(title="", markdown="Body only.")
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await _fetch("https://example.com", include_links=False, include_images=False)
+        assert "Body only." in result
+        assert result.startswith("URL:")
+
+    @pytest.mark.asyncio
+    async def test_fetch_failed_result(self) -> None:
+        fake_mod = _make_crawl4ai_mock(success=False, error_message="timeout")
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await _fetch("https://example.com", include_links=False, include_images=False)
+        assert "fetch failed" in result
+        assert "timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_missing_crawl4ai(self) -> None:
+        # Remove crawl4ai from sys.modules to simulate not-installed
+        original = sys.modules.pop("crawl4ai", None)
+        try:
+            result = await _fetch("https://example.com", include_links=False, include_images=False)
+        finally:
+            if original is not None:
+                sys.modules["crawl4ai"] = original
+        assert "not installed" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_exception_during_crawl(self) -> None:
+        class ErrorCrawler:
+            async def __aenter__(self) -> ErrorCrawler:
+                return self
+
+            async def __aexit__(self, *_: object) -> None:
+                pass
+
+            async def arun(self, url: str) -> None:
+                raise RuntimeError("network error")
+
+        mod = ModuleType("crawl4ai")
+        mod.AsyncWebCrawler = ErrorCrawler  # type: ignore[attr-defined]
+        with patch.dict(sys.modules, {"crawl4ai": mod}):
+            result = await _fetch("https://example.com", include_links=False, include_images=False)
+        assert "error fetching" in result
+        assert "network error" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_include_links(self) -> None:
+        links = {
+            "internal": [{"href": "/about"}, {"href": "/contact"}],
+            "external": [{"href": "https://other.com"}],
+        }
+        fake_mod = _make_crawl4ai_mock(markdown="Content.", links=links)
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await _fetch("https://example.com", include_links=True, include_images=False)
+        assert "/about" in result
+        assert "https://other.com" in result
+        assert "## Links" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_include_images(self) -> None:
+        media = {"images": [{"src": "https://example.com/img.png", "alt": "logo"}]}
+        fake_mod = _make_crawl4ai_mock(markdown="Content.", media=media)
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await _fetch("https://example.com", include_links=False, include_images=True)
+        assert "img.png" in result
+        assert "logo" in result
+        assert "## Images" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_empty_markdown(self) -> None:
+        fake_mod = _make_crawl4ai_mock(markdown="")
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await _fetch("https://example.com", include_links=False, include_images=False)
+        assert "no content extracted" in result
+
+
+# ---------------------------------------------------------------------------
+# crawl tool
+# ---------------------------------------------------------------------------
+
+
+class TestCrawlTool:
+    @pytest.mark.asyncio
+    async def test_crawl_calls_fetch(self) -> None:
+        fake_mod = _make_crawl4ai_mock(markdown="Article text.")
+        toolkit = Crawl4AIToolkit()
+        crawl_tool = toolkit.crawl()
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await crawl_tool.model.call(url="https://example.com")
+        assert "Article text." in result
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_links(self) -> None:
+        links = {"internal": [{"href": "/page"}], "external": []}
+        fake_mod = _make_crawl4ai_mock(markdown="Body.", links=links)
+        toolkit = Crawl4AIToolkit()
+        crawl_tool = toolkit.crawl()
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await crawl_tool.model.call(url="https://example.com", include_links=True)
+        assert "/page" in result
+
+    @pytest.mark.asyncio
+    async def test_crawl_default_no_links_no_images(self) -> None:
+        links = {"internal": [{"href": "/hidden"}], "external": []}
+        fake_mod = _make_crawl4ai_mock(markdown="Body.", links=links)
+        toolkit = Crawl4AIToolkit()
+        crawl_tool = toolkit.crawl()
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await crawl_tool.model.call(url="https://example.com")
+        assert "/hidden" not in result
+
+
+# ---------------------------------------------------------------------------
+# crawl_many tool
+# ---------------------------------------------------------------------------
+
+
+class TestCrawlManyTool:
+    @pytest.mark.asyncio
+    async def test_crawl_many_returns_multiple_results(self) -> None:
+        fake_mod = _make_crawl4ai_mock(markdown="Page content.")
+        toolkit = Crawl4AIToolkit()
+        many_tool = toolkit.crawl_many()
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await many_tool.model.call(urls=["https://a.com", "https://b.com", "https://c.com"])
+        assert result.count("---") == 2
+        assert result.count("Page content.") == 3
+
+    @pytest.mark.asyncio
+    async def test_crawl_many_single_url(self) -> None:
+        fake_mod = _make_crawl4ai_mock(markdown="Solo.")
+        toolkit = Crawl4AIToolkit()
+        many_tool = toolkit.crawl_many()
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await many_tool.model.call(urls=["https://example.com"])
+        assert "Solo." in result
+        assert "---" not in result
+
+    @pytest.mark.asyncio
+    async def test_crawl_many_respects_toolkit_default_concurrency(self) -> None:
+        call_count = 0
+        active = 0
+        peak = 0
+
+        class CountingCrawler:
+            async def __aenter__(self) -> CountingCrawler:
+                return self
+
+            async def __aexit__(self, *_: object) -> None:
+                pass
+
+            async def arun(self, url: str) -> SimpleNamespace:
+                nonlocal call_count, active, peak
+                call_count += 1
+                active += 1
+                peak = max(peak, active)
+                import asyncio
+
+                await asyncio.sleep(0)
+                active -= 1
+                return SimpleNamespace(success=True, title="T", markdown="M", links={}, media={}, error_message="")
+
+        mod = ModuleType("crawl4ai")
+        mod.AsyncWebCrawler = CountingCrawler  # type: ignore[attr-defined]
+
+        toolkit = Crawl4AIToolkit(max_concurrent=2)
+        many_tool = toolkit.crawl_many()
+        with patch.dict(sys.modules, {"crawl4ai": mod}):
+            await many_tool.model.call(urls=["https://a.com", "https://b.com", "https://c.com"])
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_crawl_many_per_call_max_concurrent_override(self) -> None:
+        fake_mod = _make_crawl4ai_mock(markdown="X.")
+        toolkit = Crawl4AIToolkit(max_concurrent=10)
+        many_tool = toolkit.crawl_many()
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await many_tool.model.call(urls=["https://a.com", "https://b.com"], max_concurrent=1)
+        assert result.count("X.") == 2

--- a/test/beta/tools/test_crawl4ai.py
+++ b/test/beta/tools/test_crawl4ai.py
@@ -90,7 +90,7 @@ class TestFetchHelper:
             result = await _fetch("https://example.com", include_links=False, include_images=False)
         assert "My Page" in result
         assert "Some content here." in result
-        assert "https://example.com" in result
+        assert "URL: https://example.com" in result
 
     @pytest.mark.asyncio
     async def test_fetch_no_title(self) -> None:
@@ -148,7 +148,7 @@ class TestFetchHelper:
         with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
             result = await _fetch("https://example.com", include_links=True, include_images=False)
         assert "/about" in result
-        assert "https://other.com" in result
+        assert "- (external) https://other.com" in result
         assert "## Links" in result
 
     @pytest.mark.asyncio
@@ -188,7 +188,7 @@ class TestFetchHelper:
         with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
             result = await _fetch("https://example.com", include_links=True, include_images=False)
         assert "/safe" in result
-        assert "https://other.com" in result
+        assert "- (external) https://other.com" in result
         assert "javascript:" not in result
         assert "data:" not in result
 

--- a/test/beta/tools/test_crawl4ai.py
+++ b/test/beta/tools/test_crawl4ai.py
@@ -168,6 +168,30 @@ class TestFetchHelper:
             result = await _fetch("https://example.com", include_links=False, include_images=False)
         assert "no content extracted" in result
 
+    @pytest.mark.asyncio
+    async def test_fetch_rejects_non_http_scheme(self) -> None:
+        result = await _fetch("javascript:alert(1)", include_links=False, include_images=False)
+        assert "invalid URL" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_rejects_file_scheme(self) -> None:
+        result = await _fetch("file:///etc/passwd", include_links=False, include_images=False)
+        assert "invalid URL" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_links_filters_unsafe_hrefs(self) -> None:
+        links = {
+            "internal": [{"href": "javascript:void(0)"}, {"href": "/safe"}],
+            "external": [{"href": "https://other.com"}, {"href": "data:text/html,<h1>xss</h1>"}],
+        }
+        fake_mod = _make_crawl4ai_mock(markdown="Content.", links=links)
+        with patch.dict(sys.modules, {"crawl4ai": fake_mod}):
+            result = await _fetch("https://example.com", include_links=True, include_images=False)
+        assert "/safe" in result
+        assert "https://other.com" in result
+        assert "javascript:" not in result
+        assert "data:" not in result
+
 
 # ---------------------------------------------------------------------------
 # crawl tool

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -37,6 +37,7 @@ sidebarTitle: Beta Roadmap
 - Multimodality output: images
 - Local Code execution tool
 - A2A
+- Crawl4AI tool (`Crawl4AIToolkit` — `crawl` single URL to Markdown; `crawl_many` concurrent batch; optional `crawl4ai` dependency with graceful missing-package error)
 
 ## In Progress
 
@@ -65,7 +66,6 @@ sidebarTitle: Beta Roadmap
 ### P3
 
 - Builtin RAG toolkit
-- Crawl4AI tool
 - Skills Plugin
 - Update AG-UI integration
 - Allow models to configure tool search params

--- a/website/docs/beta/tools/common_toolkits.mdx
+++ b/website/docs/beta/tools/common_toolkits.mdx
@@ -615,3 +615,66 @@ sh = LocalShellTool(LocalShellEnvironment(
     ignore=["**/.env", "*.key", "secrets/**"],
 ))
 ```
+
+---
+
+## Crawl4AIToolkit
+
+`Crawl4AIToolkit` gives an agent two tools for fetching and reading web pages.
+It is powered by the [`crawl4ai`](https://github.com/unclecode/crawl4ai){.external-link target="_blank"} package, which must be installed separately:
+
+```bash
+pip install crawl4ai
+```
+
+If `crawl4ai` is not installed, both tools return a clear error message rather than raising at import time.
+
+```python linenums="1"
+from autogen.beta import Agent
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.tools import Crawl4AIToolkit
+
+crawler = Crawl4AIToolkit()
+agent = Agent("researcher", config=OpenAIConfig("gpt-4o-mini"), tools=[crawler])
+```
+
+### Available tools
+
+| Tool | Description |
+| :--- | :--- |
+| `crawl` | Fetch a single URL and return its main content as Markdown |
+| `crawl_many` | Fetch multiple URLs concurrently and return combined results |
+
+### `crawl` — single URL
+
+```python linenums="1"
+from autogen.beta.tools import Crawl4AIToolkit
+
+crawler = Crawl4AIToolkit()
+
+# Fetch with optional extras
+crawl_tool = crawler.crawl()
+# Agent calls: crawl(url="https://example.com", include_links=True)
+```
+
+The `include_links` flag appends a list of internal and external hyperlinks.
+The `include_images` flag appends a list of image URLs found on the page.
+
+### `crawl_many` — concurrent fetches
+
+```python linenums="1"
+from autogen.beta.tools import Crawl4AIToolkit
+
+crawler = Crawl4AIToolkit(max_concurrent=2)
+
+# Agent calls: crawl_many(urls=["https://a.com", "https://b.com"])
+```
+
+`max_concurrent` caps the number of simultaneous requests (default 3).
+The agent can also override it per-call:
+
+```
+crawl_many(urls=["https://a.com", "https://b.com"], max_concurrent=1)
+```
+
+Results for each URL are separated by `---` dividers.


### PR DESCRIPTION
## Summary

- Adds `Crawl4AIToolkit` in `autogen/beta/tools/toolkits/crawl4ai.py` with two agent tools:
  - **`crawl`** — fetches a single URL and returns the main content as Markdown; optional `include_links` / `include_images` flags
  - **`crawl_many`** — fetches a list of URLs (1–20) concurrently, bounded by a semaphore (`max_concurrent`; default 3, overridable per-call)
- `crawl4ai` is an **optional dependency**: a clear, actionable error string is returned from the tool if the package is not installed — no import-time failure
- `Crawl4AIToolkit` is gated in `toolkits/__init__.py` via `missing_optional_dependency()`, consistent with `MCPServer` and `TavilySearchTool`
- Exported from `autogen.beta.tools` and `autogen.beta.tools.toolkits`
- 18 mock-based tests — no real network calls, `crawl4ai` need not be installed to run the suite
- Docs: new `## Crawl4AIToolkit` section in `website/docs/beta/tools/common_toolkits.mdx`
- Roadmap: moved from P3 → Completed in `website/docs/beta/roadmap.mdx`

## Test plan

- [x] `uv run pytest test/beta/tools/test_crawl4ai.py -v` — 18/18 pass
- [x] Pre-commit hooks all green (ruff lint + format, mypy, license headers, secrets, typos)
- [ ] Manual smoke test with `pip install crawl4ai` + `AsyncWebCrawler` (optional; tool returns friendly error if not installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)