### PR TITLE
feat(beta/ag_ui): forward ModelReasoning to AG-UI Thinking events

### DIFF
--- a/autogen/beta/ag_ui/stream.py
+++ b/autogen/beta/ag_ui/stream.py
@@ -22,6 +22,11 @@ from ag_ui.core import (
     TextMessageContentEvent,
     TextMessageEndEvent,
     TextMessageStartEvent,
+    ThinkingEndEvent,
+    ThinkingStartEvent,
+    ThinkingTextMessageContentEvent,
+    ThinkingTextMessageEndEvent,
+    ThinkingTextMessageStartEvent,
     ToolCallArgsEvent,
     ToolCallChunkEvent,
     ToolCallEndEvent,
@@ -146,7 +151,31 @@ async def run_stream(
     async def map_events_to_ag_ui(event: events.BaseEvent) -> None:
         nonlocal streaming_msg_id
 
-        if isinstance(event, events.ModelMessageChunk):
+        if isinstance(event, events.ModelReasoning):
+            thinking_id = str(uuid4())
+            await write_events_stream.send(ThinkingStartEvent(timestamp=_get_timestamp()))
+            await write_events_stream.send(
+                ThinkingTextMessageStartEvent(
+                    message_id=thinking_id,
+                    timestamp=_get_timestamp(),
+                )
+            )
+            await write_events_stream.send(
+                ThinkingTextMessageContentEvent(
+                    message_id=thinking_id,
+                    delta=event.content,
+                    timestamp=_get_timestamp(),
+                )
+            )
+            await write_events_stream.send(
+                ThinkingTextMessageEndEvent(
+                    message_id=thinking_id,
+                    timestamp=_get_timestamp(),
+                )
+            )
+            await write_events_stream.send(ThinkingEndEvent(timestamp=_get_timestamp()))
+
+        elif isinstance(event, events.ModelMessageChunk):
             if not event.content:
                 return
 

--- a/autogen/beta/testing.py
+++ b/autogen/beta/testing.py
@@ -10,7 +10,15 @@ from typing_extensions import Self
 
 from autogen.beta import Context
 from autogen.beta.config import LLMClient, ModelConfig
-from autogen.beta.events import BaseEvent, ModelMessage, ModelResponse, ToolCallEvent, ToolCallsEvent, ToolErrorEvent
+from autogen.beta.events import (
+    BaseEvent,
+    ModelMessage,
+    ModelReasoning,
+    ModelResponse,
+    ToolCallEvent,
+    ToolCallsEvent,
+    ToolErrorEvent,
+)
 
 __all__ = (
     "TestConfig",
@@ -21,7 +29,7 @@ __all__ = (
 class TestClient(LLMClient):
     __test__ = False
 
-    def __init__(self, *events: ModelResponse | ToolCallEvent | Iterable[ToolCallEvent] | str) -> None:
+    def __init__(self, *events: ModelResponse | ToolCallEvent | Iterable[ToolCallEvent] | ModelReasoning | str) -> None:
         self.events = iter(events)
 
     async def __call__(
@@ -35,6 +43,11 @@ class TestClient(LLMClient):
                 raise m.error
 
         next_msg = next(self.events)
+
+        # Emit any pre-response reasoning events before the actual model response.
+        if isinstance(next_msg, ModelReasoning):
+            await context.send(next_msg)
+            next_msg = next(self.events)
 
         if isinstance(next_msg, str):
             message = ModelMessage(next_msg)
@@ -83,7 +96,7 @@ class TrackingConfig(ModelConfig):
 class TestConfig(ModelConfig):
     __test__ = False
 
-    def __init__(self, *events: ModelResponse | ToolCallEvent | Iterable[ToolCallEvent] | str) -> None:
+    def __init__(self, *events: ModelResponse | ToolCallEvent | Iterable[ToolCallEvent] | ModelReasoning | str) -> None:
         self.events = events
 
     def copy(self) -> Self:

--- a/test/beta/ag_ui/test_reasoning.py
+++ b/test/beta/ag_ui/test_reasoning.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ModelReasoning → AG-UI Thinking event forwarding."""
+
+import pytest
+from ag_ui.core import UserMessage
+from dirty_equals import IsStr
+
+from autogen.beta import Agent
+from autogen.beta.ag_ui import AGUIStream
+from autogen.beta.events import ModelReasoning
+from autogen.beta.testing import TestConfig
+
+from .utils import assert_event_type, assert_no_event_type, collect_events, create_run_input
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestReasoningForwarding:
+    async def test_reasoning_emits_thinking_events(self) -> None:
+        """ModelReasoning before a reply produces the full Thinking event sequence."""
+        agent = Agent(
+            "test_agent",
+            config=TestConfig(
+                ModelReasoning("Let me think about this carefully."),
+                "The answer is 42.",
+            ),
+        )
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="msg_1", content="What is the answer?"))
+
+        events = await collect_events(stream, run_input)
+
+        assert_event_type(events, "THINKING_START")
+        start = assert_event_type(events, "THINKING_TEXT_MESSAGE_START")
+        assert "message_id" in start
+
+        content = assert_event_type(events, "THINKING_TEXT_MESSAGE_CONTENT")
+        assert content["delta"] == "Let me think about this carefully."
+        assert content["message_id"] == start["message_id"]
+
+        end = assert_event_type(events, "THINKING_TEXT_MESSAGE_END")
+        assert end["message_id"] == start["message_id"]
+
+        assert_event_type(events, "THINKING_END")
+
+    async def test_reasoning_followed_by_reply(self) -> None:
+        """Both the thinking block and the reply are forwarded."""
+        agent = Agent(
+            "test_agent",
+            config=TestConfig(
+                ModelReasoning("Thinking..."),
+                "My reply.",
+            ),
+        )
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="msg_1", content="Hello"))
+
+        events = await collect_events(stream, run_input)
+
+        assert_event_type(events, "THINKING_START")
+        assert_event_type(events, "TEXT_MESSAGE_CHUNK")
+
+    async def test_no_reasoning_emits_no_thinking_events(self) -> None:
+        """When the model does not reason, no Thinking events are emitted."""
+        agent = Agent("test_agent", config=TestConfig("Just a reply."))
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="msg_1", content="Hello"))
+
+        events = await collect_events(stream, run_input)
+
+        assert_no_event_type(events, "THINKING_START")
+        assert_no_event_type(events, "THINKING_TEXT_MESSAGE_START")
+        assert_no_event_type(events, "THINKING_TEXT_MESSAGE_CONTENT")
+        assert_no_event_type(events, "THINKING_END")
+
+    async def test_thinking_events_precede_reply(self) -> None:
+        """Thinking events appear before the reply in the event stream."""
+        agent = Agent(
+            "test_agent",
+            config=TestConfig(
+                ModelReasoning("Reasoning first."),
+                "Then replying.",
+            ),
+        )
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="msg_1", content="Go"))
+
+        events = await collect_events(stream, run_input)
+        types = [e["type"] for e in events]
+
+        thinking_start = types.index("THINKING_START")
+        # TEXT_MESSAGE_CHUNK or TEXT_MESSAGE_START should come after thinking
+        text_idx = next(
+            (i for i, t in enumerate(types) if t in ("TEXT_MESSAGE_CHUNK", "TEXT_MESSAGE_START")),
+            len(types),
+        )
+        assert thinking_start < text_idx
+
+    async def test_thinking_message_ids_are_consistent(self) -> None:
+        """Start/content/end events all share the same message_id."""
+        agent = Agent(
+            "test_agent",
+            config=TestConfig(
+                ModelReasoning("My reasoning."),
+                "Done.",
+            ),
+        )
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="msg_1", content="Hi"))
+
+        events = await collect_events(stream, run_input)
+
+        start = assert_event_type(events, "THINKING_TEXT_MESSAGE_START")
+        content = assert_event_type(events, "THINKING_TEXT_MESSAGE_CONTENT")
+        end = assert_event_type(events, "THINKING_TEXT_MESSAGE_END")
+
+        assert start["message_id"] == content["message_id"] == end["message_id"]
+        assert start["message_id"] == IsStr()

--- a/website/docs/beta/ag-ui/index.mdx
+++ b/website/docs/beta/ag-ui/index.mdx
@@ -36,6 +36,7 @@ Verified AG-UI features are supported in AG2:
 * [x] [Frontend-tool dispatch](https://docs.copilotkit.ai/ag2/generative-ui/frontend-tools){.external-link target="_blank"} (`TOOL_CALL_CHUNK` for client tools in `RunAgentInput.tools`)
 * [x] [Shared-state snapshots](https://docs.copilotkit.ai/ag2/shared-state){.external-link target="_blank"} (`STATE_SNAPSHOT`) from context and agent state
 * [x] [Human input checkpoints](https://docs.copilotkit.ai/ag2/human-in-the-loop){.external-link target="_blank"} (`input_required` surfaced as user-visible message events)
+* [x] Model reasoning / thinking events (`THINKING_START`, `THINKING_TEXT_MESSAGE_START`, `THINKING_TEXT_MESSAGE_CONTENT`, `THINKING_TEXT_MESSAGE_END`, `THINKING_END`) — forwarded from `ModelReasoning` events emitted by extended-thinking models
 
 ## Installation
 

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -37,6 +37,7 @@ sidebarTitle: Beta Roadmap
 - Multimodality output: images
 - Local Code execution tool
 - A2A
+- Update AG-UI integration (`ModelReasoning` forwarded to AG-UI as `ThinkingStart/TextMessageStart/Content/End/ThinkingEnd` events; `TestConfig`/`TestClient` support `ModelReasoning` injection)
 
 ## In Progress
 
@@ -67,7 +68,6 @@ sidebarTitle: Beta Roadmap
 - Builtin RAG toolkit
 - Crawl4AI tool
 - Skills Plugin
-- Update AG-UI integration
 - Allow models to configure tool search params
 
 ### P4


### PR DESCRIPTION
## Summary

- `ModelReasoning` events (intermediate thinking content from models like Claude or o3) are now forwarded to AG-UI clients as the full Thinking event sequence:
  - `ThinkingStartEvent`
  - `ThinkingTextMessageStartEvent(message_id)`
  - `ThinkingTextMessageContentEvent(message_id, delta=content)`
  - `ThinkingTextMessageEndEvent(message_id)`
  - `ThinkingEndEvent`
- AG-UI frontends that render thinking blocks (e.g. the reference implementation) will now receive these events automatically when the agent's model emits reasoning
- `TestConfig` / `TestClient` in `autogen.beta.testing` extended to accept `ModelReasoning` in the event sequence — the client emits them via `context.send()` before consuming the next response event, making reasoning testable without a real model
- 5 tests added in `test/beta/ag_ui/test_reasoning.py`
- Roadmap: "Update AG-UI integration" P3 → Completed

## Test plan

- [x] `uv run pytest test/beta/ag_ui/test_reasoning.py -v` — 5/5 pass
- [x] Pre-commit hooks all green (ruff, mypy, license headers, secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)