### PR TITLE
feat(beta): SkillsPlugin — pre-load local skills into agent system prompt

### DIFF
--- a/autogen/beta/tools/__init__.py
+++ b/autogen/beta/tools/__init__.py
@@ -46,6 +46,7 @@ __all__ = (
     "ShellTool",
     "Skill",
     "SkillSearchToolkit",
+    "SkillsPlugin",  # noqa: F822 — lazy-loaded via __getattr__ below
     "SkillsTool",
     "SkillsToolkit",
     "TavilySearchTool",
@@ -56,3 +57,11 @@ __all__ = (
     "WebSearchTool",
     "tool",
 )
+
+
+def __getattr__(name: str) -> object:
+    if name == "SkillsPlugin":
+        from .skills import SkillsPlugin
+
+        return SkillsPlugin
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/autogen/beta/tools/skills/__init__.py
+++ b/autogen/beta/tools/skills/__init__.py
@@ -10,5 +10,14 @@ __all__ = (
     "LocalRuntime",
     "SkillSearchToolkit",
     "SkillsClientConfig",
+    "SkillsPlugin",  # noqa: F822 — lazy-loaded via __getattr__ below
     "SkillsToolkit",
 )
+
+
+def __getattr__(name: str) -> object:
+    if name == "SkillsPlugin":
+        from .skills_plugin import SkillsPlugin
+
+        return SkillsPlugin
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/autogen/beta/tools/skills/skills_plugin.py
+++ b/autogen/beta/tools/skills/skills_plugin.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from collections.abc import Iterable
+
+from autogen.beta.middleware import ToolMiddleware
+from autogen.beta.plugin import Plugin
+
+from .local_skills import SkillsToolkit
+from .runtime import LocalRuntime, SkillRuntime
+
+
+class SkillsPlugin(Plugin):
+    """Plugin that pre-loads local skills into an agent.
+
+    Pre-loads the named skills' ``SKILL.md`` instructions into the agent's
+    system prompt and adds :class:`SkillsToolkit` tools so the agent can
+    execute skill scripts.
+
+    Unlike using :class:`SkillsToolkit` alone — which requires the agent to
+    call ``load_skill()`` at runtime — ``SkillsPlugin`` makes the skill
+    instructions immediately available without any extra tool calls.
+
+    Args:
+        *skills:    Names of skills to pre-load.  Each must be installed in
+                    the runtime's skill directory.  Pass no names to skip
+                    pre-loading (toolkit tools are still added).
+        runtime:    A :class:`SkillRuntime`, a directory path, or ``None``
+                    for the default ``.agents/skills`` directory.
+        middleware: Optional :class:`ToolMiddleware` instances forwarded to
+                    :class:`SkillsToolkit`.
+
+    Example::
+
+        agent = Agent(
+            "assistant",
+            plugins=[SkillsPlugin("web-search", "code-review")],
+        )
+    """
+
+    def __init__(
+        self,
+        *skills: str,
+        runtime: SkillRuntime | str | os.PathLike[str] | None = None,
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> None:
+        _runtime: SkillRuntime = LocalRuntime.ensure_runtime(runtime) if runtime is not None else LocalRuntime()
+
+        skill_sections: list[str] = []
+        for name in skills:
+            content = _runtime.load(name)
+            skill_sections.append(f"## Skill: {name}\n\n{content}")
+
+        prompt = "\n\n".join(skill_sections)
+        toolkit = SkillsToolkit(runtime=_runtime, middleware=middleware)
+
+        super().__init__(prompt=prompt, tools=[toolkit])

--- a/test/beta/tools/test_skills_plugin.py
+++ b/test/beta/tools/test_skills_plugin.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.testing import TestConfig
+from autogen.beta.tools.skills import LocalRuntime, SkillsPlugin
+
+
+@pytest.fixture
+def skill_dir(tmp_path: Path) -> Path:
+    alpha = tmp_path / "alpha"
+    alpha.mkdir()
+    (alpha / "SKILL.md").write_text(
+        textwrap.dedent("""\
+            ---
+            name: alpha
+            description: Alpha skill
+            ---
+            # Alpha
+            Alpha instructions.
+        """),
+        encoding="utf-8",
+    )
+
+    beta = tmp_path / "beta"
+    beta.mkdir()
+    (beta / "SKILL.md").write_text(
+        textwrap.dedent("""\
+            ---
+            name: beta
+            description: Beta skill
+            ---
+            # Beta
+            Beta instructions.
+        """),
+        encoding="utf-8",
+    )
+
+    return tmp_path
+
+
+class TestSkillsPluginUnit:
+    def test_prompt_contains_loaded_skills(self, skill_dir: Path) -> None:
+        plugin = SkillsPlugin("alpha", runtime=skill_dir)
+        assert "## Skill: alpha" in plugin._system_prompt[0]
+        assert "Alpha instructions." in plugin._system_prompt[0]
+
+    def test_prompt_contains_multiple_skills(self, skill_dir: Path) -> None:
+        plugin = SkillsPlugin("alpha", "beta", runtime=skill_dir)
+        assert "## Skill: alpha" in plugin._system_prompt[0]
+        assert "## Skill: beta" in plugin._system_prompt[0]
+
+    def test_no_skills_produces_empty_prompt(self, skill_dir: Path) -> None:
+        plugin = SkillsPlugin(runtime=skill_dir)
+        # No skill names → no system prompt entries, toolkit still added
+        assert plugin._system_prompt == [] or plugin._system_prompt == [""]
+
+    def test_tools_include_skills_toolkit(self, skill_dir: Path) -> None:
+        plugin = SkillsPlugin("alpha", runtime=skill_dir)
+        tool_names = {t.name for t in plugin._tools}
+        assert any("list" in n or "skill" in n for n in tool_names)
+
+    def test_accepts_runtime_instance(self, skill_dir: Path) -> None:
+        runtime = LocalRuntime(dir=skill_dir)
+        plugin = SkillsPlugin("alpha", runtime=runtime)
+        assert "Alpha instructions." in plugin._system_prompt[0]
+
+    def test_accepts_path_string(self, skill_dir: Path) -> None:
+        plugin = SkillsPlugin("alpha", runtime=str(skill_dir))
+        assert "Alpha instructions." in plugin._system_prompt[0]
+
+    def test_registers_system_prompt_on_agent(self, skill_dir: Path) -> None:
+        plugin = SkillsPlugin("alpha", runtime=skill_dir)
+        agent = Agent("agent", config=TestConfig("done"), plugins=[plugin])
+        assert any("alpha" in p.lower() for p in agent._system_prompt)

--- a/website/docs/beta/roadmap.mdx
+++ b/website/docs/beta/roadmap.mdx
@@ -37,6 +37,7 @@ sidebarTitle: Beta Roadmap
 - Multimodality output: images
 - Local Code execution tool
 - A2A
+- Skills Plugin
 
 ## In Progress
 
@@ -66,7 +67,6 @@ sidebarTitle: Beta Roadmap
 
 - Builtin RAG toolkit
 - Crawl4AI tool
-- Skills Plugin
 - Update AG-UI integration
 - Allow models to configure tool search params
 

--- a/website/docs/beta/tools/common_toolkits.mdx
+++ b/website/docs/beta/tools/common_toolkits.mdx
@@ -169,6 +169,43 @@ Available tools:
 | `load_skill` | Fetch the full `SKILL.md` content for a specific skill |
 | `run_skill_script` | Execute a `.py` or `.sh` script from a skill's `scripts/` directory |
 
+### SkillsPlugin — pre-load skills at construction time
+
+`SkillsPlugin` is a `Plugin` subclass that loads one or more skills' `SKILL.md` content
+directly into the agent's **system prompt** at construction time, and adds `SkillsToolkit`
+tools so the agent can run skill scripts.
+
+The difference from `SkillsToolkit` alone:
+
+| | `SkillsToolkit` | `SkillsPlugin` |
+|---|---|---|
+| Skills available | After agent calls `load_skill()` | Immediately, before the first turn |
+| System-prompt injection | No | Yes — `SKILL.md` content prepended |
+| Can run skill scripts | Yes | Yes (via bundled `SkillsToolkit`) |
+
+Use `SkillsPlugin` when you know at construction time which skills the agent will need and
+want the instructions present from the very first message.
+
+```python linenums="1"
+from autogen.beta import Agent
+from autogen.beta.tools.skills import SkillsPlugin
+
+agent = Agent(
+    "assistant",
+    plugins=[SkillsPlugin("web-search", "code-review")],
+)
+```
+
+Skills are looked up by name in the runtime's skill directory (default: `.agents/skills`).
+Pass `runtime=` to override:
+
+```python linenums="1"
+from autogen.beta.tools.skills import LocalRuntime, SkillsPlugin
+
+plugin = SkillsPlugin("web-search", runtime=LocalRuntime("./my-skills"))
+agent = Agent("assistant", plugins=[plugin])
+```
+
 ---
 
 ## SkillSearchToolkit


### PR DESCRIPTION
## Summary

- Adds `SkillsPlugin` class in `autogen/beta/tools/skills/skills_plugin.py` that subclasses `Plugin`
- Pre-loads named skills' `SKILL.md` content into the agent's system prompt at construction time, so the agent has skill instructions immediately without needing to call `load_skill()` at runtime
- Also adds `SkillsToolkit` tools so the agent can execute skill scripts
- Uses lazy `__getattr__` in `__init__.py` files to break the circular import that would arise during the config initialization chain
- Moves "Skills Plugin" from P3 → Completed in the beta roadmap

## Usage

```python
agent = Agent(
    "assistant",
    plugins=[SkillsPlugin("web-search", "code-review")],
)
```

## Test plan

- [ ] `test/beta/tools/test_skills_plugin.py` — 7 unit tests covering prompt injection, multi-skill loading, runtime variants (instance/path/string), toolkit registration, and agent integration
- [ ] All pre-commit hooks pass (ruff, mypy, typos, license headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)