### PR TITLE
feat(beta/ag_ui): A2UIPlugin — expose an Agent via AG-UI protocol

### DIFF
--- a/autogen/beta/ag_ui/__init__.py
+++ b/autogen/beta/ag_ui/__init__.py
@@ -9,9 +9,11 @@ except ImportError as e:
 
 
 from .events import AGUIEvent
+from .plugin import A2UIPlugin
 from .stream import AGUIStream
 
 __all__ = (
+    "A2UIPlugin",
     "AGUIEvent",
     "AGUIStream",
     "RunAgentInput",

--- a/autogen/beta/ag_ui/plugin.py
+++ b/autogen/beta/ag_ui/plugin.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``A2UIPlugin`` — attach AG-UI protocol support to an Agent via the Plugin API."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from autogen.beta.agent import Plugin
+from autogen.beta.middleware import HistoryLimiter
+
+from .stream import AGUIStream
+
+if TYPE_CHECKING:
+    from autogen.beta.agent import Agent
+
+__all__ = ("A2UIPlugin",)
+
+
+class A2UIPlugin(Plugin):
+    """Expose an Agent over the AG-UI protocol.
+
+    Registering this plugin with an agent records a reference to that
+    agent so that :meth:`stream` and :meth:`build_asgi` can be called
+    directly on the plugin without passing the agent each time.
+
+    Args:
+        history_limit: Optional maximum number of conversation events
+            the LLM sees per turn.  When set, a
+            :class:`~autogen.beta.middleware.HistoryLimiter` is added to
+            the agent's middleware stack automatically.  ``None`` (the
+            default) leaves history unbounded.
+
+    Example::
+
+        from autogen.beta import Agent
+        from autogen.beta.ag_ui import A2UIPlugin
+
+        plugin = A2UIPlugin(history_limit=40)
+        agent = Agent("assistant", plugins=[plugin])
+
+        # Serve the agent:
+        asgi_endpoint = plugin.build_asgi()
+
+        # Or stream events directly:
+        async for chunk in plugin.stream.dispatch(run_input):
+            ...
+    """
+
+    def __init__(self, *, history_limit: int | None = None) -> None:
+        middleware = [HistoryLimiter(history_limit)] if history_limit is not None else []
+        super().__init__(middleware=middleware)
+        self._history_limit = history_limit
+        self._agent: Agent | None = None
+
+    def register(self, agent: Agent[Any]) -> None:
+        """Apply middleware to the agent and record the reference."""
+        super().register(agent)
+        self._agent = agent
+
+    @property
+    def stream(self) -> AGUIStream:
+        """Return an :class:`~autogen.beta.ag_ui.AGUIStream` bound to the registered agent.
+
+        Raises:
+            RuntimeError: If the plugin has not been registered with an agent yet.
+        """
+        if self._agent is None:
+            raise RuntimeError(
+                "A2UIPlugin has not been registered with an agent. "
+                "Pass this plugin to Agent(..., plugins=[plugin]) before calling .stream."
+            )
+        return AGUIStream(self._agent)
+
+    def build_asgi(self) -> Any:
+        """Build and return the ASGI endpoint class for the registered agent.
+
+        Shortcut for ``plugin.stream.build_asgi()``.
+
+        Returns:
+            An ASGI-compatible ``HTTPEndpoint`` class (Starlette).
+
+        Raises:
+            RuntimeError: If the plugin has not been registered with an agent yet.
+        """
+        return self.stream.build_asgi()

--- a/test/beta/ag_ui/test_plugin.py
+++ b/test/beta/ag_ui/test_plugin.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.ag_ui import A2UIPlugin, AGUIStream
+from autogen.beta.middleware import HistoryLimiter
+
+try:
+    from starlette.endpoints import HTTPEndpoint
+
+    starlette = True
+except ImportError:
+    starlette = False
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestA2UIPlugin:
+    def test_plugin_stores_history_limit(self) -> None:
+        plugin = A2UIPlugin(history_limit=20)
+        assert plugin._history_limit == 20
+
+    def test_plugin_no_history_limit(self) -> None:
+        plugin = A2UIPlugin()
+        assert plugin._history_limit is None
+
+    def test_plugin_adds_history_limiter_middleware(self) -> None:
+        plugin = A2UIPlugin(history_limit=15)
+        assert any(isinstance(m, HistoryLimiter) for m in plugin._middleware)
+
+    def test_plugin_no_middleware_without_limit(self) -> None:
+        plugin = A2UIPlugin()
+        assert not any(isinstance(m, HistoryLimiter) for m in plugin._middleware)
+
+    def test_stream_raises_before_registration(self) -> None:
+        plugin = A2UIPlugin()
+        with pytest.raises(RuntimeError, match="not been registered"):
+            _ = plugin.stream
+
+    def test_build_asgi_raises_before_registration(self) -> None:
+        plugin = A2UIPlugin()
+        with pytest.raises(RuntimeError, match="not been registered"):
+            plugin.build_asgi()
+
+    def test_register_stores_agent(self) -> None:
+        plugin = A2UIPlugin()
+        agent = Agent("test_agent")
+        plugin.register(agent)
+        assert plugin._agent is agent
+
+    def test_stream_returns_agui_stream_after_registration(self) -> None:
+        plugin = A2UIPlugin()
+        agent = Agent("test_agent")
+        plugin.register(agent)
+        assert isinstance(plugin.stream, AGUIStream)
+
+    def test_register_via_agent_constructor(self) -> None:
+        plugin = A2UIPlugin()
+        agent = Agent("test_agent", plugins=[plugin])
+        # Plugin is registered automatically by Agent.__init__
+        assert plugin._agent is agent
+
+    def test_history_limiter_wired_to_agent(self) -> None:
+        plugin = A2UIPlugin(history_limit=10)
+        agent = Agent("test_agent", plugins=[plugin])
+        middleware_types = [type(m).__name__ for m in agent._middleware]
+        assert "HistoryLimiter" in middleware_types
+
+    @pytest.mark.skipif(not starlette, reason="starlette not installed")
+    def test_build_asgi_returns_endpoint_class(self) -> None:
+        plugin = A2UIPlugin()
+        Agent("test_agent", plugins=[plugin])
+        endpoint_class = plugin.build_asgi()
+        assert issubclass(endpoint_class, HTTPEndpoint)
+
+    @pytest.mark.skipif(not starlette, reason="starlette not installed")
+    def test_build_asgi_shortcut_equals_stream_build_asgi(self) -> None:
+        plugin = A2UIPlugin()
+        Agent("test_agent", plugins=[plugin])
+        # Both calls produce distinct endpoint classes wrapping the same agent.
+        # They should have the same base class; identity check would be too strict
+        # since each call to build_asgi() creates a new class.
+        assert issubclass(plugin.build_asgi(), HTTPEndpoint)
+        assert issubclass(plugin.stream.build_asgi(), HTTPEndpoint)

--- a/website/docs/beta/ag-ui/index.mdx
+++ b/website/docs/beta/ag-ui/index.mdx
@@ -120,6 +120,29 @@ data: {"type":"TEXT_MESSAGE_CHUNK","delta":"Hello! How can I help?",...}
 data: {"type":"RUN_FINISHED","threadId":"thread-1","runId":"run-1",...}
 ```
 
+## Plugin pattern (A2UIPlugin)
+
+`#!python A2UIPlugin` is a `#!python Plugin` subclass that wires `#!python AGUIStream` to an
+agent through the Plugin API. Use it when:
+
+- You want to **bundle AG-UI configuration with the agent definition** (history limiting, etc.) rather than set it up at server construction time.
+- You prefer a **single object** you can pass to `#!python Agent(..., plugins=[plugin])` and later call `#!python plugin.build_asgi()` on.
+
+```python linenums="1"
+import uvicorn
+from autogen.beta import Agent
+from autogen.beta.ag_ui import A2UIPlugin
+
+plugin = A2UIPlugin(history_limit=40)   # cap LLM context to 40 events per turn
+agent  = Agent("assistant", plugins=[plugin])
+
+uvicorn.run(plugin.build_asgi(), host="0.0.0.0", port=8000)
+```
+
+`#!python A2UIPlugin.build_asgi()` is a shortcut for `#!python plugin.stream.build_asgi()`.
+You can also access `#!python plugin.stream` directly to call `#!python dispatch()` inside
+your own FastAPI / Starlette route if you need custom auth or middleware.
+
 ## UI clients
 
 Any AG-UI client works with this endpoint.


### PR DESCRIPTION
## Summary

- Adds `A2UIPlugin`, a `Plugin` subclass that wires an `AGUIStream` to an `Agent` through the standard Plugin API
- Accepts an optional `history_limit` parameter; when set, automatically installs `HistoryLimiter` middleware on the agent
- Exposes `.stream` property (returns a bound `AGUIStream`) and `.build_asgi()` shortcut after registration
- Exports `A2UIPlugin` from `autogen.beta.ag_ui`

## Usage

```python
from autogen.beta import Agent
from autogen.beta.ag_ui import A2UIPlugin

plugin = A2UIPlugin(history_limit=40)
agent = Agent("assistant", plugins=[plugin])

# Serve via ASGI:
endpoint = plugin.build_asgi()

# Or stream directly:
async for chunk in plugin.stream.dispatch(run_input):
    ...
```

## Test plan

- [ ] `test_plugin_stores_history_limit` — `_history_limit` attribute set correctly
- [ ] `test_plugin_no_history_limit` — defaults to `None`
- [ ] `test_plugin_adds_history_limiter_middleware` — `HistoryLimiter` in `_middleware` when limit provided
- [ ] `test_plugin_no_middleware_without_limit` — no `HistoryLimiter` without limit
- [ ] `test_stream_raises_before_registration` — `RuntimeError` with helpful message before `register()`
- [ ] `test_build_asgi_raises_before_registration` — same guard on `build_asgi()`
- [ ] `test_register_stores_agent` — `_agent` attribute set after `register()`
- [ ] `test_stream_returns_agui_stream_after_registration` — `.stream` returns `AGUIStream`
- [ ] `test_register_via_agent_constructor` — plugin auto-registers when passed to `Agent(..., plugins=[plugin])`
- [ ] `test_history_limiter_wired_to_agent` — `HistoryLimiter` appears in `agent._middleware` after constructor wiring
- [ ] `test_build_asgi_returns_endpoint_class` — returns `HTTPEndpoint` subclass (starlette required)
- [ ] `test_build_asgi_shortcut_equals_stream_build_asgi` — both paths return `HTTPEndpoint` subclasses (starlette required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)