### PR TITLE
feat(beta/nlip): NLIPPlugin — expose a beta Agent via NLIP protocol

### DIFF
--- a/autogen/beta/nlip/__init__.py
+++ b/autogen/beta/nlip/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .plugin import NLIPPlugin
+
+__all__ = ("NLIPPlugin",)

--- a/autogen/beta/nlip/app.py
+++ b/autogen/beta/nlip/app.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Beta-Agent NLIP session and application wrappers."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ...import_utils import optional_import_block, require_optional_import
+
+with optional_import_block() as _nlip_available:
+    from nlip_sdk.nlip import NLIP_Factory, NLIP_Message
+    from nlip_server.server import NLIP_Application, NLIP_Session, setup_server
+
+if not _nlip_available.is_successful:
+    NLIP_Session = object  # type: ignore[assignment,misc]
+    NLIP_Application = object  # type: ignore[assignment,misc]
+
+if TYPE_CHECKING:
+    from ..agent import Agent
+
+logger = logging.getLogger(__name__)
+
+__all__ = ("BetaNlipApplication", "BetaNlipSession")
+
+
+@require_optional_import(["nlip_sdk", "nlip_server"], "nlip")
+class BetaNlipSession(NLIP_Session):
+    """NLIP Session backed by a beta :class:`~autogen.beta.Agent`."""
+
+    def __init__(self, agent: Agent[Any]) -> None:
+        super().__init__()
+        self._agent = agent
+
+    async def start(self) -> None:
+        await super().start()
+        logger.info("Started NLIP session for beta agent: %s", self._agent.name)
+
+    async def execute(self, msg: NLIP_Message) -> NLIP_Message:
+        """Run the agent and return an NLIP response.
+
+        The top-level text of ``msg`` is extracted and fed to the agent via
+        :meth:`~autogen.beta.Agent.ask`.  The agent's reply body is returned
+        as the top-level content of the response ``NLIP_Message``.
+        """
+        text = msg.extract_text() or ""
+        logger.info("Executing beta agent %s with NLIP message (len=%d)", self._agent.name, len(text))
+
+        reply = await self._agent.ask(text)
+        response_text = reply.body or ""
+        return NLIP_Factory.create_text(response_text, language="english")
+
+    async def correlated_execute(self, msg: NLIP_Message) -> dict[str, Any]:  # type: ignore[override]
+        response: NLIP_Message = await super().correlated_execute(msg)
+        return response.model_dump(exclude_none=True)
+
+    async def stop(self) -> None:
+        logger.info("Stopping NLIP session for beta agent: %s", self._agent.name)
+        await super().stop()
+
+
+@require_optional_import(["nlip_sdk", "nlip_server"], "nlip")
+class BetaNlipApplication(NLIP_Application):
+    """NLIP Application that serves a beta :class:`~autogen.beta.Agent`.
+
+    Both an :class:`nlip_server.server.NLIP_Application` (so ``nlip-server``
+    can call :meth:`create_session` / :meth:`startup` / :meth:`shutdown` on
+    it) **and** an ASGI callable.  Pass directly to any ASGI server::
+
+        import uvicorn
+        from autogen.beta import Agent
+        from autogen.beta.nlip import NLIPPlugin
+
+        plugin = NLIPPlugin()
+        agent = Agent("assistant", plugins=[plugin])
+        uvicorn.run(plugin.build_asgi(), host="0.0.0.0", port=8000)
+    """
+
+    def __init__(self, agent: Agent[Any]) -> None:
+        super().__init__()
+        self._agent = agent
+        self._asgi_app = setup_server(self)
+
+    @property
+    def asgi_app(self) -> Any:
+        return self._asgi_app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        """ASGI entrypoint — delegates to the wrapped nlip-server app."""
+        await self._asgi_app(scope, receive, send)
+
+    async def startup(self) -> None:
+        logger.info("Starting NLIP application for beta agent: %s", self._agent.name)
+
+    async def shutdown(self) -> None:
+        logger.info("Shutting down NLIP application for beta agent: %s", self._agent.name)
+
+    def create_session(self) -> BetaNlipSession:
+        return BetaNlipSession(self._agent)

--- a/autogen/beta/nlip/plugin.py
+++ b/autogen/beta/nlip/plugin.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``NLIPPlugin`` — attach NLIP protocol support to a beta Agent via the Plugin API."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ..agent import Plugin
+from ..middleware import HistoryLimiter
+
+if TYPE_CHECKING:
+    from ..agent import Agent
+    from .app import BetaNlipApplication
+
+__all__ = ("NLIPPlugin",)
+
+
+class NLIPPlugin(Plugin):
+    """Expose a beta Agent over the NLIP (Natural Language Interaction Protocol).
+
+    Registering this plugin with an agent records a reference to that
+    agent so that :meth:`build_asgi` can be called directly on the plugin
+    without passing the agent each time.
+
+    Args:
+        history_limit: Optional maximum number of conversation events
+            the LLM sees per turn.  When set, a
+            :class:`~autogen.beta.middleware.HistoryLimiter` is added to
+            the agent's middleware stack automatically.  ``None`` (the
+            default) leaves history unbounded.
+
+    Example::
+
+        import uvicorn
+        from autogen.beta import Agent
+        from autogen.beta.nlip import NLIPPlugin
+
+        plugin = NLIPPlugin(history_limit=40)
+        agent = Agent("assistant", plugins=[plugin])
+
+        # Serve the agent:
+        uvicorn.run(plugin.build_asgi(), host="0.0.0.0", port=8000)
+    """
+
+    def __init__(self, *, history_limit: int | None = None) -> None:
+        middleware = [HistoryLimiter(history_limit)] if history_limit is not None else []
+        super().__init__(middleware=middleware)
+        self._history_limit = history_limit
+        self._agent: Agent | None = None
+
+    def register(self, agent: Agent[Any]) -> None:
+        """Apply middleware to the agent and record the reference."""
+        super().register(agent)
+        self._agent = agent
+
+    def build_asgi(self) -> BetaNlipApplication:
+        """Build and return the ASGI-callable NLIP application for the registered agent.
+
+        Returns:
+            A :class:`BetaNlipApplication` instance (both ``NLIP_Application``
+            and ASGI callable).
+
+        Raises:
+            RuntimeError: If the plugin has not been registered with an agent yet.
+        """
+        if self._agent is None:
+            raise RuntimeError(
+                "NLIPPlugin has not been registered with an agent. "
+                "Pass this plugin to Agent(..., plugins=[plugin]) before calling .build_asgi()."
+            )
+        from .app import BetaNlipApplication
+
+        return BetaNlipApplication(self._agent)

--- a/test/beta/nlip/__init__.py
+++ b/test/beta/nlip/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/beta/nlip/test_plugin.py
+++ b/test/beta/nlip/test_plugin.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.middleware import HistoryLimiter
+from autogen.beta.nlip import NLIPPlugin
+
+try:
+    from nlip_server.server import NLIP_Application
+
+    nlip_server = True
+except ImportError:
+    nlip_server = False
+
+
+class TestNLIPPlugin:
+    def test_plugin_stores_history_limit(self) -> None:
+        plugin = NLIPPlugin(history_limit=20)
+        assert plugin._history_limit == 20
+
+    def test_plugin_no_history_limit(self) -> None:
+        plugin = NLIPPlugin()
+        assert plugin._history_limit is None
+
+    def test_plugin_adds_history_limiter_middleware(self) -> None:
+        plugin = NLIPPlugin(history_limit=15)
+        assert any(isinstance(m, HistoryLimiter) for m in plugin._middleware)
+
+    def test_plugin_no_middleware_without_limit(self) -> None:
+        plugin = NLIPPlugin()
+        assert not any(isinstance(m, HistoryLimiter) for m in plugin._middleware)
+
+    def test_build_asgi_raises_before_registration(self) -> None:
+        plugin = NLIPPlugin()
+        with pytest.raises(RuntimeError, match="not been registered"):
+            plugin.build_asgi()
+
+    def test_register_stores_agent(self) -> None:
+        plugin = NLIPPlugin()
+        agent = Agent("test_agent")
+        plugin.register(agent)
+        assert plugin._agent is agent
+
+    def test_register_via_agent_constructor(self) -> None:
+        plugin = NLIPPlugin()
+        agent = Agent("test_agent", plugins=[plugin])
+        assert plugin._agent is agent
+
+    def test_history_limiter_wired_to_agent(self) -> None:
+        plugin = NLIPPlugin(history_limit=10)
+        agent = Agent("test_agent", plugins=[plugin])
+        middleware_types = [type(m).__name__ for m in agent._middleware]
+        assert "HistoryLimiter" in middleware_types
+
+    @pytest.mark.skipif(not nlip_server, reason="nlip-server not installed")
+    def test_build_asgi_returns_nlip_application(self) -> None:
+        plugin = NLIPPlugin()
+        Agent("test_agent", plugins=[plugin])
+        app = plugin.build_asgi()
+        assert isinstance(app, NLIP_Application)
+
+    @pytest.mark.skipif(not nlip_server, reason="nlip-server not installed")
+    def test_build_asgi_is_asgi_callable(self) -> None:
+        plugin = NLIPPlugin()
+        Agent("test_agent", plugins=[plugin])
+        app = plugin.build_asgi()
+        assert callable(app)
+
+    @pytest.mark.skipif(not nlip_server, reason="nlip-server not installed")
+    def test_each_build_asgi_call_produces_new_application(self) -> None:
+        plugin = NLIPPlugin()
+        Agent("test_agent", plugins=[plugin])
+        app1 = plugin.build_asgi()
+        app2 = plugin.build_asgi()
+        # Each call creates a fresh BetaNlipApplication wrapping the same agent.
+        assert app1 is not app2
+        assert isinstance(app1, NLIP_Application)
+        assert isinstance(app2, NLIP_Application)

--- a/website/docs/beta/nlip/index.mdx
+++ b/website/docs/beta/nlip/index.mdx
@@ -1,0 +1,118 @@
+---
+title: NLIP Integration
+sidebarTitle: NLIP
+description: "Expose an AG2 beta Agent over the Natural Language Interaction Protocol (NLIP / ECMA-430) using NLIPPlugin."
+---
+
+The `#!python autogen.beta.nlip` module exposes any AG2 `#!python Agent` over the
+[Natural Language Interaction Protocol (NLIP)](https://ecma-international.org/publications-and-standards/standards/ecma-430/){.external-link target="_blank"}
+(ECMA-430), making it reachable from any NLIP-compatible client.
+
+## When to use NLIP
+
+Use NLIP when you need:
+
+- **Protocol-neutral chat front-ends.** NLIP is a vendor-agnostic standard; any NLIP client can talk to your agent without knowing it is backed by AG2.
+- **ECMA-430 compliance.** You operate in an environment that mandates ECMA-430 for human-agent communication channels.
+- **Drop-in ASGI app.** You want a self-contained ASGI callable (uvicorn, Gunicorn + Uvicorn worker, Hypercorn, etc.) without building HTTP routing by hand.
+
+For AG-UI–based frontends see [AG-UI integration](/docs/beta/ag-ui/index). For cross-process agent-to-agent calls see [A2A](/docs/beta/a2a/overview).
+
+## Installation
+
+```bash
+pip install "ag2[nlip]"
+```
+
+This pulls in `nlip-sdk` (message types and factory helpers) and `nlip-server` (ASGI application scaffold).
+
+## Quick start
+
+```python title="run_nlip.py" linenums="1"
+import uvicorn
+from autogen.beta import Agent
+from autogen.beta.nlip import NLIPPlugin
+
+plugin = NLIPPlugin()
+agent = Agent(
+    name="assistant",
+    prompt="You are a helpful assistant.",
+)
+agent.register_plugin(plugin)  # or: Agent("assistant", plugins=[plugin])
+
+uvicorn.run(plugin.build_asgi(), host="0.0.0.0", port=8000)
+```
+
+The `#!python build_asgi()` call returns a `#!python BetaNlipApplication`, which is both an
+`#!python nlip_server.NLIP_Application` and a standard ASGI callable.
+
+### Shorthand via the Agent constructor
+
+```python linenums="1"
+plugin = NLIPPlugin()
+agent = Agent("assistant", plugins=[plugin])
+app   = plugin.build_asgi()
+```
+
+Each `#!python build_asgi()` call creates a fresh `#!python BetaNlipApplication`; the plugin
+holds the agent reference and can be called any number of times.
+
+## Limiting history
+
+By default the agent sees its full conversation history on every turn. For long-running
+sessions this can grow without bound. Pass `#!python history_limit=` to cap it:
+
+```python linenums="1"
+plugin = NLIPPlugin(history_limit=40)
+agent  = Agent("assistant", plugins=[plugin])
+```
+
+Under the hood this wires a `#!python HistoryLimiter(40)` into the agent's middleware
+stack — the 40 most recent events are forwarded to the LLM and older events are dropped.
+
+## How it works
+
+```
+NLIP client
+    │  POST /  (NLIP_Message)
+    ▼
+BetaNlipApplication (NLIP_Application + ASGI callable)
+    │  create_session()
+    ▼
+BetaNlipSession (NLIP_Session)
+    │  execute(msg)  →  agent.ask(text)
+    ▼
+Agent  →  LLM  →  AgentReply.body
+    │
+    ▼
+NLIP_Factory.create_text(response_text)  →  NLIP_Message
+```
+
+`#!python BetaNlipSession.execute()` extracts the top-level text from the inbound
+`#!python NLIP_Message`, calls `#!python agent.ask()`, and wraps the reply body in a new
+`#!python NLIP_Message` with `#!python language="english"`.
+
+## Deploying with Gunicorn
+
+```bash
+pip install gunicorn uvicorn
+gunicorn run_nlip:app -k uvicorn.workers.UvicornWorker --workers 4 --bind 0.0.0.0:8000
+```
+
+Where `#!python app` is the value returned by `#!python plugin.build_asgi()` (store it at module level in `run_nlip.py`).
+
+## Public API
+
+```python linenums="1"
+from autogen.beta.nlip import NLIPPlugin
+```
+
+| Symbol | Purpose |
+|---|---|
+| `#!python NLIPPlugin` | `#!python Plugin` subclass — register with an agent, then call `#!python build_asgi()` |
+| `#!python BetaNlipApplication` | ASGI app + `#!python NLIP_Application`; returned by `#!python build_asgi()` |
+| `#!python BetaNlipSession` | Per-request session; calls `#!python agent.ask()` per NLIP turn |
+
+`#!python NLIPPlugin` can be instantiated and registered with an agent without the optional
+`#!python ag2[nlip]` extras installed. The import-time guard is only triggered when
+`#!python build_asgi()` is called.

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -486,6 +486,12 @@
             "docs/beta/a2a/advanced"
           ]
         },
+        {
+          "group": "NLIP",
+          "pages": [
+            "docs/beta/nlip/index"
+          ]
+        },
         "docs/beta/ag2_compatibility",
         "docs/beta/roadmap",
         "docs/beta/contribution_policy",


### PR DESCRIPTION
## Summary

- Adds `NLIPPlugin`, a `Plugin` subclass that exposes a beta `Agent` over the [NLIP (Natural Language Interaction Protocol, ECMA-430)](https://ecma-international.org/publications-and-standards/standards/ecma-430/) standard
- `BetaNlipSession` — `NLIP_Session` that calls `agent.ask()` per request and maps the response back to `NLIP_Message`
- `BetaNlipApplication` — `NLIP_Application` + ASGI callable; pass directly to `uvicorn.run()`
- `NLIPPlugin` — `Plugin` subclass with optional `HistoryLimiter`; lazy NLIP import so the class works without `ag2[nlip]` installed (only `build_asgi()` requires it)
- Completes P2 roadmap item: **NLIP**

## Usage

```python
import uvicorn
from autogen.beta import Agent
from autogen.beta.nlip import NLIPPlugin

plugin = NLIPPlugin(history_limit=40)
agent = Agent("assistant", plugins=[plugin])

uvicorn.run(plugin.build_asgi(), host="0.0.0.0", port=8000)
```

## Test plan

- [ ] `test_plugin_stores_history_limit` — `_history_limit` stored correctly
- [ ] `test_plugin_no_history_limit` — defaults to `None`
- [ ] `test_plugin_adds_history_limiter_middleware` — `HistoryLimiter` in `_middleware` when limit provided
- [ ] `test_plugin_no_middleware_without_limit` — no `HistoryLimiter` without limit
- [ ] `test_build_asgi_raises_before_registration` — `RuntimeError` with helpful message before `register()`
- [ ] `test_register_stores_agent` — `_agent` attribute set after `register()`
- [ ] `test_register_via_agent_constructor` — plugin auto-registers when passed to `Agent(..., plugins=[plugin])`
- [ ] `test_history_limiter_wired_to_agent` — `HistoryLimiter` appears in `agent._middleware`
- [ ] `test_build_asgi_returns_nlip_application` — returns `NLIP_Application` instance (nlip-server required)
- [ ] `test_build_asgi_is_asgi_callable` — ASGI app is callable (nlip-server required)
- [ ] `test_each_build_asgi_call_produces_new_application` — each call returns a fresh instance (nlip-server required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)