### PR TITLE
fix(agentchat/guardrails): use private response model in LLMGuardrail to avoid duplicate-kwarg Pydantic error

### DIFF
--- a/autogen/agentchat/group/guardrails.py
+++ b/autogen/agentchat/group/guardrails.py
@@ -45,6 +45,13 @@ class Guardrail(ABC):
         pass
 
 
+class _LLMGuardrailResponse(BaseModel):
+    """Internal response schema sent to the LLM — excludes the non-serialisable `guardrail` ref."""
+
+    activated: bool
+    justification: str = Field(default="No justification provided")
+
+
 class LLMGuardrail(Guardrail):
     """Guardrail that uses an LLM to check the context."""
 
@@ -62,7 +69,7 @@ class LLMGuardrail(Guardrail):
             raise ValueError("LLMConfig is required.")
 
         self.llm_config = llm_config.deepcopy()
-        setattr(self.llm_config, "response_format", GuardrailResult)
+        setattr(self.llm_config, "response_format", _LLMGuardrailResponse)
         self.client = OpenAIWrapper(**self.llm_config.model_dump())
 
         self.check_prompt = f"""You are a guardrail that checks if a condition is met in the conversation you are given.
@@ -94,7 +101,8 @@ You will activate the guardrail only if the condition is met.
             raise ValueError("Context must be a string or a list of messages.")
         # Call the LLM with the check messages
         response = self.client.create(messages=check_messages)
-        return GuardrailResult.parse(response.choices[0].message.content, guardrail=self)  # type: ignore
+        llm_result = _LLMGuardrailResponse.model_validate_json(response.choices[0].message.content)  # type: ignore[arg-type]
+        return GuardrailResult(activated=llm_result.activated, justification=llm_result.justification, guardrail=self)
 
 
 class RegexGuardrail(Guardrail):

--- a/test/agentchat/group/test_guardrails.py
+++ b/test/agentchat/group/test_guardrails.py
@@ -219,8 +219,37 @@ class TestLLMGuardrail:
                 name="test_llm_guardrail", condition="test condition", target=mock_target, llm_config=mock_llm_config
             )
 
-            # Verify that response_format was set to GuardrailResult
             mock_llm_config.deepcopy.assert_called_once()
+
+    def test_check_tolerates_guardrail_key_in_llm_response(
+        self, mock_target: TransitionTarget, mock_llm_config: MagicMock
+    ) -> None:
+        """LLM response that includes a 'guardrail' key must not raise TypeError.
+
+        Some LLMs echo back every field in the response_format schema (including
+        non-serialisable ones like 'guardrail') as null.  Previously this caused
+        `TypeError: got multiple values for argument 'guardrail'` in parse().
+        """
+        with patch("autogen.agentchat.group.guardrails.OpenAIWrapper") as mock_openai:
+            mock_wrapper = MagicMock()
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            # LLM includes 'guardrail' key — must be silently ignored
+            mock_response.choices[
+                0
+            ].message.content = '{"activated": true, "justification": "Triggered", "guardrail": null}'
+            mock_wrapper.create.return_value = mock_response
+            mock_openai.return_value = mock_wrapper
+
+            guardrail = LLMGuardrail(
+                name="test_llm_guardrail", condition="test condition", target=mock_target, llm_config=mock_llm_config
+            )
+
+            result = guardrail.check("Some context")
+
+            assert result.activated is True
+            assert result.justification == "Triggered"
+            assert result.guardrail is guardrail
 
 
 class TestRegexGuardrail:


### PR DESCRIPTION
## Summary

Fixes #2334.

**Root cause:** `LLMGuardrail.__init__` set `response_format=GuardrailResult` on the OpenAI client. `GuardrailResult` contains a `guardrail: Guardrail` field — a non-serialisable Python object. Some LLMs (including Claude) faithfully echo every schema field back in their JSON response, producing:

```json
{"activated": true, "justification": "...", "guardrail": null}
```

`GuardrailResult.parse()` then called:

```python
GuardrailResult(**data, guardrail=guardrail)
```

which raised `TypeError: got multiple values for argument 'guardrail'` because `data` already contained `"guardrail"` from the LLM response.

**Fix:** Introduce `_LLMGuardrailResponse` — a minimal Pydantic model with only `activated` and `justification`. Use this as the `response_format` schema instead of `GuardrailResult`. After the LLM call, validate the response against `_LLMGuardrailResponse`, then construct the full `GuardrailResult` with the concrete guardrail reference. The non-serialisable field never appears in the JSON schema, so no LLM can echo it back.

## Changes

- `autogen/agentchat/group/guardrails.py`: add `_LLMGuardrailResponse`, update `LLMGuardrail` to use it
- `test/agentchat/group/test_guardrails.py`: add regression test `test_check_tolerates_guardrail_key_in_llm_response` that simulates the exact failure mode

## Test plan

- [x] All 25 existing guardrail tests pass
- [x] New regression test confirms the fix: LLM response with `"guardrail": null` no longer raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)