### PR TITLE
feat(beta): AG-UI support reasoning messages in both directions

### DIFF
--- a/autogen/beta/ag_ui/stream.py
+++ b/autogen/beta/ag_ui/stream.py
@@ -11,6 +11,11 @@ from uuid import uuid4
 
 from ag_ui.core import (
     BaseEvent,
+    ReasoningEndEvent,
+    ReasoningMessageContentEvent,
+    ReasoningMessageEndEvent,
+    ReasoningMessageStartEvent,
+    ReasoningStartEvent,
     RunAgentInput,
     RunErrorEvent,
     RunFinishedEvent,
@@ -131,7 +136,7 @@ async def run_stream(
         client_tools.append(tool)
         client_tools_names.add(tool.name)
 
-    extracted_prompt, history_messages = map_agui_messages_to_events(command)
+    extracted_prompt, history_messages, current_turn = map_agui_messages_to_events(command)
     if extracted_prompt:
         command.prompt.extend(extracted_prompt)
     if client_tools:
@@ -141,10 +146,55 @@ async def run_stream(
     await stream.history.replace(history_messages)
 
     streaming_msg_id: str | None = None
+    reasoning_msg_id: str | None = None
 
     @stream.subscribe
     async def map_events_to_ag_ui(event: events.BaseEvent) -> None:
-        nonlocal streaming_msg_id
+        nonlocal streaming_msg_id, reasoning_msg_id
+
+        if reasoning_msg_id is not None and not isinstance(event, events.ModelReasoning):
+            await write_events_stream.send(
+                ReasoningMessageEndEvent(
+                    message_id=reasoning_msg_id,
+                    timestamp=_get_timestamp(),
+                )
+            )
+            await write_events_stream.send(
+                ReasoningEndEvent(
+                    message_id=reasoning_msg_id,
+                    timestamp=_get_timestamp(),
+                )
+            )
+            reasoning_msg_id = None
+
+        if isinstance(event, events.ModelReasoning):
+            if not event.content:
+                return
+
+            if reasoning_msg_id is None:
+                reasoning_msg_id = str(uuid4())
+                await write_events_stream.send(
+                    ReasoningStartEvent(
+                        message_id=reasoning_msg_id,
+                        timestamp=_get_timestamp(),
+                    )
+                )
+                await write_events_stream.send(
+                    ReasoningMessageStartEvent(
+                        message_id=reasoning_msg_id,
+                        role="reasoning",
+                        timestamp=_get_timestamp(),
+                    )
+                )
+
+            await write_events_stream.send(
+                ReasoningMessageContentEvent(
+                    message_id=reasoning_msg_id,
+                    delta=event.content,
+                    timestamp=_get_timestamp(),
+                )
+            )
+            return
 
         if isinstance(event, events.ModelMessageChunk):
             if not event.content:
@@ -270,6 +320,7 @@ async def run_stream(
             initial_state = (command.incoming.state or {}) | initial_vars
 
             result = await agent.ask(
+                *current_turn,
                 prompt=command.prompt,
                 tools=command.tools,
                 variables=initial_state,
@@ -308,10 +359,21 @@ async def run_stream(
             )
 
 
-def map_agui_messages_to_events(command: AGStreamInput) -> tuple[list[str], list[events.BaseEvent]]:
+def map_agui_messages_to_events(
+    command: AGStreamInput,
+) -> tuple[list[str], list[events.BaseEvent], list[events.Input]]:
+    """Translate AG-UI history into the parts ``run_stream`` hands to the agent.
+
+    Returns the system/developer ``prompt`` strings, the prior-turn ``history``
+    events, and the parts of the current user turn (trailing run of
+    ``UserMessage`` entries). The current turn is kept separate because
+    ``Agent.ask`` always constructs a ``ModelRequest`` from ``*msg`` and sends
+    it as the loop's initial event — putting the current turn there gives the
+    LLM a meaningful ``messages[-1]`` instead of an empty placeholder.
+    """
     prompt, messages = [], []
 
-    input_buffer = []
+    input_buffer: list[events.Input] = []
     for m in command.incoming.messages:
         if m.role == "user":
             content = m.content
@@ -351,7 +413,7 @@ def map_agui_messages_to_events(command: AGStreamInput) -> tuple[list[str], list
 
         if input_buffer:
             messages.append(events.ModelRequest(input_buffer))
-            input_buffer.clear()
+            input_buffer = []
 
         if m.role in ["system", "developer"]:
             prompt.append(m.content)
@@ -373,6 +435,10 @@ def map_agui_messages_to_events(command: AGStreamInput) -> tuple[list[str], list
                 )
             )
 
+        elif m.role == "reasoning":
+            if m.content:
+                messages.append(events.ModelReasoning(m.content))
+
         elif m.role == "tool":
             messages.append(
                 events.ToolResultsEvent([
@@ -383,10 +449,7 @@ def map_agui_messages_to_events(command: AGStreamInput) -> tuple[list[str], list
                 ])
             )
 
-    if input_buffer:
-        messages.append(events.ModelRequest(input_buffer))
-
-    return prompt, messages
+    return prompt, messages, input_buffer
 
 
 def _stringify_tool_result(result: ToolResult, serializer: SerializerProto) -> str:

--- a/test/beta/ag_ui/test_reasoning.py
+++ b/test/beta/ag_ui/test_reasoning.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+from ag_ui.core import ReasoningMessage, UserMessage
+from dirty_equals import IsPartialDict
+from typing_extensions import Self
+
+from autogen.beta import Agent, Context
+from autogen.beta.ag_ui import AGUIStream
+from autogen.beta.config import LLMClient, ModelConfig
+from autogen.beta.events import (
+    BaseEvent,
+    ModelMessage,
+    ModelReasoning,
+    ModelResponse,
+    ToolCallsEvent,
+)
+from autogen.beta.testing import TestConfig, TrackingConfig
+
+from .utils import (
+    assert_event_type,
+    assert_no_event_type,
+    collect_events,
+    create_run_input,
+    get_events_of_type,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class _ReasoningClient(LLMClient):
+    """Emits a fixed sequence of ``ModelReasoning`` events followed by a
+    final ``ModelMessage`` — used to drive the outbound subscriber under
+    test. ``TestConfig`` cannot inject ``ModelReasoning`` events, so a
+    custom client is required (mirrors the streaming pattern in
+    ``test_empty_chunks.py``)."""
+
+    def __init__(self, *chunks: str, final: str = "Done") -> None:
+        self.chunks = chunks
+        self.final = final
+
+    async def __call__(
+        self,
+        messages: Sequence[BaseEvent],
+        context: Context,
+        **kwargs: Any,
+    ) -> ModelResponse:
+        for chunk in self.chunks:
+            await context.send(ModelReasoning(chunk))
+
+        message = ModelMessage(self.final)
+        await context.send(message)
+        return ModelResponse(message=message, tool_calls=ToolCallsEvent([]))
+
+
+class _ReasoningConfig(ModelConfig):
+    def __init__(self, *chunks: str, final: str = "Done") -> None:
+        self.chunks = chunks
+        self.final = final
+
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> _ReasoningClient:
+        return _ReasoningClient(*self.chunks, final=self.final)
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+class _CapturingClient(LLMClient):
+    """Stores the full ``messages`` sequence handed to the LLM so the test
+    can assert on the entire pre-LLM history. ``TrackingConfig`` only
+    records ``messages[-1]`` and so cannot verify that a particular event
+    sits *anywhere* in the list."""
+
+    def __init__(self) -> None:
+        self.messages: list[BaseEvent] = []
+
+    async def __call__(
+        self,
+        messages: Sequence[BaseEvent],
+        context: Context,
+        **kwargs: Any,
+    ) -> ModelResponse:
+        self.messages = list(messages)
+        message = ModelMessage("Done")
+        await context.send(message)
+        return ModelResponse(message=message, tool_calls=ToolCallsEvent([]))
+
+
+class _CapturingConfig(ModelConfig):
+    def __init__(self) -> None:
+        self.client = _CapturingClient()
+
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> _CapturingClient:
+        return self.client
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+class TestInboundReasoning:
+    async def test_reasoning_message_becomes_model_reasoning_event(self) -> None:
+        config = _CapturingConfig()
+        agent = Agent("test_agent", config=config)
+        stream = AGUIStream(agent)
+
+        run_input = create_run_input(
+            UserMessage(id="msg_1", content="Hi"),
+            ReasoningMessage(id="msg_2", content="user is greeting me"),
+        )
+
+        await collect_events(stream, run_input)
+
+        # ReasoningMessage from AG-UI history is restored as a
+        # ``ModelReasoning`` event before the agent's turn runs, so the
+        # LLM sees it in the messages list.
+        assert ModelReasoning("user is greeting me") in config.client.messages
+
+    async def test_empty_reasoning_message_dropped(self) -> None:
+        tracking = TrackingConfig(TestConfig("Done"))
+        agent = Agent("test_agent", config=tracking)
+        stream = AGUIStream(agent)
+
+        run_input = create_run_input(
+            UserMessage(id="msg_1", content="Hi"),
+            ReasoningMessage(id="msg_2", content=""),
+        )
+
+        await collect_events(stream, run_input)
+
+        # Empty reasoning is dropped — last message handed to the LLM is
+        # the user's ``ModelRequest``, not a ``ModelReasoning``.
+        [(last_msg,)] = [call.args for call in tracking.mock.call_args_list]
+        assert not isinstance(last_msg, ModelReasoning)
+
+
+class TestOutboundReasoning:
+    async def test_reasoning_chunks_emit_full_session(self) -> None:
+        agent = Agent("test_agent", config=_ReasoningConfig("Thinking", " more"))
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="m1", content="hi"))
+
+        events = await collect_events(stream, run_input)
+
+        start = assert_event_type(events, "REASONING_START")
+        message_id = start["messageId"]
+
+        assert assert_event_type(events, "REASONING_MESSAGE_START") == IsPartialDict({
+            "messageId": message_id,
+            "role": "reasoning",
+        })
+        assert get_events_of_type(events, "REASONING_MESSAGE_CONTENT") == [
+            IsPartialDict({"messageId": message_id, "delta": "Thinking"}),
+            IsPartialDict({"messageId": message_id, "delta": " more"}),
+        ]
+        assert assert_event_type(events, "REASONING_MESSAGE_END") == IsPartialDict({
+            "messageId": message_id,
+        })
+        assert assert_event_type(events, "REASONING_END") == IsPartialDict({
+            "messageId": message_id,
+        })
+
+    async def test_reasoning_session_closes_before_text_message(self) -> None:
+        agent = Agent("test_agent", config=_ReasoningConfig("thinking", final="Final answer"))
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="m1", content="hi"))
+
+        events = await collect_events(stream, run_input)
+
+        types = [e["type"] for e in events if e["type"].startswith(("REASONING_", "TEXT_MESSAGE_"))]
+        reasoning_end_idx = types.index("REASONING_END")
+        first_text_idx = next(i for i, t in enumerate(types) if t.startswith("TEXT_MESSAGE_"))
+        assert reasoning_end_idx < first_text_idx
+
+    async def test_empty_reasoning_chunk_skipped(self) -> None:
+        agent = Agent("test_agent", config=_ReasoningConfig("", "real thought"))
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="m1", content="hi"))
+
+        events = await collect_events(stream, run_input)
+
+        assert get_events_of_type(events, "REASONING_MESSAGE_CONTENT") == [
+            IsPartialDict({"delta": "real thought"}),
+        ]
+
+    async def test_no_reasoning_emits_no_reasoning_events(self) -> None:
+        agent = Agent("test_agent", config=_ReasoningConfig(final="Hello"))
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="m1", content="hi"))
+
+        events = await collect_events(stream, run_input)
+
+        assert_no_event_type(events, "REASONING_START")
+        assert_no_event_type(events, "REASONING_MESSAGE_START")
+        assert_no_event_type(events, "REASONING_MESSAGE_CONTENT")
+        assert_no_event_type(events, "REASONING_MESSAGE_END")
+        assert_no_event_type(events, "REASONING_END")


### PR DESCRIPTION
## Summary
- Add outbound translation of `ModelReasoning` events into the AG-UI `REASONING_*` event sequence; session opens lazily on the first non-empty chunk and closes before any subsequent non-reasoning event.
- Add inbound mapping so `ReasoningMessage` entries in `RunAgentInput.messages` are restored as `ModelReasoning` events in stream history before the turn runs. Empty content is dropped.
- Fix a pre-existing structural issue in `run_stream`: the AG-UI flow used to flush the trailing `UserMessage` into history *and* call `agent.ask` with no `*msg`, which made `Agent.ask` append an empty `ModelRequest(parts=[])` as the loop's initial event. `map_agui_messages_to_events` now returns the trailing user parts separately, and `run_stream` passes them as `*msg` so the LLM sees the real current turn at `messages[-1]`.

## Test plan
- [x] `uv run pytest test/beta/ag_ui/` — all 28 tests green (including the new `test_reasoning.py`)
- [x] New `test/beta/ag_ui/test_reasoning.py` covers:
  - Inbound: `ReasoningMessage` becomes a `ModelReasoning` event visible to the LLM
  - Inbound: empty `ReasoningMessage` is dropped
  - Outbound: full `REASONING_START → MESSAGE_START → CONTENT × N → MESSAGE_END → END` session with stable `messageId` and `role="reasoning"`
  - Outbound: reasoning session closes before any subsequent `TEXT_MESSAGE_*` event
  - Outbound: empty reasoning chunks are skipped
  - Outbound: no reasoning emitted → no `REASONING_*` events
- [x] Manually verified the LLM-side `messages` list for 6 scenarios (single user, user+trailing reasoning, multi-turn ending with user, reasoning+tool round-trip, system/developer+user, user+empty reasoning) — normal flows no longer carry an empty trailing `ModelRequest`; the two scenarios where AG-UI input does not end with a `UserMessage` still leave a harmless empty placeholder, which is a structural property of `Agent.ask` and out of scope here.
