### PR TITLE
feat(beta): AG-UI support multimodal user message content

### DIFF
--- a/autogen/beta/ag_ui/stream.py
+++ b/autogen/beta/ag_ui/stream.py
@@ -322,36 +322,39 @@ def map_agui_messages_to_events(command: AGStreamInput) -> tuple[list[str], list
             for c in content:
                 if c.type == "text":
                     input_buffer.append(events.TextInput(c.text))
+                    continue
 
-                elif c.url:
-                    input_buffer.append(
-                        events.UrlInput(
-                            c.url,
-                            kind=events.BinaryType.BINARY,
+                match c.type:
+                    case "image":
+                        factory = events.ImageInput
+                    case "audio":
+                        factory = events.AudioInput
+                    case "video":
+                        factory = events.VideoInput
+                    case "document":
+                        factory = events.DocumentInput
+                    case "binary":
+                        raise ValueError(
+                            "AG-UI 'binary' content type is deprecated; "
+                            "use ImageInputContent / AudioInputContent / "
+                            "VideoInputContent / DocumentInputContent instead."
                         )
-                    )
 
-                elif c.id:
-                    input_buffer.append(
-                        events.FileIdInput(
-                            c.id,
-                            filename=c.filename,
-                        )
-                    )
+                src = c.source
+                if src.type == "url":
+                    inp = factory(src.value)
+                else:
+                    inp = factory(data=b64decode(src.value), media_type=src.mime_type)
 
-                elif c.data:
-                    input_buffer.append(
-                        events.BinaryInput(
-                            b64decode(c.data),
-                            media_type=c.mime_type,
-                        )
-                    )
+                if c.metadata:
+                    inp.metadata = c.metadata
+                input_buffer.append(inp)
 
             continue
 
         if input_buffer:
             messages.append(events.ModelRequest(input_buffer))
-            input_buffer.clear()
+            input_buffer = []
 
         if m.role in ["system", "developer"]:
             prompt.append(m.content)

--- a/test/beta/ag_ui/test_mapper.py
+++ b/test/beta/ag_ui/test_mapper.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+from base64 import b64encode
+from typing import Any
+
+import pytest
+from ag_ui.core import (
+    AssistantMessage,
+    AudioInputContent,
+    BinaryInputContent,
+    DocumentInputContent,
+    FunctionCall,
+    ImageInputContent,
+    InputContentDataSource,
+    InputContentUrlSource,
+    SystemMessage,
+    TextInputContent,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+    VideoInputContent,
+)
+
+from autogen.beta import ToolResult
+from autogen.beta.ag_ui.stream import AGStreamInput, map_agui_messages_to_events
+from autogen.beta.events import (
+    AudioInput,
+    DocumentInput,
+    ImageInput,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    ToolCallEvent,
+    ToolCallsEvent,
+    ToolResultEvent,
+    ToolResultsEvent,
+    VideoInput,
+)
+
+from .utils import create_run_input
+
+RAW_BYTES = b"\xff\xd8\xff\xe0"
+B64_VALUE = b64encode(RAW_BYTES).decode()
+
+
+def _command(*messages: object) -> AGStreamInput:
+    return AGStreamInput(incoming=create_run_input(*messages), variables={})
+
+
+class TestUserMessageString:
+    def test_plain_string_becomes_text_input(self) -> None:
+        command = _command(UserMessage(id="m1", content="hello"))
+
+        prompt, messages = map_agui_messages_to_events(command)
+
+        assert prompt == []
+        assert messages == [ModelRequest([TextInput("hello")])]
+
+    def test_text_content_becomes_text_input(self) -> None:
+        command = _command(UserMessage(id="m1", content=[TextInputContent(text="hi")]))
+
+        prompt, messages = map_agui_messages_to_events(command)
+
+        assert messages == [ModelRequest([TextInput("hi")])]
+
+
+@pytest.mark.parametrize(
+    "content_cls,factory,mime",
+    [
+        (ImageInputContent, ImageInput, "image/jpeg"),
+        (AudioInputContent, AudioInput, "audio/wav"),
+        (VideoInputContent, VideoInput, "video/mp4"),
+        (DocumentInputContent, DocumentInput, "application/pdf"),
+    ],
+)
+class TestMediaContentMapping:
+    def test_url_source_maps_to_url_input(self, content_cls: type, factory: Any, mime: str) -> None:
+        url = "https://example.com/file"
+        content = content_cls(source=InputContentUrlSource(value=url))
+        command = _command(UserMessage(id="m1", content=[content]))
+
+        _, messages = map_agui_messages_to_events(command)
+
+        assert messages == [ModelRequest([factory(url)])]
+
+    def test_data_source_maps_to_binary_input(self, content_cls: type, factory: Any, mime: str) -> None:
+        content = content_cls(source=InputContentDataSource(value=B64_VALUE, mime_type=mime))
+        command = _command(UserMessage(id="m1", content=[content]))
+
+        _, messages = map_agui_messages_to_events(command)
+
+        assert messages == [ModelRequest([factory(data=RAW_BYTES, media_type=mime)])]
+
+
+class TestBinaryContentRejected:
+    def test_binary_type_raises(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            binary = BinaryInputContent(mime_type="application/octet-stream", url="https://x/blob")
+        command = _command(UserMessage(id="m1", content=[binary]))
+
+        with pytest.raises(ValueError, match="deprecated"):
+            map_agui_messages_to_events(command)
+
+
+class TestMetadata:
+    def test_content_metadata_propagates_to_input_metadata(self) -> None:
+        command = _command(
+            UserMessage(
+                id="m1",
+                content=[
+                    TextInputContent(text="hi"),
+                    ImageInputContent(
+                        source=InputContentUrlSource(value="https://x/i.png"),
+                        metadata={"alt": "cat"},
+                    ),
+                ],
+            )
+        )
+
+        _, messages = map_agui_messages_to_events(command)
+
+        text_part, image_part = messages[0].parts
+        assert text_part.metadata == {}
+        assert image_part.metadata == {"alt": "cat"}
+
+
+class TestNonUserRoles:
+    def test_system_message_goes_to_prompt(self) -> None:
+        command = _command(
+            SystemMessage(id="s1", content="be brief"),
+            UserMessage(id="u1", content="hi"),
+        )
+
+        prompt, messages = map_agui_messages_to_events(command)
+
+        assert prompt == ["be brief"]
+        assert messages == [ModelRequest([TextInput("hi")])]
+
+    def test_assistant_message_becomes_model_response(self) -> None:
+        command = _command(
+            UserMessage(id="u1", content="hi"),
+            AssistantMessage(id="a1", content="hello!"),
+        )
+
+        _, messages = map_agui_messages_to_events(command)
+
+        assert messages == [
+            ModelRequest([TextInput("hi")]),
+            ModelResponse(ModelMessage("hello!"), tool_calls=ToolCallsEvent([])),
+        ]
+
+    def test_tool_message_becomes_tool_result(self) -> None:
+        command = _command(
+            UserMessage(id="u1", content="run tool"),
+            AssistantMessage(
+                id="a1",
+                content=None,
+                tool_calls=[
+                    ToolCall(id="t1", type="function", function=FunctionCall(name="do", arguments="{}")),
+                ],
+            ),
+            ToolMessage(id="tm1", tool_call_id="t1", content="42"),
+        )
+
+        _, messages = map_agui_messages_to_events(command)
+
+        assert messages == [
+            ModelRequest([TextInput("run tool")]),
+            ModelResponse(
+                None,
+                tool_calls=ToolCallsEvent([ToolCallEvent(id="t1", name="do", arguments="{}")]),
+            ),
+            ToolResultsEvent([ToolResultEvent(parent_id="t1", result=ToolResult(["42"]))]),
+        ]

--- a/test/beta/ag_ui/test_mapper.py
+++ b/test/beta/ag_ui/test_mapper.py
@@ -55,17 +55,19 @@ class TestUserMessageString:
     def test_plain_string_becomes_text_input(self) -> None:
         command = _command(UserMessage(id="m1", content="hello"))
 
-        prompt, messages = map_agui_messages_to_events(command)
+        prompt, messages, current_turn = map_agui_messages_to_events(command)
 
         assert prompt == []
-        assert messages == [ModelRequest([TextInput("hello")])]
+        assert messages == []
+        assert current_turn == [TextInput("hello")]
 
     def test_text_content_becomes_text_input(self) -> None:
         command = _command(UserMessage(id="m1", content=[TextInputContent(text="hi")]))
 
-        prompt, messages = map_agui_messages_to_events(command)
+        _, messages, current_turn = map_agui_messages_to_events(command)
 
-        assert messages == [ModelRequest([TextInput("hi")])]
+        assert messages == []
+        assert current_turn == [TextInput("hi")]
 
 
 @pytest.mark.parametrize(
@@ -83,17 +85,19 @@ class TestMediaContentMapping:
         content = content_cls(source=InputContentUrlSource(value=url))
         command = _command(UserMessage(id="m1", content=[content]))
 
-        _, messages = map_agui_messages_to_events(command)
+        _, messages, current_turn = map_agui_messages_to_events(command)
 
-        assert messages == [ModelRequest([factory(url)])]
+        assert messages == []
+        assert current_turn == [factory(url)]
 
     def test_data_source_maps_to_binary_input(self, content_cls: type, factory: Any, mime: str) -> None:
         content = content_cls(source=InputContentDataSource(value=B64_VALUE, mime_type=mime))
         command = _command(UserMessage(id="m1", content=[content]))
 
-        _, messages = map_agui_messages_to_events(command)
+        _, messages, current_turn = map_agui_messages_to_events(command)
 
-        assert messages == [ModelRequest([factory(data=RAW_BYTES, media_type=mime)])]
+        assert messages == []
+        assert current_turn == [factory(data=RAW_BYTES, media_type=mime)]
 
 
 class TestBinaryContentRejected:
@@ -122,9 +126,10 @@ class TestMetadata:
             )
         )
 
-        _, messages = map_agui_messages_to_events(command)
+        _, messages, current_turn = map_agui_messages_to_events(command)
 
-        text_part, image_part = messages[0].parts
+        assert messages == []
+        text_part, image_part = current_turn
         assert text_part.metadata == {}
         assert image_part.metadata == {"alt": "cat"}
 
@@ -136,10 +141,11 @@ class TestNonUserRoles:
             UserMessage(id="u1", content="hi"),
         )
 
-        prompt, messages = map_agui_messages_to_events(command)
+        prompt, messages, current_turn = map_agui_messages_to_events(command)
 
         assert prompt == ["be brief"]
-        assert messages == [ModelRequest([TextInput("hi")])]
+        assert messages == []
+        assert current_turn == [TextInput("hi")]
 
     def test_assistant_message_becomes_model_response(self) -> None:
         command = _command(
@@ -147,8 +153,9 @@ class TestNonUserRoles:
             AssistantMessage(id="a1", content="hello!"),
         )
 
-        _, messages = map_agui_messages_to_events(command)
+        _, messages, current_turn = map_agui_messages_to_events(command)
 
+        assert current_turn == []
         assert messages == [
             ModelRequest([TextInput("hi")]),
             ModelResponse(ModelMessage("hello!"), tool_calls=ToolCallsEvent([])),
@@ -167,8 +174,9 @@ class TestNonUserRoles:
             ToolMessage(id="tm1", tool_call_id="t1", content="42"),
         )
 
-        _, messages = map_agui_messages_to_events(command)
+        _, messages, current_turn = map_agui_messages_to_events(command)
 
+        assert current_turn == []
         assert messages == [
             ModelRequest([TextInput("run tool")]),
             ModelResponse(
@@ -177,3 +185,32 @@ class TestNonUserRoles:
             ),
             ToolResultsEvent([ToolResultEvent(parent_id="t1", result=ToolResult(["42"]))]),
         ]
+
+
+class TestCurrentTurnSplit:
+    def test_trailing_user_messages_split_from_history(self) -> None:
+        command = _command(
+            UserMessage(id="u1", content="first turn"),
+            AssistantMessage(id="a1", content="reply"),
+            UserMessage(id="u2", content="follow-up"),
+        )
+
+        prompt, messages, current_turn = map_agui_messages_to_events(command)
+
+        assert prompt == []
+        assert messages == [
+            ModelRequest([TextInput("first turn")]),
+            ModelResponse(ModelMessage("reply"), tool_calls=ToolCallsEvent([])),
+        ]
+        assert current_turn == [TextInput("follow-up")]
+
+    def test_consecutive_trailing_user_messages_accumulate_in_current_turn(self) -> None:
+        command = _command(
+            UserMessage(id="u1", content="hello"),
+            UserMessage(id="u2", content="and more"),
+        )
+
+        _, messages, current_turn = map_agui_messages_to_events(command)
+
+        assert messages == []
+        assert current_turn == [TextInput("hello"), TextInput("and more")]

--- a/test/beta/ag_ui/test_multimodal_input.py
+++ b/test/beta/ag_ui/test_multimodal_input.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from base64 import b64encode
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+from ag_ui.core import (
+    AudioInputContent,
+    DocumentInputContent,
+    ImageInputContent,
+    InputContentDataSource,
+    InputContentUrlSource,
+    TextInputContent,
+    UserMessage,
+    VideoInputContent,
+)
+from typing_extensions import Self
+
+from autogen.beta import Agent, Context
+from autogen.beta.ag_ui import AGUIStream
+from autogen.beta.config import LLMClient, ModelConfig
+from autogen.beta.events import (
+    AudioInput,
+    BaseEvent,
+    DocumentInput,
+    ImageInput,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    VideoInput,
+)
+
+from .utils import collect_events, create_run_input
+
+pytestmark = pytest.mark.asyncio
+
+
+RAW_BYTES = b"\xff\xd8\xff\xe0"
+B64_VALUE = b64encode(RAW_BYTES).decode()
+
+
+class _CaptureClient(LLMClient):
+    """LLM client that records the full ``messages`` list handed to the LLM.
+
+    ``TrackingConfig`` only stores ``messages[-1]``, which in the current
+    ``Agent.ask`` flow is an empty placeholder ``ModelRequest`` rather than
+    the user turn we want to assert on. A custom client is needed to inspect
+    the rest of the list (same pattern as ``_StreamingClient`` in
+    ``test_empty_chunks.py``).
+    """
+
+    def __init__(self, captured: list[list[BaseEvent]]) -> None:
+        self.captured = captured
+
+    async def __call__(self, messages: Sequence[BaseEvent], context: Context, **kwargs: Any) -> ModelResponse:
+        self.captured.append(list(messages))
+        msg = ModelMessage("ok")
+        await context.send(msg)
+        return ModelResponse(msg)
+
+
+class _CaptureConfig(ModelConfig):
+    def __init__(self) -> None:
+        self.captured: list[list[BaseEvent]] = []
+
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> _CaptureClient:
+        return _CaptureClient(self.captured)
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+def _user_request(config: _CaptureConfig) -> ModelRequest:
+    [messages] = config.captured
+    for m in messages:
+        if isinstance(m, ModelRequest) and m.parts:
+            return m
+    raise AssertionError(f"No non-empty ModelRequest in {messages!r}")
+
+
+async def _dispatch(*content_items: object) -> ModelRequest:
+    config = _CaptureConfig()
+    agent = Agent("test_agent", config=config)
+    stream = AGUIStream(agent)
+    run_input = create_run_input(UserMessage(id="msg_1", content=list(content_items)))
+
+    await collect_events(stream, run_input)
+
+    return _user_request(config)
+
+
+class TestTextContent:
+    async def test_plain_string_content(self) -> None:
+        config = _CaptureConfig()
+        agent = Agent("test_agent", config=config)
+        stream = AGUIStream(agent)
+        run_input = create_run_input(UserMessage(id="msg_1", content="hi there"))
+
+        await collect_events(stream, run_input)
+
+        assert _user_request(config).parts == [TextInput("hi there")]
+
+    async def test_text_input_content(self) -> None:
+        request = await _dispatch(TextInputContent(text="hello"))
+
+        assert request.parts == [TextInput("hello")]
+
+    async def test_mixed_text_and_image_url(self) -> None:
+        request = await _dispatch(
+            TextInputContent(text="describe this"),
+            ImageInputContent(source=InputContentUrlSource(value="https://x/img.png")),
+        )
+
+        assert request.parts == [
+            TextInput("describe this"),
+            ImageInput("https://x/img.png"),
+        ]
+
+
+class TestImageContent:
+    async def test_image_url(self) -> None:
+        request = await _dispatch(
+            ImageInputContent(source=InputContentUrlSource(value="https://x/img.png", mime_type="image/png"))
+        )
+
+        assert request.parts == [ImageInput("https://x/img.png")]
+
+    async def test_image_data_base64(self) -> None:
+        request = await _dispatch(
+            ImageInputContent(source=InputContentDataSource(value=B64_VALUE, mime_type="image/jpeg"))
+        )
+
+        assert request.parts == [ImageInput(data=RAW_BYTES, media_type="image/jpeg")]
+
+
+class TestDocumentContent:
+    async def test_document_url(self) -> None:
+        request = await _dispatch(DocumentInputContent(source=InputContentUrlSource(value="https://x/doc.pdf")))
+
+        assert request.parts == [DocumentInput("https://x/doc.pdf")]
+
+    async def test_document_data_base64(self) -> None:
+        request = await _dispatch(
+            DocumentInputContent(source=InputContentDataSource(value=B64_VALUE, mime_type="application/pdf"))
+        )
+
+        assert request.parts == [DocumentInput(data=RAW_BYTES, media_type="application/pdf")]
+
+
+class TestAudioContent:
+    async def test_audio_url(self) -> None:
+        request = await _dispatch(AudioInputContent(source=InputContentUrlSource(value="https://x/a.wav")))
+
+        assert request.parts == [AudioInput("https://x/a.wav")]
+
+    async def test_audio_data_base64(self) -> None:
+        request = await _dispatch(
+            AudioInputContent(source=InputContentDataSource(value=B64_VALUE, mime_type="audio/wav"))
+        )
+
+        assert request.parts == [AudioInput(data=RAW_BYTES, media_type="audio/wav")]
+
+
+class TestVideoContent:
+    async def test_video_url(self) -> None:
+        request = await _dispatch(VideoInputContent(source=InputContentUrlSource(value="https://x/v.mp4")))
+
+        assert request.parts == [VideoInput("https://x/v.mp4")]
+
+    async def test_video_data_base64(self) -> None:
+        request = await _dispatch(
+            VideoInputContent(source=InputContentDataSource(value=B64_VALUE, mime_type="video/mp4"))
+        )
+
+        assert request.parts == [VideoInput(data=RAW_BYTES, media_type="video/mp4")]
+
+
+class TestMetadata:
+    async def test_metadata_propagates_to_url_input(self) -> None:
+        request = await _dispatch(
+            ImageInputContent(
+                source=InputContentUrlSource(value="https://x/img.png"),
+                metadata={"alt": "a cat"},
+            )
+        )
+
+        expected = ImageInput("https://x/img.png")
+        expected.metadata = {"alt": "a cat"}
+        assert request.parts == [expected]
+
+    async def test_metadata_propagates_to_binary_input(self) -> None:
+        request = await _dispatch(
+            DocumentInputContent(
+                source=InputContentDataSource(value=B64_VALUE, mime_type="application/pdf"),
+                metadata={"source_filename": "report.pdf"},
+            )
+        )
+
+        expected = DocumentInput(data=RAW_BYTES, media_type="application/pdf")
+        expected.metadata = {"source_filename": "report.pdf"}
+        assert request.parts == [expected]


### PR DESCRIPTION
## Summary
- Rewrite `map_agui_messages_to_events` against the current AG-UI protocol:
  non-text `UserMessage.content` (`Image/Audio/Video/DocumentInputContent`)
  is now correctly translated into the typed `events.ImageInput / AudioInput /
  VideoInput / DocumentInput` factories. Previously the mapper read fields
  that only existed on the deprecated `BinaryInputContent` and crashed with
  `AttributeError` on any non-string content.
- Deprecated `BinaryInputContent` (`type="binary"`) is rejected with a
  `ValueError` pointing at the typed alternatives — matches the deprecation
  posture of the upstream AG-UI Python SDK.
- Fix a pre-existing aliasing bug in the same function: `input_buffer.clear()`
  emptied the list already stored inside the appended `ModelRequest`, so any
  AG-UI history with mixed user/assistant turns produced empty
  `ModelRequest.parts`.

## Test plan
- [x] New `test/beta/ag_ui/test_mapper.py`: parametrized unit tests for every
      media type × url/data source; non-user roles (system/assistant/tool);
      metadata propagation; `BinaryInputContent` rejection.
- [x] New `test/beta/ag_ui/test_multimodal_input.py`: integration tests
      through `AGUIStream.dispatch` covering all 5 AG-UI content types. Uses a
      `_CaptureClient` because `TrackingConfig` only stores `messages[-1]`,
      which is the empty placeholder appended by `Agent.ask` — same pattern
      as `_StreamingClient` in `test_empty_chunks.py`.
- [x] `uv run pytest test/beta/ag_ui/` — all 50 tests pass (22 pre-existing + 28 new).
- [x] Smoke-tested end-to-end on real Anthropic Claude (claude-sonnet-4-6)
      via a local uvicorn + starlette server with `AGUIStream.build_asgi()`:
      image-by-URL, image-by-base64, document-PDF-by-URL all produced
      sensible Claude responses; audio surfaced `UnsupportedInputError`
      from the Anthropic mapper as expected.
