### PR TITLE
docs: add Gemini and Azure OpenAI tabs to Quick Start

### DIFF
--- a/website/docs/quick-start.mdx
+++ b/website/docs/quick-start.mdx
@@ -6,10 +6,27 @@ sidebarTitle: Quick Start
 Get up and running with AG2 in just **3 minutes**! This guide will help you set up your environment and build your very first agent workflow.
 
 !!! tip "Prerequisites"
-    Make sure you've [installed AG2](/docs/user-guide/basic-concepts/installing-ag2) before continuing. Need just 30 seconds: `pip install "ag2[openai]"`
+    Make sure you've [installed AG2](/docs/user-guide/basic-concepts/installing-ag2) before continuing. Need just 30 seconds for your provider of choice:
+
+    === "OpenAI"
+
+        ```
+        pip install "ag2[openai]"
+        ```
+
+    === "Gemini"
+
+        ```
+        pip install "ag2[gemini]"
+        ```
+
+    === "Azure OpenAI"
+
+        ```
+        pip install "ag2[openai]"
+        ```
 
 ### Set Up Your Environment
-
 
 **Python Version**
 
@@ -17,60 +34,155 @@ AG2 requires **Python version >= 3.10, < 3.14**. We recommend using a virtual en
 
 **Set Your API Key**
 
-Make sure to set your LLM API key as an environment variable:
+Make sure to set your LLM API key (and any provider-specific endpoint values) as environment variables. Pick the provider you plan to use:
 
-=== "macOS / Linux"
+=== "OpenAI"
 
-    ```
-    export OPENAI_API_KEY="YOUR_API_KEY"
-    ```
+    === "macOS / Linux"
 
-=== "Windows"
+        ```
+        export OPENAI_API_KEY="YOUR_API_KEY"
+        ```
 
-    ```
-    setx OPENAI_API_KEY "YOUR_API_KEY"
-    ```
+    === "Windows"
 
+        ```
+        setx OPENAI_API_KEY "YOUR_API_KEY"
+        ```
+
+=== "Gemini"
+
+    === "macOS / Linux"
+
+        ```
+        export GEMINI_API_KEY="YOUR_API_KEY"
+        ```
+
+    === "Windows"
+
+        ```
+        setx GEMINI_API_KEY "YOUR_API_KEY"
+        ```
+
+=== "Azure OpenAI"
+
+    === "macOS / Linux"
+
+        ```
+        export AZURE_OPENAI_API_KEY="YOUR_API_KEY"
+        export AZURE_OPENAI_ENDPOINT="https://YOUR-RESOURCE.openai.azure.com/"
+        ```
+
+    === "Windows"
+
+        ```
+        setx AZURE_OPENAI_API_KEY "YOUR_API_KEY"
+        setx AZURE_OPENAI_ENDPOINT "https://YOUR-RESOURCE.openai.azure.com/"
+        ```
 
 ### Build Your First Agent Workflow
 
+Let's build a poetic AI assistant that responds in rhymes using AG2 and your model provider of choice.
 
-Let's build a poetic AI assistant that responds in rhymes using AG2 and OpenAI's gpt-5-nano model.
+Create a Python script called `first_agent.py`, and paste the code for your provider into it. The agent behaviour is identical across providers — only the `LLMConfig` differs.
 
-Create a Python script called `first_agent.py`, and paste the following code into it:
+=== "OpenAI"
 
-```python
-import os
+    ```python
+    import os
 
-from autogen import ConversableAgent, LLMConfig
+    from autogen import ConversableAgent, LLMConfig
 
-# 1. Define our LLM configuration for OpenAI's gpt-5-nano
-#    uses the OPENAI_API_KEY environment variable
-llm_config = LLMConfig(
-    {"api_type": "openai", "model": "gpt-5-nano", "api_key": os.environ["OPENAI_API_KEY"]}
-)
+    # 1. Define our LLM configuration for OpenAI's gpt-5-nano
+    #    uses the OPENAI_API_KEY environment variable
+    llm_config = LLMConfig(
+        {"api_type": "openai", "model": "gpt-5-nano", "api_key": os.environ["OPENAI_API_KEY"]}
+    )
 
-# 2. Create our LLM agent
-my_agent = ConversableAgent(
-    name="helpful_agent",
-    system_message="You are a poetic AI assistant, respond in rhyme.",
-    llm_config=llm_config,
-)
+    # 2. Create our LLM agent
+    my_agent = ConversableAgent(
+        name="helpful_agent",
+        system_message="You are a poetic AI assistant, respond in rhyme.",
+        llm_config=llm_config,
+    )
 
-# 3. Run the agent with a prompt and process the response
-response = my_agent.run(
-    message="In one sentence, what's the big deal about AI?",
-    max_turns=3,
-    user_input=True,
-)
-response.process()
-```
+    # 3. Run the agent with a prompt and process the response
+    response = my_agent.run(
+        message="In one sentence, what's the big deal about AI?",
+        max_turns=3,
+        user_input=True,
+    )
+    response.process()
+    ```
+
+=== "Gemini"
+
+    ```python
+    import os
+
+    from autogen import ConversableAgent, LLMConfig
+
+    # 1. Define our LLM configuration for Google Gemini
+    #    uses the GEMINI_API_KEY environment variable
+    llm_config = LLMConfig(
+        {"api_type": "google", "model": "gemini-2.5-flash", "api_key": os.environ["GEMINI_API_KEY"]}
+    )
+
+    # 2. Create our LLM agent
+    my_agent = ConversableAgent(
+        name="helpful_agent",
+        system_message="You are a poetic AI assistant, respond in rhyme.",
+        llm_config=llm_config,
+    )
+
+    # 3. Run the agent with a prompt and process the response
+    response = my_agent.run(
+        message="In one sentence, what's the big deal about AI?",
+        max_turns=3,
+        user_input=True,
+    )
+    response.process()
+    ```
+
+=== "Azure OpenAI"
+
+    ```python
+    import os
+
+    from autogen import ConversableAgent, LLMConfig
+
+    # 1. Define our LLM configuration for Azure OpenAI
+    #    "model" must match your Azure *deployment name*, not the underlying model name
+    llm_config = LLMConfig(
+        {
+            "api_type": "azure",
+            "model": "my-gpt-deployment",
+            "api_key": os.environ["AZURE_OPENAI_API_KEY"],
+            "base_url": os.environ["AZURE_OPENAI_ENDPOINT"],
+            "api_version": "2025-01-01",
+        }
+    )
+
+    # 2. Create our LLM agent
+    my_agent = ConversableAgent(
+        name="helpful_agent",
+        system_message="You are a poetic AI assistant, respond in rhyme.",
+        llm_config=llm_config,
+    )
+
+    # 3. Run the agent with a prompt and process the response
+    response = my_agent.run(
+        message="In one sentence, what's the big deal about AI?",
+        max_turns=3,
+        user_input=True,
+    )
+    response.process()
+    ```
 
 !!! note "Why `run()` then `process()`?"
     `run()` prepares the conversation, `process()` executes it. This two-step pattern gives you a chance to inspect or modify the workflow before it runs.
 
 ### Run Your Example
-
 
 In your terminal, run:
 


### PR DESCRIPTION
## Why are these changes needed?

The Quick Start guide (`website/docs/quick-start.mdx`) only showed how to set up AG2 with OpenAI. Readers who wanted to use Google Gemini or Azure OpenAI had to leave the Quick Start and piece things together from the deeper provider docs (`user-guide/models/google-gemini.mdx`, `user-guide/advanced-concepts/llm-configuration-deep-dive.mdx`).

This PR restructures the three OpenAI-only segments of the Quick Start into MkDocs material tabbed sections with one tab per provider:

- **Prerequisites**: per-provider `pip install` extra.
- **Set Your API Key**: per-provider env-var instructions, each with macOS/Linux and Windows sub-tabs. The Azure tab includes `AZURE_OPENAI_ENDPOINT` as required by the SDK.
- **Build Your First Agent Workflow**: per-provider `LLMConfig` snippet. The agent body is identical across providers so the reader can see at a glance that only the config differs.

OpenAI remains the first tab in every group, so the default rendered experience is unchanged. The Gemini snippet matches the patterns in `user-guide/models/google-gemini.mdx` (`api_type: "google"`, `gemini-2.5-flash`), and the Azure snippet matches `user-guide/advanced-concepts/llm-configuration-deep-dive.mdx` (`api_type: "azure"`, `base_url`, `api_version: "2025-01-01"`).

## Related issue number

Closes #1680

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR. N/A, documentation-only change.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.