### PR TITLE
feat(beta): Add custom span attributes/values for telemetry

### DIFF
--- a/autogen/beta/middleware/builtin/telemetry.py
+++ b/autogen/beta/middleware/builtin/telemetry.py
@@ -57,6 +57,7 @@ class TelemetryMiddleware(MiddlewareFactory):
         agent_name: Agent name for span attributes. If not set, defaults to "unknown".
         provider_name: LLM provider name (e.g. "openai", "anthropic").
         model_name: Model name (e.g. "gpt-4o-mini").
+        span_attributes: Optional dict of extra key-value pairs stamped onto every span this middleware emits.
     """
 
     def __init__(
@@ -67,12 +68,14 @@ class TelemetryMiddleware(MiddlewareFactory):
         agent_name: str | None = None,
         provider_name: str | None = None,
         model_name: str | None = None,
+        span_attributes: dict[str, str] | None = None,
     ) -> None:
         self._tracer = _get_tracer(tracer_provider)
         self._capture_content = capture_content
         self._agent_name = agent_name or "unknown"
         self._provider_name = provider_name
         self._model_name = model_name
+        self._span_attributes: dict[str, str] = span_attributes or {}
 
     def __call__(self, event: BaseEvent, context: Context) -> BaseMiddleware:
         return _TelemetryMiddlewareInstance(
@@ -83,6 +86,7 @@ class TelemetryMiddleware(MiddlewareFactory):
             agent_name=self._agent_name,
             provider_name=self._provider_name,
             model_name=self._model_name,
+            span_attributes=self._span_attributes,
         )
 
 
@@ -97,6 +101,7 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
         agent_name: str,
         provider_name: str | None,
         model_name: str | None,
+        span_attributes: dict[str, str],
     ) -> None:
         super().__init__(event, context)
         self._tracer = tracer
@@ -104,6 +109,7 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
         self._agent_name = agent_name
         self._provider_name = provider_name
         self._model_name = model_name
+        self._span_attributes = span_attributes
 
     async def on_turn(
         self,
@@ -115,6 +121,8 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
             f"invoke_agent {self._agent_name}",
             kind=SpanKind.INTERNAL,
         ) as span:
+            for k, v in self._span_attributes.items():
+                span.set_attribute(k, v)
             span.set_attribute("ag2.span.type", "agent")
             span.set_attribute("gen_ai.operation.name", "invoke_agent")
             span.set_attribute("gen_ai.agent.name", self._agent_name)
@@ -144,6 +152,8 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
             span_name,
             kind=SpanKind.CLIENT,
         ) as span:
+            for k, v in self._span_attributes.items():
+                span.set_attribute(k, v)
             span.set_attribute("ag2.span.type", "llm")
             span.set_attribute("gen_ai.operation.name", "chat")
             if self._provider_name:
@@ -209,6 +219,8 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
             f"execute_tool {event.name}",
             kind=SpanKind.INTERNAL,
         ) as span:
+            for k, v in self._span_attributes.items():
+                span.set_attribute(k, v)
             span.set_attribute("ag2.span.type", "tool")
             span.set_attribute("gen_ai.operation.name", "execute_tool")
             span.set_attribute("gen_ai.tool.name", event.name)
@@ -245,6 +257,8 @@ class _TelemetryMiddlewareInstance(BaseMiddleware):
             f"await_human_input {self._agent_name}",
             kind=SpanKind.INTERNAL,
         ) as span:
+            for k, v in self._span_attributes.items():
+                span.set_attribute(k, v)
             span.set_attribute("ag2.span.type", "human_input")
             span.set_attribute("gen_ai.operation.name", "await_human_input")
             span.set_attribute("gen_ai.agent.name", self._agent_name)

--- a/test/beta/middleware/telemetry/test_telemetry.py
+++ b/test/beta/middleware/telemetry/test_telemetry.py
@@ -472,6 +472,94 @@ async def test_thinking_tokens_when_nonzero(otel_setup):
 
 
 @pytest.mark.asyncio()
+async def test_span_attributes_stamped_on_all_spans(otel_setup):
+    """Extra span_attributes are applied to every span type the middleware emits."""
+    exporter, provider = otel_setup
+
+    @tool
+    def echo(msg: str) -> str:
+        """Echo."""
+        return msg
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(
+            ModelResponse(
+                tool_calls=ToolCallsEvent(calls=[ToolCallEvent(id="call_1", name="echo", arguments='{"msg": "hi"}')]),
+            ),
+            ModelResponse(ModelMessage("Done")),
+        ),
+        tools=[echo],
+        middleware=[
+            TelemetryMiddleware(
+                tracer_provider=provider,
+                agent_name="assistant",
+                span_attributes={"ag2.org.id": "org-123", "deployment": "prod"},
+            )
+        ],
+    )
+
+    await agent.ask("Go")
+
+    spans = exporter.get_finished_spans()
+    for span in spans:
+        assert span.attributes.get("ag2.org.id") == "org-123", f"missing on span {span.name!r}"
+        assert span.attributes.get("deployment") == "prod", f"missing on span {span.name!r}"
+
+
+@pytest.mark.asyncio()
+async def test_intrinsic_attributes_win_on_collision(otel_setup):
+    """Middleware-owned attributes overwrite span_attributes when keys collide."""
+    exporter, provider = otel_setup
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(ModelResponse(ModelMessage("Hi!"))),
+        middleware=[
+            TelemetryMiddleware(
+                tracer_provider=provider,
+                agent_name="assistant",
+                span_attributes={
+                    "ag2.span.type": "SHOULD_BE_OVERWRITTEN",
+                    "gen_ai.operation.name": "SHOULD_BE_OVERWRITTEN",
+                    "gen_ai.agent.name": "SHOULD_BE_OVERWRITTEN",
+                },
+            )
+        ],
+    )
+
+    await agent.ask("Hi")
+
+    spans = exporter.get_finished_spans()
+    agent_span = next(s for s in spans if s.attributes.get("ag2.span.type") == "agent")
+    assert agent_span.attributes["ag2.span.type"] == "agent"
+    assert agent_span.attributes["gen_ai.operation.name"] == "invoke_agent"
+    assert agent_span.attributes["gen_ai.agent.name"] == "assistant"
+
+    llm_span = next(s for s in spans if s.attributes.get("ag2.span.type") == "llm")
+    assert llm_span.attributes["ag2.span.type"] == "llm"
+    assert llm_span.attributes["gen_ai.operation.name"] == "chat"
+
+
+@pytest.mark.asyncio()
+async def test_span_attributes_omitted_when_not_provided(otel_setup):
+    """No extra attributes appear when span_attributes is not passed."""
+    exporter, provider = otel_setup
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(ModelResponse(ModelMessage("Hi!"))),
+        middleware=[TelemetryMiddleware(tracer_provider=provider, agent_name="assistant")],
+    )
+
+    await agent.ask("Hello")
+
+    spans = exporter.get_finished_spans()
+    for span in spans:
+        assert "ag2.org.id" not in span.attributes
+
+
+@pytest.mark.asyncio()
 async def test_thinking_tokens_omitted_when_zero(otel_setup):
     """thinking_tokens=0 is treated as absent and not exported."""
     exporter, provider = otel_setup

--- a/website/docs/beta/telemetry.mdx
+++ b/website/docs/beta/telemetry.mdx
@@ -120,6 +120,27 @@ When content capture is enabled (the default), spans include these additional at
 !!! warning
     With `capture_content=True`, message content, tool arguments, and human input will appear in your tracing backend. Ensure your backend has appropriate access controls.
 
+## Custom Span Attributes
+
+Use `span_attributes` to stamp custom key-value pairs onto spans the middleware emits. This is useful for routing or filtering traces by tenant, environment, deployment, or any other label your backend supports. Every span will carry these attributes.
+
+```python
+TelemetryMiddleware(
+    tracer_provider=tracer_provider,
+    agent_name="assistant",
+    span_attributes={
+        "deployment": "production",
+        "ag2.org.id": "org-abc123",
+    },
+)
+```
+
+!!! tip
+    This is the right place to add tenant or organization identifiers when your tracing backend filters traces by span-level labels (for example, Google Cloud Trace label filters or Datadog tags).
+
+!!! note
+    If a key in `span_attributes` collides with an intrinsic attribute set by the middleware (such as `ag2.span.type` or `gen_ai.usage.input_tokens`), the middleware's value always wins.
+
 ## Configuration
 
 `TelemetryMiddleware` accepts:
@@ -131,6 +152,7 @@ When content capture is enabled (the default), spans include these additional at
 | `agent_name` | `str \| None` | `"unknown"` | Agent name for span attributes |
 | `provider_name` | `str \| None` | `None` | LLM provider name (auto-detected from response if not set) |
 | `model_name` | `str \| None` | `None` | Model name (auto-detected from response if not set) |
+| `span_attributes` | `dict[str, str] \| None` | `None` | Extra key-value pairs stamped onto every span (tenant IDs, environment tags, etc.) |
 
 ## Tool Execution Example
 


### PR DESCRIPTION
## Why are these changes needed?

AG2's beta telemetry middleware doesn't currently allow a developer to add their own attributes and values to spans. This is useful if you need to filter the spans downstream.

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
