### PR TITLE
feat(middleware): add ConditionalMiddleware to gate middleware activation

### DIFF
--- a/autogen/beta/middleware/__init__.py
+++ b/autogen/beta/middleware/__init__.py
@@ -5,6 +5,7 @@
 from .base import (
     AgentTurn,
     BaseMiddleware,
+    ConditionalMiddleware,
     HumanInputHook,
     LLMCall,
     Middleware,
@@ -24,6 +25,7 @@ from .builtin import (
 __all__ = (
     "AgentTurn",
     "BaseMiddleware",
+    "ConditionalMiddleware",
     "HistoryLimiter",
     "HumanInputHook",
     "LLMCall",

--- a/autogen/beta/middleware/base.py
+++ b/autogen/beta/middleware/base.py
@@ -9,6 +9,7 @@ from autogen.beta.annotations import Context
 from autogen.beta.events import (
     BaseEvent,
     ClientToolCallEvent,
+    Condition,
     HumanInputRequest,
     HumanMessage,
     ModelResponse,
@@ -49,6 +50,31 @@ HumanInputHook: TypeAlias = Callable[["HumanInputRequest", "Context"], Awaitable
 ToolExecution: TypeAlias = Callable[["ToolCallEvent", "Context"], Awaitable[ToolResultType]]
 # call_next + ToolExecution type. BaseMiddleware.on_tool_execution() hook signature.
 ToolMiddleware: TypeAlias = Callable[[ToolExecution, "ToolCallEvent", "Context"], Awaitable[ToolResultType]]
+
+
+class ConditionalMiddleware:
+    """Middleware wrapper that only activates when a condition matches the initial event.
+
+    When the condition evaluates to True, delegates to the wrapped middleware.
+    When False, returns a passthrough BaseMiddleware (all hooks call call_next).
+    """
+
+    def __init__(
+        self,
+        middleware: "MiddlewareFactory",
+        condition: Condition,
+    ) -> None:
+        self._middleware = middleware
+        self._condition = condition
+
+    def __call__(
+        self,
+        event: "BaseEvent",
+        context: "Context",
+    ) -> "BaseMiddleware":
+        if self._condition(event):
+            return self._middleware(event, context)
+        return BaseMiddleware(event, context)
 
 
 class BaseMiddleware:

--- a/autogen/beta/middleware/base.py
+++ b/autogen/beta/middleware/base.py
@@ -52,31 +52,6 @@ ToolExecution: TypeAlias = Callable[["ToolCallEvent", "Context"], Awaitable[Tool
 ToolMiddleware: TypeAlias = Callable[[ToolExecution, "ToolCallEvent", "Context"], Awaitable[ToolResultType]]
 
 
-class ConditionalMiddleware:
-    """Middleware wrapper that only activates when a condition matches the initial event.
-
-    When the condition evaluates to True, delegates to the wrapped middleware.
-    When False, returns a passthrough BaseMiddleware (all hooks call call_next).
-    """
-
-    def __init__(
-        self,
-        middleware: "MiddlewareFactory",
-        condition: Condition,
-    ) -> None:
-        self._middleware = middleware
-        self._condition = condition
-
-    def __call__(
-        self,
-        event: "BaseEvent",
-        context: "Context",
-    ) -> "BaseMiddleware":
-        if self._condition(event):
-            return self._middleware(event, context)
-        return BaseMiddleware(event, context)
-
-
 class BaseMiddleware:
     def __init__(
         self,
@@ -117,3 +92,84 @@ class BaseMiddleware:
         context: "Context",
     ) -> "HumanMessage":
         return await call_next(event, context)
+
+
+class _ConditionalWrapper(BaseMiddleware):
+    """Evaluates a condition per-hook against each hook's own event."""
+
+    def __init__(
+        self,
+        event: "BaseEvent",
+        context: "Context",
+        inner: BaseMiddleware,
+        condition: Condition,
+    ) -> None:
+        super().__init__(event, context)
+        self._inner = inner
+        self._condition = condition
+
+    async def on_turn(
+        self,
+        call_next: AgentTurn,
+        event: "BaseEvent",
+        context: "Context",
+    ) -> "ModelResponse":
+        if self._condition(event):
+            return await self._inner.on_turn(call_next, event, context)
+        return await call_next(event, context)
+
+    async def on_tool_execution(
+        self,
+        call_next: ToolExecution,
+        event: "ToolCallEvent",
+        context: "Context",
+    ) -> ToolResultType:
+        if self._condition(event):
+            return await self._inner.on_tool_execution(call_next, event, context)
+        return await call_next(event, context)
+
+    async def on_llm_call(
+        self,
+        call_next: LLMCall,
+        events: "Sequence[BaseEvent]",
+        context: "Context",
+    ) -> "ModelResponse":
+        return await self._inner.on_llm_call(call_next, events, context)
+
+    async def on_human_input(
+        self,
+        call_next: HumanInputHook,
+        event: "HumanInputRequest",
+        context: "Context",
+    ) -> "HumanMessage":
+        if self._condition(event):
+            return await self._inner.on_human_input(call_next, event, context)
+        return await call_next(event, context)
+
+
+class ConditionalMiddleware:
+    """Middleware wrapper that evaluates a condition per-hook.
+
+    Each hook checks the condition against its own event parameter.
+    When the condition matches, the hook delegates to the wrapped middleware.
+    When it does not match, the hook passes through to call_next.
+
+    on_llm_call always delegates to the wrapped middleware because it receives
+    a sequence of events rather than a single event to match against.
+    """
+
+    def __init__(
+        self,
+        middleware: "MiddlewareFactory",
+        condition: Condition,
+    ) -> None:
+        self._middleware = middleware
+        self._condition = condition
+
+    def __call__(
+        self,
+        event: "BaseEvent",
+        context: "Context",
+    ) -> "BaseMiddleware":
+        inner = self._middleware(event, context)
+        return _ConditionalWrapper(event, context, inner=inner, condition=self._condition)

--- a/autogen/beta/middleware/base.py
+++ b/autogen/beta/middleware/base.py
@@ -96,8 +96,6 @@ class BaseMiddleware:
 
 
 class _ConditionalWrapper(BaseMiddleware):
-    """Evaluates a condition per-hook against each hook's own event."""
-
     def __init__(
         self,
         event: "BaseEvent",
@@ -135,7 +133,9 @@ class _ConditionalWrapper(BaseMiddleware):
         events: "Sequence[BaseEvent]",
         context: "Context",
     ) -> "ModelResponse":
-        return await self._inner.on_llm_call(call_next, events, context)
+        if self._condition(self.initial_event):
+            return await self._inner.on_llm_call(call_next, events, context)
+        return await call_next(events, context)
 
     async def on_human_input(
         self,
@@ -149,15 +149,7 @@ class _ConditionalWrapper(BaseMiddleware):
 
 
 class ConditionalMiddleware:
-    """Middleware wrapper that evaluates a condition per-hook.
-
-    Each hook checks the condition against its own event parameter.
-    When the condition matches, the hook delegates to the wrapped middleware.
-    When it does not match, the hook passes through to call_next.
-
-    on_llm_call always delegates to the wrapped middleware because it receives
-    a sequence of events rather than a single event to match against.
-    """
+    """Middleware wrapper that evaluates a condition per-hook."""
 
     def __init__(
         self,

--- a/autogen/beta/middleware/base.py
+++ b/autogen/beta/middleware/base.py
@@ -17,6 +17,7 @@ from autogen.beta.events import (
     ToolErrorEvent,
     ToolResultEvent,
 )
+from autogen.beta.events.conditions import TypeCondition
 
 
 class MiddlewareFactory(Protocol):
@@ -161,10 +162,10 @@ class ConditionalMiddleware:
     def __init__(
         self,
         middleware: "MiddlewareFactory",
-        condition: Condition,
+        condition: "Condition | type",
     ) -> None:
         self._middleware = middleware
-        self._condition = condition
+        self._condition = condition if isinstance(condition, Condition) else TypeCondition(condition)
 
     def __call__(
         self,

--- a/test/beta/middleware/test_conditional.py
+++ b/test/beta/middleware/test_conditional.py
@@ -8,8 +8,16 @@ from unittest.mock import MagicMock
 import pytest
 
 from autogen.beta import Agent, Context
-from autogen.beta.events import BaseEvent, ModelResponse, ToolCallEvent, ToolResultEvent
-from autogen.beta.middleware import AgentTurn, BaseMiddleware, ConditionalMiddleware, LLMCall, Middleware, ToolExecution
+from autogen.beta.events import BaseEvent, HumanInputRequest, HumanMessage, ModelResponse, ToolCallEvent, ToolResultEvent
+from autogen.beta.middleware import (
+    AgentTurn,
+    BaseMiddleware,
+    ConditionalMiddleware,
+    HumanInputHook,
+    LLMCall,
+    Middleware,
+    ToolExecution,
+)
 from autogen.beta.testing import TestConfig
 
 
@@ -49,6 +57,15 @@ class TrackingMiddleware(BaseMiddleware):
     ) -> ModelResponse:
         self.mock.on_llm(len(events))
         return await call_next(events, ctx)
+
+    async def on_human_input(
+        self,
+        call_next: HumanInputHook,
+        event: HumanInputRequest,
+        ctx: Context,
+    ) -> HumanMessage:
+        self.mock.on_human(event.content)
+        return await call_next(event, ctx)
 
 
 @pytest.mark.asyncio()
@@ -228,3 +245,65 @@ class TestConditionalMiddleware:
         assert mock.on_tool.call_count == 2
         mock.on_tool.assert_any_call("tool_a")
         mock.on_tool.assert_any_call("tool_b")
+
+    async def test_human_input_activates_when_condition_matches(self, mock: MagicMock) -> None:
+        """on_human_input fires when condition matches HumanInputRequest."""
+
+        async def my_tool(ctx: Context) -> str:
+            await ctx.input("Approve?", timeout=1.0)
+            return "done"
+
+        def hitl_hook(event: HumanInputRequest) -> HumanMessage:
+            return HumanMessage("yes")
+
+        agent = Agent(
+            "",
+            config=TestConfig(
+                ToolCallEvent(name="my_tool"),
+                "result",
+            ),
+            tools=[my_tool],
+            hitl_hook=hitl_hook,
+            middleware=[
+                ConditionalMiddleware(
+                    Middleware(TrackingMiddleware, mock=mock),
+                    condition=HumanInputRequest,
+                ),
+            ],
+        )
+
+        await agent.ask("Hi!")
+
+        mock.on_human.assert_called_once_with("Approve?")
+        mock.on_turn.assert_not_called()
+        mock.on_tool.assert_not_called()
+
+    async def test_human_input_skipped_when_condition_does_not_match(self, mock: MagicMock) -> None:
+        """on_human_input skipped when condition targets a different event type."""
+
+        async def my_tool(ctx: Context) -> str:
+            await ctx.input("Approve?", timeout=1.0)
+            return "done"
+
+        def hitl_hook(event: HumanInputRequest) -> HumanMessage:
+            return HumanMessage("yes")
+
+        agent = Agent(
+            "",
+            config=TestConfig(
+                ToolCallEvent(name="my_tool"),
+                "result",
+            ),
+            tools=[my_tool],
+            hitl_hook=hitl_hook,
+            middleware=[
+                ConditionalMiddleware(
+                    Middleware(TrackingMiddleware, mock=mock),
+                    condition=ToolCallEvent.name == "other_tool",
+                ),
+            ],
+        )
+
+        await agent.ask("Hi!")
+
+        mock.on_human.assert_not_called()

--- a/test/beta/middleware/test_conditional.py
+++ b/test/beta/middleware/test_conditional.py
@@ -8,7 +8,14 @@ from unittest.mock import MagicMock
 import pytest
 
 from autogen.beta import Agent, Context
-from autogen.beta.events import BaseEvent, HumanInputRequest, HumanMessage, ModelResponse, ToolCallEvent, ToolResultEvent
+from autogen.beta.events import (
+    BaseEvent,
+    HumanInputRequest,
+    HumanMessage,
+    ModelResponse,
+    ToolCallEvent,
+    ToolResultEvent,
+)
 from autogen.beta.middleware import (
     AgentTurn,
     BaseMiddleware,

--- a/test/beta/middleware/test_conditional.py
+++ b/test/beta/middleware/test_conditional.py
@@ -9,8 +9,8 @@ import pytest
 
 from autogen.beta import Agent, Context
 from autogen.beta.events import BaseEvent, ModelResponse, ToolCallEvent, ToolResultEvent
-from autogen.beta.events.conditions import TypeCondition
 from autogen.beta.middleware import AgentTurn, BaseMiddleware, ConditionalMiddleware, LLMCall, Middleware, ToolExecution
+from autogen.beta.testing import TestConfig
 
 
 class TrackingMiddleware(BaseMiddleware):
@@ -55,14 +55,13 @@ class TrackingMiddleware(BaseMiddleware):
 class TestConditionalMiddleware:
     async def test_tool_condition_activates_on_matching_tool(self, mock: MagicMock) -> None:
         """The motivating example from #2781: condition on ToolCallEvent.name."""
-        condition = ToolCallEvent.name == "my_tool"
 
         def my_tool() -> str:
             return "done"
 
         agent = Agent(
             "",
-            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig(
+            config=TestConfig(
                 ToolCallEvent(name="my_tool"),
                 "result",
             ),
@@ -70,7 +69,7 @@ class TestConditionalMiddleware:
             middleware=[
                 ConditionalMiddleware(
                     Middleware(TrackingMiddleware, mock=mock),
-                    condition=condition,
+                    condition=ToolCallEvent.name == "my_tool",
                 ),
             ],
         )
@@ -81,14 +80,13 @@ class TestConditionalMiddleware:
 
     async def test_tool_condition_skips_non_matching_tool(self, mock: MagicMock) -> None:
         """Condition targets a different tool name — middleware should not fire."""
-        condition = ToolCallEvent.name == "other_tool"
 
         def my_tool() -> str:
             return "done"
 
         agent = Agent(
             "",
-            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig(
+            config=TestConfig(
                 ToolCallEvent(name="my_tool"),
                 "result",
             ),
@@ -96,7 +94,7 @@ class TestConditionalMiddleware:
             middleware=[
                 ConditionalMiddleware(
                     Middleware(TrackingMiddleware, mock=mock),
-                    condition=condition,
+                    condition=ToolCallEvent.name == "other_tool",
                 ),
             ],
         )
@@ -105,16 +103,15 @@ class TestConditionalMiddleware:
 
         mock.on_tool.assert_not_called()
 
-    async def test_type_condition_on_tool_event(self, mock: MagicMock) -> None:
-        """TypeCondition(ToolCallEvent) should activate on_tool_execution but not on_turn."""
-        condition = TypeCondition(ToolCallEvent)
+    async def test_type_condition_activates_per_hook(self, mock: MagicMock) -> None:
+        """Bare event type as condition: activates on_tool_execution but not on_turn."""
 
         def my_tool() -> str:
             return "done"
 
         agent = Agent(
             "",
-            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig(
+            config=TestConfig(
                 ToolCallEvent(name="my_tool"),
                 "result",
             ),
@@ -122,7 +119,7 @@ class TestConditionalMiddleware:
             middleware=[
                 ConditionalMiddleware(
                     Middleware(TrackingMiddleware, mock=mock),
-                    condition=condition,
+                    condition=ToolCallEvent,
                 ),
             ],
         )
@@ -134,15 +131,13 @@ class TestConditionalMiddleware:
 
     async def test_llm_call_always_delegates(self, mock: MagicMock) -> None:
         """on_llm_call always delegates regardless of condition."""
-        condition = TypeCondition(ToolCallEvent)
-
         agent = Agent(
             "",
-            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig("result"),
+            config=TestConfig("result"),
             middleware=[
                 ConditionalMiddleware(
                     Middleware(TrackingMiddleware, mock=mock),
-                    condition=condition,
+                    condition=ToolCallEvent,
                 ),
             ],
         )
@@ -153,15 +148,14 @@ class TestConditionalMiddleware:
         mock.on_llm.assert_called()
 
     async def test_inverted_condition(self, mock: MagicMock) -> None:
-        """~TypeCondition(ToolCallEvent) activates on_turn but not on_tool_execution."""
-        condition = ~TypeCondition(ToolCallEvent)
+        """~ToolCallEvent activates on_turn but not on_tool_execution."""
 
         def my_tool() -> str:
             return "done"
 
         agent = Agent(
             "",
-            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig(
+            config=TestConfig(
                 ToolCallEvent(name="my_tool"),
                 "result",
             ),
@@ -169,7 +163,7 @@ class TestConditionalMiddleware:
             middleware=[
                 ConditionalMiddleware(
                     Middleware(TrackingMiddleware, mock=mock),
-                    condition=condition,
+                    condition=~(ToolCallEvent.name == "my_tool"),
                 ),
             ],
         )
@@ -194,7 +188,7 @@ class TestConditionalMiddleware:
 
         agent = Agent(
             "",
-            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig(
+            config=TestConfig(
                 [
                     ToolCallEvent(name="tool_a"),
                     ToolCallEvent(name="tool_b"),

--- a/test/beta/middleware/test_conditional.py
+++ b/test/beta/middleware/test_conditional.py
@@ -129,8 +129,8 @@ class TestConditionalMiddleware:
         mock.on_tool.assert_called_once_with("my_tool")
         mock.on_turn.assert_not_called()
 
-    async def test_llm_call_always_delegates(self, mock: MagicMock) -> None:
-        """on_llm_call always delegates regardless of condition."""
+    async def test_llm_call_skipped_when_condition_does_not_match(self, mock: MagicMock) -> None:
+        """on_llm_call checks condition against initial event — skipped when it doesn't match."""
         agent = Agent(
             "",
             config=TestConfig("result"),
@@ -145,6 +145,24 @@ class TestConditionalMiddleware:
         await agent.ask("Hi!")
 
         mock.on_turn.assert_not_called()
+        mock.on_llm.assert_not_called()
+
+    async def test_llm_call_delegates_when_condition_matches(self, mock: MagicMock) -> None:
+        """on_llm_call delegates when condition matches the initial event."""
+        agent = Agent(
+            "",
+            config=TestConfig("result"),
+            middleware=[
+                ConditionalMiddleware(
+                    Middleware(TrackingMiddleware, mock=mock),
+                    condition=BaseEvent,
+                ),
+            ],
+        )
+
+        await agent.ask("Hi!")
+
+        mock.on_turn.assert_called()
         mock.on_llm.assert_called()
 
     async def test_inverted_condition(self, mock: MagicMock) -> None:

--- a/test/beta/middleware/test_conditional.py
+++ b/test/beta/middleware/test_conditional.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from autogen.beta import Agent, Context
+from autogen.beta.events import BaseEvent, ToolCallEvent, ToolResultEvent
+from autogen.beta.events.conditions import TypeCondition
+from autogen.beta.middleware import BaseMiddleware, ConditionalMiddleware, Middleware, ToolExecution
+from autogen.beta.testing import TestConfig
+
+
+class TrackingMiddleware(BaseMiddleware):
+    def __init__(
+        self,
+        event: BaseEvent,
+        ctx: Context,
+        mock: MagicMock,
+    ) -> None:
+        super().__init__(event, ctx)
+        self.mock = mock
+
+    async def on_tool_execution(
+        self,
+        call_next: ToolExecution,
+        event: ToolCallEvent,
+        ctx: Context,
+    ) -> ToolResultEvent:
+        self.mock.on_tool(event.name)
+        return await call_next(event, ctx)
+
+
+@pytest.mark.asyncio()
+class TestConditionalMiddleware:
+    async def test_activates_when_condition_matches(self, mock: MagicMock) -> None:
+        condition = TypeCondition(BaseEvent)
+
+        def my_tool() -> str:
+            return "done"
+
+        agent = Agent(
+            "",
+            config=TestConfig(
+                ToolCallEvent(name="my_tool"),
+                "result",
+            ),
+            tools=[my_tool],
+            middleware=[
+                ConditionalMiddleware(
+                    Middleware(TrackingMiddleware, mock=mock),
+                    condition=condition,
+                ),
+            ],
+        )
+
+        await agent.ask("Hi!")
+
+        mock.on_tool.assert_called_once_with("my_tool")
+
+    async def test_skips_when_condition_does_not_match(self, mock: MagicMock) -> None:
+        condition = TypeCondition(ToolCallEvent)
+
+        def my_tool() -> str:
+            return "done"
+
+        agent = Agent(
+            "",
+            config=TestConfig(
+                ToolCallEvent(name="my_tool"),
+                "result",
+            ),
+            tools=[my_tool],
+            middleware=[
+                ConditionalMiddleware(
+                    Middleware(TrackingMiddleware, mock=mock),
+                    condition=condition,
+                ),
+            ],
+        )
+
+        await agent.ask("Hi!")
+
+        mock.on_tool.assert_not_called()
+
+    async def test_inverted_condition(self, mock: MagicMock) -> None:
+        condition = ~TypeCondition(ToolCallEvent)
+
+        def my_tool() -> str:
+            return "done"
+
+        agent = Agent(
+            "",
+            config=TestConfig(
+                ToolCallEvent(name="my_tool"),
+                "result",
+            ),
+            tools=[my_tool],
+            middleware=[
+                ConditionalMiddleware(
+                    Middleware(TrackingMiddleware, mock=mock),
+                    condition=condition,
+                ),
+            ],
+        )
+
+        await agent.ask("Hi!")
+
+        mock.on_tool.assert_called_once_with("my_tool")
+
+    async def test_multiple_conditional_middleware(self, mock: MagicMock) -> None:
+        always_match = TypeCondition(BaseEvent)
+        never_match = TypeCondition(ToolCallEvent)
+
+        def my_tool() -> str:
+            return "done"
+
+        mock_active = MagicMock()
+        mock_skipped = MagicMock()
+
+        agent = Agent(
+            "",
+            config=TestConfig(
+                ToolCallEvent(name="my_tool"),
+                "result",
+            ),
+            tools=[my_tool],
+            middleware=[
+                ConditionalMiddleware(
+                    Middleware(TrackingMiddleware, mock=mock_active),
+                    condition=always_match,
+                ),
+                ConditionalMiddleware(
+                    Middleware(TrackingMiddleware, mock=mock_skipped),
+                    condition=never_match,
+                ),
+            ],
+        )
+
+        await agent.ask("Hi!")
+
+        mock_active.on_tool.assert_called_once_with("my_tool")
+        mock_skipped.on_tool.assert_not_called()

--- a/test/beta/middleware/test_conditional.py
+++ b/test/beta/middleware/test_conditional.py
@@ -2,15 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Sequence
 from unittest.mock import MagicMock
 
 import pytest
 
 from autogen.beta import Agent, Context
-from autogen.beta.events import BaseEvent, ToolCallEvent, ToolResultEvent
+from autogen.beta.events import BaseEvent, ModelResponse, ToolCallEvent, ToolResultEvent
 from autogen.beta.events.conditions import TypeCondition
-from autogen.beta.middleware import BaseMiddleware, ConditionalMiddleware, Middleware, ToolExecution
-from autogen.beta.testing import TestConfig
+from autogen.beta.middleware import AgentTurn, BaseMiddleware, ConditionalMiddleware, LLMCall, Middleware, ToolExecution
 
 
 class TrackingMiddleware(BaseMiddleware):
@@ -23,6 +23,15 @@ class TrackingMiddleware(BaseMiddleware):
         super().__init__(event, ctx)
         self.mock = mock
 
+    async def on_turn(
+        self,
+        call_next: AgentTurn,
+        event: BaseEvent,
+        ctx: Context,
+    ) -> ModelResponse:
+        self.mock.on_turn(event.__class__.__name__)
+        return await call_next(event, ctx)
+
     async def on_tool_execution(
         self,
         call_next: ToolExecution,
@@ -32,18 +41,28 @@ class TrackingMiddleware(BaseMiddleware):
         self.mock.on_tool(event.name)
         return await call_next(event, ctx)
 
+    async def on_llm_call(
+        self,
+        call_next: LLMCall,
+        events: Sequence[BaseEvent],
+        ctx: Context,
+    ) -> ModelResponse:
+        self.mock.on_llm(len(events))
+        return await call_next(events, ctx)
+
 
 @pytest.mark.asyncio()
 class TestConditionalMiddleware:
-    async def test_activates_when_condition_matches(self, mock: MagicMock) -> None:
-        condition = TypeCondition(BaseEvent)
+    async def test_tool_condition_activates_on_matching_tool(self, mock: MagicMock) -> None:
+        """The motivating example from #2781: condition on ToolCallEvent.name."""
+        condition = ToolCallEvent.name == "my_tool"
 
         def my_tool() -> str:
             return "done"
 
         agent = Agent(
             "",
-            config=TestConfig(
+            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig(
                 ToolCallEvent(name="my_tool"),
                 "result",
             ),
@@ -60,15 +79,16 @@ class TestConditionalMiddleware:
 
         mock.on_tool.assert_called_once_with("my_tool")
 
-    async def test_skips_when_condition_does_not_match(self, mock: MagicMock) -> None:
-        condition = TypeCondition(ToolCallEvent)
+    async def test_tool_condition_skips_non_matching_tool(self, mock: MagicMock) -> None:
+        """Condition targets a different tool name — middleware should not fire."""
+        condition = ToolCallEvent.name == "other_tool"
 
         def my_tool() -> str:
             return "done"
 
         agent = Agent(
             "",
-            config=TestConfig(
+            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig(
                 ToolCallEvent(name="my_tool"),
                 "result",
             ),
@@ -85,15 +105,16 @@ class TestConditionalMiddleware:
 
         mock.on_tool.assert_not_called()
 
-    async def test_inverted_condition(self, mock: MagicMock) -> None:
-        condition = ~TypeCondition(ToolCallEvent)
+    async def test_type_condition_on_tool_event(self, mock: MagicMock) -> None:
+        """TypeCondition(ToolCallEvent) should activate on_tool_execution but not on_turn."""
+        condition = TypeCondition(ToolCallEvent)
 
         def my_tool() -> str:
             return "done"
 
         agent = Agent(
             "",
-            config=TestConfig(
+            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig(
                 ToolCallEvent(name="my_tool"),
                 "result",
             ),
@@ -109,37 +130,89 @@ class TestConditionalMiddleware:
         await agent.ask("Hi!")
 
         mock.on_tool.assert_called_once_with("my_tool")
+        mock.on_turn.assert_not_called()
 
-    async def test_multiple_conditional_middleware(self, mock: MagicMock) -> None:
-        always_match = TypeCondition(BaseEvent)
-        never_match = TypeCondition(ToolCallEvent)
-
-        def my_tool() -> str:
-            return "done"
-
-        mock_active = MagicMock()
-        mock_skipped = MagicMock()
+    async def test_llm_call_always_delegates(self, mock: MagicMock) -> None:
+        """on_llm_call always delegates regardless of condition."""
+        condition = TypeCondition(ToolCallEvent)
 
         agent = Agent(
             "",
-            config=TestConfig(
-                ToolCallEvent(name="my_tool"),
-                "result",
-            ),
-            tools=[my_tool],
+            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig("result"),
             middleware=[
                 ConditionalMiddleware(
-                    Middleware(TrackingMiddleware, mock=mock_active),
-                    condition=always_match,
-                ),
-                ConditionalMiddleware(
-                    Middleware(TrackingMiddleware, mock=mock_skipped),
-                    condition=never_match,
+                    Middleware(TrackingMiddleware, mock=mock),
+                    condition=condition,
                 ),
             ],
         )
 
         await agent.ask("Hi!")
 
-        mock_active.on_tool.assert_called_once_with("my_tool")
-        mock_skipped.on_tool.assert_not_called()
+        mock.on_turn.assert_not_called()
+        mock.on_llm.assert_called()
+
+    async def test_inverted_condition(self, mock: MagicMock) -> None:
+        """~TypeCondition(ToolCallEvent) activates on_turn but not on_tool_execution."""
+        condition = ~TypeCondition(ToolCallEvent)
+
+        def my_tool() -> str:
+            return "done"
+
+        agent = Agent(
+            "",
+            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig(
+                ToolCallEvent(name="my_tool"),
+                "result",
+            ),
+            tools=[my_tool],
+            middleware=[
+                ConditionalMiddleware(
+                    Middleware(TrackingMiddleware, mock=mock),
+                    condition=condition,
+                ),
+            ],
+        )
+
+        await agent.ask("Hi!")
+
+        mock.on_turn.assert_called()
+        mock.on_tool.assert_not_called()
+
+    async def test_composed_or_condition(self, mock: MagicMock) -> None:
+        """Composed condition from issue: (name == 'a') | (name == 'b')."""
+        condition = (ToolCallEvent.name == "tool_a") | (ToolCallEvent.name == "tool_b")
+
+        def tool_a() -> str:
+            return "a"
+
+        def tool_b() -> str:
+            return "b"
+
+        def tool_c() -> str:
+            return "c"
+
+        agent = Agent(
+            "",
+            config=__import__("autogen.beta.testing", fromlist=["TestConfig"]).TestConfig(
+                [
+                    ToolCallEvent(name="tool_a"),
+                    ToolCallEvent(name="tool_b"),
+                    ToolCallEvent(name="tool_c"),
+                ],
+                "result",
+            ),
+            tools=[tool_a, tool_b, tool_c],
+            middleware=[
+                ConditionalMiddleware(
+                    Middleware(TrackingMiddleware, mock=mock),
+                    condition=condition,
+                ),
+            ],
+        )
+
+        await agent.ask("Hi!")
+
+        assert mock.on_tool.call_count == 2
+        mock.on_tool.assert_any_call("tool_a")
+        mock.on_tool.assert_any_call("tool_b")

--- a/website/docs/beta/middleware.mdx
+++ b/website/docs/beta/middleware.mdx
@@ -400,16 +400,15 @@ Use it when you need lightweight context budgeting without depending on a model-
 
 ## Conditional Middleware
 
-`ConditionalMiddleware` lets you gate any middleware so it only activates when a condition matches the initial event for the turn. When the condition is not met, the middleware is skipped entirely — all hooks pass through to the next middleware in the chain.
+`ConditionalMiddleware` lets you gate any middleware so each hook only activates when a condition matches the hook's own event. When the condition is not met, that hook passes through to the next middleware in the chain.
 
-This is useful when you have middleware that should only run for certain types of requests, without writing condition checks inside every hook method.
+This is useful when you have middleware that should only run for certain event types — for example, approval middleware that only fires for a specific tool — without writing condition checks inside every hook method.
 
 ```python linenums="1"
 from autogen.beta import Agent
 from autogen.beta.config import OpenAIConfig
-from autogen.beta.events import ModelRequest
-from autogen.beta.events.conditions import TypeCondition
-from autogen.beta.middleware import ConditionalMiddleware, LoggingMiddleware, Middleware
+from autogen.beta.events import ToolCallEvent
+from autogen.beta.middleware import ConditionalMiddleware, Middleware
 
 agent = Agent(
     "assistant",
@@ -417,16 +416,16 @@ agent = Agent(
     config=OpenAIConfig("gpt-4o-mini"),
     middleware=[
         ConditionalMiddleware(
-            LoggingMiddleware(),
-            condition=TypeCondition(ModelRequest),
+            Middleware(ApprovalMiddleware),
+            condition=ToolCallEvent.name == "execute_code",
         ),
     ],
 )
 ```
 
-In this example, `LoggingMiddleware` only activates when the turn is triggered by a `ModelRequest` event. For any other event type, all four hooks pass through without running the logging logic.
+In this example, `ApprovalMiddleware` only activates during `on_tool_execution` when the tool name is `"execute_code"`. The `on_turn` hook receives a different event type (`ModelRequest`), so the condition does not match there and the middleware passes through.
 
-Each hook checks the condition against its own event: `on_turn`, `on_tool_execution`, and `on_human_input` check against the event they receive. `on_llm_call` checks against the initial turn event, since it receives a sequence of events rather than a single one.
+Each hook — `on_turn`, `on_tool_execution`, `on_human_input` — checks the condition against its own event. `on_llm_call` checks against the initial turn event, since it receives a sequence of events rather than a single one. When a condition targets a specific event type like `ToolCallEvent`, hooks that receive a different type will naturally pass through.
 
 ### Composing Conditions
 

--- a/website/docs/beta/middleware.mdx
+++ b/website/docs/beta/middleware.mdx
@@ -424,7 +424,9 @@ agent = Agent(
 )
 ```
 
-In this example, `LoggingMiddleware` only activates when the turn is triggered by a `ModelRequest` event. For any other event type, all four hooks (`on_turn`, `on_llm_call`, `on_tool_execution`, `on_human_input`) pass through without running the logging logic.
+In this example, `LoggingMiddleware` only activates when the turn is triggered by a `ModelRequest` event. For any other event type, all four hooks pass through without running the logging logic.
+
+Each hook checks the condition against its own event: `on_turn`, `on_tool_execution`, and `on_human_input` check against the event they receive. `on_llm_call` checks against the initial turn event, since it receives a sequence of events rather than a single one.
 
 ### Composing Conditions
 

--- a/website/docs/beta/middleware.mdx
+++ b/website/docs/beta/middleware.mdx
@@ -398,6 +398,58 @@ It uses a character-based estimate controlled by `chars_per_token`.
 
 Use it when you need lightweight context budgeting without depending on a model-specific tokenizer.
 
+## Conditional Middleware
+
+`ConditionalMiddleware` lets you gate any middleware so it only activates when a condition matches the initial event for the turn. When the condition is not met, the middleware is skipped entirely — all hooks pass through to the next middleware in the chain.
+
+This is useful when you have middleware that should only run for certain types of requests, without writing condition checks inside every hook method.
+
+```python linenums="1"
+from autogen.beta import Agent
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.events import ModelRequest
+from autogen.beta.events.conditions import TypeCondition
+from autogen.beta.middleware import ConditionalMiddleware, LoggingMiddleware, Middleware
+
+agent = Agent(
+    "assistant",
+    prompt="Be helpful.",
+    config=OpenAIConfig("gpt-4o-mini"),
+    middleware=[
+        ConditionalMiddleware(
+            LoggingMiddleware(),
+            condition=TypeCondition(ModelRequest),
+        ),
+    ],
+)
+```
+
+In this example, `LoggingMiddleware` only activates when the turn is triggered by a `ModelRequest` event. For any other event type, all four hooks (`on_turn`, `on_llm_call`, `on_tool_execution`, `on_human_input`) pass through without running the logging logic.
+
+### Composing Conditions
+
+Conditions support `&` (and), `|` (or), and `~` (not) operators, so you can build expressive gates:
+
+```python linenums="1"
+from autogen.beta.events import ModelRequest, ToolCallEvent
+from autogen.beta.events.conditions import TypeCondition
+from autogen.beta.middleware import ConditionalMiddleware, Middleware
+
+# Activate only when the event is NOT a ToolCallEvent
+conditional = ConditionalMiddleware(
+    Middleware(MyAuditMiddleware, logger=logger),
+    condition=~TypeCondition(ToolCallEvent),
+)
+
+# Activate for ModelRequest OR ToolCallEvent
+conditional = ConditionalMiddleware(
+    Middleware(MyAuditMiddleware, logger=logger),
+    condition=TypeCondition(ModelRequest) | TypeCondition(ToolCallEvent),
+)
+```
+
+`ConditionalMiddleware` wraps any `MiddlewareFactory` — including `Middleware(...)` instances, bare `BaseMiddleware` subclasses, and other `ConditionalMiddleware` wrappers.
+
 ## Choosing the Right Hook
 
 If you are unsure where a behavior belongs, use this rule of thumb:

--- a/website/docs/beta/middleware.mdx
+++ b/website/docs/beta/middleware.mdx
@@ -432,20 +432,29 @@ Each hook — `on_turn`, `on_tool_execution`, `on_human_input` — checks the co
 Conditions support `&` (and), `|` (or), and `~` (not) operators, so you can build expressive gates:
 
 ```python linenums="1"
-from autogen.beta.events import ModelRequest, ToolCallEvent
-from autogen.beta.events.conditions import TypeCondition
+from autogen.beta.events import ToolCallEvent
 from autogen.beta.middleware import ConditionalMiddleware, Middleware
 
-# Activate only when the event is NOT a ToolCallEvent
+# Activate only for tool calls named "search" or "browse"
 conditional = ConditionalMiddleware(
     Middleware(MyAuditMiddleware, logger=logger),
-    condition=~TypeCondition(ToolCallEvent),
+    condition=(ToolCallEvent.name == "search") | (ToolCallEvent.name == "browse"),
 )
 
-# Activate for ModelRequest OR ToolCallEvent
+# Activate for all tool calls EXCEPT "calculate"
 conditional = ConditionalMiddleware(
     Middleware(MyAuditMiddleware, logger=logger),
-    condition=TypeCondition(ModelRequest) | TypeCondition(ToolCallEvent),
+    condition=~(ToolCallEvent.name == "calculate"),
+)
+```
+
+You can also pass a bare event type as the condition — it is automatically wrapped:
+
+```python linenums="1"
+# Activate only when the hook receives a ToolCallEvent
+conditional = ConditionalMiddleware(
+    Middleware(MyAuditMiddleware, logger=logger),
+    condition=ToolCallEvent,
 )
 ```
 


### PR DESCRIPTION
This pull request introduces the new `ConditionalMiddleware` feature, which allows middleware to be conditionally activated based on the event type or other criteria. This enables more flexible and composable middleware pipelines, making it easier to apply middleware only when relevant. The update includes the implementation, documentation, and comprehensive tests.

**New Conditional Middleware feature:**

* Added the `ConditionalMiddleware` class to `autogen.beta.middleware.base`, which wraps any middleware and activates it only when a given condition is met; otherwise, it passes through to the next middleware without running any hooks.
* Updated `autogen/beta/middleware/__init__.py` to export `ConditionalMiddleware` for public use. [[1]](diffhunk://#diff-2785bafe504f617c2b1c1d5990618c51e63b352eabb74592955c21ac46882164R8) [[2]](diffhunk://#diff-2785bafe504f617c2b1c1d5990618c51e63b352eabb74592955c21ac46882164R28)

**Testing:**

* Added `test/beta/middleware/test_conditional.py` with thorough tests covering condition matching, skipping, inversion, and multiple conditional middleware scenarios.

**Documentation:**

* Extended `website/docs/beta/middleware.mdx` with a new section explaining `ConditionalMiddleware`, usage examples, and how to compose conditions for advanced gating logic.

**Dependencies:**

* Imported the `Condition` class into `autogen.beta.middleware.base` to support the new feature.

closes #2781 