### PR TITLE
fix+docs(beta): Remove say tool from DiscussionAdapter + What Survives (Network blog post 3/4)

### DIFF
--- a/autogen/beta/network/adapters/discussion.py
+++ b/autogen/beta/network/adapters/discussion.py
@@ -23,7 +23,6 @@ from ..channel import (
     Expectation,
     ParticipantSchema,
 )
-from ..client.tools.say import make_say_tool
 from ..envelope import (
     EV_CHANNEL_CLOSED,
     EV_CHANNEL_EXPIRED,
@@ -116,7 +115,6 @@ class DiscussionAdapter:
     """
 
     def __init__(self) -> None:
-        self._say_tool_cache: dict[str, object] = {}
         self.manifest = ChannelManifest(
             type=DISCUSSION_TYPE,
             version=1,
@@ -219,22 +217,7 @@ class DiscussionAdapter:
         return default_render_envelope(envelope)
 
     def tools_for(self, client, metadata, state, participant_id):
-        """Discussion offers ``say`` only when it is this participant's
-        round (round-robin ordering). Tool resolution is memoized
-        per-client to avoid per-turn schema rebuild.
-        """
-        if state.expected_next_speaker == participant_id:
-            return [self._cached_say_tool(client)]
         return []
-
-    def _cached_say_tool(self, client):
-        """Memoize ``make_say_tool`` per ``client.agent_id``."""
-        cached = self._say_tool_cache.get(client.agent_id)
-        if cached is not None:
-            return cached
-        tool = make_say_tool(client)
-        self._say_tool_cache[client.agent_id] = tool
-        return tool
 
     def build_text_envelope(self, channel_id, sender_id, text, *, audience=None, causation_id=None):
         return default_build_text_envelope(channel_id, sender_id, text, audience=audience, causation_id=causation_id)

--- a/test/beta/network/test_adapter_tools.py
+++ b/test/beta/network/test_adapter_tools.py
@@ -113,7 +113,11 @@ async def test_conversation_tools_for_always_offers_say() -> None:
 
 
 @pytest.mark.asyncio
-async def test_discussion_tools_for_gates_by_round_robin() -> None:
+async def test_discussion_tools_for_returns_empty() -> None:
+    """Discussion ships no adapter tools — round-robin turn-passing posts the
+    speaker's reply via the handler's round-end envelope, so no per-turn
+    ``say`` tool is needed.
+    """
     store = MemoryKnowledgeStore()
     hub = await Hub.open(store, ttl_sweep_interval=0)
     link = LocalLink(hub)
@@ -134,8 +138,8 @@ async def test_discussion_tools_for_gates_by_round_robin() -> None:
 
     adapter = DiscussionAdapter()
     state = hub.adapter_state(channel.channel_id)
-    # Initial expected_next_speaker is the creator (alice).
-    assert [t.name for t in adapter.tools_for(alice, channel.metadata, state, alice.agent_id)] == ["say"]
+    # No adapter tools for any participant, regardless of whose turn it is.
+    assert adapter.tools_for(alice, channel.metadata, state, alice.agent_id) == []
     assert adapter.tools_for(bob, channel.metadata, state, bob.agent_id) == []
     assert adapter.tools_for(carol, channel.metadata, state, carol.agent_id) == []
 

--- a/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/index.mdx
+++ b/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/index.mdx
@@ -19,8 +19,8 @@ That's what the **AG2 Network** is built for: a layer where stateful, identity-b
 This is the first post in a four-part series introducing the AG2 Network:
 
 1. **One Coherent Agent Isn't Enough** *(this post)* — the action-driven multi-agent network, the key primitives, and the four conversation shapes.
-2. **Choreography You Can Dial In** — setting expectations, audience addressing, deeper choreography patterns, and the orchestration cookbook.
-3. **What Survives, Survives Exactly** — the substrate: write-ahead log + fold + hub restart, plus identity (Passport / Resume / SKILL.md) and the audit log.
+2. [**Choreography You Can Dial In**](/docs/blog/2026/05/15/AG2-Network-Choreography-Dial/) — setting expectations, audience addressing, deeper choreography patterns, and the orchestration cookbook.
+3. [**What Survives, Survives Exactly**](/docs/blog/2026/05/16/AG2-Network-What-Survives/) — the substrate: write-ahead log + fold + hub restart, plus identity (Passport / Resume / SKILL.md) and the audit log.
 4. **Networks You Can Deploy** — federation across organizations (Visa), dynamic register / unregister, omni-modal streaming, and a full production-incident walk-through.
 
 In parallel, to build strong and capable agents, a companion post, **The Agent Harness: An Agent Is More Than a Loop**, zooms *inside* a single agent to make them long-running and knowledge-centric.
@@ -394,8 +394,8 @@ Reach for `workflow` when "who speaks next" is structured — pipelines, escalat
 
 You've now run all four conversation shapes. There are three more layers the network adds on top, each covered in an upcoming post:
 
-- **A choreography dial** — same primitive, more knobs. *Expectations* like `reply_within(30s, auto_close)` give the channel a deterministic response when a participant misses a deadline. *Audience* on each envelope (`audience=[a, b]`) lets a single channel carry private side-channels for free. Deeper `TransitionGraph` patterns — conditional handoffs, dynamic `Handoff` returns, context-aware routing — sit alongside. **Post 2: Choreography You Can Dial In (coming soon).**
-- **A trustworthy substrate** — what's written down and who you are. The hub's WAL is the source of truth: kill the hub, restart it, every channel comes back byte-for-byte. Identity is three records (`Passport` + `Resume` + `SKILL.md`), not a name string. The audit log records every envelope. **Post 3: What Survives, Survives Exactly (coming soon).**
+- **A choreography dial** — same primitive, more knobs. *Expectations* like `reply_within(30s, auto_close)` give the channel a deterministic response when a participant misses a deadline. *Audience* on each envelope (`audience=[a, b]`) lets a single channel carry private side-channels for free. Deeper `TransitionGraph` patterns — conditional handoffs, dynamic `Handoff` returns, context-aware routing — sit alongside. **Post 2: [Choreography You Can Dial In](/docs/blog/2026/05/15/AG2-Network-Choreography-Dial/).**
+- **A trustworthy substrate** — what's written down and who you are. The hub's WAL is the source of truth: kill the hub, restart it, every channel comes back byte-for-byte. Identity is three records (`Passport` + `Resume` + `SKILL.md`), not a name string. The audit log records every envelope. **Post 3: [What Survives, Survives Exactly](/docs/blog/2026/05/16/AG2-Network-What-Survives/).**
 - **Cross-boundary deployment** — what lets you actually ship this. A single channel can span two organizations through Passport + Visa. Participants register and unregister dynamically. Text, audio, image, and video ride the same fan-out. And a real production-incident demo ties it all together. **Post 4: Networks You Can Deploy (coming soon)**
 
 ## Interactive Playground

--- a/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/index.mdx
+++ b/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/index.mdx
@@ -10,7 +10,7 @@ slug: ag2-network-choreography-dial
 
 We've touched on the four built-in conversation shapes; now you need to make them survive contact with the real world.
 
-In the first post — [*One Coherent Agent Isn't Enough*](/docs/blog/2026/05/14/AG2-Action-Driven-Network) — you opened a channel, watched agents take turns, and saw the hub fold envelopes into a durable thread. That's the *shape*. This post is about the *dials* on top of that shape — the knobs that turn a loose multi-agent free-for-all into something you'd actually run when an agent goes quiet at 2am, a step needs to time out, or a sub-conversation has to stay off the main thread.
+In the first post — [*One Coherent Agent Isn't Enough*](/docs/blog/2026/05/14/AG2-Action-Driven-Network/) — you opened a channel, watched agents take turns, and saw the hub fold envelopes into a durable thread. That's the *shape*. This post is about the *dials* on top of that shape — the knobs that turn a loose multi-agent free-for-all into something you'd actually run when an agent goes quiet at 2am, a step needs to time out, or a sub-conversation has to stay off the main thread.
 
 <!-- more -->
 
@@ -18,9 +18,9 @@ If you haven't run the first post's examples yet, start there — every snippet 
 
 This is the second post in a four-part series introducing the AG2 Network:
 
-1. [**One Coherent Agent Isn't Enough**](/docs/blog/2026/05/14/AG2-Action-Driven-Network) — the action-driven multi-agent network, the key primitives, and the four conversation shapes.
+1. [**One Coherent Agent Isn't Enough**](/docs/blog/2026/05/14/AG2-Action-Driven-Network/) — the action-driven multi-agent network, the key primitives, and the four conversation shapes.
 2. **Choreography You Can Dial In** *(this post)* — setting expectations, audience addressing, deeper choreography patterns, and the orchestration cookbook.
-3. **What Survives, Survives Exactly** — the substrate: write-ahead log + fold + hub restart, plus identity (Passport / Resume / SKILL.md) and the audit log.
+3. [**What Survives, Survives Exactly**](/docs/blog/2026/05/16/AG2-Network-What-Survives/) — the substrate: write-ahead log + fold + hub restart, plus identity (Passport / Resume / SKILL.md) and the audit log.
 4. **Networks You Can Deploy** — federation across organizations (Visa), dynamic register / unregister, omni-modal streaming, and a full production-incident walk-through.
 
 In parallel, to build strong and capable agents, we're preparing a companion post, **The Agent Harness: An Agent Is More Than a Loop**, that zooms *inside* a single agent to make them long-running and knowledge-centric. Keep an eye out for that one (we'll update this when it's ready).
@@ -355,4 +355,4 @@ Every dial lands exactly once, in the right place, in the right order. The `EV_C
 
 Two dials, one primitive. Audience addressing governs *visibility* — who sees which envelope on which thread. `TransitionGraph` conditions govern *routing* — who speaks next based on what was said or what state was written. The built-in expectations govern *time* automatically: every adapter ships SLAs that fire without any configuration. All three are first-class envelopes on the WAL, which means everything you dial in survives a hub restart exactly as written.
 
-The next post in this series — **What Survives, Survives Exactly** — zooms into that WAL. You'll see how the hub re-derives every channel from scratch on restart, how identity (Passport / Resume / SKILL.md) and the audit log compose with the same fold model, and what "durable" really means for a multi-agent conversation.
+The next post in this series — [**What Survives, Survives Exactly**](/docs/blog/2026/05/16/AG2-Network-What-Survives/) — zooms into that WAL. You'll see how the hub re-derives every channel from scratch on restart, how identity (Passport / Resume / SKILL.md) and the audit log compose with the same fold model, and what "durable" really means for a multi-agent conversation.

--- a/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-audit.webp
+++ b/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-audit.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79a42d06a0b814ebd4b1683c7531b8f5465baf88f067ce3d2155c5bb74f3b2f4
+size 2015022

--- a/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-banner-animated.webp
+++ b/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-banner-animated.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8b86d2f2720bc591afdc54fcd6b424141e12b533ae4f2da7c16968a98910445
+size 229406

--- a/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-identity.webp
+++ b/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-identity.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cea5cb26729ff4ee38429711b7db00c2f14fe071862d59d4df222a9fd07a46c
+size 2984212

--- a/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-wal.webp
+++ b/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-wal.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e08ea0107662437d6893d7c28737dbcbf45dd3ac272cc1d0570c1f5a7957c8fd
+size 1172088

--- a/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/index.mdx
+++ b/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/index.mdx
@@ -10,49 +10,36 @@ slug: ag2-network-what-survives
 
 Three agents are mid-conversation. The hub process restarts. When it comes back up, does the conversation survive?
 
-Yes. Exactly as it was — envelope for envelope, in the same order, with the same adapter state. No "we think it sent." No partial log. No replay from an approximation. The write-ahead log is the conversation.
-
-This is the third post in a four-part series on the AG2 Network:
-
-1. **One Coherent Agent Isn't Enough** — the action-driven network; four conversation shapes.
-2. **Choreography You Can Dial In** — turn limits, reply deadlines, audience addressing, and the orchestration cookbook.
-3. **What Survives, Survives Exactly** *(this post)* — the trustworthy substrate: WAL + fold + hub restart, three identity records, audit log.
-4. **Networks You Can Deploy** — federation across organisations, dynamic membership, omni-modal streaming, a full production-incident walk-through.
-
-<!-- more -->
+Yes. Exactly as it was, envelope for envelope, in the same order, with the same adapter state. No partial log or replay from an approximation. The write-ahead log is the exact conversation.
 
 The previous posts showed *what* the network lets agents do. This one explains *why you can trust it*.
 
+<!-- more -->
+
+This is the third post in a four-part series on the AG2 Network:
+
+1. [**One Coherent Agent Isn't Enough**](/docs/blog/2026/05/14/AG2-Action-Driven-Network/) — the action-driven network; four conversation shapes.
+2. [**Choreography You Can Dial In**](/docs/blog/2026/05/15/AG2-Network-Choreography-Dial/) — audience addressing, dynamic Handoff routing, and the TransitionGraph.
+3. **What Survives, Survives Exactly** *(this post)* — the trustworthy substrate: WAL + fold + hub restart, three identity records, audit log.
+4. **Networks You Can Deploy** — federation across organizations, dynamic membership, omni-modal streaming, a full production-incident walk-through.
+
 ## The Write-Ahead Log
 
-Every channel has one write-ahead log — a `.jsonl` file in the hub's `KnowledgeStore`. Before the hub fans an envelope out to any participant, it appends it to that log. The append comes first. Fan-out second.
+Every channel has one write-ahead log, stored as a `.jsonl` file in the hub's `KnowledgeStore`. Before the hub fans an envelope out to any participant, it appends it to that log. The append comes first. Fan-out second.
 
 That ordering is the whole guarantee.
 
-```mermaid
-sequenceDiagram
-    participant S as Sender
-    participant H as Hub
-    participant W as WAL (.jsonl)
-    participant P1 as Participant A
-    participant P2 as Participant B
-
-    S->>H: EV_TEXT envelope
-    H->>W: append → wal.jsonl  ← happens first
-    H->>P1: deliver
-    H->>P2: deliver
-    Note over W: if the process dies here,<br/>the envelope is already in the log
-```
+![The write-ahead log: envelopes append in order, the channel state is a pure fold of the log, and re-folding from disk after a crash yields identical state](img/n3-wal.webp)
 
 If the hub process dies after the append but before the fan-out, the envelope is still in the log. When the hub restarts, it re-derives the channel's state by replaying the log through the adapter — a pure fold with no side effects. Participants reconnect, see their missed envelopes, and pick up exactly where they left off.
 
 > **If it's in the log, it survived. If the process died before the append, it never happened.**
 
-That's not eventual consistency. There's no "maybe" tier. An envelope either made it to the log — and therefore exists, permanently, exactly — or it didn't, and the sender gets an error and can retry.
+An envelope either made it to the log — and therefore exists, permanently, exactly — or it didn't, and the sender gets an error and can retry.
 
 ### The fold
 
-Each channel's adapter maintains a state that's a pure function of the log: a fold. The `discussion` adapter's state is "which participant speaks next." The `workflow` adapter's state is "which graph node is active." Neither depends on memory that lives outside the log.
+Each channel's adapter maintains a state that's a pure function of the log: a **fold**. The `discussion` adapter's state is "which participant speaks next." The `workflow` adapter's state is "which graph node is active." Neither depends on memory that lives outside the log.
 
 When the hub restarts, it calls `hydrate()`:
 
@@ -65,11 +52,11 @@ for channel_id in channel_children:
     # ... which re-folds the WAL through the adapter
 ```
 
-The adapter state is rebuilt deterministically from disk. Nothing is approximated.
+The adapter state is rebuilt deterministically from disk.
 
 ## Hub Restart: A Worked Example
 
-The default `MemoryKnowledgeStore` is in-process — fine for development, nothing survives a restart. For production (or this example), use `DiskKnowledgeStore`:
+The default `MemoryKnowledgeStore` is in-process — fine for development, but nothing survives a restart. For production, as shown in this example, use a store like `DiskKnowledgeStore`:
 
 ```python linenums="1"
 import asyncio
@@ -91,7 +78,7 @@ DATA_DIR = Path("./hub-data")  # persisted across restarts
 
 
 async def first_run() -> str:
-    """Start a consulting channel, send one message, then abruptly stop."""
+    """Alice asks, Bob's LLM replies — then abruptly stop."""
     hub = await Hub.open(DiskKnowledgeStore(DATA_DIR), ttl_sweep_interval=0)
     link = LocalLink(hub)
 
@@ -115,11 +102,16 @@ async def first_run() -> str:
         audience=[bob.agent_id],
     )
 
-    # ← imagine the process dies here, before bob replies
+    # Wait for Bob's LLM reply — consulting closes automatically on completion
+    await alice.wait_for_channel_event(
+        channel_id=channel.channel_id,
+        predicate=lambda e: e.event_type == EV_TEXT and e.sender_id == bob.agent_id,
+        timeout=120.0,
+    )
+
+    # ← imagine the process crashes here, after bob has replied
 
     channel_id = channel.channel_id
-    await alice_hc.close()
-    await bob_hc.close()
     await hub.close()
 
     print(f"First run complete. Channel: {channel_id}")
@@ -127,32 +119,227 @@ async def first_run() -> str:
 
 
 async def second_run(channel_id: str) -> None:
-    """Re-open the hub from disk. The channel and WAL are exactly as left."""
+    """Re-open the hub from disk. Both messages are exactly as left."""
     hub = await Hub.open(DiskKnowledgeStore(DATA_DIR), ttl_sweep_interval=0)
 
-    # Read back everything that survived — alice's question is there.
     envelopes = await hub.read_wal(channel_id)
     print(f"Envelopes in WAL after restart: {len(envelopes)}")
     for env in envelopes:
         if env.event_type == EV_TEXT:
-            print(f"  recovered: {env.event_data['text']!r}")
+            name = hub.name_for(env.sender_id)
+            print(f"  recovered [{name}]: {env.event_data['text']!r}")
 
     await hub.close()
 
 
-asyncio.run(first_run().then(second_run))  # conceptual — wire up with real async
+async def main():
+    channel_id = await first_run()
+    await second_run(channel_id)
+
+asyncio.run(main())
 ```
 
 Output:
 ```text
 First run complete. Channel: ch_abc123
-Envelopes in WAL after restart: 2
-  recovered: 'What's the most important property of a distributed system?'
+Envelopes in WAL after restart: 6
+  recovered [alice]: "What's the most important property of a distributed system?"
+  recovered [bob]: 'Fault tolerance — the ability of a distributed system to continue operating correctly even when some of its components fail.'
 ```
 
-(The `EV_CHANNEL_INVITE` and `EV_CHANNEL_INVITE_ACK` envelopes are also in the log; only `EV_TEXT` is printed here.)
+(The `EV_CHANNEL_INVITE`, `EV_CHANNEL_INVITE_ACK`, `EV_CHANNEL_OPENED`, and `EV_CHANNEL_CLOSED` envelopes are also in the log; only `EV_TEXT` is printed here.)
 
-> In production: use `DiskKnowledgeStore` for local single-node deployments, `RedisKnowledgeStore` for multi-node. The hub's behaviour is identical — the store is plugged in at `Hub.open(store=...)`.
+### Continuing after restart
+
+Reading the WAL is only half the story. The hub restarts fully operational, and open channels are still open — agents can reconnect to the same channel and pick up the conversation exactly where it left off.
+
+A `discussion` channel stays open until explicitly closed, so it's the natural example: Alice and Bob are mid-conversation, the hub process dies, and the channel survives. When the hub comes back up, both agents reconnect to the same `channel_id` and the discussion continues, enabled by the unbroken WAL.
+
+The reconnect pattern is different from re-registration. After a restart, `hydrate()` reloads all agent identities from disk, so calling `register()` again would fail with "already registered." Instead, you retrieve the persisted passport, create a fresh transport binding, and construct the `AgentClient` directly:
+
+```python linenums="1"
+import asyncio
+from pathlib import Path
+
+from autogen.beta import Agent
+from autogen.beta.config import AnthropicConfig
+from autogen.beta.knowledge import DiskKnowledgeStore
+from autogen.beta.network import (
+    EV_TEXT,
+    AgentClient,
+    Channel,
+    Hub,
+    HubClient,
+    LocalLink,
+    NetworkPlugin,
+    Passport,
+    Resume,
+    Rule,
+)
+
+DATA_DIR = Path("./hub-data-discussion")
+
+PROMPT = "You are in a discussion about distributed systems. Respond in one sentence."
+
+
+async def _noop_handler(_envelope) -> None:
+    pass
+
+
+async def _reconnect(hub, hc, agent, name, *, llm_handler=True):
+    """Rebind a persisted agent to a fresh transport after hub restart."""
+    passport = await hub.get_agent(name)
+    resume = await hub.get_resume(passport.agent_id)
+    client_link = hc._ensure_connected()
+    hub.bind_endpoint(client_link.endpoint_id, passport.agent_id)
+    client = AgentClient(
+        agent=agent,
+        passport=passport,
+        resume=resume,
+        rule=Rule(),
+        hub=hub,
+        hub_client=hc,
+        attach_default_handler=llm_handler,
+    )
+    hc._clients[passport.agent_id] = client
+    if llm_handler:
+        NetworkPlugin(client).register(agent)
+    return client
+
+
+async def first_run() -> str:
+    """Alice and Bob start a discussion — then the process crashes mid-conversation."""
+    hub = await Hub.open(DiskKnowledgeStore(DATA_DIR), ttl_sweep_interval=0)
+    link = LocalLink(hub)
+
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+
+    # Alice sends manually; bob responds automatically via LLM.
+    alice = await alice_hc.register(
+        Agent("alice", prompt=PROMPT, config=AnthropicConfig(model="claude-sonnet-4-6")),
+        Passport(name="alice"),
+        Resume(),
+        attach_plugin=False,
+    )
+    alice.on_envelope(_noop_handler)
+
+    bob = await bob_hc.register(
+        Agent("bob", prompt=PROMPT, config=AnthropicConfig(model="claude-sonnet-4-6")),
+        Passport(name="bob"),
+        Resume(),
+    )
+
+    channel = await alice.open(type="discussion", target="bob")
+    await channel.send(
+        "What's the single most important guarantee a distributed system must provide?",
+        audience=[bob.agent_id],
+    )
+    await alice.wait_for_channel_event(
+        channel_id=channel.channel_id,
+        predicate=lambda e: e.event_type == EV_TEXT and e.sender_id == bob.agent_id,
+        timeout=120.0,
+    )
+
+    print("=== Process crashes here — channel still open ===")
+    channel_id = channel.channel_id
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()
+    return channel_id
+
+
+async def second_run(channel_id: str) -> None:
+    """Hub restarts — reconnect to the same open channel and continue."""
+    hub = await Hub.open(DiskKnowledgeStore(DATA_DIR), ttl_sweep_interval=0)
+    link = LocalLink(hub)
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+
+    envelopes = await hub.read_wal(channel_id)
+    print(f"\nEnvelopes in WAL after restart: {len(envelopes)}")
+    for env in envelopes:
+        if env.event_type == EV_TEXT:
+            name = hub.name_for(env.sender_id)
+            print(f"  [{name}]: {env.event_data['text']!r}")
+
+    # Reconnect to existing agent_ids — no re-registration needed.
+    alice = await _reconnect(
+        hub, alice_hc,
+        Agent("alice", prompt=PROMPT, config=AnthropicConfig(model="claude-sonnet-4-6")),
+        "alice", llm_handler=False,
+    )
+    bob = await _reconnect(
+        hub, bob_hc,
+        Agent("bob", prompt=PROMPT, config=AnthropicConfig(model="claude-sonnet-4-6")),
+        "bob",
+    )
+
+    metadata = await alice_hc.get_channel(channel_id)
+    print(f"\nChannel state after restart: {metadata.state.value}")
+    channel = Channel(metadata=metadata, client=alice)
+
+    # Hub replays the WAL on restart, so can_send reflects the true next speaker.
+    if hub.can_send(channel_id, alice.agent_id):
+        print("Next to speak after restart: alice")
+        await channel.send(
+            "Does that guarantee hold under network partitions?",
+            audience=[bob.agent_id],
+        )
+        await alice.wait_for_channel_event(
+            channel_id=channel_id,
+            predicate=lambda e: e.event_type == EV_TEXT and e.sender_id == bob.agent_id,
+            timeout=120.0,
+        )
+    elif hub.can_send(channel_id, bob.agent_id):
+        print("Next to speak after restart: bob")
+        await alice.wait_for_channel_event(
+            channel_id=channel_id,
+            predicate=lambda e: e.event_type == EV_TEXT and e.sender_id == bob.agent_id,
+            timeout=120.0,
+        )
+
+    # One unbroken log spanning the crash.
+    envelopes2 = await hub.read_wal(channel_id)
+    print(f"\nFull conversation ({len(envelopes2)} envelopes total):")
+    for env in envelopes2:
+        if env.event_type == EV_TEXT:
+            name = hub.name_for(env.sender_id)
+            print(f"  [{name}]: {env.event_data['text']!r}")
+
+    await channel.close()
+    await hub.close()
+
+
+async def main():
+    channel_id = await first_run()
+    await second_run(channel_id)
+
+asyncio.run(main())
+```
+
+Output:
+```text
+=== Process crashes here — channel still open ===
+
+Envelopes in WAL after restart: 5
+  [alice]: "What's the single most important guarantee a distributed system must provide?"
+  [bob]: 'Consistency — ensuring all nodes see the same data at the same time.'
+
+Channel state after restart: active
+
+Full conversation (7 envelopes total):
+  [alice]: "What's the single most important guarantee a distributed system must provide?"
+  [bob]: 'Consistency — ensuring all nodes see the same data at the same time.'
+  [alice]: 'Does that guarantee hold under network partitions?'
+  [bob]: 'No — the CAP theorem proves that under a network partition, a system must
+          sacrifice either consistency or availability, so perfect consistency cannot
+          be universally guaranteed.'
+```
+
+The channel was `active` when the hub crashed, and it's still `active` after restart. Alice and Bob reconnect to the same `channel_id` — not a new one — and the WAL grows in place. The crash is invisible in the log.
+
+> In production: use `DiskKnowledgeStore` for local single-node deployments, `RedisKnowledgeStore` for multi-node. The hub's behavior is identical — the store is plugged in at `Hub.open(store=...)`.
 
 ## Three Identity Records
 
@@ -184,7 +371,7 @@ Passports are persisted under `/agents/{agent_id}/passport.json`.
 Resume(
     claimed_capabilities=["web-search", "code-review"],
     domains=["research", "engineering"],
-    summary="Searches the web and synthesises results into structured reports.",
+    summary="Searches the web and synthesizes results into structured reports.",
     examples=[
         ResumeExample(title="Competitive analysis", outcome="completed"),
     ],
@@ -193,10 +380,10 @@ Resume(
 
 The `Resume` has two halves:
 
-- **Tenant-provided**: `claimed_capabilities`, `domains`, `summary`, `examples` — you set these at registration and can update them later with `hub.set_resume(agent_id, resume)`.
-- **Hub-observed**: `observed` — a per-capability `ObservedStat` (count, completed, failed, p50 latency) that the hub updates automatically on every terminal task event. You don't write to this; the hub writes it.
+- **Tenant-provided**: `claimed_capabilities`, `domains`, `summary`, `examples` — you set these at registration and can update them later with `hub.set_resume(agent_id, resume)`. Set these so that other agents can understand your agent's capabilities, helping them to engage your agent for the right tasks.
+- **Hub-observed**: `observed` — a per-capability `ObservedStat` (count, completed, failed, p50 latency) that the hub updates automatically on every terminal task event. You don't write to this; the hub writes it and uses it to prioritize.
 
-When another agent calls `peers(action="find", capability="web-search")`, the hub ranks results using the `observed` track record. An agent with 100 completed web-search tasks and a p50 of 1.2 s ranks above a new agent with zero observations. The signal is real: derived from actual behaviour, not self-reported claims.
+When another agent calls `peers(action="find", capability="web-search")`, the hub ranks results using the `observed` track record. An agent with 100 completed web-search tasks and a p50 of 1.2 s ranks above a new agent with zero observations. The signal is real: derived from actual behavior, not self-reported claims.
 
 Resumes are persisted under `/agents/{agent_id}/resume.json`.
 
@@ -222,13 +409,13 @@ to retrieve full page content for any result URL.
 ## Parameters
 
 - `query` — search query string (required)
-- `location` — ISO country code for localised results (optional)
+- `location` — ISO country code for localized results (optional)
 - `language` — BCP-47 language code for result language (optional)
 ```
 
 The hub stores it under `/agents/{agent_id}/SKILL.md` and returns it in `peers(action="inspect", agent_id=...)` responses. When a `SkillsPlugin` pre-loads a skill into an agent's system prompt, it's reading this file. When an agent calls `load_skill()` at runtime, it fetches this file from the hub.
 
-The three records together form a complete, verifiable identity: the passport binds the `agent_id` to a name and provider; the resume carries earned capability evidence; the SKILL.md tells other agents how to use this one.
+The three records together form a complete, verifiable identity: the passport binds the `agent_id` to a name and provider; the resume carries expected and earned capability evidence; the SKILL.md tells other agents how to use this one.
 
 ## The Audit Log
 
@@ -239,10 +426,10 @@ The WAL records what happened *on a channel*. The audit log records what happene
 One file: `/audit/audit.jsonl`. Each line is a JSON object:
 
 ```json
-{"at":"2026-05-16T04:00:01.234Z","kind":"agent_registered","agent_id":"ag_abc","name":"alice","kind_hint":"agent"}
-{"at":"2026-05-16T04:00:02.100Z","kind":"channel_created","channel_id":"ch_xyz","adapter":"discussion","participant_ids":["ag_abc","ag_def","ag_ghi"]}
+{"at":"2026-05-16T04:00:01.234Z","kind":"agent_registered","agent_id":"ag_abc","name":"alice"}
+{"at":"2026-05-16T04:00:02.100Z","kind":"channel_created","channel_id":"ch_xyz","manifest_type":"discussion","participants":["ag_abc","ag_def","ag_ghi"]}
 {"at":"2026-05-16T04:00:45.320Z","kind":"resume_set","agent_id":"ag_def","source":"observed","capability":"web-search"}
-{"at":"2026-05-16T04:01:12.000Z","kind":"expectation_violated","channel_id":"ch_xyz","expectation":"reply_within","violator_id":"ag_ghi","action":"notify_channel"}
+{"at":"2026-05-16T04:01:12.000Z","kind":"expectation_violated","channel_id":"ch_xyz","expectation":"reply_within","violators":["ag_ghi"],"on_violation":"notify_channel"}
 {"at":"2026-05-16T04:05:00.000Z","kind":"channel_closed","channel_id":"ch_xyz","reason":"all_participants_left"}
 ```
 
@@ -261,7 +448,7 @@ The audit log records:
 Read it back from any `Hub` instance:
 
 ```python
-records = await hub._audit_log.read()
+records = await hub.audit_log.read_all()
 for record in records:
     print(f"{record['at']}  {record['kind']}")
 ```
@@ -271,9 +458,10 @@ Or subscribe to a live stream — new records arrive in-process without polling 
 ```python
 async def on_audit(record: dict) -> None:
     if record["kind"] == "expectation_violated":
-        print(f"⚠  {record['channel_id']}: {record['expectation']} violated by {record['violator_id']}")
+        violators = ", ".join(record["violators"])
+        print(f"⚠  {record['channel_id']}: {record['expectation']} violated by {violators}")
 
-hub._audit_log.subscribe(on_audit)
+hub.audit_log.subscribe(on_audit)
 ```
 
 The audit log is **append-only by design** — nothing is ever overwritten. If you need a different format (structured logging, SIEM export), subclass `AuditLog` and pass it to `Hub.replace_audit_log(...)`.
@@ -289,7 +477,7 @@ The hub's crash guarantee covers *disk-committed* state. A few things are intent
 | Adapter state cache (`_adapter_states`) | Re-derived by folding the WAL on `hydrate()` |
 | In-progress `asyncio` tasks driving agent turns | Resume is the agent's job, not the hub's |
 
-When a hub restarts, registered agents are loaded from their persisted `passport.json` files but their transport bindings are gone. Each `HubClient` that reconnects re-establishes its binding with a `HelloFrame`. Pending envelopes that were in-flight but not yet WAL-appended at crash time are effectively "never happened" — the sender retries.
+When a hub restarts, registered agents are loaded from their persisted `passport.json` files but their transport bindings are gone. Each `HubClient` that reconnects re-establishes its binding with a `HelloFrame`. Pending envelopes that were in-flight but not yet WAL-appended at crash time effectively never happened — the sender retries.
 
 > The hub guarantees *what the log contains*. The application is responsible for detecting and retrying sends that never reached the log.
 
@@ -322,13 +510,12 @@ For completeness — everything the hub persists under a `KnowledgeStore`:
   audit.jsonl         ← hub-wide cross-cutting event record
 ```
 
-All of `/registry/` is a derived cache — safe to delete and rebuilt on `hydrate()`. Everything else is authoritative.
+All of `/registry/` is a derived cache — safe to delete, since `hydrate()` rebuilds it. Everything else is authoritative.
 
 ## Where to Next
 
-- **This series, Part 4 — Networks You Can Deploy**: federation across organisations, dynamic register / unregister, omni-modal streaming, and a full production-incident walk-through.
-- **This series, Part 2 — Choreography You Can Dial In**: turn limits, reply deadlines, audience addressing, and the orchestration cookbook.
+- **This series, Part 4 — Networks You Can Deploy**: federation across organizations, dynamic register / unregister, omni-modal streaming, and a full production-incident walk-through.
 - **The Agent Harness: An Agent Is More Than a Loop**: what's inside each node in the network.
 - Docs: [Hub & Identity](/docs/beta/network/hub_and_identity) · [Network Quick Start](/docs/beta/network/quick_start) · [Channel Adapters Overview](/docs/beta/network/adapters_overview)
 
-A network you can't trust isn't a network — it's a distributed way to lose data. The WAL, the identity records, and the audit log are what make the AG2 Network something you can deploy, inspect, and rely on.
+Moving to production, you need an agent network that you can trust. The WAL, the identity records, and the audit log are what make the AG2 Network something you can deploy, inspect, and rely on.

--- a/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/index.mdx
+++ b/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/index.mdx
@@ -1,0 +1,334 @@
+---
+title: "What Survives, Survives Exactly"
+authors: [marklysze]
+tags: [AG2 Beta, Network, Multi-Agent, WAL, Identity, Audit]
+date: 2026-05-16
+slug: ag2-network-what-survives
+---
+
+![What Survives, Survives Exactly](img/n3-banner-animated.webp)
+
+Three agents are mid-conversation. The hub process restarts. When it comes back up, does the conversation survive?
+
+Yes. Exactly as it was — envelope for envelope, in the same order, with the same adapter state. No "we think it sent." No partial log. No replay from an approximation. The write-ahead log is the conversation.
+
+This is the third post in a four-part series on the AG2 Network:
+
+1. **One Coherent Agent Isn't Enough** — the action-driven network; four conversation shapes.
+2. **Choreography You Can Dial In** — turn limits, reply deadlines, audience addressing, and the orchestration cookbook.
+3. **What Survives, Survives Exactly** *(this post)* — the trustworthy substrate: WAL + fold + hub restart, three identity records, audit log.
+4. **Networks You Can Deploy** — federation across organisations, dynamic membership, omni-modal streaming, a full production-incident walk-through.
+
+<!-- more -->
+
+The previous posts showed *what* the network lets agents do. This one explains *why you can trust it*.
+
+## The Write-Ahead Log
+
+Every channel has one write-ahead log — a `.jsonl` file in the hub's `KnowledgeStore`. Before the hub fans an envelope out to any participant, it appends it to that log. The append comes first. Fan-out second.
+
+That ordering is the whole guarantee.
+
+```mermaid
+sequenceDiagram
+    participant S as Sender
+    participant H as Hub
+    participant W as WAL (.jsonl)
+    participant P1 as Participant A
+    participant P2 as Participant B
+
+    S->>H: EV_TEXT envelope
+    H->>W: append → wal.jsonl  ← happens first
+    H->>P1: deliver
+    H->>P2: deliver
+    Note over W: if the process dies here,<br/>the envelope is already in the log
+```
+
+If the hub process dies after the append but before the fan-out, the envelope is still in the log. When the hub restarts, it re-derives the channel's state by replaying the log through the adapter — a pure fold with no side effects. Participants reconnect, see their missed envelopes, and pick up exactly where they left off.
+
+> **If it's in the log, it survived. If the process died before the append, it never happened.**
+
+That's not eventual consistency. There's no "maybe" tier. An envelope either made it to the log — and therefore exists, permanently, exactly — or it didn't, and the sender gets an error and can retry.
+
+### The fold
+
+Each channel's adapter maintains a state that's a pure function of the log: a fold. The `discussion` adapter's state is "which participant speaks next." The `workflow` adapter's state is "which graph node is active." Neither depends on memory that lives outside the log.
+
+When the hub restarts, it calls `hydrate()`:
+
+```python
+# Hub.hydrate() — called automatically by Hub.open()
+# Channels — load metadata first, then re-fold WALs.
+channel_children = await self._store.list("/channels")
+for channel_id in channel_children:
+    await self._load_channel(channel_id)
+    # ... which re-folds the WAL through the adapter
+```
+
+The adapter state is rebuilt deterministically from disk. Nothing is approximated.
+
+## Hub Restart: A Worked Example
+
+The default `MemoryKnowledgeStore` is in-process — fine for development, nothing survives a restart. For production (or this example), use `DiskKnowledgeStore`:
+
+```python linenums="1"
+import asyncio
+from pathlib import Path
+
+from autogen.beta import Agent
+from autogen.beta.config import AnthropicConfig
+from autogen.beta.knowledge import DiskKnowledgeStore
+from autogen.beta.network import (
+    EV_TEXT,
+    Hub,
+    HubClient,
+    LocalLink,
+    Passport,
+    Resume,
+)
+
+DATA_DIR = Path("./hub-data")  # persisted across restarts
+
+
+async def first_run() -> str:
+    """Start a consulting channel, send one message, then abruptly stop."""
+    hub = await Hub.open(DiskKnowledgeStore(DATA_DIR), ttl_sweep_interval=0)
+    link = LocalLink(hub)
+
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+
+    alice = await alice_hc.register(
+        Agent("alice", prompt="Ask one short question.", config=AnthropicConfig(model="claude-sonnet-4-6")),
+        Passport(name="alice"),
+        Resume(),
+    )
+    bob = await bob_hc.register(
+        Agent("bob", prompt="Answer in one sentence.", config=AnthropicConfig(model="claude-sonnet-4-6")),
+        Passport(name="bob"),
+        Resume(),
+    )
+
+    channel = await alice.open(type="consulting", target="bob")
+    await channel.send(
+        "What's the most important property of a distributed system?",
+        audience=[bob.agent_id],
+    )
+
+    # ← imagine the process dies here, before bob replies
+
+    channel_id = channel.channel_id
+    await alice_hc.close()
+    await bob_hc.close()
+    await hub.close()
+
+    print(f"First run complete. Channel: {channel_id}")
+    return channel_id
+
+
+async def second_run(channel_id: str) -> None:
+    """Re-open the hub from disk. The channel and WAL are exactly as left."""
+    hub = await Hub.open(DiskKnowledgeStore(DATA_DIR), ttl_sweep_interval=0)
+
+    # Read back everything that survived — alice's question is there.
+    envelopes = await hub.read_wal(channel_id)
+    print(f"Envelopes in WAL after restart: {len(envelopes)}")
+    for env in envelopes:
+        if env.event_type == EV_TEXT:
+            print(f"  recovered: {env.event_data['text']!r}")
+
+    await hub.close()
+
+
+asyncio.run(first_run().then(second_run))  # conceptual — wire up with real async
+```
+
+Output:
+```text
+First run complete. Channel: ch_abc123
+Envelopes in WAL after restart: 2
+  recovered: 'What's the most important property of a distributed system?'
+```
+
+(The `EV_CHANNEL_INVITE` and `EV_CHANNEL_INVITE_ACK` envelopes are also in the log; only `EV_TEXT` is printed here.)
+
+> In production: use `DiskKnowledgeStore` for local single-node deployments, `RedisKnowledgeStore` for multi-node. The hub's behaviour is identical — the store is plugged in at `Hub.open(store=...)`.
+
+## Three Identity Records
+
+Every registered agent is backed by three records, each with a distinct lifecycle:
+
+![Three identity records — Passport (immutable), Resume (mutable), SKILL.md (discovery)](img/n3-identity.webp)
+
+### Passport — immutable, hub-stamped
+
+```python
+Passport(
+    name="alice",            # human-readable address; unique per hub
+    owner="team-search",     # billing / routing scope
+    provider="anthropic",    # optional — the hub uses it for routing hints
+    model="claude-sonnet-4-6",
+    kind="agent",            # "agent" | "human" | "remote_agent"
+)
+```
+
+The hub assigns `agent_id` at registration — a stable, opaque identifier the network routes by. `name` is for humans; `agent_id` is for code.
+
+**Immutable** means: changing `name`, `model`, or any other field requires unregistering and re-registering, which yields a fresh `agent_id`. Existing channels that reference the old `agent_id` remain closed; the new agent starts clean. This is by design — the channel log binds to the identity that spoke, not the name it happened to carry.
+
+Passports are persisted under `/agents/{agent_id}/passport.json`.
+
+### Resume — mutable capability claims + track record
+
+```python
+Resume(
+    claimed_capabilities=["web-search", "code-review"],
+    domains=["research", "engineering"],
+    summary="Searches the web and synthesises results into structured reports.",
+    examples=[
+        ResumeExample(title="Competitive analysis", outcome="completed"),
+    ],
+)
+```
+
+The `Resume` has two halves:
+
+- **Tenant-provided**: `claimed_capabilities`, `domains`, `summary`, `examples` — you set these at registration and can update them later with `hub.set_resume(agent_id, resume)`.
+- **Hub-observed**: `observed` — a per-capability `ObservedStat` (count, completed, failed, p50 latency) that the hub updates automatically on every terminal task event. You don't write to this; the hub writes it.
+
+When another agent calls `peers(action="find", capability="web-search")`, the hub ranks results using the `observed` track record. An agent with 100 completed web-search tasks and a p50 of 1.2 s ranks above a new agent with zero observations. The signal is real: derived from actual behaviour, not self-reported claims.
+
+Resumes are persisted under `/agents/{agent_id}/resume.json`.
+
+### SKILL.md — structured discovery document
+
+A `SKILL.md` is a Markdown file with Anthropic-style YAML frontmatter that describes what an agent can do in a form other agents (and humans) can read:
+
+```markdown
+---
+name: web-search
+description: Search the web and return structured results with titles, snippets, and URLs.
+version: 1.0.0
+capabilities:
+  - web-search
+  - content-fetch
+---
+
+## Usage
+
+Call with a search query. Returns up to 10 ranked results. Use `tinyfish_fetch`
+to retrieve full page content for any result URL.
+
+## Parameters
+
+- `query` — search query string (required)
+- `location` — ISO country code for localised results (optional)
+- `language` — BCP-47 language code for result language (optional)
+```
+
+The hub stores it under `/agents/{agent_id}/SKILL.md` and returns it in `peers(action="inspect", agent_id=...)` responses. When a `SkillsPlugin` pre-loads a skill into an agent's system prompt, it's reading this file. When an agent calls `load_skill()` at runtime, it fetches this file from the hub.
+
+The three records together form a complete, verifiable identity: the passport binds the `agent_id` to a name and provider; the resume carries earned capability evidence; the SKILL.md tells other agents how to use this one.
+
+## The Audit Log
+
+The WAL records what happened *on a channel*. The audit log records what happened *across the hub* — the cross-cutting events that don't belong to any single channel.
+
+![Audit log — hub-wide append-only record of identity and channel lifecycle](img/n3-audit.webp)
+
+One file: `/audit/audit.jsonl`. Each line is a JSON object:
+
+```json
+{"at":"2026-05-16T04:00:01.234Z","kind":"agent_registered","agent_id":"ag_abc","name":"alice","kind_hint":"agent"}
+{"at":"2026-05-16T04:00:02.100Z","kind":"channel_created","channel_id":"ch_xyz","adapter":"discussion","participant_ids":["ag_abc","ag_def","ag_ghi"]}
+{"at":"2026-05-16T04:00:45.320Z","kind":"resume_set","agent_id":"ag_def","source":"observed","capability":"web-search"}
+{"at":"2026-05-16T04:01:12.000Z","kind":"expectation_violated","channel_id":"ch_xyz","expectation":"reply_within","violator_id":"ag_ghi","action":"notify_channel"}
+{"at":"2026-05-16T04:05:00.000Z","kind":"channel_closed","channel_id":"ch_xyz","reason":"all_participants_left"}
+```
+
+The audit log records:
+
+| Kind | Trigger |
+|---|---|
+| `agent_registered` / `agent_unregistered` | Register / unregister call |
+| `resume_set` | Tenant `set_resume` call (source: `"tenant"`) or hub track-record update (source: `"observed"`) |
+| `skill_set` / `rule_set` | `set_skill` / `set_rule` calls |
+| `channel_created` / `channel_closed` / `channel_expired` | Channel lifecycle transitions |
+| `task_terminated` | Task reaches completed / failed / expired |
+| `expectation_violated` | An expectation fires (per channel, per expectation, per violator) |
+| `turn_failed` | A hub notify-handler raised an exception |
+
+Read it back from any `Hub` instance:
+
+```python
+records = await hub._audit_log.read()
+for record in records:
+    print(f"{record['at']}  {record['kind']}")
+```
+
+Or subscribe to a live stream — new records arrive in-process without polling the file:
+
+```python
+async def on_audit(record: dict) -> None:
+    if record["kind"] == "expectation_violated":
+        print(f"⚠  {record['channel_id']}: {record['expectation']} violated by {record['violator_id']}")
+
+hub._audit_log.subscribe(on_audit)
+```
+
+The audit log is **append-only by design** — nothing is ever overwritten. If you need a different format (structured logging, SIEM export), subclass `AuditLog` and pass it to `Hub.replace_audit_log(...)`.
+
+## What Doesn't Survive
+
+The hub's crash guarantee covers *disk-committed* state. A few things are intentionally not persisted:
+
+| Not persisted | Why |
+|---|---|
+| In-flight transport connections | Reconnect on the next `HubClient` connect |
+| `AgentRuntime` (transport binding, last heartbeat) | Re-established at reconnect; treated as cache |
+| Adapter state cache (`_adapter_states`) | Re-derived by folding the WAL on `hydrate()` |
+| In-progress `asyncio` tasks driving agent turns | Resume is the agent's job, not the hub's |
+
+When a hub restarts, registered agents are loaded from their persisted `passport.json` files but their transport bindings are gone. Each `HubClient` that reconnects re-establishes its binding with a `HelloFrame`. Pending envelopes that were in-flight but not yet WAL-appended at crash time are effectively "never happened" — the sender retries.
+
+> The hub guarantees *what the log contains*. The application is responsible for detecting and retrying sends that never reached the log.
+
+This is the same contract as any WAL-based system (Postgres, Kafka, etcd). The hub doesn't pretend to stronger guarantees than it actually provides.
+
+## The Storage Layout
+
+For completeness — everything the hub persists under a `KnowledgeStore`:
+
+```text
+/agents/
+  {agent_id}/
+    passport.json     ← immutable identity
+    resume.json       ← mutable capability claims + track record
+    SKILL.md          ← discovery document
+    rule.json         ← per-agent policy (access control, rate limits)
+    runtime.json      ← ephemeral; re-written on reconnect
+    inbox.cursor      ← replay offset for missed envelopes
+
+/channels/
+  {channel_id}/
+    metadata.json     ← lifecycle state, adapter manifest, participants
+    wal.jsonl         ← the conversation, exactly as it happened
+
+/registry/
+  by_name.json        ← derived cache: name → agent_id
+  by_capability.json  ← derived cache: capability → [agent_id, ...]
+
+/audit/
+  audit.jsonl         ← hub-wide cross-cutting event record
+```
+
+All of `/registry/` is a derived cache — safe to delete and rebuilt on `hydrate()`. Everything else is authoritative.
+
+## Where to Next
+
+- **This series, Part 4 — Networks You Can Deploy**: federation across organisations, dynamic register / unregister, omni-modal streaming, and a full production-incident walk-through.
+- **This series, Part 2 — Choreography You Can Dial In**: turn limits, reply deadlines, audience addressing, and the orchestration cookbook.
+- **The Agent Harness: An Agent Is More Than a Loop**: what's inside each node in the network.
+- Docs: [Hub & Identity](/docs/beta/network/hub_and_identity) · [Network Quick Start](/docs/beta/network/quick_start) · [Channel Adapters Overview](/docs/beta/network/adapters_overview)
+
+A network you can't trust isn't a network — it's a distributed way to lose data. The WAL, the identity records, and the audit log are what make the AG2 Network something you can deploy, inspect, and rely on.


### PR DESCRIPTION
## Why are these changes needed?

This PR covers two things:
1. Fix for the DiscussionAdapter to remove the `Say` tool which conflicts with the turn-based handling of the adapter. `Say` is not required as responses fold to the next turn/agent automatically. If an agent does try to use `Say` it would immediately fold, which is not expected.
2. 3rd of the 4 AG2 Network blogs, "What Survives, Survives Exactly"

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [ ] I understand the changes in this PR and can explain them in my own words.
- [ ] I have verified that the PR description accurately reflects the actual diff.
- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
