### PR TITLE
Add __invert__ to _ConditionMeta for event type negation

### DIFF
--- a/autogen/beta/events/base.py
+++ b/autogen/beta/events/base.py
@@ -98,7 +98,7 @@ class Field:
 
 
 class _ConditionMeta(type):
-    """Metaclass providing class-level condition operators (|, or_, not_)."""
+    """Metaclass providing class-level condition operators (~, |, or_, not_)."""
 
     def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, Any], **kwargs: Any) -> None:
         super().__init__(name, bases, namespace, **kwargs)
@@ -109,6 +109,9 @@ class _ConditionMeta(type):
 
     def or_(cls, other: Any) -> OrCondition:
         return TypeCondition(cls).or_(other)
+
+    def __invert__(cls) -> NotCondition:
+        return cls.not_()
 
     def not_(cls) -> NotCondition:
         return TypeCondition(cls).not_()

--- a/test/beta/agent/test_observer.py
+++ b/test/beta/agent/test_observer.py
@@ -52,6 +52,24 @@ async def test_observer_does_not_fire_on_non_matching_event(
 
 
 @pytest.mark.asyncio()
+async def test_observer_with_inverted_type(
+    mock: MagicMock,
+    test_config: TestConfig,
+) -> None:
+    agent = Agent(
+        "",
+        config=test_config,
+        observers=[observer(~ToolCallEvent, mock)],
+    )
+
+    await agent.ask("Hi!")
+
+    mock.assert_called()
+    for call in mock.call_args_list:
+        assert not isinstance(call[0][0], ToolCallEvent)
+
+
+@pytest.mark.asyncio()
 async def test_multiple_observers(
     mock: MagicMock,
     test_config: TestConfig,

--- a/test/beta/events/test_conditions.py
+++ b/test/beta/events/test_conditions.py
@@ -212,6 +212,26 @@ class TestEventConditions:
         assert condition(ChildEvent(field="1"))
         assert not condition(TestEvent(field="1"))
 
+    def test_invert_event_class(self):
+        condition = ~TestEvent
+
+        assert not condition(TestEvent(field="1"))
+        assert not condition(ChildEvent(field="1"))
+        assert condition(AnotherEvent(field="test"))
+
+    def test_invert_event_class_composition(self):
+        condition = ~TestEvent & (AnotherEvent.field == "ok")
+
+        assert not condition(TestEvent(field="1"))
+        assert condition(AnotherEvent(field="ok"))
+        assert not condition(AnotherEvent(field="nope"))
+
+    def test_not_method_on_event_class(self):
+        condition = TestEvent.not_()
+
+        assert not condition(TestEvent(field="1"))
+        assert condition(AnotherEvent(field="test"))
+
     def test_different_event_with_condition(self):
         condition = TestEvent.field == "1"
 

--- a/test/beta/events/test_conditions_repr.py
+++ b/test/beta/events/test_conditions_repr.py
@@ -115,3 +115,12 @@ class TestMixed:
         condition = (TestEvent.field > 10) | AnotherEvent
         expected = "Or(Is(TestEvent.field > 10) | IsType(AnotherEvent))"
         assert repr(condition) == expected
+
+    def test_invert_class_repr(self):
+        condition = ~TestEvent
+        assert repr(condition) == "~IsType(TestEvent)"
+
+    def test_invert_class_or_repr(self):
+        condition = ~TestEvent | AnotherEvent
+        expected = "Or(~IsType(TestEvent) | IsType(AnotherEvent))"
+        assert repr(condition) == expected

--- a/test/beta/observer/test_observer.py
+++ b/test/beta/observer/test_observer.py
@@ -108,6 +108,38 @@ class TestBaseObserver:
             assert obs.process_count == 1
 
 
+class InvertedObserver(BaseObserver):
+    """Observer that watches everything except ToolCallEvent."""
+
+    def __init__(self):
+        super().__init__("inverted-observer", watch=EventWatch(~ToolCallEvent))
+        self.process_count = 0
+        self.seen_types: list[type] = []
+
+    async def process(self, events, ctx) -> ObserverAlert | None:
+        self.process_count += 1
+        self.seen_types.extend(type(e) for e in events)
+        return None
+
+
+@pytest.mark.asyncio
+class TestInvertedConditionObserver:
+    async def test_inverted_watch_excludes_matching_type(self) -> None:
+        stream = MemoryStream()
+        ctx = Context(stream=stream)
+        obs = InvertedObserver()
+
+        with ExitStack() as stack:
+            obs.register(stack, ctx)
+
+            await stream.send(ToolCallEvent(name="t", arguments="{}"), ctx)
+            assert obs.process_count == 0
+
+            await stream.send(ModelMessage(content="hello"), ctx)
+            assert obs.process_count == 1
+            assert obs.seen_types == [ModelMessage]
+
+
 class _CrashingObserver(BaseObserver):
     """Observer whose ``process()`` always raises."""
 

--- a/test/beta/stream/test_stream.py
+++ b/test/beta/stream/test_stream.py
@@ -93,6 +93,36 @@ class TestStreamWhereTypeFilter:
         mock.assert_not_called()
 
 
+class TestStreamWhereNegation:
+    @pytest.mark.asyncio
+    async def test_where_inverted_type_excludes_matching(self, mock: MagicMock) -> None:
+        stream = MemoryStream()
+
+        stream.where(~ToolCallEvent).subscribe(mock)
+
+        event1 = ToolCallEvent(name="func1", arguments="test1")
+        event2 = ModelMessage("response")
+        event3 = ToolCallEvent(name="func2", arguments="test2")
+        await stream.send(event1, context=Context(stream))
+        await stream.send(event2, context=Context(stream))
+        await stream.send(event3, context=Context(stream))
+
+        assert [c[0][0] for c in mock.call_args_list] == [event2]
+
+    @pytest.mark.asyncio
+    async def test_where_inverted_type_with_union(self, mock: MagicMock) -> None:
+        stream = MemoryStream()
+
+        stream.where(~ToolCallEvent | ModelMessage).subscribe(mock)
+
+        event1 = ToolCallEvent(name="func1", arguments="test1")
+        event2 = ModelMessage("response")
+        await stream.send(event1, context=Context(stream))
+        await stream.send(event2, context=Context(stream))
+
+        assert [c[0][0] for c in mock.call_args_list] == [event2]
+
+
 class TestStreamWhereConditionFilter:
     @pytest.mark.asyncio
     async def test_where_condition_filter_by_condition(self, mock: MagicMock) -> None:

--- a/website/docs/beta/advanced/observers.mdx
+++ b/website/docs/beta/advanced/observers.mdx
@@ -93,7 +93,7 @@ reply = await agent.ask(
 
 Observers support the same condition system as [stream subscriptions](/docs/beta/advanced/stream). You can filter by event type, combine types, or match on field values:
 
-```python linenums="1" hl_lines="4 9 14"
+```python linenums="1" hl_lines="4 9 14 19"
 from autogen.beta.events import ModelRequest, ModelResponse, ToolCallEvent
 
 # Single event type
@@ -110,6 +110,11 @@ def on_any(event: ModelRequest | ModelResponse) -> None:
 @agent.observer(ToolCallEvent.name == "search")
 def on_search(event: ToolCallEvent) -> None:
     print(f"Search: {event.name}")
+
+# Negation — everything except a specific type
+@agent.observer(~ToolCallEvent)
+def on_non_tool(event) -> None:
+    print(f"Non-tool event: {event}")
 ```
 
 ## Dependency Injection

--- a/website/docs/beta/advanced/stream.mdx
+++ b/website/docs/beta/advanced/stream.mdx
@@ -73,6 +73,15 @@ def handle_event(event):
 stream.where(ToolCallEvent | ModelMessage).subscribe(handle_event)
 ```
 
+### Exclude events of a specific type
+
+You can negate an event type using the bitwise NOT operator (`~`). This creates a condition that matches everything *except* the specified type.
+
+```python
+# Subscribe to all events except ToolCallEvent
+stream.where(~ToolCallEvent).subscribe(handle_event)
+```
+
 ### Subscribe to events with a specific value
 
 You can filter events based on the value of their fields. The event classes define fields that support comparison operators.

--- a/website/docs/beta/advanced/watches.mdx
+++ b/website/docs/beta/advanced/watches.mdx
@@ -71,13 +71,16 @@ async def on_response(events, ctx):
 watch.arm(stream, on_response)
 ```
 
-`EventWatch` also supports field conditions:
+`EventWatch` also supports field conditions and negation:
 
 ```python linenums="1"
 from autogen.beta.watch import EventWatch
 from autogen.beta.events import ToolCallEvent
 
 watch = EventWatch(ToolCallEvent.name == "search")
+
+# Fire on every event that is NOT a ToolCallEvent
+watch = EventWatch(~ToolCallEvent)
 ```
 
 ### CadenceWatch


### PR DESCRIPTION
## Why are these changes needed?

Event types can be passed directly as conditions (e.g., `ConditionalMiddleware(condition=ToolCallEvent)`), and the `|` (OR) operator already works on bare event classes via `_ConditionMeta.__or__`. However, the `~` (invert/NOT) operator raises `TypeError` on bare event types because `__invert__` is only defined on `Condition` instances, not on the metaclass.

This adds `__invert__` to `_ConditionMeta` so the full condition algebra works uniformly on bare event types:

```python
# Before: TypeError
condition = ~ToolCallEvent

# After: works — returns NotCondition(TypeCondition(ToolCallEvent))
condition = ~ToolCallEvent                    # "not a tool call"
condition = ~ToolCallEvent | ModelResponse    # "not a tool call, or a model response"
```

## Related issue number

Closes #2885

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.