### PR TITLE
docs(beta): Fix cookbook document examples re wait_for_channel_event

### DIFF
--- a/website/docs/beta/network/pattern_cookbook/context_aware_routing.mdx
+++ b/website/docs/beta/network/pattern_cookbook/context_aware_routing.mdx
@@ -278,7 +278,7 @@ async def main() -> None:
     # Wait for the workflow to terminate (any of the five close routes
     # documented in /docs/beta/network/termination — this demo uses
     # FromSpeaker(<specialist>) → TerminateTarget("<category>_resolved")).
-    close_env = await user_hc.wait_for_channel_event(
+    close_env = await user.wait_for_channel_event(
         channel_id=channel.channel_id,
         predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED,
         timeout=120.0,

--- a/website/docs/beta/network/pattern_cookbook/escalation.mdx
+++ b/website/docs/beta/network/pattern_cookbook/escalation.mdx
@@ -263,7 +263,7 @@ async def main() -> None:
     # Wait for the workflow to terminate (any of the five close routes
     # documented in /docs/beta/network/termination — this demo uses
     # ToolCalled("resolve") → TerminateTarget("resolved")).
-    close_env = await user_hc.wait_for_channel_event(
+    close_env = await user.wait_for_channel_event(
         channel_id=channel.channel_id,
         predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED,
         timeout=180.0,

--- a/website/docs/beta/network/pattern_cookbook/feedback_loop.mdx
+++ b/website/docs/beta/network/pattern_cookbook/feedback_loop.mdx
@@ -227,7 +227,7 @@ async def main() -> None:
     # Wait for the workflow to terminate (any of the five close routes
     # documented in /docs/beta/network/termination — this demo uses
     # ContextEquals("done", True) → TerminateTarget("approved")).
-    close_env = await intake_hc.wait_for_channel_event(
+    close_env = await intake.wait_for_channel_event(
         channel_id=channel.channel_id,
         predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED,
         timeout=360.0,

--- a/website/docs/beta/network/pattern_cookbook/hierarchical.mdx
+++ b/website/docs/beta/network/pattern_cookbook/hierarchical.mdx
@@ -244,7 +244,7 @@ async def main() -> None:
     # Wait for the workflow to terminate (any of the five close routes
     # documented in /docs/beta/network/termination — this demo uses
     # FromSpeaker(writer) → TerminateTarget("written")).
-    close_env = await intake_hc.wait_for_channel_event(
+    close_env = await intake.wait_for_channel_event(
         channel_id=channel.channel_id,
         predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED,
         timeout=180.0,

--- a/website/docs/beta/network/pattern_cookbook/pattern_cookbook.mdx
+++ b/website/docs/beta/network/pattern_cookbook/pattern_cookbook.mdx
@@ -112,7 +112,7 @@ Every cookbook page below uses the same close-detection primitive in
 its demo `#!python main`:
 
 ```python linenums="1"
-close_env = await intake_hc.wait_for_channel_event(
+close_env = await intake.wait_for_channel_event(
     channel_id=channel.channel_id,
     predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED,
     timeout=180.0,
@@ -120,7 +120,7 @@ close_env = await intake_hc.wait_for_channel_event(
 print(f"closed: reason={close_env.event_data.get('reason')!r}")
 ```
 
-`#!python HubClient.wait_for_channel_event` blocks on the per-channel
+`#!python AgentClient.wait_for_channel_event` blocks on the per-channel
 inbox until an envelope matching the predicate arrives — here, the
 `#!python EV_CHANNEL_CLOSED` envelope every termination route emits.
 The reason string distinguishes the close (e.g. `'sequence_complete'`,

--- a/website/docs/beta/network/pattern_cookbook/pipeline.mdx
+++ b/website/docs/beta/network/pattern_cookbook/pipeline.mdx
@@ -182,7 +182,7 @@ async def main() -> None:
     # Wait for the workflow to terminate (any of the five close routes
     # documented in /docs/beta/network/termination — this demo uses
     # TerminateTarget("sequence_complete") as its happy path).
-    close_env = await intake_hc.wait_for_channel_event(
+    close_env = await intake.wait_for_channel_event(
         channel_id=channel.channel_id,
         predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED,
         timeout=180.0,

--- a/website/docs/beta/network/pattern_cookbook/redundant.mdx
+++ b/website/docs/beta/network/pattern_cookbook/redundant.mdx
@@ -208,7 +208,7 @@ async def main() -> None:
     # Wait for the workflow to terminate (any of the five close routes
     # documented in /docs/beta/network/termination — this demo uses
     # TerminateTarget("sequence_complete") after the evaluator's reply).
-    close_env = await intake_hc.wait_for_channel_event(
+    close_env = await intake.wait_for_channel_event(
         channel_id=channel.channel_id,
         predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED,
         timeout=240.0,

--- a/website/docs/beta/network/pattern_cookbook/star.mdx
+++ b/website/docs/beta/network/pattern_cookbook/star.mdx
@@ -325,7 +325,7 @@ async def main() -> None:
     # Wait for the workflow to terminate (any of the five close routes
     # documented in /docs/beta/network/termination — this demo uses
     # ToolCalled("synthesise") → TerminateTarget("answered")).
-    close_env = await user_hc.wait_for_channel_event(
+    close_env = await user.wait_for_channel_event(
         channel_id=channel.channel_id,
         predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED,
         timeout=240.0,

--- a/website/docs/beta/network/pattern_cookbook/triage_with_tasks.mdx
+++ b/website/docs/beta/network/pattern_cookbook/triage_with_tasks.mdx
@@ -270,7 +270,7 @@ async def main() -> None:
     # Wait for the workflow to terminate (any of the five close routes
     # documented in /docs/beta/network/termination — this demo uses
     # TerminateTarget("sequence_complete") after the reviewer's reply).
-    close_env = await intake_hc.wait_for_channel_event(
+    close_env = await intake.wait_for_channel_event(
         channel_id=channel.channel_id,
         predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED,
         timeout=240.0,


### PR DESCRIPTION
## Why are these changes needed?

`wait_for_channel_event` is not used on the correct object in the Beta cookbook examples. This corrects that.

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [ ] I understand the changes in this PR and can explain them in my own words.
- [ ] I have verified that the PR description accurately reflects the actual diff.
- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
