### PR TITLE
feat(beta): add xAI provider

### DIFF
--- a/autogen/beta/config/__init__.py
+++ b/autogen/beta/config/__init__.py
@@ -37,6 +37,11 @@ try:
 except ImportError as e:
     OllamaConfig = missing_optional_dependency("OllamaConfig", "ollama", e)  # type: ignore[misc]
 
+try:
+    from .xai import XAIConfig
+except ImportError as e:
+    XAIConfig = missing_optional_dependency("XAIConfig", "xai", e)  # type: ignore[misc]
+
 __all__ = (
     "AnthropicConfig",
     "ContainerInfo",
@@ -50,4 +55,5 @@ __all__ = (
     "OpenAIConfig",
     "OpenAIResponsesConfig",
     "VertexAIConfig",
+    "XAIConfig",
 )

--- a/autogen/beta/config/xai/__init__.py
+++ b/autogen/beta/config/xai/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .config import XAIConfig
+from .events import XAIAssistantEvent
+from .xai_client import XAIClient
+
+__all__ = (
+    "XAIAssistantEvent",
+    "XAIClient",
+    "XAIConfig",
+)

--- a/autogen/beta/config/xai/config.py
+++ b/autogen/beta/config/xai/config.py
@@ -13,7 +13,6 @@ from autogen.beta.config.config import ModelConfig
 from .xai_client import CreateOptions, IncludeOption, ReasoningEffort, XAIClient
 
 XAI_DEFAULT_API_HOST = "api.x.ai"
-XAI_DEFAULT_TIMEOUT = 1620.0  # seconds; matches xai-sdk default
 
 
 class XAIConfigOverrides(TypedDict, total=False):
@@ -50,7 +49,7 @@ class XAIConfig(ModelConfig):
     model: str
     api_key: str | None = None
     api_host: str = XAI_DEFAULT_API_HOST
-    timeout: float | None = XAI_DEFAULT_TIMEOUT
+    timeout: float | None = None
     metadata: tuple[tuple[str, str], ...] | None = None
     channel_options: list[tuple[str, Any]] | None = None
     streaming: bool = False

--- a/autogen/beta/config/xai/config.py
+++ b/autogen/beta/config/xai/config.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Any, TypedDict
+
+from typing_extensions import Unpack
+
+from autogen.beta.config.config import ModelConfig
+
+from .xai_client import CreateOptions, IncludeOption, ReasoningEffort, XAIClient
+
+XAI_DEFAULT_API_HOST = "api.x.ai"
+XAI_DEFAULT_TIMEOUT = 1620.0  # seconds; matches xai-sdk default
+
+
+class XAIConfigOverrides(TypedDict, total=False):
+    model: str
+    api_key: str | None
+    api_host: str
+    timeout: float | None
+    metadata: tuple[tuple[str, str], ...] | None
+    channel_options: list[tuple[str, Any]] | None
+    streaming: bool
+    temperature: float | None
+    top_p: float | None
+    max_tokens: int | None
+    frequency_penalty: float | None
+    presence_penalty: float | None
+    seed: int | None
+    stop: Sequence[str] | None
+    user: str | None
+    logprobs: bool | None
+    top_logprobs: int | None
+    tool_choice: str | None
+    parallel_tool_calls: bool | None
+    reasoning_effort: ReasoningEffort | None
+    store_messages: bool | None
+    previous_response_id: str | None
+    use_encrypted_content: bool | None
+    max_turns: int | None
+    include: Sequence[IncludeOption] | None
+    conversation_id: str | None
+
+
+@dataclass(slots=True)
+class XAIConfig(ModelConfig):
+    model: str
+    api_key: str | None = None
+    api_host: str = XAI_DEFAULT_API_HOST
+    timeout: float | None = XAI_DEFAULT_TIMEOUT
+    metadata: tuple[tuple[str, str], ...] | None = None
+    channel_options: list[tuple[str, Any]] | None = None
+    streaming: bool = False
+    temperature: float | None = None
+    top_p: float | None = None
+    max_tokens: int | None = None
+    frequency_penalty: float | None = None
+    presence_penalty: float | None = None
+    seed: int | None = None
+    stop: Sequence[str] | None = None
+    user: str | None = None
+    logprobs: bool | None = None
+    top_logprobs: int | None = None
+    tool_choice: str | None = None
+    parallel_tool_calls: bool | None = None
+    reasoning_effort: ReasoningEffort | None = None
+    store_messages: bool | None = None
+    previous_response_id: str | None = None
+    use_encrypted_content: bool | None = None
+    max_turns: int | None = None
+    include: Sequence[IncludeOption] | None = None
+    conversation_id: str | None = None
+
+    def copy(self, /, **overrides: Unpack[XAIConfigOverrides]) -> "XAIConfig":
+        return replace(self, **overrides)
+
+    def create(self) -> XAIClient:
+        options = CreateOptions(
+            model=self.model,
+            temperature=self.temperature,
+            top_p=self.top_p,
+            max_tokens=self.max_tokens,
+            frequency_penalty=self.frequency_penalty,
+            presence_penalty=self.presence_penalty,
+            seed=self.seed,
+            stop=self.stop,
+            user=self.user,
+            logprobs=self.logprobs,
+            top_logprobs=self.top_logprobs,
+            tool_choice=self.tool_choice,
+            parallel_tool_calls=self.parallel_tool_calls,
+            reasoning_effort=self.reasoning_effort,
+            store_messages=self.store_messages,
+            previous_response_id=self.previous_response_id,
+            use_encrypted_content=self.use_encrypted_content,
+            max_turns=self.max_turns,
+            include=self.include,
+            conversation_id=self.conversation_id,
+        )
+
+        return XAIClient(
+            api_key=self.api_key,
+            api_host=self.api_host,
+            timeout=self.timeout,
+            metadata=self.metadata,
+            channel_options=self.channel_options,
+            streaming=self.streaming,
+            create_options=options,
+        )
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError(f"{type(self).__name__} does not support Files API.")

--- a/autogen/beta/config/xai/events.py
+++ b/autogen/beta/config/xai/events.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from xai_sdk.chat import Response as XAIResponse
+
+from autogen.beta.events import BaseEvent, Field
+
+
+class XAIAssistantEvent(BaseEvent):
+    """Carries the raw xAI ``GetChatCompletionResponse`` proto for multi-turn round-trip.
+
+    The xai-sdk ``Chat`` object is stateful: rebuilding an assistant turn with
+    ``tool_calls`` requires passing the original ``Response`` proto back via
+    ``chat.append(response)``. The proto is the only canonical source — there is
+    no public helper that constructs an assistant message with tool_calls from
+    primitives. Persisted (NOT transient) so it survives history storage.
+    """
+
+    proto_bytes: bytes = Field(repr=False)
+    model: str | None = Field(default=None, compare=False)
+    finish_reason: str | None = Field(default=None, compare=False)
+
+    @classmethod
+    def from_response(cls, response: XAIResponse) -> "XAIAssistantEvent":
+        return cls(
+            proto_bytes=response.proto.SerializeToString(),
+            model=getattr(response, "model", None),
+            finish_reason=getattr(response, "finish_reason", None),
+        )

--- a/autogen/beta/config/xai/events.py
+++ b/autogen/beta/config/xai/events.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from xai_sdk.chat import Response as XAIResponse
+from xai_sdk.proto import sample_pb2
 
 from autogen.beta.events import BaseEvent, Field
 
@@ -23,8 +24,16 @@ class XAIAssistantEvent(BaseEvent):
 
     @classmethod
     def from_response(cls, response: XAIResponse) -> "XAIAssistantEvent":
+        # finish_reason comes back as "FINISH_REASON_STOP" / proto enum — normalise
+        # to "stop" so this metadata matches ModelResponse.finish_reason.
+        fr = response.finish_reason
+        finish_reason: str | None = None
+        if fr:
+            name = sample_pb2.FinishReason.Name(fr) if isinstance(fr, int) else str(fr)
+            finish_reason = name.removeprefix("FINISH_REASON_").removeprefix("REASON_").lower() or None
+
         return cls(
             proto_bytes=response.proto.SerializeToString(),
-            model=getattr(response, "model", None),
-            finish_reason=getattr(response, "finish_reason", None),
+            model=response.proto.model or None,
+            finish_reason=finish_reason,
         )

--- a/autogen/beta/config/xai/mappers.py
+++ b/autogen/beta/config/xai/mappers.py
@@ -229,16 +229,26 @@ def _content_from_input(part: Input, serializer: SerializerProto) -> chat_pb2.Co
 
 
 def _tool_result_to_string(parts: Sequence[Input], serializer: SerializerProto) -> str:
-    """xAI ``tool_result`` takes ``result: str``; flatten parts to a single string."""
-    chunks: list[str] = []
+    """xAI ``tool_result`` accepts only ``result: str`` (see ``xai_sdk.chat.tool_result``).
+
+    Strategy mirrors other providers (single text → bare str) and aligns with xAI
+    docs that recommend JSON for structured results. Multiple text/data fragments
+    are emitted as a JSON array so the model sees the part boundary explicitly
+    instead of a silent ``\\n`` flatten. Binary/URL inputs are not supported by
+    the API for tool results.
+    """
+    fragments: list[str] = []
     for part in parts:
         if isinstance(part, TextInput):
-            chunks.append(part.content)
+            fragments.append(part.content)
         elif isinstance(part, DataInput):
-            chunks.append(serializer.encode(part.data).decode())
+            fragments.append(serializer.encode(part.data).decode())
         else:
             raise UnsupportedInputError(f"tool_result/{type(part).__name__}", PROVIDER)
-    return "\n".join(chunks)
+
+    if len(fragments) == 1:
+        return fragments[0]
+    return json.dumps(fragments, ensure_ascii=False)
 
 
 def convert_messages(

--- a/autogen/beta/config/xai/mappers.py
+++ b/autogen/beta/config/xai/mappers.py
@@ -221,7 +221,8 @@ def _content_from_input(part: Input, serializer: SerializerProto) -> chat_pb2.Co
         raise UnsupportedInputError(f"BinaryInput({part.kind.value})", PROVIDER)
 
     if isinstance(part, FileIdInput):
-        return xai_file(file_id=part.file_id, filename=part.filename)
+        # xai_sdk rejects filename/mime_type when referencing by file_id
+        return xai_file(file_id=part.file_id)
 
     raise UnsupportedInputError(type(part).__name__, PROVIDER)
 

--- a/autogen/beta/config/xai/mappers.py
+++ b/autogen/beta/config/xai/mappers.py
@@ -197,11 +197,9 @@ def _content_from_input(part: Input, serializer: SerializerProto) -> chat_pb2.Co
 
     if isinstance(part, UrlInput):
         if part.kind is BinaryType.IMAGE:
-            detail = part.metadata.get("detail", "auto") if isinstance(part.metadata, dict) else "auto"
-            return xai_image(part.url, detail=detail)
+            return xai_image(part.url, detail=part.metadata.get("detail", "auto"))
         if part.kind in (BinaryType.DOCUMENT, BinaryType.BINARY):
-            filename = part.metadata.get("filename") if isinstance(part.metadata, dict) else None
-            return xai_file(url=part.url, filename=filename)
+            return xai_file(url=part.url, filename=part.metadata.get("filename"))
         raise UnsupportedInputError(f"UrlInput({part.kind.value})", PROVIDER)
 
     if isinstance(part, BinaryInput):
@@ -317,14 +315,10 @@ def normalize_usage(usage: usage_pb2.SamplingUsage | None) -> Usage:
     if usage is None:
         return Usage()
 
-    def _get(name: str) -> float | None:
-        v = getattr(usage, name, None)
-        return float(v) if v else None
-
     return Usage(
-        prompt_tokens=_get("prompt_tokens"),
-        completion_tokens=_get("completion_tokens"),
-        total_tokens=_get("total_tokens"),
-        cache_read_input_tokens=_get("cached_prompt_text_tokens"),
-        thinking_tokens=_get("reasoning_tokens"),
+        prompt_tokens=float(usage.prompt_tokens) if usage.prompt_tokens else None,
+        completion_tokens=float(usage.completion_tokens) if usage.completion_tokens else None,
+        total_tokens=float(usage.total_tokens) if usage.total_tokens else None,
+        cache_read_input_tokens=float(usage.cached_prompt_text_tokens) if usage.cached_prompt_text_tokens else None,
+        thinking_tokens=float(usage.reasoning_tokens) if usage.reasoning_tokens else None,
     )

--- a/autogen/beta/config/xai/mappers.py
+++ b/autogen/beta/config/xai/mappers.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import json
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+from fast_depends.library.serializer import SerializerProto
+from xai_sdk import tools as xai_tools
+from xai_sdk.chat import (
+    Response as XAIResponse,
+)
+from xai_sdk.chat import (
+    assistant,
+    chat_pb2,
+    system,
+    tool_result,
+    user,
+)
+from xai_sdk.chat import (
+    file as xai_file,
+)
+from xai_sdk.chat import (
+    image as xai_image,
+)
+from xai_sdk.chat import (
+    text as xai_text,
+)
+from xai_sdk.chat import (
+    tool as xai_tool,
+)
+from xai_sdk.proto import usage_pb2
+
+from autogen.beta.events import (
+    BaseEvent,
+    BinaryInput,
+    BinaryType,
+    DataInput,
+    FileIdInput,
+    Input,
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    ToolResultsEvent,
+    UrlInput,
+    Usage,
+)
+from autogen.beta.exceptions import UnsupportedInputError, UnsupportedToolError
+from autogen.beta.response import ResponseProto
+from autogen.beta.tools.builtin.code_execution import CodeExecutionToolSchema
+from autogen.beta.tools.builtin.mcp_server import MCPServerToolSchema
+from autogen.beta.tools.builtin.web_search import WebSearchToolSchema
+from autogen.beta.tools.builtin.x_search import XSearchToolSchema
+from autogen.beta.tools.final import FunctionToolSchema
+from autogen.beta.tools.schemas import ToolSchema
+
+from .events import XAIAssistantEvent
+
+PROVIDER = "xai"
+
+
+def _ensure_object_schema(params: dict[str, Any]) -> dict[str, Any]:
+    """xAI tool parameters follow JSON Schema. Ensure top-level is an object."""
+    schema = dict(params)
+    schema["type"] = "object"
+    schema.setdefault("properties", {})
+    schema.setdefault("additionalProperties", False)
+    return schema
+
+
+def _ensure_additional_properties_false(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively set ``additionalProperties: false`` on every object node.
+
+    xAI's strict JSON Schema mode (FORMAT_TYPE_JSON_SCHEMA) follows the OpenAI
+    convention — every object schema must explicitly disallow extra keys.
+    """
+    schema = dict(schema)
+
+    if schema.get("type") == "object":
+        schema.setdefault("additionalProperties", False)
+
+    if "properties" in schema:
+        schema["properties"] = {
+            k: _ensure_additional_properties_false(v) if isinstance(v, dict) else v
+            for k, v in schema["properties"].items()
+        }
+
+    if "$defs" in schema:
+        schema["$defs"] = {
+            k: _ensure_additional_properties_false(v) if isinstance(v, dict) else v for k, v in schema["$defs"].items()
+        }
+
+    for key in ("anyOf", "oneOf", "allOf"):
+        if key in schema:
+            schema[key] = [
+                _ensure_additional_properties_false(item) if isinstance(item, dict) else item for item in schema[key]
+            ]
+
+    if "items" in schema and isinstance(schema["items"], dict):
+        schema["items"] = _ensure_additional_properties_false(schema["items"])
+
+    return schema
+
+
+def response_proto_to_format(response: ResponseProto | None) -> chat_pb2.ResponseFormat | None:
+    """Convert AG2 ``ResponseProto`` to xAI's ``chat_pb2.ResponseFormat`` proto.
+
+    xAI's chat.create accepts either a Pydantic class, a Literal alias, or a
+    ResponseFormat proto. A plain JSON-schema dict is NOT accepted, so we build
+    the proto ourselves with the schema serialized to JSON.
+    """
+    if not response or not response.json_schema:
+        return None
+
+    strict_schema = _ensure_additional_properties_false(response.json_schema)
+    return chat_pb2.ResponseFormat(
+        format_type=chat_pb2.FORMAT_TYPE_JSON_SCHEMA,
+        schema=json.dumps(strict_schema),
+    )
+
+
+def tool_to_api(t: ToolSchema) -> chat_pb2.Tool:
+    """Convert an AG2 ToolSchema to an xAI ``chat_pb2.Tool`` proto."""
+    if isinstance(t, FunctionToolSchema):
+        return xai_tool(
+            name=t.function.name,
+            description=t.function.description,
+            parameters=_ensure_object_schema(t.function.parameters),
+        )
+
+    if isinstance(t, WebSearchToolSchema):
+        kwargs: dict[str, Any] = {}
+        if t.allowed_domains is not None:
+            kwargs["allowed_domains"] = t.allowed_domains
+        if t.blocked_domains is not None:
+            kwargs["excluded_domains"] = t.blocked_domains
+        if t.user_location is not None:
+            if t.user_location.country is not None:
+                kwargs["user_location_country"] = t.user_location.country
+            if t.user_location.city is not None:
+                kwargs["user_location_city"] = t.user_location.city
+            if t.user_location.region is not None:
+                kwargs["user_location_region"] = t.user_location.region
+            if t.user_location.timezone is not None:
+                kwargs["user_location_timezone"] = t.user_location.timezone
+        return xai_tools.web_search(**kwargs)
+
+    if isinstance(t, XSearchToolSchema):
+        kwargs = {}
+        if t.allowed_x_handles is not None:
+            kwargs["allowed_x_handles"] = t.allowed_x_handles
+        if t.excluded_x_handles is not None:
+            kwargs["excluded_x_handles"] = t.excluded_x_handles
+        if t.from_date is not None:
+            kwargs["from_date"] = t.from_date
+        if t.to_date is not None:
+            kwargs["to_date"] = t.to_date
+        if t.enable_image_understanding is not None:
+            kwargs["enable_image_understanding"] = t.enable_image_understanding
+        if t.enable_video_understanding is not None:
+            kwargs["enable_video_understanding"] = t.enable_video_understanding
+        return xai_tools.x_search(**kwargs)
+
+    if isinstance(t, CodeExecutionToolSchema):
+        return xai_tools.code_execution()
+
+    if isinstance(t, MCPServerToolSchema):
+        kwargs = {"server_url": t.server_url}
+        if t.server_label is not None:
+            kwargs["server_label"] = t.server_label
+        if t.description is not None:
+            kwargs["server_description"] = t.description
+        if t.allowed_tools is not None:
+            kwargs["allowed_tool_names"] = t.allowed_tools
+        if t.authorization_token is not None:
+            kwargs["authorization"] = f"Bearer {t.authorization_token}"
+        elif t.headers is not None and "Authorization" in t.headers:
+            kwargs["authorization"] = t.headers["Authorization"]
+        if t.headers is not None:
+            extra = {k: v for k, v in t.headers.items() if k != "Authorization"}
+            if extra:
+                kwargs["extra_headers"] = extra
+        return xai_tools.mcp(**kwargs)
+
+    raise UnsupportedToolError(t.type, PROVIDER)
+
+
+def _content_from_input(part: Input, serializer: SerializerProto) -> chat_pb2.Content:
+    """Convert a single AG2 ``Input`` part to an xAI ``Content`` proto."""
+    if isinstance(part, TextInput):
+        return xai_text(part.content)
+
+    if isinstance(part, DataInput):
+        return xai_text(serializer.encode(part.data).decode())
+
+    if isinstance(part, UrlInput):
+        if part.kind is BinaryType.IMAGE:
+            detail = part.metadata.get("detail", "auto") if isinstance(part.metadata, dict) else "auto"
+            return xai_image(part.url, detail=detail)
+        if part.kind in (BinaryType.DOCUMENT, BinaryType.BINARY):
+            filename = part.metadata.get("filename") if isinstance(part.metadata, dict) else None
+            return xai_file(url=part.url, filename=filename)
+        raise UnsupportedInputError(f"UrlInput({part.kind.value})", PROVIDER)
+
+    if isinstance(part, BinaryInput):
+        if part.kind is BinaryType.IMAGE:
+            b64 = base64.b64encode(part.data).decode()
+            data_url = f"data:{part.media_type};base64,{b64}"
+            detail = part.vendor_metadata.get("detail", "auto")
+            return xai_image(data_url, detail=detail)
+        if part.kind in (BinaryType.DOCUMENT, BinaryType.BINARY):
+            filename = part.vendor_metadata.get("filename")
+            if not filename:
+                suffix = str(part.media_type).rsplit("/", 1)[-1].split("+", 1)[0]
+                filename = f"file.{suffix}"
+            return xai_file(
+                data=part.data,
+                filename=filename,
+                mime_type=str(part.media_type),
+            )
+        raise UnsupportedInputError(f"BinaryInput({part.kind.value})", PROVIDER)
+
+    if isinstance(part, FileIdInput):
+        return xai_file(file_id=part.file_id, filename=part.filename)
+
+    raise UnsupportedInputError(type(part).__name__, PROVIDER)
+
+
+def _tool_result_to_string(parts: Sequence[Input], serializer: SerializerProto) -> str:
+    """xAI ``tool_result`` takes ``result: str``; flatten parts to a single string."""
+    chunks: list[str] = []
+    for part in parts:
+        if isinstance(part, TextInput):
+            chunks.append(part.content)
+        elif isinstance(part, DataInput):
+            chunks.append(serializer.encode(part.data).decode())
+        else:
+            raise UnsupportedInputError(f"tool_result/{type(part).__name__}", PROVIDER)
+    return "\n".join(chunks)
+
+
+def convert_messages(
+    system_prompt: Iterable[str],
+    messages: Iterable[BaseEvent],
+    serializer: SerializerProto,
+) -> tuple[list[chat_pb2.Message], list["XAIResponse"]]:
+    """Convert AG2 events to xAI helper messages + persisted assistant ``Response`` objects.
+
+    Returns a 2-tuple:
+
+    * ``messages`` — list of ``chat_pb2.Message`` to pass to ``chat.create(messages=...)``.
+    * ``responses`` — list of ``xai_sdk.chat.Response`` objects (restored from
+      ``XAIAssistantEvent.proto_bytes``) to ``chat.append(...)`` AFTER chat is
+      created. This is the canonical way xai-sdk replays assistant turns with
+      tool_calls — there is no public helper to construct them from primitives.
+
+    The order is preserved: an ``XAIAssistantEvent`` followed by a
+    ``ToolResultsEvent`` becomes a Response + tool_result message at the
+    corresponding offset in the output stream.
+    """
+    result: list[chat_pb2.Message] = []
+    prompt_text = "\n".join(s for s in system_prompt if s)
+    if prompt_text:
+        result.append(system(prompt_text))
+
+    responses: list[XAIResponse] = []
+    skip_next_model_response = False
+
+    for message in messages:
+        if isinstance(message, XAIAssistantEvent):
+            proto = chat_pb2.GetChatCompletionResponse.FromString(message.proto_bytes)
+            responses.append(XAIResponse(proto, None))
+            # The companion ModelResponse (emitted alongside) carries the same
+            # turn — skip it so we don't double-append the assistant message.
+            skip_next_model_response = True
+
+        elif isinstance(message, ModelResponse):
+            if skip_next_model_response:
+                skip_next_model_response = False
+                continue
+            # Degraded fallback: no XAIAssistantEvent → reconstruct text-only.
+            # tool_calls cannot be replayed without the proto; they're lost.
+            if message.message and message.message.content:
+                result.append(assistant(message.message.content))
+
+        elif isinstance(message, ToolResultsEvent):
+            for r in message.results:
+                payload = _tool_result_to_string(r.result.parts, serializer)
+                result.append(tool_result(payload, tool_call_id=r.parent_id))
+
+        elif isinstance(message, ModelRequest):
+            contents: list[chat_pb2.Content] = [_content_from_input(p, serializer) for p in message.parts]
+            result.append(user(*contents))
+
+    return result, responses
+
+
+def normalize_usage(usage: usage_pb2.SamplingUsage | None) -> Usage:
+    """Normalise xai-sdk usage object to AG2 ``Usage``.
+
+    xai-sdk Usage proto fields (see ``usage_pb2.SamplingUsage``):
+    ``prompt_tokens``, ``completion_tokens``, ``total_tokens``,
+    ``reasoning_tokens``, ``cached_prompt_text_tokens``.
+    """
+    if usage is None:
+        return Usage()
+
+    def _get(name: str) -> float | None:
+        v = getattr(usage, name, None)
+        return float(v) if v else None
+
+    return Usage(
+        prompt_tokens=_get("prompt_tokens"),
+        completion_tokens=_get("completion_tokens"),
+        total_tokens=_get("total_tokens"),
+        cache_read_input_tokens=_get("cached_prompt_text_tokens"),
+        thinking_tokens=_get("reasoning_tokens"),
+    )

--- a/autogen/beta/config/xai/xai_client.py
+++ b/autogen/beta/config/xai/xai_client.py
@@ -129,16 +129,16 @@ class XAIClient(LLMClient):
     ) -> ModelResponse:
         response = await chat.sample()
 
-        if reasoning := getattr(response, "reasoning_content", None):
-            await context.send(ModelReasoning(reasoning))
+        if response.reasoning_content:
+            await context.send(ModelReasoning(response.reasoning_content))
 
         model_msg: ModelMessage | None = None
-        if content := getattr(response, "content", None):
-            model_msg = ModelMessage(content)
+        if response.content:
+            model_msg = ModelMessage(response.content)
             await context.send(model_msg)
 
         calls: list[ToolCallEvent] = []
-        for tc in getattr(response, "tool_calls", None) or ():
+        for tc in response.tool_calls:
             cls = ToolCallEvent if tc.type == chat_pb2.TOOL_CALL_TYPE_CLIENT_SIDE_TOOL else BuiltinToolCallEvent
             ev = cls(id=tc.id, name=tc.function.name, arguments=tc.function.arguments or "{}")
             if isinstance(ev, BuiltinToolCallEvent):
@@ -150,16 +150,16 @@ class XAIClient(LLMClient):
 
         # xai-sdk returns finish_reason as either a string (e.g. "FINISH_REASON_STOP")
         # or a proto enum int — strip the prefix and lowercase to match openai's "stop".
-        fr = getattr(response, "finish_reason", None)
+        fr = response.finish_reason
         finish_reason: str | None = None
-        if fr is not None:
+        if fr:
             name = sample_pb2.FinishReason.Name(fr) if isinstance(fr, int) else str(fr)
             finish_reason = name.removeprefix("FINISH_REASON_").removeprefix("REASON_").lower() or None
 
         return ModelResponse(
             message=model_msg,
             tool_calls=ToolCallsEvent(calls),
-            usage=normalize_usage(getattr(response, "usage", None)),
+            usage=normalize_usage(response.usage),
             model=response.proto.model or None,
             provider=PROVIDER,
             finish_reason=finish_reason,
@@ -182,14 +182,14 @@ class XAIClient(LLMClient):
         async for response, chunk in chat.stream():
             last_response = response
 
-            if reasoning := getattr(chunk, "reasoning_content", None):
-                await context.send(ModelReasoning(reasoning))
+            if chunk.reasoning_content:
+                await context.send(ModelReasoning(chunk.reasoning_content))
 
-            if content := getattr(chunk, "content", None):
-                full_content += content
-                await context.send(ModelMessageChunk(content))
+            if chunk.content:
+                full_content += chunk.content
+                await context.send(ModelMessageChunk(chunk.content))
 
-            for tc in getattr(chunk, "tool_calls", None) or ():
+            for tc in chunk.tool_calls:
                 if not tc.id:
                     continue
                 if tc.id in tool_calls_by_id or tc.id in builtin_emitted:
@@ -202,11 +202,11 @@ class XAIClient(LLMClient):
                 else:
                     tool_calls_by_id[tc.id] = ev
 
-            if u := getattr(chunk, "usage", None):
-                usage = normalize_usage(u)
+            if chunk.usage:
+                usage = normalize_usage(chunk.usage)
             if model := chunk.proto.model or None:
                 resolved_model = model
-            if fr := getattr(chunk, "finish_reason", None):
+            if fr := chunk.finish_reason:
                 finish_reason_raw = fr
 
         message: ModelMessage | None = None
@@ -217,11 +217,11 @@ class XAIClient(LLMClient):
         if last_response is not None:
             await context.send(XAIAssistantEvent.from_response(last_response))
             if not usage:
-                usage = normalize_usage(getattr(last_response, "usage", None))
+                usage = normalize_usage(last_response.usage)
             if not resolved_model:
                 resolved_model = last_response.proto.model or None
             if finish_reason_raw is None:
-                finish_reason_raw = getattr(last_response, "finish_reason", None)
+                finish_reason_raw = last_response.finish_reason
 
         # xai-sdk returns finish_reason as either a string (e.g. "FINISH_REASON_STOP")
         # or a proto enum int — strip the prefix and lowercase to match openai's "stop".

--- a/autogen/beta/config/xai/xai_client.py
+++ b/autogen/beta/config/xai/xai_client.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterable, Sequence
+from itertools import chain
+from typing import Any, TypedDict
+
+from fast_depends.library.serializer import SerializerProto
+from typing_extensions import Required
+from xai_sdk import AsyncClient
+from xai_sdk.aio.chat import Chat as XAIChat
+from xai_sdk.chat import Response as XAIResponse
+from xai_sdk.proto import sample_pb2
+from xai_sdk.types.chat import IncludeOption, ReasoningEffort, ToolMode
+
+from autogen.beta.config.client import LLMClient
+from autogen.beta.context import ConversationContext
+from autogen.beta.events import (
+    BaseEvent,
+    ModelMessage,
+    ModelMessageChunk,
+    ModelReasoning,
+    ModelResponse,
+    ToolCallEvent,
+    ToolCallsEvent,
+    Usage,
+)
+from autogen.beta.response import ResponseProto
+from autogen.beta.tools.schemas import ToolSchema
+
+from .events import XAIAssistantEvent
+from .mappers import (
+    PROVIDER,
+    convert_messages,
+    normalize_usage,
+    response_proto_to_format,
+    tool_to_api,
+)
+
+__all__ = ["CreateOptions", "IncludeOption", "ReasoningEffort", "XAIClient"]
+
+
+class CreateOptions(TypedDict, total=False):
+    model: Required[str]
+
+    temperature: float | None
+    top_p: float | None
+    max_tokens: int | None
+    frequency_penalty: float | None
+    presence_penalty: float | None
+    seed: int | None
+    stop: Sequence[str] | None
+    user: str | None
+    logprobs: bool | None
+    top_logprobs: int | None
+    tool_choice: ToolMode | None
+    parallel_tool_calls: bool | None
+    reasoning_effort: ReasoningEffort | None
+    store_messages: bool | None
+    previous_response_id: str | None
+    use_encrypted_content: bool | None
+    max_turns: int | None
+    include: Sequence[IncludeOption] | None
+    conversation_id: str | None
+
+
+class XAIClient(LLMClient):
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_host: str = "api.x.ai",
+        timeout: float | None = None,
+        metadata: tuple[tuple[str, str], ...] | None = None,
+        channel_options: list[tuple[str, Any]] | None = None,
+        streaming: bool = False,
+        create_options: CreateOptions | None = None,
+    ) -> None:
+        # Defer AsyncClient construction to call time — it eagerly opens a gRPC
+        # channel and validates XAI_API_KEY in its constructor, which would
+        # otherwise turn ``XAIConfig.create()`` into a side-effecting call.
+        self._api_key = api_key
+        self._api_host = api_host
+        self._timeout = timeout
+        self._metadata = metadata
+        self._channel_options = channel_options
+        self._client: AsyncClient | None = None
+
+        self._create_options: dict[str, Any] = {k: v for k, v in (create_options or {}).items() if v is not None}
+        self._streaming = streaming
+
+    def _get_client(self) -> AsyncClient:
+        if self._client is None:
+            self._client = AsyncClient(
+                api_key=self._api_key,
+                api_host=self._api_host,
+                timeout=self._timeout,
+                metadata=self._metadata,
+                channel_options=self._channel_options,
+            )
+        return self._client
+
+    async def __call__(
+        self,
+        messages: Sequence[BaseEvent],
+        context: "ConversationContext",
+        *,
+        tools: Iterable[ToolSchema],
+        response_schema: ResponseProto | None,
+        serializer: SerializerProto,
+    ) -> ModelResponse:
+        if response_schema and response_schema.system_prompt:
+            prompt: Iterable[str] = chain(context.prompt, (response_schema.system_prompt,))
+        else:
+            prompt = context.prompt
+
+        xai_messages, replay_responses = convert_messages(prompt, messages, serializer)
+        xai_tools = [tool_to_api(t) for t in tools]
+        response_format = response_proto_to_format(response_schema)
+
+        create_kwargs: dict[str, Any] = dict(self._create_options)
+        if xai_messages:
+            create_kwargs["messages"] = xai_messages
+        if xai_tools:
+            create_kwargs["tools"] = xai_tools
+        if response_format is not None:
+            create_kwargs["response_format"] = response_format
+
+        chat = self._get_client().chat.create(**create_kwargs)
+        for resp in replay_responses:
+            chat.append(resp)
+
+        if self._streaming:
+            return await self._call_streaming(chat, context)
+        return await self._call_non_streaming(chat, context)
+
+    async def _call_non_streaming(
+        self,
+        chat: XAIChat,
+        context: "ConversationContext",
+    ) -> ModelResponse:
+        response = await chat.sample()
+
+        if reasoning := getattr(response, "reasoning_content", None):
+            await context.send(ModelReasoning(reasoning))
+
+        model_msg: ModelMessage | None = None
+        if content := getattr(response, "content", None):
+            model_msg = ModelMessage(content)
+            await context.send(model_msg)
+
+        calls: list[ToolCallEvent] = []
+        for tc in getattr(response, "tool_calls", None) or ():
+            calls.append(
+                ToolCallEvent(
+                    id=tc.id,
+                    name=tc.function.name,
+                    arguments=tc.function.arguments or "{}",
+                )
+            )
+
+        await context.send(XAIAssistantEvent.from_response(response))
+
+        return ModelResponse(
+            message=model_msg,
+            tool_calls=ToolCallsEvent(calls),
+            usage=normalize_usage(getattr(response, "usage", None)),
+            model=getattr(response, "model", None),
+            provider=PROVIDER,
+            finish_reason=_finish_reason_to_str(getattr(response, "finish_reason", None)),
+        )
+
+    async def _call_streaming(
+        self,
+        chat: XAIChat,
+        context: "ConversationContext",
+    ) -> ModelResponse:
+        full_content: str = ""
+        usage: Usage = Usage()
+        finish_reason: str | None = None
+        resolved_model: str | None = None
+        last_response: XAIResponse | None = None
+        # tool_calls accumulate by id; the SDK delivers whole calls per chunk.
+        tool_calls_by_id: dict[str, ToolCallEvent] = {}
+
+        async for response, chunk in chat.stream():
+            last_response = response
+
+            if reasoning := getattr(chunk, "reasoning_content", None):
+                await context.send(ModelReasoning(reasoning))
+
+            if content := getattr(chunk, "content", None):
+                full_content += content
+                await context.send(ModelMessageChunk(content))
+
+            for tc in getattr(chunk, "tool_calls", None) or ():
+                if tc.id and tc.id not in tool_calls_by_id:
+                    tool_calls_by_id[tc.id] = ToolCallEvent(
+                        id=tc.id,
+                        name=tc.function.name,
+                        arguments=tc.function.arguments or "{}",
+                    )
+
+            if u := getattr(chunk, "usage", None):
+                usage = normalize_usage(u)
+            if model := getattr(chunk, "model", None):
+                resolved_model = model
+            if fr := getattr(chunk, "finish_reason", None):
+                finish_reason = _finish_reason_to_str(fr)
+
+        message: ModelMessage | None = None
+        if full_content:
+            message = ModelMessage(full_content)
+            await context.send(message)
+
+        if last_response is not None:
+            await context.send(XAIAssistantEvent.from_response(last_response))
+            if not usage:
+                usage = normalize_usage(getattr(last_response, "usage", None))
+            if not resolved_model:
+                resolved_model = getattr(last_response, "model", None)
+            if not finish_reason:
+                finish_reason = _finish_reason_to_str(getattr(last_response, "finish_reason", None))
+
+        return ModelResponse(
+            message=message,
+            tool_calls=ToolCallsEvent(list(tool_calls_by_id.values())),
+            usage=usage,
+            model=resolved_model,
+            provider=PROVIDER,
+            finish_reason=finish_reason,
+        )
+
+
+def _finish_reason_to_str(reason: "str | int | sample_pb2.FinishReason.ValueType | None") -> str | None:
+    """Normalise xai-sdk finish_reason (string or proto enum) to a plain string.
+
+    xai-sdk emits ``FinishReason`` proto-enum names like
+    ``FINISH_REASON_STOP`` / ``FINISH_REASON_TOOL_CALLS``. Strip the prefix so
+    downstream consumers see ``stop`` / ``tool_calls`` (consistent with openai).
+    """
+    if reason is None:
+        return None
+    if isinstance(reason, str):
+        s = reason
+    else:
+        name = sample_pb2.FinishReason.Name(reason) if isinstance(reason, int) else str(reason)
+        s = name
+    if s.startswith("FINISH_REASON_"):
+        s = s[len("FINISH_REASON_") :]
+    return s.lower() or None

--- a/autogen/beta/config/xai/xai_client.py
+++ b/autogen/beta/config/xai/xai_client.py
@@ -202,11 +202,11 @@ class XAIClient(LLMClient):
                 else:
                     tool_calls_by_id[tc.id] = ev
 
-            if chunk.usage:
-                usage = normalize_usage(chunk.usage)
-            if model := chunk.proto.model or None:
+            if response.usage:
+                usage = normalize_usage(response.usage)
+            if model := response.proto.model or None:
                 resolved_model = model
-            if fr := chunk.finish_reason:
+            if fr := response.finish_reason:
                 finish_reason_raw = fr
 
         message: ModelMessage | None = None

--- a/autogen/beta/config/xai/xai_client.py
+++ b/autogen/beta/config/xai/xai_client.py
@@ -11,13 +11,14 @@ from typing_extensions import Required
 from xai_sdk import AsyncClient
 from xai_sdk.aio.chat import Chat as XAIChat
 from xai_sdk.chat import Response as XAIResponse
-from xai_sdk.proto import sample_pb2
+from xai_sdk.proto import chat_pb2, sample_pb2
 from xai_sdk.types.chat import IncludeOption, ReasoningEffort, ToolMode
 
 from autogen.beta.config.client import LLMClient
 from autogen.beta.context import ConversationContext
 from autogen.beta.events import (
     BaseEvent,
+    BuiltinToolCallEvent,
     ModelMessage,
     ModelMessageChunk,
     ModelReasoning,
@@ -138,23 +139,30 @@ class XAIClient(LLMClient):
 
         calls: list[ToolCallEvent] = []
         for tc in getattr(response, "tool_calls", None) or ():
-            calls.append(
-                ToolCallEvent(
-                    id=tc.id,
-                    name=tc.function.name,
-                    arguments=tc.function.arguments or "{}",
-                )
-            )
+            cls = ToolCallEvent if tc.type == chat_pb2.TOOL_CALL_TYPE_CLIENT_SIDE_TOOL else BuiltinToolCallEvent
+            ev = cls(id=tc.id, name=tc.function.name, arguments=tc.function.arguments or "{}")
+            if isinstance(ev, BuiltinToolCallEvent):
+                await context.send(ev)
+            else:
+                calls.append(ev)
 
         await context.send(XAIAssistantEvent.from_response(response))
+
+        # xai-sdk returns finish_reason as either a string (e.g. "FINISH_REASON_STOP")
+        # or a proto enum int — strip the prefix and lowercase to match openai's "stop".
+        fr = getattr(response, "finish_reason", None)
+        finish_reason: str | None = None
+        if fr is not None:
+            name = sample_pb2.FinishReason.Name(fr) if isinstance(fr, int) else str(fr)
+            finish_reason = name.removeprefix("FINISH_REASON_").removeprefix("REASON_").lower() or None
 
         return ModelResponse(
             message=model_msg,
             tool_calls=ToolCallsEvent(calls),
             usage=normalize_usage(getattr(response, "usage", None)),
-            model=getattr(response, "model", None),
+            model=response.proto.model or None,
             provider=PROVIDER,
-            finish_reason=_finish_reason_to_str(getattr(response, "finish_reason", None)),
+            finish_reason=finish_reason,
         )
 
     async def _call_streaming(
@@ -164,11 +172,12 @@ class XAIClient(LLMClient):
     ) -> ModelResponse:
         full_content: str = ""
         usage: Usage = Usage()
-        finish_reason: str | None = None
+        finish_reason_raw: str | int | sample_pb2.FinishReason.ValueType | None = None
         resolved_model: str | None = None
         last_response: XAIResponse | None = None
         # tool_calls accumulate by id; the SDK delivers whole calls per chunk.
         tool_calls_by_id: dict[str, ToolCallEvent] = {}
+        builtin_emitted: set[str] = set()
 
         async for response, chunk in chat.stream():
             last_response = response
@@ -181,19 +190,24 @@ class XAIClient(LLMClient):
                 await context.send(ModelMessageChunk(content))
 
             for tc in getattr(chunk, "tool_calls", None) or ():
-                if tc.id and tc.id not in tool_calls_by_id:
-                    tool_calls_by_id[tc.id] = ToolCallEvent(
-                        id=tc.id,
-                        name=tc.function.name,
-                        arguments=tc.function.arguments or "{}",
-                    )
+                if not tc.id:
+                    continue
+                if tc.id in tool_calls_by_id or tc.id in builtin_emitted:
+                    continue
+                cls = ToolCallEvent if tc.type == chat_pb2.TOOL_CALL_TYPE_CLIENT_SIDE_TOOL else BuiltinToolCallEvent
+                ev = cls(id=tc.id, name=tc.function.name, arguments=tc.function.arguments or "{}")
+                if isinstance(ev, BuiltinToolCallEvent):
+                    await context.send(ev)
+                    builtin_emitted.add(tc.id)
+                else:
+                    tool_calls_by_id[tc.id] = ev
 
             if u := getattr(chunk, "usage", None):
                 usage = normalize_usage(u)
-            if model := getattr(chunk, "model", None):
+            if model := chunk.proto.model or None:
                 resolved_model = model
             if fr := getattr(chunk, "finish_reason", None):
-                finish_reason = _finish_reason_to_str(fr)
+                finish_reason_raw = fr
 
         message: ModelMessage | None = None
         if full_content:
@@ -205,9 +219,20 @@ class XAIClient(LLMClient):
             if not usage:
                 usage = normalize_usage(getattr(last_response, "usage", None))
             if not resolved_model:
-                resolved_model = getattr(last_response, "model", None)
-            if not finish_reason:
-                finish_reason = _finish_reason_to_str(getattr(last_response, "finish_reason", None))
+                resolved_model = last_response.proto.model or None
+            if finish_reason_raw is None:
+                finish_reason_raw = getattr(last_response, "finish_reason", None)
+
+        # xai-sdk returns finish_reason as either a string (e.g. "FINISH_REASON_STOP")
+        # or a proto enum int — strip the prefix and lowercase to match openai's "stop".
+        finish_reason: str | None = None
+        if finish_reason_raw is not None:
+            name = (
+                sample_pb2.FinishReason.Name(finish_reason_raw)
+                if isinstance(finish_reason_raw, int)
+                else str(finish_reason_raw)
+            )
+            finish_reason = name.removeprefix("FINISH_REASON_").removeprefix("REASON_").lower() or None
 
         return ModelResponse(
             message=message,
@@ -217,22 +242,3 @@ class XAIClient(LLMClient):
             provider=PROVIDER,
             finish_reason=finish_reason,
         )
-
-
-def _finish_reason_to_str(reason: "str | int | sample_pb2.FinishReason.ValueType | None") -> str | None:
-    """Normalise xai-sdk finish_reason (string or proto enum) to a plain string.
-
-    xai-sdk emits ``FinishReason`` proto-enum names like
-    ``FINISH_REASON_STOP`` / ``FINISH_REASON_TOOL_CALLS``. Strip the prefix so
-    downstream consumers see ``stop`` / ``tool_calls`` (consistent with openai).
-    """
-    if reason is None:
-        return None
-    if isinstance(reason, str):
-        s = reason
-    else:
-        name = sample_pb2.FinishReason.Name(reason) if isinstance(reason, int) else str(reason)
-        s = name
-    if s.startswith("FINISH_REASON_"):
-        s = s[len("FINISH_REASON_") :]
-    return s.lower() or None

--- a/autogen/beta/config/xai/xai_client.py
+++ b/autogen/beta/config/xai/xai_client.py
@@ -77,29 +77,15 @@ class XAIClient(LLMClient):
         streaming: bool = False,
         create_options: CreateOptions | None = None,
     ) -> None:
-        # Defer AsyncClient construction to call time — it eagerly opens a gRPC
-        # channel and validates XAI_API_KEY in its constructor, which would
-        # otherwise turn ``XAIConfig.create()`` into a side-effecting call.
-        self._api_key = api_key
-        self._api_host = api_host
-        self._timeout = timeout
-        self._metadata = metadata
-        self._channel_options = channel_options
-        self._client: AsyncClient | None = None
-
+        self._client = AsyncClient(
+            api_key=api_key,
+            api_host=api_host,
+            timeout=timeout,
+            metadata=metadata,
+            channel_options=channel_options,
+        )
         self._create_options: dict[str, Any] = {k: v for k, v in (create_options or {}).items() if v is not None}
         self._streaming = streaming
-
-    def _get_client(self) -> AsyncClient:
-        if self._client is None:
-            self._client = AsyncClient(
-                api_key=self._api_key,
-                api_host=self._api_host,
-                timeout=self._timeout,
-                metadata=self._metadata,
-                channel_options=self._channel_options,
-            )
-        return self._client
 
     async def __call__(
         self,
@@ -127,7 +113,7 @@ class XAIClient(LLMClient):
         if response_format is not None:
             create_kwargs["response_format"] = response_format
 
-        chat = self._get_client().chat.create(**create_kwargs)
+        chat = self._client.chat.create(**create_kwargs)
         for resp in replay_responses:
             chat.append(resp)
 

--- a/autogen/beta/tools/__init__.py
+++ b/autogen/beta/tools/__init__.py
@@ -18,6 +18,7 @@ from .builtin import (
     UserLocation,
     WebFetchTool,
     WebSearchTool,
+    XSearchTool,
 )
 from .code import SandboxCodeTool
 from .final import Toolkit, tool
@@ -54,5 +55,6 @@ __all__ = (
     "UserLocation",
     "WebFetchTool",
     "WebSearchTool",
+    "XSearchTool",
     "tool",
 )

--- a/autogen/beta/tools/builtin/__init__.py
+++ b/autogen/beta/tools/builtin/__init__.py
@@ -10,6 +10,7 @@ from .shell import ContainerAutoEnvironment, ContainerReferenceEnvironment, Netw
 from .skills import Skill, SkillsTool
 from .web_fetch import WebFetchTool
 from .web_search import UserLocation, WebSearchTool
+from .x_search import XSearchTool
 
 __all__ = (
     "CodeExecutionTool",
@@ -25,4 +26,5 @@ __all__ = (
     "UserLocation",
     "WebFetchTool",
     "WebSearchTool",
+    "XSearchTool",
 )

--- a/autogen/beta/tools/builtin/x_search.py
+++ b/autogen/beta/tools/builtin/x_search.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterable
+from contextlib import AsyncExitStack, ExitStack
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from autogen.beta.annotations import Context, Variable
+from autogen.beta.events import BuiltinToolCallEvent, ToolCallEvent
+from autogen.beta.middleware import BaseMiddleware
+from autogen.beta.tools.schemas import ToolSchema
+from autogen.beta.tools.tool import Tool
+
+from ._resolve import resolve_variable
+
+X_SEARCH_TOOL_NAME = "x_search"
+
+
+@dataclass(slots=True)
+class XSearchToolSchema(ToolSchema):
+    type: str = field(default=X_SEARCH_TOOL_NAME, init=False)
+    allowed_x_handles: list[str] | None = None
+    excluded_x_handles: list[str] | None = None
+    from_date: datetime | None = None
+    to_date: datetime | None = None
+    enable_image_understanding: bool | None = None
+    enable_video_understanding: bool | None = None
+
+
+class XSearchTool(Tool):
+    __slots__ = (
+        "_params",
+        "name",
+    )
+
+    def __init__(
+        self,
+        *,
+        allowed_x_handles: list[str] | Variable | None = None,
+        excluded_x_handles: list[str] | Variable | None = None,
+        from_date: datetime | Variable | None = None,
+        to_date: datetime | Variable | None = None,
+        enable_image_understanding: bool | Variable | None = None,
+        enable_video_understanding: bool | Variable | None = None,
+    ) -> None:
+        self._params: dict[str, object] = {}
+        if allowed_x_handles is not None:
+            self._params["allowed_x_handles"] = allowed_x_handles
+        if excluded_x_handles is not None:
+            self._params["excluded_x_handles"] = excluded_x_handles
+        if from_date is not None:
+            self._params["from_date"] = from_date
+        if to_date is not None:
+            self._params["to_date"] = to_date
+        if enable_image_understanding is not None:
+            self._params["enable_image_understanding"] = enable_image_understanding
+        if enable_video_understanding is not None:
+            self._params["enable_video_understanding"] = enable_video_understanding
+
+        self.name = X_SEARCH_TOOL_NAME
+
+    async def schemas(self, context: "Context") -> list[XSearchToolSchema]:
+        resolved = {k: resolve_variable(v, context, param_name=k) for k, v in self._params.items()}
+        return [XSearchToolSchema(**resolved)]
+
+    def register(
+        self,
+        stack: "ExitStack | AsyncExitStack",
+        context: "Context",
+        *,
+        middleware: Iterable["BaseMiddleware"] = (),
+    ) -> None:
+        async def execute(event: "ToolCallEvent", context: "Context") -> None:
+            pass
+
+        stack.enter_context(
+            context.stream.where(BuiltinToolCallEvent.name == X_SEARCH_TOOL_NAME).sub_scope(execute),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,8 @@ gemini-realtime = [
 
 groq = ["groq>=0.9.0"]
 
+xai = ["xai-sdk>=1.12.2,<2"]
+
 ollama = ["ollama>=0.4.7", "fix_busted_json>=0.0.18"]
 
 bedrock = ["boto3>=1.34.149"]
@@ -335,6 +337,7 @@ docs = [
     "ag2[gemini]",                     # Gemini is exposed in the public API by the optional `autogen.beta.config` module
     "ag2[ollama]",                     # Ollama is exposed in the public API by the optional `autogen.beta.config` module
     "ag2[dashscope]",                  # DashScope is exposed in the public API by the optional `autogen.beta.config` module
+    "ag2[xai]",                        # xAI is exposed in the public API by the optional `autogen.beta.config` module
     "ag2[redis]",                      # Redis is exposed in the public API by the optional `autogen.beta.streams` module
     "ag2[watchdog]",                   # Watchdog is exposed in the public API by the optional `autogen.beta.knowledge` module
     "ag2[tavily,exa,ddgs,perplexity]", # Search tools are exposed in the public API by the optional `autogen.beta.tools.search` module
@@ -400,6 +403,7 @@ optionals = [
     "ag2[gemini]",
     "ag2[ollama]",
     "ag2[dashscope]",
+    "ag2[xai]",
 ]
 
 testing = [

--- a/setup_autogen.py
+++ b/setup_autogen.py
@@ -39,6 +39,7 @@ setuptools.setup(
         "gemini": ["ag2[gemini]==" + __version__],
         "gemini-realtime": ["ag2[gemini-realtime]==" + __version__],
         "groq": ["ag2[groq]==" + __version__],
+        "xai": ["ag2[xai]==" + __version__],
         "ollama": ["ag2[ollama]==" + __version__],
         "bedrock": ["ag2[bedrock]==" + __version__],
         "mistral": ["ag2[mistral]==" + __version__],

--- a/test/beta/config/anthropic/tools/test_unsupported.py
+++ b/test/beta/config/anthropic/tools/test_unsupported.py
@@ -9,6 +9,7 @@ from autogen.beta.config.anthropic.mappers import tool_to_api
 from autogen.beta.exceptions import UnsupportedToolError
 from autogen.beta.tools.builtin.image_generation import ImageGenerationTool
 from autogen.beta.tools.builtin.shell import ShellTool
+from autogen.beta.tools.builtin.x_search import XSearchTool
 
 
 @pytest.mark.asyncio
@@ -25,6 +26,16 @@ async def test_image_generation(context: Context) -> None:
 async def test_shell(context: Context) -> None:
     """ShellTool is unsupported on Anthropic (client-side bash; use LocalShellTool)."""
     tool = ShellTool()
+
+    [schema] = await tool.schemas(context)
+
+    with pytest.raises(UnsupportedToolError):
+        tool_to_api(schema)
+
+
+@pytest.mark.asyncio
+async def test_x_search(context: Context) -> None:
+    tool = XSearchTool()
 
     [schema] = await tool.schemas(context)
 

--- a/test/beta/config/dashscope/tools/test_unsupported.py
+++ b/test/beta/config/dashscope/tools/test_unsupported.py
@@ -15,6 +15,7 @@ from autogen.beta.tools.builtin.shell import ShellTool
 from autogen.beta.tools.builtin.skills import SkillsTool
 from autogen.beta.tools.builtin.web_fetch import WebFetchTool
 from autogen.beta.tools.builtin.web_search import WebSearchTool
+from autogen.beta.tools.builtin.x_search import XSearchTool
 
 
 @pytest.mark.asyncio
@@ -90,6 +91,16 @@ async def test_mcp_server(context: Context) -> None:
 @pytest.mark.asyncio
 async def test_skills(context: Context) -> None:
     tool = SkillsTool("pptx")
+
+    [schema] = await tool.schemas(context)
+
+    with pytest.raises(UnsupportedToolError):
+        tool_to_api(schema)
+
+
+@pytest.mark.asyncio
+async def test_x_search(context: Context) -> None:
+    tool = XSearchTool()
 
     [schema] = await tool.schemas(context)
 

--- a/test/beta/config/ollama/tools/test_unsupported.py
+++ b/test/beta/config/ollama/tools/test_unsupported.py
@@ -15,6 +15,7 @@ from autogen.beta.tools.builtin.shell import ShellTool
 from autogen.beta.tools.builtin.skills import SkillsTool
 from autogen.beta.tools.builtin.web_fetch import WebFetchTool
 from autogen.beta.tools.builtin.web_search import WebSearchTool
+from autogen.beta.tools.builtin.x_search import XSearchTool
 
 
 @pytest.mark.asyncio
@@ -90,6 +91,16 @@ async def test_mcp_server(context: Context) -> None:
 @pytest.mark.asyncio
 async def test_skills(context: Context) -> None:
     tool = SkillsTool("pptx")
+
+    [schema] = await tool.schemas(context)
+
+    with pytest.raises(UnsupportedToolError):
+        tool_to_api(schema)
+
+
+@pytest.mark.asyncio
+async def test_x_search(context: Context) -> None:
+    tool = XSearchTool()
 
     [schema] = await tool.schemas(context)
 

--- a/test/beta/config/openai/tools/test_unsupported.py
+++ b/test/beta/config/openai/tools/test_unsupported.py
@@ -15,6 +15,7 @@ from autogen.beta.tools.builtin.shell import ShellTool
 from autogen.beta.tools.builtin.skills import SkillsTool
 from autogen.beta.tools.builtin.web_fetch import WebFetchTool
 from autogen.beta.tools.builtin.web_search import WebSearchTool
+from autogen.beta.tools.builtin.x_search import XSearchTool
 
 
 class TestCompletionsApi:
@@ -90,6 +91,15 @@ class TestCompletionsApi:
         with pytest.raises(UnsupportedToolError):
             tool_to_api(schema)
 
+    @pytest.mark.asyncio
+    async def test_x_search(self, context: Context) -> None:
+        tool = XSearchTool()
+
+        [schema] = await tool.schemas(context)
+
+        with pytest.raises(UnsupportedToolError):
+            tool_to_api(schema)
+
 
 class TestResponsesApi:
     @pytest.mark.asyncio
@@ -113,6 +123,15 @@ class TestResponsesApi:
     @pytest.mark.asyncio
     async def test_skills(self, context: Context) -> None:
         tool = SkillsTool("pptx")
+
+        [schema] = await tool.schemas(context)
+
+        with pytest.raises(UnsupportedToolError):
+            tool_to_responses_api(schema)
+
+    @pytest.mark.asyncio
+    async def test_x_search(self, context: Context) -> None:
+        tool = XSearchTool()
 
         [schema] = await tool.schemas(context)
 

--- a/test/beta/config/xai/__init__.py
+++ b/test/beta/config/xai/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+pytest.importorskip("xai_sdk")

--- a/test/beta/config/xai/test_convert_messages.py
+++ b/test/beta/config/xai/test_convert_messages.py
@@ -156,6 +156,21 @@ class TestToolResult:
         assert msg.tool_call_id == "tc_1"
         assert _content_texts(msg) == ["ok"]
 
+    def test_multi_text_tool_result_serialises_to_json_array(self) -> None:
+        event = ToolResultsEvent(
+            results=[
+                ToolResultEvent(
+                    parent_id="tc_1",
+                    name="t",
+                    result=ToolResult(TextInput("first"), TextInput("second")),
+                )
+            ]
+        )
+
+        [msg], _ = convert_messages([], [event], SerializerCls)
+
+        assert _content_texts(msg) == ['["first", "second"]']
+
     def test_binary_in_tool_result_unsupported(self) -> None:
         event = ToolResultsEvent(
             results=[

--- a/test/beta/config/xai/test_convert_messages.py
+++ b/test/beta/config/xai/test_convert_messages.py
@@ -15,6 +15,7 @@ from autogen.beta.events import (
     AudioInput,
     BinaryInput,
     BinaryType,
+    DataInput,
     DocumentInput,
     FileIdInput,
     ImageInput,
@@ -62,10 +63,15 @@ class TestUserContent:
         assert msg.role == chat_pb2.ROLE_USER
         assert _content_texts(msg) == ["hello"]
 
-    def test_data_input_serialized(self) -> None:
+    def test_multiple_text_parts(self) -> None:
         [msg], _ = convert_messages([], [ModelRequest([TextInput("hi"), TextInput("there")])], SerializerCls)
 
         assert _content_texts(msg) == ["hi", "there"]
+
+    def test_data_input_serialized_via_serializer(self) -> None:
+        [msg], _ = convert_messages([], [ModelRequest([DataInput({"key": "value"})])], SerializerCls)
+
+        assert _content_texts(msg) == ['{"key":"value"}']
 
     def test_image_url(self) -> None:
         [msg], _ = convert_messages([], [ModelRequest([ImageInput(url=self.IMG_URL)])], SerializerCls)

--- a/test/beta/config/xai/test_convert_messages.py
+++ b/test/beta/config/xai/test_convert_messages.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+
+import pytest
+from fast_depends.use import SerializerCls
+from xai_sdk.chat import chat_pb2
+
+from autogen.beta import ToolResult
+from autogen.beta.config.xai.events import XAIAssistantEvent
+from autogen.beta.config.xai.mappers import convert_messages
+from autogen.beta.events import (
+    AudioInput,
+    BinaryInput,
+    BinaryType,
+    DocumentInput,
+    FileIdInput,
+    ImageInput,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    ToolResultEvent,
+    ToolResultsEvent,
+    VideoInput,
+)
+from autogen.beta.exceptions import UnsupportedInputError
+
+
+def _content_texts(msg: chat_pb2.Message) -> list[str]:
+    return [c.text for c in msg.content if c.HasField("text")]
+
+
+def _content_kinds(msg: chat_pb2.Message) -> list[str]:
+    return [c.WhichOneof("content") for c in msg.content]
+
+
+class TestSystemPrompt:
+    def test_no_system_messages_when_prompt_empty(self) -> None:
+        result, replays = convert_messages([], [], SerializerCls)
+        assert result == []
+        assert replays == []
+
+    def test_system_prompts_joined_with_newline(self) -> None:
+        result, replays = convert_messages(["be helpful", "be terse"], [], SerializerCls)
+
+        assert len(result) == 1
+        assert result[0].role == chat_pb2.ROLE_SYSTEM
+        assert _content_texts(result[0]) == ["be helpful\nbe terse"]
+        assert replays == []
+
+
+class TestUserContent:
+    IMG_URL = "https://example.com/image.png"
+    PNG = b"\x89PNG\r\n"
+
+    def test_text_only_request(self) -> None:
+        [msg], _ = convert_messages([], [ModelRequest([TextInput("hello")])], SerializerCls)
+
+        assert msg.role == chat_pb2.ROLE_USER
+        assert _content_texts(msg) == ["hello"]
+
+    def test_data_input_serialized(self) -> None:
+        [msg], _ = convert_messages([], [ModelRequest([TextInput("hi"), TextInput("there")])], SerializerCls)
+
+        assert _content_texts(msg) == ["hi", "there"]
+
+    def test_image_url(self) -> None:
+        [msg], _ = convert_messages([], [ModelRequest([ImageInput(url=self.IMG_URL)])], SerializerCls)
+
+        assert msg.role == chat_pb2.ROLE_USER
+        # Image is a Content oneof — not text
+        kinds = _content_kinds(msg)
+        assert "image_url" in kinds
+
+    def test_image_binary_base64(self) -> None:
+        [msg], _ = convert_messages(
+            [], [ModelRequest([ImageInput(data=self.PNG, media_type="image/png")])], SerializerCls
+        )
+
+        kinds = _content_kinds(msg)
+        assert "image_url" in kinds
+
+        # Confirm the data URL ended up in the proto
+        b64 = base64.b64encode(self.PNG).decode()
+        image_block = next(c for c in msg.content if c.WhichOneof("content") == "image_url")
+        assert f"data:image/png;base64,{b64}" in image_block.image_url.image_url
+
+    def test_pdf_binary_becomes_file(self) -> None:
+        [msg], _ = convert_messages(
+            [], [ModelRequest([DocumentInput(data=b"%PDF", media_type="application/pdf")])], SerializerCls
+        )
+
+        kinds = _content_kinds(msg)
+        assert "file" in kinds
+        file_block = next(c for c in msg.content if c.WhichOneof("content") == "file")
+        assert file_block.file.data == b"%PDF"
+        assert file_block.file.mime_type == "application/pdf"
+
+    def test_text_plus_image_interleaved(self) -> None:
+        [msg], _ = convert_messages(
+            [],
+            [ModelRequest([TextInput("describe"), ImageInput(url=self.IMG_URL)])],
+            SerializerCls,
+        )
+
+        kinds = _content_kinds(msg)
+        assert kinds == ["text", "image_url"]
+
+    def test_audio_input_unsupported(self) -> None:
+        with pytest.raises(UnsupportedInputError, match="xai"):
+            convert_messages(
+                [],
+                [
+                    ModelRequest([
+                        BinaryInput(b"\x00", media_type="audio/wav", kind=BinaryType.AUDIO),
+                    ])
+                ],
+                SerializerCls,
+            )
+
+    def test_video_input_unsupported(self) -> None:
+        with pytest.raises(UnsupportedInputError, match="xai"):
+            convert_messages(
+                [],
+                [ModelRequest([VideoInput(url="https://example.com/clip.mp4")])],
+                SerializerCls,
+            )
+
+    def test_audio_url_input_unsupported(self) -> None:
+        with pytest.raises(UnsupportedInputError, match="xai"):
+            convert_messages(
+                [],
+                [ModelRequest([AudioInput(url="https://example.com/a.wav")])],
+                SerializerCls,
+            )
+
+    def test_file_id_input_passes_through(self) -> None:
+        [msg], _ = convert_messages([], [ModelRequest([FileIdInput(file_id="file-abc")])], SerializerCls)
+
+        kinds = _content_kinds(msg)
+        assert "file" in kinds
+        file_block = next(c for c in msg.content if c.WhichOneof("content") == "file")
+        assert file_block.file.file_id == "file-abc"
+
+
+class TestToolResult:
+    def test_text_only_tool_result(self) -> None:
+        event = ToolResultsEvent(results=[ToolResultEvent(parent_id="tc_1", name="t", result=ToolResult("ok"))])
+
+        [msg], _ = convert_messages([], [event], SerializerCls)
+
+        assert msg.role == chat_pb2.ROLE_TOOL
+        assert msg.tool_call_id == "tc_1"
+        assert _content_texts(msg) == ["ok"]
+
+    def test_binary_in_tool_result_unsupported(self) -> None:
+        event = ToolResultsEvent(
+            results=[
+                ToolResultEvent(
+                    parent_id="tc_1",
+                    name="t",
+                    result=ToolResult(ImageInput(url="https://x/img.png")),
+                )
+            ]
+        )
+
+        with pytest.raises(UnsupportedInputError, match="tool_result"):
+            convert_messages([], [event], SerializerCls)
+
+
+class TestAssistantRoundTrip:
+    def test_xai_assistant_event_round_trips_via_replay_list(self) -> None:
+        proto = chat_pb2.GetChatCompletionResponse()
+        event = XAIAssistantEvent(
+            proto_bytes=proto.SerializeToString(),
+            model="grok-4-fast",
+            finish_reason="stop",
+        )
+
+        messages, replays = convert_messages([], [event], SerializerCls)
+
+        assert messages == []
+        assert len(replays) == 1
+        # The replay is an xai-sdk Response wrapping the proto
+        assert replays[0].proto.SerializeToString() == proto.SerializeToString()
+
+    def test_companion_model_response_after_assistant_event_is_skipped(self) -> None:
+        """An ``XAIAssistantEvent`` shadows the next ``ModelResponse`` for the same turn."""
+        proto = chat_pb2.GetChatCompletionResponse()
+        event = XAIAssistantEvent(proto_bytes=proto.SerializeToString())
+        mr = ModelResponse(message=ModelMessage("Hello"))
+
+        messages, replays = convert_messages([], [event, mr], SerializerCls)
+
+        assert messages == []  # neither the proto nor the synthesized assistant
+        assert len(replays) == 1
+
+    def test_orphan_model_response_falls_back_to_assistant_text(self) -> None:
+        """When no XAIAssistantEvent precedes it, ModelResponse becomes ``assistant(text)``."""
+        mr = ModelResponse(message=ModelMessage("Hi"))
+
+        [msg], replays = convert_messages([], [mr], SerializerCls)
+
+        assert msg.role == chat_pb2.ROLE_ASSISTANT
+        assert _content_texts(msg) == ["Hi"]
+        assert replays == []

--- a/test/beta/config/xai/test_response_schema_to_api.py
+++ b/test/beta/config/xai/test_response_schema_to_api.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from dataclasses import dataclass
+
+import pytest
+from dirty_equals import IsPartialDict
+from xai_sdk.chat import chat_pb2
+
+from autogen.beta.config.xai.mappers import response_proto_to_format
+from autogen.beta.response import ResponseSchema
+
+
+def test_none_returns_none() -> None:
+    assert response_proto_to_format(None) is None
+
+
+@pytest.mark.parametrize(
+    ("type_", "expected_inner"),
+    [
+        pytest.param(int, "integer", id="int"),
+        pytest.param(float, "number", id="float"),
+        pytest.param(bool, "boolean", id="bool"),
+    ],
+)
+def test_primitive_schemas_wrap_into_data_field(type_: type, expected_inner: str) -> None:
+    schema = ResponseSchema(type_, name="Num")
+
+    result = response_proto_to_format(schema)
+
+    assert isinstance(result, chat_pb2.ResponseFormat)
+    assert result.format_type == chat_pb2.FORMAT_TYPE_JSON_SCHEMA
+
+    assert json.loads(result.schema) == IsPartialDict({
+        "type": "object",
+        "properties": IsPartialDict({"data": IsPartialDict({"type": expected_inner})}),
+        "required": ["data"],
+        "additionalProperties": False,
+    })
+
+
+def test_str_schema_returns_none() -> None:
+    """``ResponseSchema(str)`` has no json_schema — model can output free text."""
+    schema = ResponseSchema(str, name="Text")
+
+    assert response_proto_to_format(schema) is None
+
+
+def test_dataclass_schema() -> None:
+    @dataclass
+    class User:
+        name: str
+        age: int
+
+    result = response_proto_to_format(ResponseSchema(User))
+
+    assert isinstance(result, chat_pb2.ResponseFormat)
+    assert json.loads(result.schema) == IsPartialDict({
+        "type": "object",
+        "properties": IsPartialDict({
+            "name": IsPartialDict({"type": "string"}),
+            "age": IsPartialDict({"type": "integer"}),
+        }),
+        "additionalProperties": False,
+    })
+
+
+def test_additional_properties_false_propagates_to_nested_objects() -> None:
+    @dataclass
+    class Address:
+        city: str
+
+    @dataclass
+    class User:
+        name: str
+        address: Address
+
+    result = response_proto_to_format(ResponseSchema(User))
+    assert result is not None
+
+    decoded = json.loads(result.schema)
+    assert decoded == IsPartialDict({"additionalProperties": False})
+    assert decoded.get("$defs"), "expected $defs for nested dataclass"
+
+    [address_def] = decoded["$defs"].values()
+    assert address_def == IsPartialDict({"additionalProperties": False})

--- a/test/beta/config/xai/test_xai_client.py
+++ b/test/beta/config/xai/test_xai_client.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fast_depends.use import SerializerCls
 from xai_sdk.chat import chat_pb2
+from xai_sdk.proto import usage_pb2
 
 from autogen.beta import Context
 from autogen.beta.config.xai import XAIConfig
@@ -41,7 +42,7 @@ def _fake_response(
         reasoning_content=reasoning_content,
         tool_calls=tool_calls or [],
         finish_reason=finish_reason,
-        usage=usage or SimpleNamespace(prompt_tokens=3, completion_tokens=5, total_tokens=8),
+        usage=usage or usage_pb2.SamplingUsage(prompt_tokens=3, completion_tokens=5, total_tokens=8),
         proto=proto,
     )
 
@@ -154,12 +155,12 @@ async def test_streaming_accumulates_chunks() -> None:
         _fake_response(content="world!", usage=None, finish_reason=""),
         _fake_response(
             content="",
-            usage=SimpleNamespace(prompt_tokens=2, completion_tokens=4, total_tokens=6),
+            usage=usage_pb2.SamplingUsage(prompt_tokens=2, completion_tokens=4, total_tokens=6),
         ),
     ]
     final_response = _fake_response(
         content="Hello, world!",
-        usage=SimpleNamespace(prompt_tokens=2, completion_tokens=4, total_tokens=6),
+        usage=usage_pb2.SamplingUsage(prompt_tokens=2, completion_tokens=4, total_tokens=6),
     )
 
     async def fake_stream() -> object:

--- a/test/beta/config/xai/test_xai_client.py
+++ b/test/beta/config/xai/test_xai_client.py
@@ -35,21 +35,27 @@ def _fake_response(
     finish_reason: str = "FINISH_REASON_STOP",
     usage: object | None = None,
 ) -> SimpleNamespace:
-    proto = chat_pb2.GetChatCompletionResponse()
+    proto = chat_pb2.GetChatCompletionResponse(model=model)
     return SimpleNamespace(
         content=content,
         reasoning_content=reasoning_content,
         tool_calls=tool_calls or [],
-        model=model,
         finish_reason=finish_reason,
         usage=usage or SimpleNamespace(prompt_tokens=3, completion_tokens=5, total_tokens=8),
         proto=proto,
     )
 
 
-def _fake_tool_call(call_id: str, name: str, arguments: str) -> SimpleNamespace:
+def _fake_tool_call(
+    call_id: str,
+    name: str,
+    arguments: str,
+    *,
+    type: int = chat_pb2.TOOL_CALL_TYPE_CLIENT_SIDE_TOOL,
+) -> SimpleNamespace:
     return SimpleNamespace(
         id=call_id,
+        type=type,
         function=SimpleNamespace(name=name, arguments=arguments),
     )
 
@@ -143,41 +149,17 @@ async def test_tool_calls_surface_in_response() -> None:
 
 @pytest.mark.asyncio
 async def test_streaming_accumulates_chunks() -> None:
-    proto = chat_pb2.GetChatCompletionResponse()
     chunks = [
-        SimpleNamespace(
-            content="Hello, ",
-            reasoning_content="",
-            tool_calls=[],
-            usage=None,
-            model="grok-4-fast",
-            finish_reason=None,
-        ),
-        SimpleNamespace(
-            content="world!",
-            reasoning_content="",
-            tool_calls=[],
-            usage=None,
-            model="grok-4-fast",
-            finish_reason=None,
-        ),
-        SimpleNamespace(
+        _fake_response(content="Hello, ", usage=None, finish_reason=""),
+        _fake_response(content="world!", usage=None, finish_reason=""),
+        _fake_response(
             content="",
-            reasoning_content="",
-            tool_calls=[],
             usage=SimpleNamespace(prompt_tokens=2, completion_tokens=4, total_tokens=6),
-            model="grok-4-fast",
-            finish_reason="FINISH_REASON_STOP",
         ),
     ]
-    final_response = SimpleNamespace(
+    final_response = _fake_response(
         content="Hello, world!",
-        reasoning_content="",
-        tool_calls=[],
         usage=SimpleNamespace(prompt_tokens=2, completion_tokens=4, total_tokens=6),
-        model="grok-4-fast",
-        finish_reason="FINISH_REASON_STOP",
-        proto=proto,
     )
 
     async def fake_stream() -> object:

--- a/test/beta/config/xai/test_xai_client.py
+++ b/test/beta/config/xai/test_xai_client.py
@@ -61,8 +61,6 @@ def _make_client_with_stub_chat(stub_chat: MagicMock) -> tuple[object, Context]:
         mock_async_client.return_value = instance
 
         client = XAIConfig(model="grok-4-fast", api_key="t").create()
-        # Force lazy AsyncClient to materialize against our patched class
-        client._get_client()
 
     stream = MemoryStream(persist_all=True)
     return client, Context(stream=stream)
@@ -195,7 +193,6 @@ async def test_streaming_accumulates_chunks() -> None:
         mock_async_client.return_value = instance
 
         client = XAIConfig(model="grok-4-fast", api_key="t", streaming=True).create()
-        client._get_client()
 
     context = Context(stream=MemoryStream(persist_all=True))
 
@@ -254,7 +251,6 @@ async def test_response_format_passed_to_chat_create() -> None:
         mock_async_client.return_value = instance
 
         client = XAIConfig(model="grok-4-fast", api_key="t").create()
-        client._get_client()
 
     context = Context(stream=MemoryStream(persist_all=True))
 

--- a/test/beta/config/xai/test_xai_client.py
+++ b/test/beta/config/xai/test_xai_client.py
@@ -1,0 +1,272 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fast_depends.use import SerializerCls
+from xai_sdk.chat import chat_pb2
+
+from autogen.beta import Context
+from autogen.beta.config.xai import XAIConfig
+from autogen.beta.config.xai.events import XAIAssistantEvent
+from autogen.beta.events import (
+    ModelMessageChunk,
+    ModelReasoning,
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    ToolCallEvent,
+    ToolCallsEvent,
+    Usage,
+)
+from autogen.beta.response import ResponseSchema
+from autogen.beta.stream import MemoryStream
+
+
+def _fake_response(
+    *,
+    content: str = "",
+    reasoning_content: str = "",
+    tool_calls: list[object] | None = None,
+    model: str = "grok-4-fast",
+    finish_reason: str = "FINISH_REASON_STOP",
+    usage: object | None = None,
+) -> SimpleNamespace:
+    proto = chat_pb2.GetChatCompletionResponse()
+    return SimpleNamespace(
+        content=content,
+        reasoning_content=reasoning_content,
+        tool_calls=tool_calls or [],
+        model=model,
+        finish_reason=finish_reason,
+        usage=usage or SimpleNamespace(prompt_tokens=3, completion_tokens=5, total_tokens=8),
+        proto=proto,
+    )
+
+
+def _fake_tool_call(call_id: str, name: str, arguments: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=call_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _make_client_with_stub_chat(stub_chat: MagicMock) -> tuple[object, Context]:
+    with patch("autogen.beta.config.xai.xai_client.AsyncClient") as mock_async_client:
+        instance = MagicMock()
+        instance.chat.create.return_value = stub_chat
+        mock_async_client.return_value = instance
+
+        client = XAIConfig(model="grok-4-fast", api_key="t").create()
+        # Force lazy AsyncClient to materialize against our patched class
+        client._get_client()
+
+    stream = MemoryStream(persist_all=True)
+    return client, Context(stream=stream)
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_happy_path() -> None:
+    stub_chat = MagicMock()
+    stub_chat.sample = AsyncMock(return_value=_fake_response(content="Hi there"))
+
+    client, context = _make_client_with_stub_chat(stub_chat)
+
+    result = await client(
+        messages=[ModelRequest([TextInput("hello")])],
+        context=context,
+        tools=[],
+        response_schema=None,
+        serializer=SerializerCls,
+    )
+
+    assert isinstance(result, ModelResponse)
+    assert result.provider == "xai"
+    assert result.model == "grok-4-fast"
+    assert result.message is not None
+    assert result.message.content == "Hi there"
+    assert result.finish_reason == "stop"
+    assert result.usage == Usage(prompt_tokens=3.0, completion_tokens=5.0, total_tokens=8.0)
+
+    events = await context.stream.history.get_events()
+    kinds = [type(e).__name__ for e in events]
+    assert "ModelMessage" in kinds
+    assert "XAIAssistantEvent" in kinds
+
+
+@pytest.mark.asyncio
+async def test_reasoning_event_emitted() -> None:
+    stub_chat = MagicMock()
+    stub_chat.sample = AsyncMock(return_value=_fake_response(content="ans", reasoning_content="think..."))
+
+    client, context = _make_client_with_stub_chat(stub_chat)
+
+    await client(
+        messages=[ModelRequest([TextInput("hi")])],
+        context=context,
+        tools=[],
+        response_schema=None,
+        serializer=SerializerCls,
+    )
+
+    events = await context.stream.history.get_events()
+    reasoning = [e for e in events if isinstance(e, ModelReasoning)]
+    assert len(reasoning) == 1
+    assert reasoning[0].content == "think..."
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_surface_in_response() -> None:
+    stub_chat = MagicMock()
+    stub_chat.sample = AsyncMock(
+        return_value=_fake_response(
+            content="",
+            tool_calls=[_fake_tool_call("tc_1", "get_weather", '{"city": "Berlin"}')],
+        )
+    )
+
+    client, context = _make_client_with_stub_chat(stub_chat)
+
+    result = await client(
+        messages=[ModelRequest([TextInput("weather?")])],
+        context=context,
+        tools=[],
+        response_schema=None,
+        serializer=SerializerCls,
+    )
+
+    assert result.tool_calls == ToolCallsEvent([
+        ToolCallEvent(id="tc_1", name="get_weather", arguments='{"city": "Berlin"}')
+    ])
+
+
+@pytest.mark.asyncio
+async def test_streaming_accumulates_chunks() -> None:
+    proto = chat_pb2.GetChatCompletionResponse()
+    chunks = [
+        SimpleNamespace(
+            content="Hello, ",
+            reasoning_content="",
+            tool_calls=[],
+            usage=None,
+            model="grok-4-fast",
+            finish_reason=None,
+        ),
+        SimpleNamespace(
+            content="world!",
+            reasoning_content="",
+            tool_calls=[],
+            usage=None,
+            model="grok-4-fast",
+            finish_reason=None,
+        ),
+        SimpleNamespace(
+            content="",
+            reasoning_content="",
+            tool_calls=[],
+            usage=SimpleNamespace(prompt_tokens=2, completion_tokens=4, total_tokens=6),
+            model="grok-4-fast",
+            finish_reason="FINISH_REASON_STOP",
+        ),
+    ]
+    final_response = SimpleNamespace(
+        content="Hello, world!",
+        reasoning_content="",
+        tool_calls=[],
+        usage=SimpleNamespace(prompt_tokens=2, completion_tokens=4, total_tokens=6),
+        model="grok-4-fast",
+        finish_reason="FINISH_REASON_STOP",
+        proto=proto,
+    )
+
+    async def fake_stream() -> object:
+        for chunk in chunks:
+            yield final_response, chunk
+
+    stub_chat = MagicMock()
+    stub_chat.stream = MagicMock(return_value=fake_stream())
+
+    with patch("autogen.beta.config.xai.xai_client.AsyncClient") as mock_async_client:
+        instance = MagicMock()
+        instance.chat.create.return_value = stub_chat
+        mock_async_client.return_value = instance
+
+        client = XAIConfig(model="grok-4-fast", api_key="t", streaming=True).create()
+        client._get_client()
+
+    context = Context(stream=MemoryStream(persist_all=True))
+
+    result = await client(
+        messages=[ModelRequest([TextInput("hi")])],
+        context=context,
+        tools=[],
+        response_schema=None,
+        serializer=SerializerCls,
+    )
+
+    assert result.message is not None
+    assert result.message.content == "Hello, world!"
+    assert result.finish_reason == "stop"
+    assert result.usage == Usage(prompt_tokens=2.0, completion_tokens=4.0, total_tokens=6.0)
+
+    events = await context.stream.history.get_events()
+    chunk_events = [e for e in events if isinstance(e, ModelMessageChunk)]
+    assert [e.content for e in chunk_events] == ["Hello, ", "world!"]
+
+    assistant_events = [e for e in events if isinstance(e, XAIAssistantEvent)]
+    assert len(assistant_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_xai_assistant_event_replays_through_chat_append() -> None:
+    """Pre-existing XAIAssistantEvent in history should round-trip via chat.append()."""
+    proto = chat_pb2.GetChatCompletionResponse()
+    historical = XAIAssistantEvent(proto_bytes=proto.SerializeToString())
+
+    stub_chat = MagicMock()
+    stub_chat.sample = AsyncMock(return_value=_fake_response(content="follow up"))
+
+    client, context = _make_client_with_stub_chat(stub_chat)
+
+    await client(
+        messages=[ModelRequest([TextInput("first")]), historical],
+        context=context,
+        tools=[],
+        response_schema=None,
+        serializer=SerializerCls,
+    )
+
+    # chat.append should be called exactly once with the replay Response
+    assert stub_chat.append.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_response_format_passed_to_chat_create() -> None:
+    stub_chat = MagicMock()
+    stub_chat.sample = AsyncMock(return_value=_fake_response(content="42"))
+
+    with patch("autogen.beta.config.xai.xai_client.AsyncClient") as mock_async_client:
+        instance = MagicMock()
+        instance.chat.create.return_value = stub_chat
+        mock_async_client.return_value = instance
+
+        client = XAIConfig(model="grok-4-fast", api_key="t").create()
+        client._get_client()
+
+    context = Context(stream=MemoryStream(persist_all=True))
+
+    await client(
+        messages=[ModelRequest([TextInput("number?")])],
+        context=context,
+        tools=[],
+        response_schema=ResponseSchema(int, name="N"),
+        serializer=SerializerCls,
+    )
+
+    create_kwargs = instance.chat.create.call_args.kwargs
+    assert "response_format" in create_kwargs
+    assert isinstance(create_kwargs["response_format"], chat_pb2.ResponseFormat)
+    assert create_kwargs["response_format"].format_type == chat_pb2.FORMAT_TYPE_JSON_SCHEMA

--- a/test/beta/config/xai/test_xai_config.py
+++ b/test/beta/config/xai/test_xai_config.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fast_depends.use import SerializerCls
+from xai_sdk.chat import chat_pb2
+
+from autogen.beta import Context
+from autogen.beta.config import XAIConfig
+from autogen.beta.config.xai import XAIClient
+from autogen.beta.events import ModelRequest, TextInput
+from autogen.beta.stream import MemoryStream
+
+
+def _fake_sample_response() -> SimpleNamespace:
+    return SimpleNamespace(
+        content="",
+        reasoning_content="",
+        tool_calls=[],
+        model="grok-4-fast",
+        finish_reason="FINISH_REASON_STOP",
+        usage=None,
+        proto=chat_pb2.GetChatCompletionResponse(),
+    )
+
+
+async def _invoke_client(config: XAIConfig, *, streaming: bool = False) -> tuple[MagicMock, MagicMock]:
+    """Invoke ``config.create()`` against a mocked xai-sdk and return the (xai_client_mock, stub_chat) pair."""
+    stub_chat = MagicMock()
+
+    if streaming:
+
+        async def empty_stream() -> AsyncIterator[tuple[Any, Any]]:
+            if False:
+                yield  # pragma: no cover
+
+        stub_chat.stream = MagicMock(return_value=empty_stream())
+    else:
+        stub_chat.sample = AsyncMock(return_value=_fake_sample_response())
+
+    with patch("autogen.beta.config.xai.xai_client.AsyncClient") as mock_async_client:
+        instance = MagicMock()
+        instance.chat.create.return_value = stub_chat
+        mock_async_client.return_value = instance
+
+        client = config.create()
+
+        await client(
+            messages=[ModelRequest([TextInput("hi")])],
+            context=Context(stream=MemoryStream(persist_all=True)),
+            tools=[],
+            response_schema=None,
+            serializer=SerializerCls,
+        )
+
+    return instance, stub_chat
+
+
+def test_copy_without_overrides_returns_new_equal_instance() -> None:
+    config = XAIConfig(model="grok-4-fast", temperature=0.2, streaming=True)
+
+    copied = config.copy()
+
+    assert copied == config
+    assert copied is not config
+
+
+def test_copy_applies_overrides_without_mutating_original() -> None:
+    config = XAIConfig(model="grok-4-fast", temperature=0.2, streaming=False)
+
+    copied = config.copy(model="grok-4.20", temperature=0.8, streaming=True, reasoning_effort="high")
+
+    assert copied.model == "grok-4.20"
+    assert copied.temperature == 0.8
+    assert copied.streaming is True
+    assert copied.reasoning_effort == "high"
+
+    assert config.model == "grok-4-fast"
+    assert config.temperature == 0.2
+    assert config.streaming is False
+    assert config.reasoning_effort is None
+
+
+def test_create_returns_xai_client() -> None:
+    config = XAIConfig(model="grok-4-fast", api_key="test-key")
+    client = config.create()
+
+    assert isinstance(client, XAIClient)
+
+
+def test_defaults() -> None:
+    config = XAIConfig(model="grok-4-fast")
+
+    assert config.api_host == "api.x.ai"
+    assert config.timeout == 1620.0
+    assert config.api_key is None
+    assert config.streaming is False
+    assert config.temperature is None
+    assert config.max_tokens is None
+    assert config.reasoning_effort is None
+    assert config.include is None
+
+
+def test_api_host_can_be_overridden() -> None:
+    config = XAIConfig(model="grok-4-fast", api_host="custom.x.ai")
+    assert config.api_host == "custom.x.ai"
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_forwarded_to_chat_create() -> None:
+    instance, _ = await _invoke_client(XAIConfig(model="grok-4-fast", reasoning_effort="high"))
+
+    assert instance.chat.create.call_args.kwargs.get("reasoning_effort") == "high"
+
+
+@pytest.mark.asyncio
+async def test_include_forwarded_to_chat_create() -> None:
+    instance, _ = await _invoke_client(
+        XAIConfig(model="grok-4-fast", include=["verbose_streaming", "code_execution_call_output"])
+    )
+
+    assert instance.chat.create.call_args.kwargs.get("include") == [
+        "verbose_streaming",
+        "code_execution_call_output",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_streaming_flag_routes_to_chat_stream() -> None:
+    _, stub_chat = await _invoke_client(XAIConfig(model="grok-4-fast", streaming=True), streaming=True)
+
+    assert stub_chat.stream.called
+    assert not stub_chat.sample.called
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_routes_to_chat_sample() -> None:
+    _, stub_chat = await _invoke_client(XAIConfig(model="grok-4-fast", streaming=False))
+
+    assert stub_chat.sample.called
+    assert not stub_chat.stream.called
+
+
+@pytest.mark.asyncio
+async def test_none_fields_are_dropped_from_chat_create_kwargs() -> None:
+    instance, _ = await _invoke_client(XAIConfig(model="grok-4-fast", temperature=0.5))
+    kwargs = instance.chat.create.call_args.kwargs
+
+    assert kwargs.get("temperature") == 0.5
+    assert "top_p" not in kwargs
+    assert "max_tokens" not in kwargs
+
+
+def test_files_client_not_supported() -> None:
+    config = XAIConfig(model="grok-4-fast")
+
+    with pytest.raises(NotImplementedError, match="Files API"):
+        config.create_files_client()

--- a/test/beta/config/xai/test_xai_config.py
+++ b/test/beta/config/xai/test_xai_config.py
@@ -98,7 +98,7 @@ def test_defaults() -> None:
     config = XAIConfig(model="grok-4-fast")
 
     assert config.api_host == "api.x.ai"
-    assert config.timeout == 1620.0
+    assert config.timeout is None
     assert config.api_key is None
     assert config.streaming is False
     assert config.temperature is None

--- a/test/beta/config/xai/test_xai_config.py
+++ b/test/beta/config/xai/test_xai_config.py
@@ -89,7 +89,11 @@ def test_copy_applies_overrides_without_mutating_original() -> None:
 
 def test_create_returns_xai_client() -> None:
     config = XAIConfig(model="grok-4-fast", api_key="test-key")
-    client = config.create()
+
+    # Patch AsyncClient because xai-sdk eagerly opens a gRPC channel in
+    # AsyncClient.__init__, which requires a running event loop on py3.11.
+    with patch("autogen.beta.config.xai.xai_client.AsyncClient"):
+        client = config.create()
 
     assert isinstance(client, XAIClient)
 

--- a/test/beta/config/xai/test_xai_usage.py
+++ b/test/beta/config/xai/test_xai_usage.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from types import SimpleNamespace
+from xai_sdk.proto import usage_pb2
 
 from autogen.beta.config.xai.mappers import normalize_usage
 from autogen.beta.events import Usage
@@ -16,7 +16,7 @@ def test_none_returns_empty_usage() -> None:
 
 
 def test_basic_token_counts() -> None:
-    raw = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    raw = usage_pb2.SamplingUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
 
     result = normalize_usage(raw)
 
@@ -24,7 +24,7 @@ def test_basic_token_counts() -> None:
 
 
 def test_cached_prompt_tokens_map_to_cache_read() -> None:
-    raw = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15, cached_prompt_text_tokens=4)
+    raw = usage_pb2.SamplingUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15, cached_prompt_text_tokens=4)
 
     result = normalize_usage(raw)
 
@@ -32,7 +32,7 @@ def test_cached_prompt_tokens_map_to_cache_read() -> None:
 
 
 def test_reasoning_tokens_map_to_thinking_tokens() -> None:
-    raw = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15, reasoning_tokens=3)
+    raw = usage_pb2.SamplingUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15, reasoning_tokens=3)
 
     result = normalize_usage(raw)
 
@@ -40,7 +40,7 @@ def test_reasoning_tokens_map_to_thinking_tokens() -> None:
 
 
 def test_zero_or_missing_fields_become_none() -> None:
-    raw = SimpleNamespace(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+    raw = usage_pb2.SamplingUsage()
 
     result = normalize_usage(raw)
 

--- a/test/beta/config/xai/test_xai_usage.py
+++ b/test/beta/config/xai/test_xai_usage.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from autogen.beta.config.xai.mappers import normalize_usage
+from autogen.beta.events import Usage
+
+
+def test_none_returns_empty_usage() -> None:
+    result = normalize_usage(None)
+
+    assert result == Usage()
+    assert not result
+
+
+def test_basic_token_counts() -> None:
+    raw = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+
+    result = normalize_usage(raw)
+
+    assert result == Usage(prompt_tokens=10.0, completion_tokens=5.0, total_tokens=15.0)
+
+
+def test_cached_prompt_tokens_map_to_cache_read() -> None:
+    raw = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15, cached_prompt_text_tokens=4)
+
+    result = normalize_usage(raw)
+
+    assert result.cache_read_input_tokens == 4.0
+
+
+def test_reasoning_tokens_map_to_thinking_tokens() -> None:
+    raw = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15, reasoning_tokens=3)
+
+    result = normalize_usage(raw)
+
+    assert result.thinking_tokens == 3.0
+
+
+def test_zero_or_missing_fields_become_none() -> None:
+    raw = SimpleNamespace(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+
+    result = normalize_usage(raw)
+
+    # zero counts collapse to None per the normalize_usage contract
+    assert result == Usage()
+    assert not result

--- a/test/beta/config/xai/tools/__init__.py
+++ b/test/beta/config/xai/tools/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/beta/config/xai/tools/test_code_execution.py
+++ b/test/beta/config/xai/tools/test_code_execution.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from autogen.beta import Context
+from autogen.beta.config.xai.mappers import tool_to_api
+from autogen.beta.tools.builtin.code_execution import CodeExecutionTool
+
+
+@pytest.mark.asyncio
+async def test_defaults(context: Context) -> None:
+    tool = CodeExecutionTool()
+
+    [schema] = await tool.schemas(context)
+    api = tool_to_api(schema)
+
+    assert api.HasField("code_execution")

--- a/test/beta/config/xai/tools/test_mcp_server.py
+++ b/test/beta/config/xai/tools/test_mcp_server.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from autogen.beta import Context
+from autogen.beta.config.xai.mappers import tool_to_api
+from autogen.beta.tools.builtin.mcp_server import MCPServerTool
+
+
+@pytest.mark.asyncio
+async def test_required_fields(context: Context) -> None:
+    tool = MCPServerTool(server_url="https://mcp.example.com/sse", server_label="ex")
+
+    [schema] = await tool.schemas(context)
+    api = tool_to_api(schema)
+
+    assert api.HasField("mcp")
+    assert api.mcp.server_url == "https://mcp.example.com/sse"
+    assert api.mcp.server_label == "ex"
+
+
+@pytest.mark.asyncio
+async def test_authorization_token_becomes_bearer(context: Context) -> None:
+    tool = MCPServerTool(
+        server_url="https://mcp.example.com/sse",
+        server_label="ex",
+        authorization_token="secret-xyz",
+    )
+
+    [schema] = await tool.schemas(context)
+    api = tool_to_api(schema)
+
+    assert api.mcp.authorization == "Bearer secret-xyz"
+
+
+@pytest.mark.asyncio
+async def test_allowed_tools(context: Context) -> None:
+    tool = MCPServerTool(
+        server_url="https://mcp.example.com/sse",
+        server_label="ex",
+        allowed_tools=["search", "fetch"],
+    )
+
+    [schema] = await tool.schemas(context)
+    api = tool_to_api(schema)
+
+    assert list(api.mcp.allowed_tool_names) == ["search", "fetch"]

--- a/test/beta/config/xai/tools/test_tool_to_api.py
+++ b/test/beta/config/xai/tools/test_tool_to_api.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from xai_sdk.chat import chat_pb2
+
+from autogen.beta.config.xai.mappers import tool_to_api
+from test.beta.config._helpers import make_tool
+
+
+def test_function_tool_to_api() -> None:
+    api_tool = tool_to_api(make_tool().schema)
+
+    assert isinstance(api_tool, chat_pb2.Tool)
+    assert api_tool.function.name == "search_docs"
+    assert api_tool.function.description == "Search documentation by query."
+
+    params = json.loads(api_tool.function.parameters)
+    assert params == {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "limit": {"type": "integer", "minimum": 1},
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    }

--- a/test/beta/config/xai/tools/test_unsupported.py
+++ b/test/beta/config/xai/tools/test_unsupported.py
@@ -5,14 +5,13 @@
 import pytest
 
 from autogen.beta import Context
-from autogen.beta.config.gemini.mappers import build_tools
+from autogen.beta.config.xai.mappers import tool_to_api
 from autogen.beta.exceptions import UnsupportedToolError
 from autogen.beta.tools.builtin.image_generation import ImageGenerationTool
-from autogen.beta.tools.builtin.mcp_server import MCPServerTool
 from autogen.beta.tools.builtin.memory import MemoryTool
 from autogen.beta.tools.builtin.shell import ShellTool
 from autogen.beta.tools.builtin.skills import SkillsTool
-from autogen.beta.tools.builtin.x_search import XSearchTool
+from autogen.beta.tools.builtin.web_fetch import WebFetchTool
 
 
 @pytest.mark.asyncio
@@ -21,8 +20,8 @@ async def test_shell(context: Context) -> None:
 
     [schema] = await tool.schemas(context)
 
-    with pytest.raises(UnsupportedToolError):
-        build_tools([schema])
+    with pytest.raises(UnsupportedToolError, match="xai"):
+        tool_to_api(schema)
 
 
 @pytest.mark.asyncio
@@ -31,8 +30,8 @@ async def test_memory(context: Context) -> None:
 
     [schema] = await tool.schemas(context)
 
-    with pytest.raises(UnsupportedToolError):
-        build_tools([schema])
+    with pytest.raises(UnsupportedToolError, match="xai"):
+        tool_to_api(schema)
 
 
 @pytest.mark.asyncio
@@ -41,18 +40,8 @@ async def test_image_generation(context: Context) -> None:
 
     [schema] = await tool.schemas(context)
 
-    with pytest.raises(UnsupportedToolError):
-        build_tools([schema])
-
-
-@pytest.mark.asyncio
-async def test_mcp_server(context: Context) -> None:
-    tool = MCPServerTool(server_url="https://mcp.example.com/sse", server_label="example-mcp")
-
-    [schema] = await tool.schemas(context)
-
-    with pytest.raises(UnsupportedToolError):
-        build_tools([schema])
+    with pytest.raises(UnsupportedToolError, match="xai"):
+        tool_to_api(schema)
 
 
 @pytest.mark.asyncio
@@ -61,15 +50,15 @@ async def test_skills(context: Context) -> None:
 
     [schema] = await tool.schemas(context)
 
-    with pytest.raises(UnsupportedToolError):
-        build_tools([schema])
+    with pytest.raises(UnsupportedToolError, match="xai"):
+        tool_to_api(schema)
 
 
 @pytest.mark.asyncio
-async def test_x_search(context: Context) -> None:
-    tool = XSearchTool()
+async def test_web_fetch(context: Context) -> None:
+    tool = WebFetchTool()
 
     [schema] = await tool.schemas(context)
 
-    with pytest.raises(UnsupportedToolError):
-        build_tools([schema])
+    with pytest.raises(UnsupportedToolError, match="xai"):
+        tool_to_api(schema)

--- a/test/beta/config/xai/tools/test_web_search.py
+++ b/test/beta/config/xai/tools/test_web_search.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from autogen.beta import Context
+from autogen.beta.config.xai.mappers import tool_to_api
+from autogen.beta.tools.builtin.web_search import UserLocation, WebSearchTool
+
+
+@pytest.mark.asyncio
+async def test_defaults(context: Context) -> None:
+    tool = WebSearchTool()
+
+    [schema] = await tool.schemas(context)
+    api = tool_to_api(schema)
+
+    assert api.HasField("web_search")
+
+
+@pytest.mark.asyncio
+async def test_allowed_and_blocked_domains(context: Context) -> None:
+    tool = WebSearchTool(allowed_domains=["example.com"], blocked_domains=["spam.com"])
+
+    [schema] = await tool.schemas(context)
+    api = tool_to_api(schema)
+
+    assert list(api.web_search.allowed_domains) == ["example.com"]
+    assert list(api.web_search.excluded_domains) == ["spam.com"]
+
+
+@pytest.mark.asyncio
+async def test_user_location(context: Context) -> None:
+    tool = WebSearchTool(user_location=UserLocation(country="US", city="San Francisco", timezone="America/Los_Angeles"))
+
+    [schema] = await tool.schemas(context)
+    api = tool_to_api(schema)
+
+    assert api.web_search.user_location.country == "US"
+    assert api.web_search.user_location.city == "San Francisco"
+    assert api.web_search.user_location.timezone == "America/Los_Angeles"

--- a/test/beta/config/xai/tools/test_x_search.py
+++ b/test/beta/config/xai/tools/test_x_search.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+
+import pytest
+
+from autogen.beta import Context
+from autogen.beta.config.xai.mappers import tool_to_api
+from autogen.beta.tools.builtin.x_search import XSearchTool
+
+
+@pytest.mark.asyncio
+async def test_defaults(context: Context) -> None:
+    tool = XSearchTool()
+
+    [schema] = await tool.schemas(context)
+    api = tool_to_api(schema)
+
+    assert api.HasField("x_search")
+
+
+@pytest.mark.asyncio
+async def test_handles_and_flags(context: Context) -> None:
+    tool = XSearchTool(
+        allowed_x_handles=["xai"],
+        excluded_x_handles=["bot"],
+        enable_image_understanding=True,
+        enable_video_understanding=False,
+    )
+
+    [schema] = await tool.schemas(context)
+    api = tool_to_api(schema)
+
+    assert list(api.x_search.allowed_x_handles) == ["xai"]
+    assert list(api.x_search.excluded_x_handles) == ["bot"]
+    assert api.x_search.enable_image_understanding is True
+
+
+@pytest.mark.asyncio
+async def test_date_range(context: Context) -> None:
+    tool = XSearchTool(
+        from_date=datetime(2025, 1, 1),
+        to_date=datetime(2025, 6, 1),
+    )
+
+    [schema] = await tool.schemas(context)
+    api = tool_to_api(schema)
+
+    # x_search proto stores timestamps; verify they're populated
+    assert api.x_search.from_date.seconds > 0
+    assert api.x_search.to_date.seconds > api.x_search.from_date.seconds

--- a/test/beta/tools/test_resolve.py
+++ b/test/beta/tools/test_resolve.py
@@ -14,6 +14,7 @@ from autogen.beta.tools.builtin.mcp_server import MCPServerTool, MCPServerToolSc
 from autogen.beta.tools.builtin.shell import ContainerAutoEnvironment, ShellTool, ShellToolSchema
 from autogen.beta.tools.builtin.web_fetch import WebFetchTool, WebFetchToolSchema
 from autogen.beta.tools.builtin.web_search import WebSearchToolSchema
+from autogen.beta.tools.builtin.x_search import XSearchTool, XSearchToolSchema
 
 
 class TestResolveVariable:
@@ -148,4 +149,23 @@ class TestMCPServerToolVariable:
         tool = MCPServerTool(server_url=Variable("url"), server_label="test-mcp")
 
         with pytest.raises(KeyError, match="url"):
+            await tool.schemas(context)
+
+
+class TestXSearchToolVariable:
+    @pytest.mark.asyncio
+    async def test_resolved(self, make_context: Callable[..., Context]) -> None:
+        ctx = make_context(handles=["xai"])
+        tool = XSearchTool(allowed_x_handles=Variable("handles"))
+
+        [schema] = await tool.schemas(ctx)
+
+        assert isinstance(schema, XSearchToolSchema)
+        assert schema.allowed_x_handles == ["xai"]
+
+    @pytest.mark.asyncio
+    async def test_missing_raises(self, context: Context) -> None:
+        tool = XSearchTool(allowed_x_handles=Variable("handles"))
+
+        with pytest.raises(KeyError, match="handles"):
             await tool.schemas(context)

--- a/website/docs/beta/inputs/inputs.mdx
+++ b/website/docs/beta/inputs/inputs.mdx
@@ -71,18 +71,18 @@ reply = await agent.ask("Compare these two images.", image1, image2)
 
 Not all providers support all input types. The table below shows what each provider accepts:
 
-| Input Type | OpenAI | OpenAI Responses | Gemini | Anthropic |
-| :--- | :---: | :---: | :---: | :---: |
-| **Text** | Yes | Yes | Yes | Yes |
-| **Image (URL)** | Yes | Yes | Yes | Yes |
-| **Image (binary)** | Yes | Yes | Yes | Yes |
-| **Audio (URL)** | - | - | Yes | - |
-| **Audio (binary)** | Yes | - | Yes | - |
-| **Video (URL)** | - | - | Yes | - |
-| **Video (binary)** | - | - | Yes | - |
-| **Document (URL)** | - | Yes | Yes | Yes |
-| **Document (binary)** | - | - | Yes | Yes |
-| **File ID** | - | Yes | - | Yes |
+| Input Type | OpenAI | OpenAI Responses | Gemini | Anthropic | xAI |
+| :--- | :---: | :---: | :---: | :---: | :---: |
+| **Text** | Yes | Yes | Yes | Yes | Yes |
+| **Image (URL)** | Yes | Yes | Yes | Yes | Yes |
+| **Image (binary)** | Yes | Yes | Yes | Yes | Yes |
+| **Audio (URL)** | - | - | Yes | - | - |
+| **Audio (binary)** | Yes | - | Yes | - | - |
+| **Video (URL)** | - | - | Yes | - | - |
+| **Video (binary)** | - | - | Yes | - | - |
+| **Document (URL)** | - | Yes | Yes | Yes | Yes |
+| **Document (binary)** | - | - | Yes | Yes | Yes |
+| **File ID** | - | Yes | - | Yes | Yes |
 
 If you pass an unsupported input type to a provider, an `#!python UnsupportedInputError` is raised with a clear message indicating what is not supported and by which provider.
 
@@ -226,5 +226,63 @@ from autogen.beta.events import DocumentInput
 doc = DocumentInput(
     path="report.pdf",
     vendor_metadata={"cache_control": {"type": "ephemeral"}},
+)
+```
+
+### xAI
+
+xAI supports images (URL and binary), documents (URL and binary), and pre-uploaded file IDs. Audio and video are not currently supported — passing them raises `#!python UnsupportedInputError`.
+
+**File ID** — reference a file previously uploaded via the xAI Files API:
+
+```python linenums="1"
+from autogen.beta.events import ImageInput, DocumentInput
+
+image = ImageInput(file_id="file-abc123", filename="photo.jpg")
+doc = DocumentInput(file_id="file-xyz789", filename="report.pdf")
+```
+
+#### Vendor Metadata
+
+xAI reads `detail` for image quality control from two **different** attributes depending on the input source — `#!python vendor_metadata` for binary, `#!python metadata` for URL. Mixing them up means the value is silently ignored and xAI falls back to `"auto"`.
+
+**Binary image** — set `detail` via `#!python vendor_metadata`:
+
+```python linenums="1"
+from autogen.beta.events import BinaryInput, BinaryType
+
+image = BinaryInput(
+    raw_bytes,
+    media_type="image/png",
+    kind=BinaryType.IMAGE,
+    vendor_metadata={"detail": "low"},  # "low", "high", or "auto"
+)
+```
+
+**URL image** — set `detail` via `#!python metadata` (not `vendor_metadata`):
+
+```python linenums="1"
+from autogen.beta.events import UrlInput, BinaryType
+
+image = UrlInput(
+    "https://example.com/photo.jpg",
+    kind=BinaryType.IMAGE,
+    metadata={"detail": "low"},
+)
+```
+
+!!! note
+    The factory `#!python ImageInput(url=...)` does not forward `metadata`. To configure `detail` on a URL image, construct `#!python UrlInput` directly as shown above.
+
+**Document filename** — xAI requires a filename for binary documents. When sending raw bytes, either provide one via `#!python vendor_metadata={"filename": ...}`, or rely on the auto-derived fallback (`file.<subtype>` from the media type, e.g. `file.pdf` for `application/pdf`):
+
+```python linenums="1"
+from autogen.beta.events import BinaryInput, BinaryType
+
+doc = BinaryInput(
+    pdf_bytes,
+    media_type="application/pdf",
+    kind=BinaryType.DOCUMENT,
+    vendor_metadata={"filename": "Q4-report.pdf"},
 )
 ```

--- a/website/docs/beta/model_configuration.mdx
+++ b/website/docs/beta/model_configuration.mdx
@@ -20,6 +20,7 @@ AG2 supports multiple LLM providers through dedicated configuration classes. Eac
 | **[Gemini on Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs)** | `VertexAIConfig` | `pip install "ag2[gemini]"` |
 | **[Ollama](https://docs.ollama.com/api/introduction)** | `OllamaConfig` | `pip install "ag2[ollama]"` |
 | **[DashScope](https://www.alibabacloud.com/help/en/model-studio/first-api-call-to-qwen)** | `DashScopeConfig` | `pip install "ag2[dashscope]"` |
+| **[xAI](https://docs.x.ai/docs/overview)** | `XAIConfig` | `pip install "ag2[xai]"` |
 
 *(Note: `OpenAIConfig` is also available for OpenAI-compatible endpoints).*
 
@@ -109,6 +110,19 @@ config = DashScopeConfig(
 ```
   </Tab>
 
+  <Tab title="xAI">
+```python linenums="1"
+from autogen.beta.config import XAIConfig
+
+# Configure an xAI Grok model
+config = XAIConfig(
+    model="grok-4",
+    api_key="xai-...",
+    streaming=True
+)
+```
+  </Tab>
+
 </Tabs>
 
 !!! tip
@@ -119,7 +133,7 @@ config = DashScopeConfig(
 
 For security and convenience, you don't need to hardcode your API keys. If `api_key` is not explicitly provided, the configuration will automatically attempt to load it from your environment variables.
 
-The system looks for provider-specific keys (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`).
+The system looks for provider-specific keys (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`).
 
 ```python linenums="1"
 from autogen.beta.config import OpenAIConfig


### PR DESCRIPTION
## Summary

Adds **xAI Grok** as a model provider.

```python
import asyncio

from autogen.beta import Agent
from autogen.beta.config import XAIConfig
from autogen.beta.tools import WebSearchTool, XSearchTool


agent = Agent(
    "researcher",
    prompt="You are a research assistant.",
    config=XAIConfig(
        model="grok-4",
        api_key="xai-...",
        streaming=True,
        reasoning_effort="high",
    ),
    tools=[
        WebSearchTool(),
        XSearchTool(allowed_x_handles=["xai"]),
    ],
)


async def main() -> None:
    reply = await agent.ask("What did @xai announce about Grok this week?")
    print(reply.body)


asyncio.run(main())
```

### Supported built-in tools

| Tool | Status |
|------|--------|
| `WebSearchTool` | ✓ |
| `XSearchTool` *(new, xAI-only)* | ✓ |
| `CodeExecutionTool` | ✓ |
| `MCPServerTool` | ✓ |
| `ShellTool` / `MemoryTool` / `ImageGenerationTool` / `SkillsTool` / `WebFetchTool` | unsupported → `UnsupportedToolError` |
