### PR TITLE
Feat(beta): implement xAI File API

### DIFF
--- a/autogen/beta/config/xai/__init__.py
+++ b/autogen/beta/config/xai/__init__.py
@@ -4,10 +4,12 @@
 
 from .config import XAIConfig
 from .events import XAIAssistantEvent
+from .files import XAIFilesClient
 from .xai_client import XAIClient
 
 __all__ = (
     "XAIAssistantEvent",
     "XAIClient",
     "XAIConfig",
+    "XAIFilesClient",
 )

--- a/autogen/beta/config/xai/config.py
+++ b/autogen/beta/config/xai/config.py
@@ -10,6 +10,7 @@ from typing_extensions import Unpack
 
 from autogen.beta.config.config import ModelConfig
 
+from .files import XAIFilesClient
 from .xai_client import CreateOptions, IncludeOption, ReasoningEffort, XAIClient
 
 XAI_DEFAULT_API_HOST = "api.x.ai"
@@ -110,5 +111,5 @@ class XAIConfig(ModelConfig):
             create_options=options,
         )
 
-    def create_files_client(self) -> None:
-        raise NotImplementedError(f"{type(self).__name__} does not support Files API.")
+    def create_files_client(self) -> XAIFilesClient:
+        return XAIFilesClient(self)

--- a/autogen/beta/config/xai/files.py
+++ b/autogen/beta/config/xai/files.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import TYPE_CHECKING
+
+from xai_sdk import AsyncClient
+
+from autogen.beta.files.types import FileContent, FileProvider, UploadedFile, _created_at_to_float
+
+if TYPE_CHECKING:
+    from autogen.beta.config.xai.config import XAIConfig
+
+
+class XAIFilesClient:
+    """Files API client for xAI."""
+
+    __slots__ = ("_client",)
+
+    def __init__(self, config: "XAIConfig") -> None:
+        self._client = AsyncClient(
+            api_key=config.api_key,
+            api_host=config.api_host,
+            timeout=config.timeout,
+            metadata=config.metadata,
+            channel_options=config.channel_options,
+        )
+
+    async def upload(self, data: bytes, filename: str, purpose: str | None = None) -> UploadedFile:
+        result = await self._client.files.upload(data, filename=filename)
+        return UploadedFile(
+            file_id=result.id,
+            filename=result.filename,
+            provider=FileProvider.XAI,
+            bytes_count=result.bytes,
+            purpose=purpose,
+            created_at=_created_at_to_float(result.created_at),
+        )
+
+    async def read(self, file_id: str) -> FileContent:
+        metadata = await self._client.files.get(file_id)
+        data = await self._client.files.content(file_id)
+        return FileContent(
+            name=metadata.filename,
+            data=data,
+            media_type=metadata.mime_type,
+        )
+
+    async def list(self) -> list[UploadedFile]:
+        result = await self._client.files.list()
+        return [
+            UploadedFile(
+                file_id=f.id,
+                filename=f.filename,
+                provider=FileProvider.XAI,
+                bytes_count=f.bytes,
+                purpose=f.purpose,
+                created_at=_created_at_to_float(f.created_at),
+            )
+            for f in result.data
+        ]
+
+    async def delete(self, file_id: str) -> None:
+        await self._client.files.delete(file_id)

--- a/autogen/beta/config/xai/files.py
+++ b/autogen/beta/config/xai/files.py
@@ -32,7 +32,7 @@ class XAIFilesClient:
             file_id=result.id,
             filename=result.filename,
             provider=FileProvider.XAI,
-            bytes_count=result.bytes,
+            bytes_count=result.size,
             purpose=purpose,
             created_at=_created_at_to_float(result.created_at),
         )
@@ -43,7 +43,6 @@ class XAIFilesClient:
         return FileContent(
             name=metadata.filename,
             data=data,
-            media_type=metadata.mime_type,
         )
 
     async def list(self) -> list[UploadedFile]:
@@ -53,8 +52,7 @@ class XAIFilesClient:
                 file_id=f.id,
                 filename=f.filename,
                 provider=FileProvider.XAI,
-                bytes_count=f.bytes,
-                purpose=f.purpose,
+                bytes_count=f.size,
                 created_at=_created_at_to_float(f.created_at),
             )
             for f in result.data

--- a/autogen/beta/files/types.py
+++ b/autogen/beta/files/types.py
@@ -25,6 +25,7 @@ class FileProvider(str, Enum):
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
     GEMINI = "gemini"
+    XAI = "xai"
 
 
 class UploadedFile(FileIdInput):

--- a/test/beta/config/xai/test_files.py
+++ b/test/beta/config/xai/test_files.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from autogen.beta.config import XAIConfig
+from autogen.beta.config.xai import XAIFilesClient
+from autogen.beta.files.types import FileContent, FileProvider, UploadedFile
+
+
+@patch("autogen.beta.config.xai.files.AsyncClient")
+def test_files_api_can_be_created_for_xai(mock_async_client: MagicMock) -> None:
+    config = XAIConfig(model="grok-4-fast", api_key="test-key")
+
+    client = config.create_files_client()
+
+    assert isinstance(client, XAIFilesClient)
+    mock_async_client.assert_called_once_with(
+        api_key="test-key",
+        api_host="api.x.ai",
+        timeout=None,
+        metadata=None,
+        channel_options=None,
+    )
+
+
+@pytest.mark.asyncio
+class TestXAIFilesClient:
+    @patch("autogen.beta.config.xai.files.AsyncClient")
+    async def test_upload(self, mock_async_client: MagicMock) -> None:
+        mock_client = AsyncMock()
+        mock_async_client.return_value = mock_client
+        mock_client.files.upload.return_value = SimpleNamespace(
+            id="file_123",
+            filename="hello.txt",
+            bytes=5,
+            created_at=123,
+        )
+
+        result = await XAIFilesClient(XAIConfig(model="grok-4-fast")).upload(
+            b"hello",
+            "hello.txt",
+            "assistants",
+        )
+
+        assert result == UploadedFile(
+            file_id="file_123",
+            filename="hello.txt",
+            provider=FileProvider.XAI,
+            bytes_count=5,
+            purpose="assistants",
+            created_at=123.0,
+        )
+        mock_client.files.upload.assert_awaited_once_with(b"hello", filename="hello.txt")
+
+    @patch("autogen.beta.config.xai.files.AsyncClient")
+    async def test_read(self, mock_async_client: MagicMock) -> None:
+        mock_client = AsyncMock()
+        mock_async_client.return_value = mock_client
+        mock_client.files.get.return_value = SimpleNamespace(filename="hello.txt", mime_type="text/plain")
+        mock_client.files.content.return_value = b"file-bytes"
+
+        result = await XAIFilesClient(XAIConfig(model="grok-4-fast")).read("file_123")
+
+        assert result == FileContent(name="hello.txt", data=b"file-bytes", media_type="text/plain")
+
+    @patch("autogen.beta.config.xai.files.AsyncClient")
+    async def test_list(self, mock_async_client: MagicMock) -> None:
+        mock_client = AsyncMock()
+        mock_async_client.return_value = mock_client
+        mock_client.files.list.return_value = SimpleNamespace(
+            data=[
+                SimpleNamespace(
+                    id="file_1",
+                    filename="a.txt",
+                    bytes=100,
+                    purpose="assistants",
+                    created_at=123,
+                ),
+            ]
+        )
+
+        result = await XAIFilesClient(XAIConfig(model="grok-4-fast")).list()
+
+        assert result == [
+            UploadedFile(
+                file_id="file_1",
+                filename="a.txt",
+                provider=FileProvider.XAI,
+                bytes_count=100,
+                purpose="assistants",
+                created_at=123.0,
+            ),
+        ]
+
+    @patch("autogen.beta.config.xai.files.AsyncClient")
+    async def test_delete(self, mock_async_client: MagicMock) -> None:
+        mock_client = AsyncMock()
+        mock_async_client.return_value = mock_client
+
+        await XAIFilesClient(XAIConfig(model="grok-4-fast")).delete("file_123")
+
+        mock_client.files.delete.assert_awaited_once_with("file_123")

--- a/test/beta/config/xai/test_files.py
+++ b/test/beta/config/xai/test_files.py
@@ -37,7 +37,7 @@ class TestXAIFilesClient:
         mock_client.files.upload.return_value = SimpleNamespace(
             id="file_123",
             filename="hello.txt",
-            bytes=5,
+            size=5,
             created_at=123,
         )
 
@@ -61,12 +61,12 @@ class TestXAIFilesClient:
     async def test_read(self, mock_async_client: MagicMock) -> None:
         mock_client = AsyncMock()
         mock_async_client.return_value = mock_client
-        mock_client.files.get.return_value = SimpleNamespace(filename="hello.txt", mime_type="text/plain")
+        mock_client.files.get.return_value = SimpleNamespace(filename="hello.txt")
         mock_client.files.content.return_value = b"file-bytes"
 
         result = await XAIFilesClient(XAIConfig(model="grok-4-fast")).read("file_123")
 
-        assert result == FileContent(name="hello.txt", data=b"file-bytes", media_type="text/plain")
+        assert result == FileContent(name="hello.txt", data=b"file-bytes")
 
     @patch("autogen.beta.config.xai.files.AsyncClient")
     async def test_list(self, mock_async_client: MagicMock) -> None:
@@ -77,8 +77,7 @@ class TestXAIFilesClient:
                 SimpleNamespace(
                     id="file_1",
                     filename="a.txt",
-                    bytes=100,
-                    purpose="assistants",
+                    size=100,
                     created_at=123,
                 ),
             ]
@@ -92,7 +91,6 @@ class TestXAIFilesClient:
                 filename="a.txt",
                 provider=FileProvider.XAI,
                 bytes_count=100,
-                purpose="assistants",
                 created_at=123.0,
             ),
         ]

--- a/test/beta/config/xai/test_xai_config.py
+++ b/test/beta/config/xai/test_xai_config.py
@@ -13,7 +13,7 @@ from xai_sdk.chat import chat_pb2
 
 from autogen.beta import Context
 from autogen.beta.config import XAIConfig
-from autogen.beta.config.xai import XAIClient
+from autogen.beta.config.xai import XAIClient, XAIFilesClient
 from autogen.beta.events import ModelRequest, TextInput
 from autogen.beta.stream import MemoryStream
 
@@ -161,8 +161,10 @@ async def test_none_fields_are_dropped_from_chat_create_kwargs() -> None:
     assert "max_tokens" not in kwargs
 
 
-def test_files_client_not_supported() -> None:
+def test_create_files_client_returns_xai_files_client() -> None:
     config = XAIConfig(model="grok-4-fast")
 
-    with pytest.raises(NotImplementedError, match="Files API"):
-        config.create_files_client()
+    with patch("autogen.beta.config.xai.files.AsyncClient"):
+        client = config.create_files_client()
+
+    assert isinstance(client, XAIFilesClient)

--- a/test/beta/config/xai/test_xai_config.py
+++ b/test/beta/config/xai/test_xai_config.py
@@ -2,64 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import AsyncIterator
-from types import SimpleNamespace
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
-import pytest
-from fast_depends.use import SerializerCls
-from xai_sdk.chat import chat_pb2
-
-from autogen.beta import Context
 from autogen.beta.config import XAIConfig
 from autogen.beta.config.xai import XAIClient, XAIFilesClient
-from autogen.beta.events import ModelRequest, TextInput
-from autogen.beta.stream import MemoryStream
-
-
-def _fake_sample_response() -> SimpleNamespace:
-    return SimpleNamespace(
-        content="",
-        reasoning_content="",
-        tool_calls=[],
-        model="grok-4-fast",
-        finish_reason="FINISH_REASON_STOP",
-        usage=None,
-        proto=chat_pb2.GetChatCompletionResponse(),
-    )
-
-
-async def _invoke_client(config: XAIConfig, *, streaming: bool = False) -> tuple[MagicMock, MagicMock]:
-    """Invoke ``config.create()`` against a mocked xai-sdk and return the (xai_client_mock, stub_chat) pair."""
-    stub_chat = MagicMock()
-
-    if streaming:
-
-        async def empty_stream() -> AsyncIterator[tuple[Any, Any]]:
-            if False:
-                yield  # pragma: no cover
-
-        stub_chat.stream = MagicMock(return_value=empty_stream())
-    else:
-        stub_chat.sample = AsyncMock(return_value=_fake_sample_response())
-
-    with patch("autogen.beta.config.xai.xai_client.AsyncClient") as mock_async_client:
-        instance = MagicMock()
-        instance.chat.create.return_value = stub_chat
-        mock_async_client.return_value = instance
-
-        client = config.create()
-
-        await client(
-            messages=[ModelRequest([TextInput("hi")])],
-            context=Context(stream=MemoryStream(persist_all=True)),
-            tools=[],
-            response_schema=None,
-            serializer=SerializerCls,
-        )
-
-    return instance, stub_chat
 
 
 def test_copy_without_overrides_returns_new_equal_instance() -> None:
@@ -72,26 +18,24 @@ def test_copy_without_overrides_returns_new_equal_instance() -> None:
 
 
 def test_copy_applies_overrides_without_mutating_original() -> None:
-    config = XAIConfig(model="grok-4-fast", temperature=0.2, streaming=False)
+    config = XAIConfig(model="grok-4-fast", api_key="key", temperature=0.2, streaming=False)
 
-    copied = config.copy(model="grok-4.20", temperature=0.8, streaming=True, reasoning_effort="high")
+    copied = config.copy(model="grok-4.20", temperature=0.8, streaming=True, api_key=None)
 
     assert copied.model == "grok-4.20"
     assert copied.temperature == 0.8
     assert copied.streaming is True
-    assert copied.reasoning_effort == "high"
+    assert copied.api_key is None
 
     assert config.model == "grok-4-fast"
     assert config.temperature == 0.2
     assert config.streaming is False
-    assert config.reasoning_effort is None
+    assert config.api_key == "key"  # pragma: allowlist secret
 
 
 def test_create_returns_xai_client() -> None:
     config = XAIConfig(model="grok-4-fast", api_key="test-key")
 
-    # Patch AsyncClient because xai-sdk eagerly opens a gRPC channel in
-    # AsyncClient.__init__, which requires a running event loop on py3.11.
     with patch("autogen.beta.config.xai.xai_client.AsyncClient"):
         client = config.create()
 
@@ -113,52 +57,20 @@ def test_defaults() -> None:
 
 def test_api_host_can_be_overridden() -> None:
     config = XAIConfig(model="grok-4-fast", api_host="custom.x.ai")
+
     assert config.api_host == "custom.x.ai"
 
 
-@pytest.mark.asyncio
-async def test_reasoning_effort_forwarded_to_chat_create() -> None:
-    instance, _ = await _invoke_client(XAIConfig(model="grok-4-fast", reasoning_effort="high"))
+def test_reasoning_effort_can_be_set() -> None:
+    config = XAIConfig(model="grok-4-fast", reasoning_effort="high")
 
-    assert instance.chat.create.call_args.kwargs.get("reasoning_effort") == "high"
-
-
-@pytest.mark.asyncio
-async def test_include_forwarded_to_chat_create() -> None:
-    instance, _ = await _invoke_client(
-        XAIConfig(model="grok-4-fast", include=["verbose_streaming", "code_execution_call_output"])
-    )
-
-    assert instance.chat.create.call_args.kwargs.get("include") == [
-        "verbose_streaming",
-        "code_execution_call_output",
-    ]
+    assert config.reasoning_effort == "high"
 
 
-@pytest.mark.asyncio
-async def test_streaming_flag_routes_to_chat_stream() -> None:
-    _, stub_chat = await _invoke_client(XAIConfig(model="grok-4-fast", streaming=True), streaming=True)
+def test_include_can_be_set() -> None:
+    config = XAIConfig(model="grok-4-fast", include=["verbose_streaming", "code_execution_call_output"])
 
-    assert stub_chat.stream.called
-    assert not stub_chat.sample.called
-
-
-@pytest.mark.asyncio
-async def test_non_streaming_routes_to_chat_sample() -> None:
-    _, stub_chat = await _invoke_client(XAIConfig(model="grok-4-fast", streaming=False))
-
-    assert stub_chat.sample.called
-    assert not stub_chat.stream.called
-
-
-@pytest.mark.asyncio
-async def test_none_fields_are_dropped_from_chat_create_kwargs() -> None:
-    instance, _ = await _invoke_client(XAIConfig(model="grok-4-fast", temperature=0.5))
-    kwargs = instance.chat.create.call_args.kwargs
-
-    assert kwargs.get("temperature") == 0.5
-    assert "top_p" not in kwargs
-    assert "max_tokens" not in kwargs
+    assert config.include == ["verbose_streaming", "code_execution_call_output"]
 
 
 def test_create_files_client_returns_xai_files_client() -> None:

--- a/website/docs/beta/advanced/files.mdx
+++ b/website/docs/beta/advanced/files.mdx
@@ -20,6 +20,7 @@ Use `#!python FilesAPI` when you want to:
 - `#!python OpenAIResponsesConfig`
 - `#!python AnthropicConfig`
 - `#!python GeminiConfig`
+- `#!python XAIConfig`
 
 !!! note
     Gemini does not support downloading file bytes via its Files API. `#!python FilesAPI.read()` raises `#!python NotImplementedError` for Gemini.


### PR DESCRIPTION
## Summary

Add xAI support to the Files API, making xAI a supported file provider for upload, read, and delete operations.

## Python API example

```python
from autogen.beta import FilesAPI
from autogen.beta.config import XAIConfig

config = XAIConfig(
    model="grok-4-fast",
    api_key="YOUR_XAI_API_KEY",
)

files = FilesAPI(config)

uploaded = await files.upload(
    data=b"hello from AG2",
    filename="hello.txt",
)

print(uploaded.file_id)
print(uploaded.filename)
print(uploaded.bytes_count)

content = await files.read(uploaded.file_id)
print(content.name)
print(content.data)

all_files = await files.list()
print([file.filename for file in all_files])

await files.delete(uploaded.file_id)
```