### PR TITLE
chore: Replace gemini-3.1-flash-lite-preview with gemini-3.1-flash-lite

### DIFF
--- a/autogen/agents/experimental/a2ui/a2ui_agent.py
+++ b/autogen/agents/experimental/a2ui/a2ui_agent.py
@@ -36,7 +36,7 @@ class A2UIAgent(ConversableAgent):
 
         agent = A2UIAgent(
             name="ui_agent",
-            llm_config={"api_type": "google", "model": "gemini-3.1-flash-lite-preview"},
+            llm_config={"api_type": "google", "model": "gemini-3.1-flash-lite"},
             validate_responses=True,
             validation_retries=2,
         )

--- a/cli/test_playground/agent_coder.py
+++ b/cli/test_playground/agent_coder.py
@@ -3,7 +3,7 @@
 from autogen import AssistantAgent, LLMConfig
 
 config = LLMConfig(
-    {"model": "gemini-3.1-flash-lite-preview", "api_type": "google"},
+    {"model": "gemini-3.1-flash-lite", "api_type": "google"},
 )
 
 agent = AssistantAgent(

--- a/cli/test_playground/agent_concise.py
+++ b/cli/test_playground/agent_concise.py
@@ -3,7 +3,7 @@
 from autogen import AssistantAgent, LLMConfig
 
 config = LLMConfig(
-    {"model": "gemini-3.1-flash-lite-preview", "api_type": "google"},
+    {"model": "gemini-3.1-flash-lite", "api_type": "google"},
 )
 
 agent = AssistantAgent(

--- a/cli/test_playground/agent_detailed.py
+++ b/cli/test_playground/agent_detailed.py
@@ -3,7 +3,7 @@
 from autogen import AssistantAgent, LLMConfig
 
 config = LLMConfig(
-    {"model": "gemini-3.1-flash-lite-preview", "api_type": "google"},
+    {"model": "gemini-3.1-flash-lite", "api_type": "google"},
 )
 
 agent = AssistantAgent(

--- a/cli/test_playground/main_agent.py
+++ b/cli/test_playground/main_agent.py
@@ -5,7 +5,7 @@ from autogen import AssistantAgent, LLMConfig
 
 async def main(message="Hello!"):
     config = LLMConfig(
-        {"model": "gemini-3.1-flash-lite-preview", "api_type": "google"},
+        {"model": "gemini-3.1-flash-lite", "api_type": "google"},
     )
 
     assistant = AssistantAgent(

--- a/cli/test_playground/single_agent.py
+++ b/cli/test_playground/single_agent.py
@@ -3,7 +3,7 @@
 from autogen import AssistantAgent, LLMConfig
 
 config = LLMConfig(
-    {"model": "gemini-3.1-flash-lite-preview", "api_type": "google"},
+    {"model": "gemini-3.1-flash-lite", "api_type": "google"},
 )
 
 agent = AssistantAgent(

--- a/cli/test_playground/team.py
+++ b/cli/test_playground/team.py
@@ -3,7 +3,7 @@
 from autogen import AssistantAgent, LLMConfig
 
 config = LLMConfig(
-    {"model": "gemini-3.1-flash-lite-preview", "api_type": "google"},
+    {"model": "gemini-3.1-flash-lite", "api_type": "google"},
 )
 
 researcher = AssistantAgent(

--- a/test/beta/providers/agent/conftest.py
+++ b/test/beta/providers/agent/conftest.py
@@ -56,7 +56,7 @@ def anthropic_config() -> AnthropicConfig:
 @pytest.fixture()
 def gemini_config() -> GeminiConfig:
     return GeminiConfig(
-        model="gemini-3.1-flash-lite-preview",
+        model="gemini-3.1-flash-lite",
         api_key=_require_gemini_key(),
         temperature=0,
     )
@@ -89,7 +89,7 @@ def streaming_config(request):
             streaming=True,
         )
     return GeminiConfig(
-        model="gemini-3.1-flash-lite-preview",
+        model="gemini-3.1-flash-lite",
         api_key=_require_gemini_key(),
         temperature=0,
         streaming=True,

--- a/test/beta/providers/gemini/test_gemini_integration.py
+++ b/test/beta/providers/gemini/test_gemini_integration.py
@@ -18,7 +18,7 @@ def gemini_config() -> GeminiConfig:
     api_key = os.getenv("GEMINI_API_KEY")
     if not api_key:
         pytest.skip("GEMINI_API_KEY not set")
-    return GeminiConfig(model="gemini-3.1-flash-lite-preview", api_key=api_key, temperature=0)
+    return GeminiConfig(model="gemini-3.1-flash-lite", api_key=api_key, temperature=0)
 
 
 @pytest.mark.gemini

--- a/website/docs/_blogs/2026-03-20-AG2-A2UI/index.mdx
+++ b/website/docs/_blogs/2026-03-20-AG2-A2UI/index.mdx
@@ -36,7 +36,7 @@ The [A2UI protocol](https://a2ui.org/) (Agent-to-Agent UI) solves this by defini
 from autogen import LLMConfig
 from autogen.agents.experimental import A2UIAgent
 
-llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite-preview"})
+llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite"})
 
 agent = A2UIAgent(
     name="ui_agent",
@@ -165,7 +165,7 @@ from autogen.a2a import A2aAgentServer, CardSettings
 from autogen.agents.experimental import A2UIAgent
 from autogen.agents.experimental.a2ui import A2UIAction
 
-llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite-preview"})
+llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite"})
 
 agent = A2UIAgent(
     name="social_previewer",

--- a/website/docs/user-guide/a2a/a2ui.mdx
+++ b/website/docs/user-guide/a2a/a2ui.mdx
@@ -22,7 +22,7 @@ from autogen import LLMConfig
 from autogen.agents.experimental import A2UIAgent
 from autogen.a2a import A2aAgentServer, CardSettings
 
-llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite-preview"})
+llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite"})
 
 agent = A2UIAgent(
     name="ui_agent",

--- a/website/docs/user-guide/reference-agents/a2uiagent.mdx
+++ b/website/docs/user-guide/reference-agents/a2uiagent.mdx
@@ -51,7 +51,7 @@ Then create an agent:
 from autogen import LLMConfig
 from autogen.agents.experimental import A2UIAgent
 
-llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite-preview"})
+llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite"})
 
 agent = A2UIAgent(
     name="ui_agent",
@@ -224,7 +224,7 @@ from autogen import LLMConfig
 from autogen.a2a import A2aAgentServer, CardSettings
 from autogen.agents.experimental import A2UIAgent
 
-llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite-preview"})
+llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite"})
 
 agent = A2UIAgent(
     name="ui_agent",


### PR DESCRIPTION
## Why are these changes needed?

Google's `gemini-3.1-flash-lite-preview` has been deprecated and should now be `gemini-3.1-flash-lite`, this PR updates it repo-wide.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [ ] I understand the changes in this PR and can explain them in my own words.
- [ ] I have verified that the PR description accurately reflects the actual diff.
- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
