### PR TITLE
fix(beta): omit empty parameters in OpenAI configs

### DIFF
--- a/autogen/beta/config/openai/config.py
+++ b/autogen/beta/config/openai/config.py
@@ -158,11 +158,11 @@ class OpenAIResponsesConfigOverrides(TypedDict, total=False):
     model: ChatModel | str
     api_key: str | None
     base_url: str | None
-    temperature: float | None
-    top_p: float | None
+    temperature: float | None | Omit
+    top_p: float | None | Omit
     streaming: bool
-    max_output_tokens: int | None
-    max_tool_calls: int | None
+    max_output_tokens: int | None | Omit
+    max_tool_calls: int | None | Omit
     store: bool | None
     websocket_base_url: str | None
     organization: str | None
@@ -173,11 +173,11 @@ class OpenAIResponsesConfigOverrides(TypedDict, total=False):
     default_query: dict[str, object] | None
     http_client: httpx.AsyncClient | None
     parallel_tool_calls: bool
-    top_logprobs: int | None
-    metadata: dict[str, str] | None
-    service_tier: str | None
+    top_logprobs: int | None | Omit
+    metadata: dict[str, str] | None | Omit
+    service_tier: str | None | Omit
     user: str
-    truncation: str | None
+    truncation: str | None | Omit
 
 
 @dataclass(slots=True)
@@ -185,11 +185,11 @@ class OpenAIResponsesConfig(ModelConfig):
     model: ChatModel | str
     api_key: str | None = None
     base_url: str | None = None
-    temperature: float | None = None
-    top_p: float | None = None
+    temperature: float | None | Omit = omit
+    top_p: float | None | Omit = omit
     streaming: bool = False
-    max_output_tokens: int | None = None
-    max_tool_calls: int | None = None
+    max_output_tokens: int | None | Omit = omit
+    max_tool_calls: int | None | Omit = omit
     store: bool | None = True
     websocket_base_url: str | None = None
     organization: str | None = None
@@ -200,11 +200,11 @@ class OpenAIResponsesConfig(ModelConfig):
     default_query: dict[str, object] | None = None
     http_client: httpx.AsyncClient | None = None
     parallel_tool_calls: bool = True
-    top_logprobs: int | None = None
-    metadata: dict[str, str] | None = None
-    service_tier: str | None = None
+    top_logprobs: int | None | Omit = omit
+    metadata: dict[str, str] | None | Omit = omit
+    service_tier: str | None | Omit = omit
     user: str = ""
-    truncation: str | None = None
+    truncation: str | None | Omit = omit
 
     def copy(self, /, **overrides: Unpack[OpenAIResponsesConfigOverrides]) -> "OpenAIResponsesConfig":
         return replace(self, **overrides)

--- a/autogen/beta/config/openai/openai_client.py
+++ b/autogen/beta/config/openai/openai_client.py
@@ -123,7 +123,6 @@ class OpenAIClient(LLMClient):
             **self._create_options,
             **kwargs,
             messages=openai_messages,
-            # Omit `tools` when empty; strict OpenAI-compatible servers (e.g. vLLM) reject `tools: []`.
             tools=openai_tools or omit,
         )
 

--- a/autogen/beta/config/openai/openai_client.py
+++ b/autogen/beta/config/openai/openai_client.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, TypedDict
 
 import httpx
 from fast_depends.library.serializer import SerializerProto
-from openai import DEFAULT_MAX_RETRIES, AsyncOpenAI, AsyncStream, Omit, not_given
+from openai import DEFAULT_MAX_RETRIES, AsyncOpenAI, AsyncStream, Omit, not_given, omit
 from openai.types import ChatModel
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from typing_extensions import Required
@@ -123,7 +123,8 @@ class OpenAIClient(LLMClient):
             **self._create_options,
             **kwargs,
             messages=openai_messages,
-            tools=openai_tools,
+            # Omit `tools` when empty; strict OpenAI-compatible servers (e.g. vLLM) reject `tools: []`.
+            tools=openai_tools or omit,
         )
 
         if self._streaming:

--- a/autogen/beta/config/openai/openai_responses_client.py
+++ b/autogen/beta/config/openai/openai_responses_client.py
@@ -9,7 +9,7 @@ from typing import Any, TypedDict
 
 import httpx
 from fast_depends.library.serializer import SerializerProto
-from openai import DEFAULT_MAX_RETRIES, AsyncOpenAI, AsyncStream, not_given, omit
+from openai import DEFAULT_MAX_RETRIES, AsyncOpenAI, AsyncStream, Omit, not_given, omit
 from openai.types import ChatModel
 from openai.types.responses import (
     Response,
@@ -52,18 +52,18 @@ from .mappers import (
 class CreateOptions(TypedDict, total=False):
     model: Required[ChatModel | str]
 
-    temperature: float | None
-    top_p: float | None
-    max_output_tokens: int | None
-    max_tool_calls: int | None
+    temperature: float | None | Omit
+    top_p: float | None | Omit
+    max_output_tokens: int | None | Omit
+    max_tool_calls: int | None | Omit
     parallel_tool_calls: bool
-    top_logprobs: int | None
+    top_logprobs: int | None | Omit
     store: bool | None
-    metadata: dict[str, str] | None
-    service_tier: str | None
+    metadata: dict[str, str] | None | Omit
+    service_tier: str | None | Omit
     user: str
     stream: bool
-    truncation: str | None
+    truncation: str | None | Omit
 
 
 class OpenAIResponsesClient(LLMClient):

--- a/test/beta/config/openai/test_openai_client_tools.py
+++ b/test/beta/config/openai/test_openai_client_tools.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import httpx
+import pytest
+from fast_depends.use import SerializerCls
+
+from autogen.beta import Context, MemoryStream
+from autogen.beta.config.openai import OpenAIClient
+from autogen.beta.events import ModelRequest, TextInput
+from autogen.beta.tools.final.function_tool import FunctionDefinition, FunctionToolSchema
+
+
+def _capturing_client(captured: dict[str, object]) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "c1",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "gpt-4o",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _weather_tool() -> FunctionToolSchema:
+    return FunctionToolSchema(
+        function=FunctionDefinition(
+            name="get_weather",
+            description="Get weather",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_tools_omits_tools_field() -> None:
+    captured: dict[str, object] = {}
+    client = OpenAIClient(
+        api_key="test",
+        http_client=_capturing_client(captured),
+        create_options={"model": "gpt-4o"},
+    )
+
+    await client(
+        messages=[ModelRequest([TextInput("capital of France?")])],
+        context=Context(stream=MemoryStream()),
+        tools=[],
+        response_schema=None,
+        serializer=SerializerCls,
+    )
+
+    assert "tools" not in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_non_empty_tools_serialized() -> None:
+    captured: dict[str, object] = {}
+    client = OpenAIClient(
+        api_key="test",
+        http_client=_capturing_client(captured),
+        create_options={"model": "gpt-4o"},
+    )
+
+    await client(
+        messages=[ModelRequest([TextInput("weather?")])],
+        context=Context(stream=MemoryStream()),
+        tools=[_weather_tool()],
+        response_schema=None,
+        serializer=SerializerCls,
+    )
+
+    tools = captured["body"]["tools"]
+    assert isinstance(tools, list)
+    assert [t["function"]["name"] for t in tools] == ["get_weather"]

--- a/test/beta/config/openai/test_openai_client_tools.py
+++ b/test/beta/config/openai/test_openai_client_tools.py
@@ -11,7 +11,7 @@ from fast_depends.use import SerializerCls
 from autogen.beta import Context, MemoryStream
 from autogen.beta.config.openai import OpenAIClient
 from autogen.beta.events import ModelRequest, TextInput
-from autogen.beta.tools.final.function_tool import FunctionDefinition, FunctionToolSchema
+from autogen.beta.tools import tool
 
 
 def _capturing_client(captured: dict[str, object]) -> httpx.AsyncClient:
@@ -38,16 +38,6 @@ def _capturing_client(captured: dict[str, object]) -> httpx.AsyncClient:
     return httpx.AsyncClient(transport=httpx.MockTransport(handler))
 
 
-def _weather_tool() -> FunctionToolSchema:
-    return FunctionToolSchema(
-        function=FunctionDefinition(
-            name="get_weather",
-            description="Get weather",
-            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
-        )
-    )
-
-
 @pytest.mark.asyncio
 async def test_empty_tools_omits_tools_field() -> None:
     captured: dict[str, object] = {}
@@ -71,6 +61,14 @@ async def test_empty_tools_omits_tools_field() -> None:
 @pytest.mark.asyncio
 async def test_non_empty_tools_serialized() -> None:
     captured: dict[str, object] = {}
+    context = Context(stream=MemoryStream())
+
+    @tool(description="Get weather")
+    def get_weather(city: str) -> str:
+        return f"Weather in {city}"
+
+    [weather_schema] = await get_weather.schemas(context)
+
     client = OpenAIClient(
         api_key="test",
         http_client=_capturing_client(captured),
@@ -79,8 +77,8 @@ async def test_non_empty_tools_serialized() -> None:
 
     await client(
         messages=[ModelRequest([TextInput("weather?")])],
-        context=Context(stream=MemoryStream()),
-        tools=[_weather_tool()],
+        context=context,
+        tools=[weather_schema],
         response_schema=None,
         serializer=SerializerCls,
     )

--- a/test/beta/config/openai/test_openai_responses_client_options.py
+++ b/test/beta/config/openai/test_openai_responses_client_options.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import httpx
+import pytest
+from fast_depends.use import SerializerCls
+
+from autogen.beta import Context, MemoryStream
+from autogen.beta.config.openai import OpenAIResponsesConfig
+from autogen.beta.events import ModelRequest, TextInput
+
+# Optional generation params that must never be serialized as an explicit
+# `null`: strict OpenAI-compatible servers (e.g. vLLM) reject e.g.
+# `service_tier: null` / `truncation: null`. When unset they must be omitted.
+NULLABLE_OPTIONS = (
+    "temperature",
+    "top_p",
+    "max_output_tokens",
+    "max_tool_calls",
+    "top_logprobs",
+    "metadata",
+    "service_tier",
+    "truncation",
+)
+
+
+def _capturing_config(captured: dict[str, object], **overrides: object) -> OpenAIResponsesConfig:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp_1",
+                "object": "response",
+                "created_at": 0,
+                "model": "m",
+                "status": "completed",
+                "output": [],
+                "usage": None,
+                "parallel_tool_calls": True,
+                "tool_choice": "auto",
+                "tools": [],
+                "instructions": None,
+                "metadata": {},
+                "text": {"format": {"type": "text"}},
+            },
+        )
+
+    return OpenAIResponsesConfig(
+        model="m",
+        api_key="test",
+        base_url="http://test/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        **overrides,
+    )
+
+
+async def _request_body(captured: dict[str, object], **overrides: object) -> dict[str, object]:
+    client = _capturing_config(captured, **overrides).create()
+    await client(
+        messages=[ModelRequest([TextInput("capital of France?")])],
+        context=Context(stream=MemoryStream(), prompt=["You are a helpful assistant."]),
+        tools=[],
+        response_schema=None,
+        serializer=SerializerCls,
+    )
+    return captured["body"]  # type: ignore[return-value]
+
+
+@pytest.mark.asyncio
+async def test_unset_options_omitted_not_null() -> None:
+    captured: dict[str, object] = {}
+    body = await _request_body(captured)
+
+    for key in NULLABLE_OPTIONS:
+        assert key not in body, f"{key} should be omitted when unset, got {body.get(key)!r}"
+    assert [k for k, v in body.items() if v is None] == []
+
+
+@pytest.mark.asyncio
+async def test_set_options_serialized() -> None:
+    captured: dict[str, object] = {}
+    body = await _request_body(
+        captured,
+        temperature=0.7,
+        top_p=0.95,
+        service_tier="auto",
+        truncation="disabled",
+    )
+
+    assert body["temperature"] == 0.7
+    assert body["top_p"] == 0.95
+    assert body["service_tier"] == "auto"
+    assert body["truncation"] == "disabled"


### PR DESCRIPTION
## Why are these changes needed?

Some OpenAI API compatible providers (e.g. vLLM) follow a stricter ruleset than OpenAI's SDK does. An example is empty tools must be omitted rather than kept as an empty array.

This PR omits optional parameters, which is still compatible with OpenAI.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [ ] I understand the changes in this PR and can explain them in my own words.
- [ ] I have verified that the PR description accurately reflects the actual diff.
- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
