### PR TITLE
feat(perplexity): add X-Pplx-Integration attribution header

### DIFF
--- a/autogen/beta/tools/search/perplexity.py
+++ b/autogen/beta/tools/search/perplexity.py
@@ -4,6 +4,7 @@
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
+from importlib.metadata import version as metadata_version
 from typing import Annotated, Any, Literal, TypeAlias
 
 import httpx
@@ -29,6 +30,12 @@ SonarModel: TypeAlias = Literal[
 SearchMode: TypeAlias = Literal["web", "academic", "sec"]
 SearchContextSize: TypeAlias = Literal["low", "medium", "high"]
 RecencyFilter: TypeAlias = Literal["hour", "day", "week", "month", "year"]
+
+
+def _client_kwargs_with_integration_headers(client_kwargs: dict[str, Any]) -> dict[str, Any]:
+    default_headers = dict(client_kwargs.get("default_headers") or {})
+    default_headers["X-Pplx-Integration"] = f"ag2/{metadata_version('ag2')}"
+    return {**client_kwargs, "default_headers": default_headers}
 
 
 @dataclass(slots=True)
@@ -156,7 +163,11 @@ class PerplexitySearchToolkit(Toolkit):
             kwargs = {k: v for k, v in params.items() if v is not None}
 
             async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
-                sdk = AsyncPerplexity(api_key=api_key, http_client=http, **client_kwargs)
+                sdk = AsyncPerplexity(
+                    api_key=api_key,
+                    http_client=http,
+                    **_client_kwargs_with_integration_headers(client_kwargs),
+                )
                 raw = await sdk.search.create(query=query, **kwargs)
 
             raw_results: list[SearchAPIResult] = getattr(raw, "results", None) or []
@@ -235,7 +246,11 @@ class PerplexitySearchToolkit(Toolkit):
                 **kwargs,
             }
             async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
-                sdk = AsyncPerplexity(api_key=api_key, http_client=http, **client_kwargs)
+                sdk = AsyncPerplexity(
+                    api_key=api_key,
+                    http_client=http,
+                    **_client_kwargs_with_integration_headers(client_kwargs),
+                )
                 raw = await sdk.chat.completions.create(**create_kwargs)
 
             content: str | None = None

--- a/test/beta/tools/search/test_perplexity.py
+++ b/test/beta/tools/search/test_perplexity.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from importlib.metadata import version as metadata_version
 from typing import Any
 
 import httpx
@@ -23,6 +24,10 @@ from autogen.beta.tools.search.perplexity import (
 )
 
 PERPLEXITY_BASE_URL = "https://api.perplexity.ai"
+
+
+def _expected_integration_header_value() -> str:
+    return f"ag2/{metadata_version('ag2')}"
 
 
 def _tool_call_config(
@@ -238,7 +243,11 @@ class TestSearch:
     async def test_client_kwargs_forwarded_to_sdk(self) -> None:
         custom_url = "https://custom.perplexity.example"
         route = respx.post(f"{custom_url}/search").mock(return_value=httpx.Response(200, json=_search_response()))
-        toolkit = PerplexitySearchToolkit(api_key="test", base_url=custom_url)
+        toolkit = PerplexitySearchToolkit(
+            api_key="test",
+            base_url=custom_url,
+            default_headers={"X-Trace-Id": "abc-123"},
+        )
 
         agent = Agent(
             "a",
@@ -248,6 +257,8 @@ class TestSearch:
         await agent.ask("search")
 
         assert route.called
+        assert route.calls.last.request.headers["X-Pplx-Integration"] == _expected_integration_header_value()
+        assert route.calls.last.request.headers["X-Trace-Id"] == "abc-123"
 
     @respx.mock
     async def test_custom_tool_name_in_agent(self) -> None:
@@ -393,7 +404,11 @@ class TestAnswer:
         route = respx.post(f"{custom_url}/chat/completions").mock(
             return_value=httpx.Response(200, json=_chat_response())
         )
-        toolkit = PerplexitySearchToolkit(api_key="test", base_url=custom_url)
+        toolkit = PerplexitySearchToolkit(
+            api_key="test",
+            base_url=custom_url,
+            default_headers={"X-Trace-Id": "abc-123"},
+        )
 
         agent = Agent(
             "a",
@@ -403,6 +418,8 @@ class TestAnswer:
         await agent.ask("answer")
 
         assert route.called
+        assert route.calls.last.request.headers["X-Pplx-Integration"] == _expected_integration_header_value()
+        assert route.calls.last.request.headers["X-Trace-Id"] == "abc-123"
 
     @respx.mock
     async def test_custom_tool_name_in_agent(self) -> None:


### PR DESCRIPTION
## Summary

- Add the `X-Pplx-Integration: ag2/<version>` default header to Perplexity SDK client construction for both AG2 Perplexity tools.
- Merge the attribution header with user-supplied SDK `default_headers` so existing client customization remains intact.
- Assert the Search API and chat-completions requests propagate the attribution header to the underlying HTTP client.

## Motivation

The original Perplexity integration in #2752 added the tools but did not include this attribution header. The header lets Perplexity attribute Search API traffic back to AG2 through api-gateway logs and metrics. This is a no-op for users; it only adds an HTTP request header on Perplexity SDK calls.

## Testing

- `uv run pytest test/beta/tools/search/test_perplexity.py`
- `uv run ruff check autogen/beta/tools/search/perplexity.py test/beta/tools/search/test_perplexity.py`
- `uv run ruff format --check autogen/beta/tools/search/perplexity.py test/beta/tools/search/test_perplexity.py`

Note: current `main` does not contain `test/beta/tools/search/test_perplexity_search_api.py`; the Perplexity Search API and chat-completions coverage is consolidated in `test/beta/tools/search/test_perplexity.py`.

---
🤖 _Generated by [PSI](https://www.notion.so/perplexity-ai/HowTo-PSI-Perplexity-Super-Intelligence-29c6172b229b80d3a8ece89a6cfb6ae6)_
🧠 _Agent used: `codex`_
