### PR TITLE
fix(tools): preserve parameters_json_schema across context_variables tool rewrap (#1814)

### DIFF
--- a/autogen/agentchat/contrib/swarm_agent.py
+++ b/autogen/agentchat/contrib/swarm_agent.py
@@ -355,10 +355,16 @@ def _change_tool_context_variables_to_depends(
         description = current_tool._description
         agent.remove_tool_for_llm(current_tool)
 
-        # Recreate the tool without the context_variables parameter
+        # Recreate the tool without the context_variables parameter,
+        # preserving any user-supplied parameters_json_schema (issue #1814).
         tool_func = _modify_context_variables_param(current_tool._func, context_variables)
         tool_func = inject_params(tool_func)
-        new_tool = ConversableAgent._create_tool_if_needed(func_or_tool=tool_func, name=name, description=description)
+        new_tool = ConversableAgent._create_tool_if_needed(
+            func_or_tool=tool_func,
+            name=name,
+            description=description,
+            parameters_json_schema=current_tool.parameters_json_schema,
+        )
 
         # Re-register with the agent
         agent.register_for_llm()(new_tool)

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -3924,15 +3924,26 @@ class ConversableAgent(LLMAgent):
         func_or_tool: F | Tool,
         name: str | None,
         description: str | None,
+        parameters_json_schema: dict[str, Any] | None = None,
     ) -> Tool:
         if isinstance(func_or_tool, Tool):
             tool: Tool = func_or_tool
-            # create new tool object if name or description is not None
-            if name or description:
-                tool = Tool(func_or_tool=tool, name=name, description=description)
+            # create new tool object if name, description or parameters_json_schema is provided
+            if name or description or parameters_json_schema is not None:
+                tool = Tool(
+                    func_or_tool=tool,
+                    name=name,
+                    description=description,
+                    parameters_json_schema=parameters_json_schema,
+                )
         elif inspect.isfunction(func_or_tool):
             function: Callable[..., Any] = func_or_tool
-            tool = Tool(func_or_tool=function, name=name, description=description)
+            tool = Tool(
+                func_or_tool=function,
+                name=name,
+                description=description,
+                parameters_json_schema=parameters_json_schema,
+            )
         else:
             raise TypeError(f"'func_or_tool' must be a function or a Tool object, got '{type(func_or_tool)}' instead.")
         return tool

--- a/autogen/agentchat/group/group_tool_executor.py
+++ b/autogen/agentchat/group/group_tool_executor.py
@@ -140,10 +140,16 @@ class GroupToolExecutor(ConversableAgent):
             name = current_tool._name
             description = current_tool._description
 
-            # Recreate the tool without the context_variables parameter
+            # Recreate the tool without the context_variables parameter,
+            # preserving any user-supplied parameters_json_schema (issue #1814).
             tool_func = self._modify_context_variables_param(tool_func, context_variables)
             tool_func = inject_params(tool_func)
-            return ConversableAgent._create_tool_if_needed(func_or_tool=tool_func, name=name, description=description)
+            return ConversableAgent._create_tool_if_needed(
+                func_or_tool=tool_func,
+                name=name,
+                description=description,
+                parameters_json_schema=current_tool.parameters_json_schema,
+            )
         return None
 
     def _change_tool_context_variables_to_depends(

--- a/autogen/tools/tool.py
+++ b/autogen/tools/tool.py
@@ -51,6 +51,8 @@ class Tool:
             self._description: str = description or func_or_tool.description
             self._func: Callable[..., Any] = func_or_tool.func
             self._chat_context_param_names: list[str] = func_or_tool._chat_context_param_names
+            if parameters_json_schema is None:
+                parameters_json_schema = func_or_tool._parameters_json_schema
         elif inspect.isfunction(func_or_tool) or inspect.ismethod(func_or_tool):
             self._chat_context_param_names = get_context_params(func_or_tool, subclass=ChatContext)
             self._func = inject_params(func_or_tool)
@@ -61,12 +63,13 @@ class Tool:
                 f"Parameter 'func_or_tool' must be a function, method or a Tool instance, it is '{type(func_or_tool)}' instead."
             )
 
+        self._parameters_json_schema: dict[str, Any] | None = parameters_json_schema
         self._func_schema = (
             {
                 "type": "function",
                 "function": {
-                    "name": name,
-                    "description": description,
+                    "name": self._name,
+                    "description": self._description,
                     "parameters": parameters_json_schema,
                 },
             }
@@ -85,6 +88,10 @@ class Tool:
     @property
     def func(self) -> Callable[..., Any]:
         return self._func
+
+    @property
+    def parameters_json_schema(self) -> dict[str, Any] | None:
+        return self._parameters_json_schema
 
     def register_for_llm(self, agent: "ConversableAgent") -> None:
         """Registers the tool for use with a ConversableAgent's language model (LLM).

--- a/test/agentchat/group/test_group_tool_executor.py
+++ b/test/agentchat/group/test_group_tool_executor.py
@@ -170,6 +170,35 @@ class TestGroupToolExecutor:
             mock_agent.remove_tool_for_llm.assert_called_once_with(mock_tool)
             mock_agent.register_for_llm.assert_called_once()
 
+    def test_make_tool_copy_preserves_parameters_json_schema(self, executor: GroupToolExecutor) -> None:
+        """Pin issue #1814: user-supplied parameters_json_schema must survive
+        the context_variables rewrap performed by GroupToolExecutor."""
+
+        def real_tool_func(arg1: str, context_variables: ContextVariables) -> str:
+            return f"Result: {arg1}"
+
+        custom_schema = {
+            "type": "object",
+            "properties": {
+                "arg1": {"type": "string", "enum": ["a", "b"]},
+                "context_variables": {"type": "object"},
+            },
+            "required": ["arg1"],
+        }
+        original_tool = Tool(
+            name="enum_tool",
+            description="enum-using tool",
+            func_or_tool=real_tool_func,
+            parameters_json_schema=custom_schema,
+        )
+        assert original_tool.parameters_json_schema == custom_schema
+
+        new_tool = executor.make_tool_copy_with_context_variables(original_tool, ContextVariables())
+        assert new_tool is not None
+        assert new_tool.parameters_json_schema == custom_schema
+        assert new_tool._func_schema is not None
+        assert new_tool._func_schema["function"]["parameters"] == custom_schema
+
     def test_register_agents_functions(self, executor: GroupToolExecutor) -> None:
         """Test registering functions from multiple agents."""
         # Create mock agents with tools and function_map

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -60,3 +60,34 @@ class TestTool:
 
     def test__call__(self) -> None:
         assert self.tool("Hello") == "Hello!"
+
+    def test_parameters_json_schema_round_trip(self) -> None:
+        # Pin issue #1814: parameters_json_schema must survive Tool-from-Tool copies
+        # (which is the path _create_tool_if_needed takes when rewrapping a tool for
+        # context_variables dependency injection in group/swarm flows).
+        custom_schema = {
+            "type": "object",
+            "properties": {"x": {"type": "string", "enum": ["a", "b"]}},
+            "required": ["x"],
+        }
+
+        def f(x: str) -> str:
+            return x + "!"
+
+        original = Tool(name="enum_tool", description="enum-using tool", func_or_tool=f, parameters_json_schema=custom_schema)
+        assert original.parameters_json_schema == custom_schema
+        assert original._func_schema is not None
+        assert original._func_schema["function"]["parameters"] == custom_schema
+
+        # Copy without explicit parameters_json_schema must carry the original through.
+        copied = Tool(func_or_tool=original)
+        assert copied.parameters_json_schema == custom_schema
+        assert copied._func_schema is not None
+        assert copied._func_schema["function"]["parameters"] == custom_schema
+
+        # Explicit override on copy still wins.
+        override_schema = {"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]}
+        overridden = Tool(func_or_tool=original, parameters_json_schema=override_schema)
+        assert overridden.parameters_json_schema == override_schema
+        assert overridden._func_schema is not None
+        assert overridden._func_schema["function"]["parameters"] == override_schema


### PR DESCRIPTION
## Summary

Closes ag2ai/ag2classic#44.

When a `Tool` was created with a user-supplied `parameters_json_schema` and then a swarm / group flow rewrapped it to inject `context_variables` via dependency injection, the replacement tool dropped the schema:

- `GroupToolExecutor.make_tool_copy_with_context_variables` (`autogen/agentchat/group/group_tool_executor.py`)
- `swarm_agent._change_tool_context_variables_to_depends` (`autogen/agentchat/contrib/swarm_agent.py`)

Both call `ConversableAgent._create_tool_if_needed` without forwarding `current_tool.parameters_json_schema`, so the new tool is registered as a function and the user's metadata (e.g. `Enum` on a parameter) is lost — exactly what the issue describes.

Also fixed a latent typo in `Tool.__init__`: `_func_schema` was built from the unresolved kwarg `name`/`description` instead of the resolved `self._name`/`self._description`, so a `Tool`-from-`Tool` copy that supplied `parameters_json_schema` but no overrides emitted a schema with `name=None`/`description=None`.

## Changes

- `Tool`: store `parameters_json_schema` as `_parameters_json_schema`, expose via property, carry it through the `Tool`-from-`Tool` branch, build `_func_schema` from resolved `self._name`/`self._description`.
- `_create_tool_if_needed`: accept and forward `parameters_json_schema`.
- Both context-variables rewrap sites: pass `current_tool.parameters_json_schema` through.

## Test plan

- [x] New `TestTool.test_parameters_json_schema_round_trip` pinning Tool-from-Tool copy preserves and overrides the schema.
- [x] New `TestGroupToolExecutor.test_make_tool_copy_preserves_parameters_json_schema` pinning the rewrap path keeps the schema.
- [x] Full `test/agentchat/group/`, `test/agentchat/contrib/test_swarm.py`, `test/tools/test_tool.py`, `test/tools/test_toolkit.py` green locally (494/494) including the existing `test_change_tool_context_variables_*` set.
- [x] `ruff check` clean on touched files.