### PR TITLE
fix(llm_config): pin config_list_from_json file reads to UTF-8

### DIFF
--- a/autogen/llm_config/utils.py
+++ b/autogen/llm_config/utils.py
@@ -56,7 +56,12 @@ def config_list_from_json(
         # The environment variable exists. We should use information from it.
         if os.path.exists(env_str):  # noqa: SIM108
             # It is a file location, and we need to load the json from the file.
-            json_str = Path(env_str).read_text()
+            # Pin UTF-8 so the read works on platforms whose default
+            # `locale.getencoding()` is not UTF-8 (notably Windows, where the
+            # default is cp1252 / cp932 and a non-ASCII byte in the JSON file
+            # raises UnicodeDecodeError mid-load). JSON is defined over UTF-8
+            # (RFC 8259 §8.1), so this matches the file's documented contract.
+            json_str = Path(env_str).read_text(encoding="utf-8")
         else:
             # Else, it should be a JSON string by itself.
             json_str = env_str
@@ -67,7 +72,10 @@ def config_list_from_json(
         # So, `env_or_file` is a filename. We should use the file location.
         config_list_path = Path(file_location) / env_or_file if file_location else Path(env_or_file)
 
-        with open(config_list_path) as json_file:
+        # Same UTF-8 pin as above — the JSON config file may carry non-ASCII
+        # bytes (vendor display names, custom labels) which crash on Windows
+        # without an explicit encoding.
+        with open(config_list_path, encoding="utf-8") as json_file:
             config_list = json.load(json_file)
 
     return filter_config(config_list, filter_dict)

--- a/test/oai/test_utils.py
+++ b/test/oai/test_utils.py
@@ -299,6 +299,35 @@ def test_config_list_from_json():
         config_list_from_json("OAI_CONFIG_LIST.missing")
 
 
+def test_config_list_from_json_handles_non_ascii_payload(tmp_path):
+    # Regression for the encoding pin in config_list_from_json: on platforms
+    # whose default `locale.getencoding()` is not UTF-8 (notably Windows,
+    # which defaults to cp1252 / cp932), reading a JSON config that carries
+    # non-ASCII bytes (here: a Chinese display name and a French model
+    # alias) without an explicit encoding raises UnicodeDecodeError mid-load.
+    # JSON is defined over UTF-8 (RFC 8259 §8.1), so the loader must pass
+    # encoding="utf-8" to both the `read_text()` and the `open()` paths.
+    payload = [
+        {"model": "gpt-4", "api_key": "k1", "display_name": "智能助手"},
+        {"model": "le-modèle", "api_key": "k2"},
+    ]
+    config_file = tmp_path / "config_list.json"
+    config_file.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    # 1) Direct file-path argument exercises the `open()` branch.
+    by_path = config_list_from_json(str(config_file))
+    assert by_path == payload
+
+    # 2) Same file referenced via an env var exercises the `read_text()` branch.
+    env_var = "CONFIG_LIST_TEST_NON_ASCII"
+    os.environ[env_var] = str(config_file)
+    try:
+        by_env = config_list_from_json(env_var)
+        assert by_env == payload
+    finally:
+        del os.environ[env_var]
+
+
 def test_config_list_openai_aoai():
     # Testing the functionality for loading configurations for different API types
     # and ensuring the API types in the loaded configurations are as expected.


### PR DESCRIPTION
## Problem

`config_list_from_json` in `autogen/llm_config/utils.py` reads JSON either via:

- `Path(env_str).read_text()` — when the env-var branch points at a file path (line 59).
- `open(config_list_path) as json_file` — when `env_or_file` is treated as a filename (line 70).

Neither call passes an explicit encoding, so on platforms whose default `locale.getencoding()` is not UTF-8 (notably Windows, which defaults to cp1252 / cp932) a non-ASCII byte in the config file — a Chinese display name, a French model alias, etc. — raises `UnicodeDecodeError` mid-load and the loader fails before any config is returned.

JSON is defined over UTF-8 (RFC 8259 §8.1), so the loader should match the file's documented contract.

## Change

- `autogen/llm_config/utils.py` — pass `encoding="utf-8"` to both file-read sites in `config_list_from_json`. No other behavioural changes.
- `test/oai/test_utils.py` — new regression test `test_config_list_from_json_handles_non_ascii_payload` writing a JSON config with both Chinese (`"智能助手"`) and accented Latin (`"le-modèle"`) characters and asserting both branches (direct file-path argument and env-var-pointing-at-file) parse correctly.

Same pattern as the previously-merged UTF-8 encoding pins (#2815, #2818, #2819, #2825, #2826, #2827).

## Validation

- `uv run python -m pytest test/oai/test_utils.py::test_config_list_from_json test/oai/test_utils.py::test_config_list_from_json_handles_non_ascii_payload -v` — **2/2 pass**.
- `uv run ruff check autogen/llm_config/utils.py test/oai/test_utils.py` — clean.
- `uv run ruff format --check autogen/llm_config/utils.py test/oai/test_utils.py` — already formatted.

## AI assistance

Diff drafted with assistance and reviewed end-to-end against the existing UTF-8 pin convention used in the surrounding codebase. The regression test exercises the actual failure mode (mixed-script bytes through both code paths) rather than synthetic markers.
