### PR TITLE
fix(oai): pin config_list_from_dotenv temp JSON write to UTF-8

### DIFF
--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -612,7 +612,15 @@ def config_list_from_dotenv(
 
     fd, temp_name = tempfile.mkstemp()
     try:
-        with os.fdopen(fd, "w+") as temp:
+        # Pin UTF-8 so the temp JSON written here round-trips correctly on
+        # platforms whose default `locale.getencoding()` is not UTF-8 —
+        # notably Windows, which defaults to cp1252 / cp932. A non-ASCII
+        # byte in the env-derived configuration (model display name,
+        # vendor label, etc.) would otherwise raise UnicodeEncodeError on
+        # write or be silently mangled, and the matching
+        # `latest_config_list_from_json` read assumes the same UTF-8
+        # contract (RFC 8259 §8.1).
+        with os.fdopen(fd, "w+", encoding="utf-8") as temp:
             env_var_str = json.dumps(env_var)
             temp.write(env_var_str)
             temp.flush()

--- a/test/oai/test_utils.py
+++ b/test/oai/test_utils.py
@@ -481,6 +481,37 @@ def test_config_list_from_dotenv(mock_os_environ, caplog):
         assert "API key not found or empty for a model" in caplog.text
 
 
+def test_config_list_from_dotenv_handles_non_ascii_model_label(mock_os_environ):
+    # Regression for the encoding pin on the os.fdopen(..., "w+") used to
+    # bridge config_list_from_dotenv to latest_config_list_from_json.
+    # The function serialises the env-derived config dict to JSON inside
+    # that temp file. On platforms whose default `locale.getencoding()` is
+    # not UTF-8 (notably Windows, which defaults to cp1252 / cp932), a
+    # non-ASCII byte in any field — here, a Chinese display name and a
+    # French model alias — raises UnicodeEncodeError on write or is
+    # silently mangled on the matching read. JSON is defined over UTF-8
+    # (RFC 8259 §8.1) so both ends of the round-trip pin encoding="utf-8".
+    fd, temp_name = tempfile.mkstemp()
+    try:
+        with os.fdopen(fd, "w+") as temp:
+            temp.write("\n".join([f"{k}={v}" for k, v in ENV_VARS.items()]))
+            temp.flush()
+            non_ascii_map = {
+                "le-modèle": "OPENAI_API_KEY",
+                "智能助手": "OPENAI_API_KEY",
+            }
+            config_list = autogen.config_list_from_dotenv(
+                dotenv_file_path=temp_name,
+                model_api_key_map=non_ascii_map,
+            )
+            assert config_list, "Non-ASCII model labels should still round-trip through the temp JSON"
+            models = {config["model"] for config in config_list}
+            assert "le-modèle" in models
+            assert "智能助手" in models
+    finally:
+        os.remove(temp_name)
+
+
 def test_get_config_list():
     # Define a list of API keys and corresponding base URLs
     api_keys = ["key1", "key2", "key3"]


### PR DESCRIPTION
## Problem

`config_list_from_dotenv` in `autogen/oai/openai_utils.py` bridges its env-derived configuration to `latest_config_list_from_json` by writing a JSON payload into a temp file via `os.fdopen(fd, "w+")` and then re-reading it from the same path. The write side did not pin an explicit encoding, so on platforms whose default `locale.getencoding()` is not UTF-8 — notably Windows, which defaults to cp1252 / cp932 — a non-ASCII byte in any field (model display name, vendor label, etc.) either raises `UnicodeEncodeError` on the write or is silently mangled, and the matching reader (covered in the sibling PR #2909 on `config_list_from_json`) assumes the same UTF-8 contract.

JSON is defined over UTF-8 (RFC 8259 §8.1), so both ends of the round-trip should pin the same encoding.

## Change

- `autogen/oai/openai_utils.py` — pass `encoding="utf-8"` to the `os.fdopen` call. No other behavioural changes.
- `test/oai/test_utils.py` — new regression test `test_config_list_from_dotenv_handles_non_ascii_model_label` writing the temp round-trip with both Chinese (`"智能助手"`) and accented Latin (`"le-modèle"`) model labels and asserting both appear in the returned config list.

Same pattern as the previously-merged UTF-8 encoding pins (#2815, #2818, #2819, #2825, #2826, #2827) and pairs with the read-side pin in #2909.

## Validation

- `uv run python -m pytest test/oai/test_utils.py::test_config_list_from_dotenv test/oai/test_utils.py::test_config_list_from_dotenv_handles_non_ascii_model_label -v` — **2/2 pass**.
- `uv run ruff check autogen/oai/openai_utils.py test/oai/test_utils.py` — clean.
- `uv run ruff format --check autogen/oai/openai_utils.py test/oai/test_utils.py` — already formatted.

## AI assistance

Diff drafted with assistance and reviewed end-to-end against the existing UTF-8 pin convention used in the surrounding codebase. The regression test exercises the temp-JSON round-trip with mixed-script bytes, mirroring the read-side test added in #2909.
