### PR TITLE
fix(a2ui): pin schema_manager file reads to UTF-8

### DIFF
--- a/autogen/agents/experimental/a2ui/schema_manager.py
+++ b/autogen/agents/experimental/a2ui/schema_manager.py
@@ -102,7 +102,14 @@ class A2UISchemaManager:
                 self._custom_catalog = custom_catalog
             else:
                 path = Path(custom_catalog)
-                with open(path) as f:
+                # Pin UTF-8 so the catalog file loads consistently across
+                # platforms whose default `locale.getencoding()` is not UTF-8
+                # (notably Windows, which defaults to cp1252 / cp932). A2UI
+                # catalogs routinely carry non-ASCII display labels and
+                # localized component descriptions; JSON is defined over
+                # UTF-8 (RFC 8259 §8.1), so this matches the file's
+                # documented contract.
+                with open(path, encoding="utf-8") as f:
                     self._custom_catalog = json.load(f)
 
         # Set catalog ID from custom catalog's $id or default
@@ -225,7 +232,12 @@ class A2UISchemaManager:
     def _load_spec_json(self, filename: str) -> dict[str, Any]:
         """Load a JSON file from the spec/ subdirectory (upstream A2UI files)."""
         path = self._spec_dir / filename
-        with open(path) as f:
+        # Pin UTF-8 — A2UI spec JSON files (catalogs, common types) carry
+        # non-ASCII bytes (localized descriptions, vendor labels) and the
+        # JSON format itself is UTF-8 per RFC 8259 §8.1. Without this the
+        # load fails on platforms whose default `locale.getencoding()` is
+        # not UTF-8 (notably Windows: cp1252 / cp932).
+        with open(path, encoding="utf-8") as f:
             data: dict[str, Any] = json.load(f)
             return data
 
@@ -233,14 +245,16 @@ class A2UISchemaManager:
         """Load a text file from the spec/ subdirectory (upstream A2UI files)."""
         path = self._spec_dir / filename
         if path.exists():
-            with open(path) as f:
+            # Same UTF-8 pin as the JSON loaders above — the .md rule files
+            # under spec/ carry non-ASCII characters in tables and examples.
+            with open(path, encoding="utf-8") as f:
                 return f.read().strip()
         return ""
 
     def _load_version_json(self, filename: str) -> list[Any] | dict[str, Any]:
         """Load a JSON file from the version directory (our files)."""
         path = self._version_dir / filename
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             result: list[Any] | dict[str, Any] = json.load(f)
             return result
 
@@ -248,7 +262,7 @@ class A2UISchemaManager:
         """Load a text file from the version directory (our files)."""
         path = self._version_dir / filename
         if path.exists():
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 return f.read().strip()
         return ""
 

--- a/test/agents/experimental/a2ui/test_schema_manager.py
+++ b/test/agents/experimental/a2ui/test_schema_manager.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -101,7 +102,7 @@ class TestA2UISchemaManager:
         assert "<<<A2UI>>>" in prompt
         assert "---a2ui_JSON---" not in prompt
 
-    def test_custom_catalog_file_load_handles_non_ascii(self, tmp_path) -> None:
+    def test_custom_catalog_file_load_handles_non_ascii(self, tmp_path: Path) -> None:
         # Regression for the UTF-8 encoding pins on the open() calls inside
         # A2UISchemaManager. A2UI catalogs commonly carry non-ASCII bytes
         # (localized component descriptions, vendor labels), and the JSON

--- a/test/agents/experimental/a2ui/test_schema_manager.py
+++ b/test/agents/experimental/a2ui/test_schema_manager.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+
 import pytest
 
 from autogen.agents.experimental.a2ui.schema_manager import A2UISchemaManager
@@ -98,3 +100,31 @@ class TestA2UISchemaManager:
         prompt = manager.generate_prompt_section(response_delimiter="<<<A2UI>>>")
         assert "<<<A2UI>>>" in prompt
         assert "---a2ui_JSON---" not in prompt
+
+    def test_custom_catalog_file_load_handles_non_ascii(self, tmp_path) -> None:
+        # Regression for the UTF-8 encoding pins on the open() calls inside
+        # A2UISchemaManager. A2UI catalogs commonly carry non-ASCII bytes
+        # (localized component descriptions, vendor labels), and the JSON
+        # format itself is UTF-8 per RFC 8259 §8.1. On platforms whose
+        # default locale.getencoding() is not UTF-8 — notably Windows,
+        # which defaults to cp1252 / cp932 — the load fails mid-parse
+        # without an explicit encoding="utf-8".
+        custom_catalog = {
+            "$id": "https://例.com/catalogue.json",
+            "components": {
+                "Bouton": {
+                    "type": "object",
+                    "description": "Composant interactif — étiquette: 智能按钮",
+                }
+            },
+        }
+        catalog_path = tmp_path / "catalogue.json"
+        catalog_path.write_text(json.dumps(custom_catalog, ensure_ascii=False), encoding="utf-8")
+
+        manager = A2UISchemaManager(custom_catalog=str(catalog_path))
+        loaded = manager.custom_catalog_schema
+        assert loaded is not None
+        assert loaded["$id"] == "https://例.com/catalogue.json"
+        bouton = loaded["components"]["Bouton"]
+        assert bouton["description"] == "Composant interactif — étiquette: 智能按钮"
+        assert manager.catalog_id == "https://例.com/catalogue.json"


### PR DESCRIPTION
## Problem

`A2UISchemaManager` in `autogen/agents/experimental/a2ui/schema_manager.py` loads JSON and text files from disk through five call sites:

- the custom catalog file passed by the caller (line 105);
- `_load_spec_json` and `_load_spec_text` reading the upstream A2UI spec bundle (lines 228, 236);
- `_load_version_json` and `_load_version_text` reading the version-pinned schemas (lines 243, 251).

None of these passed an explicit encoding, so on platforms whose default `locale.getencoding()` is not UTF-8 — notably Windows, which defaults to cp1252 / cp932 — non-ASCII bytes in catalog descriptions, component labels, or rule files raise `UnicodeDecodeError` mid-load and `A2UISchemaManager.__init__` fails before the manager can be constructed.

JSON is defined over UTF-8 (RFC 8259 §8.1), and the `.md` rule files follow the same convention.

## Change

- `autogen/agents/experimental/a2ui/schema_manager.py` — pass `encoding="utf-8"` at every file-read call site. No behavioural changes.
- `test/agents/experimental/a2ui/test_schema_manager.py` — new regression test `test_custom_catalog_file_load_handles_non_ascii` writing a catalog with Chinese (`"智能按钮"`) and accented Latin (`"Composant interactif — étiquette"`) characters across both the catalog `$id` and a nested component description, then asserting the loaded schema round-trips bit-for-bit.

Same pattern as the previously-merged UTF-8 encoding pins (#2815, #2818, #2819, #2825, #2826, #2827) and the matching pins in #2909 / #2910.

## Validation

- `uv run python -m pytest test/agents/experimental/a2ui/test_schema_manager.py -v` — **15/15 pass** (including new test).
- `uv run ruff check autogen/agents/experimental/a2ui/schema_manager.py test/agents/experimental/a2ui/test_schema_manager.py` — clean.
- `uv run ruff format --check ...` — already formatted.

Note: the `a2ui` test module is gated on the `a2a` optional dependency (`a2a-sdk>=1.0.0,<2`); installed locally via `uv pip install` before running the suite.

## AI assistance

Diff drafted with assistance and reviewed end-to-end against the existing UTF-8 pin convention used in the surrounding codebase. The regression test exercises the catalog file-load branch with mixed-script bytes through both the `$id` and a nested component description, mirroring the read-side tests added in #2909 / #2910.
