### PR TITLE
fix(safeguards): pin _load_policy file load to UTF-8

### DIFF
--- a/autogen/agentchat/group/safeguards/enforcer.py
+++ b/autogen/agentchat/group/safeguards/enforcer.py
@@ -111,7 +111,15 @@ class SafeguardEnforcer:
     def _load_policy(self, policy: dict[str, Any] | str) -> dict[str, Any]:
         """Load policy from file or use provided dict."""
         if isinstance(policy, str):
-            with open(policy) as f:
+            # Pin UTF-8 so policy files load on platforms whose default
+            # `locale.getencoding()` is not UTF-8 (notably Windows, which
+            # defaults to cp1252 / cp932). JSON is defined over UTF-8 per
+            # RFC 8259 §8.1, and safeguard policies routinely carry
+            # non-ASCII content (localized rule descriptions, regex
+            # patterns matching non-Latin text, agent names in mixed
+            # scripts) where the locale-default decoder raises
+            # `UnicodeDecodeError` mid-parse.
+            with open(policy, encoding="utf-8") as f:
                 result: dict[str, Any] = json.load(f)
                 return result
         return policy

--- a/test/agentchat/group/test_safeguards.py
+++ b/test/agentchat/group/test_safeguards.py
@@ -52,6 +52,38 @@ class TestSafeguardEnforcer:
             enforcer = SafeguardEnforcer(policy="/fake/path/policy.json")
             assert enforcer.policy == policy_content
 
+    def test_policy_file_loading_handles_non_ascii_payload(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        # Regression for the UTF-8 encoding pin on `_load_policy`. Safeguard
+        # policies routinely carry non-ASCII content (localized rule
+        # descriptions, regex patterns against non-Latin text, agent names
+        # in mixed scripts), and the JSON format itself is UTF-8 per
+        # RFC 8259 §8.1. On platforms whose default `locale.getencoding()`
+        # is not UTF-8 — notably Windows, which defaults to cp1252 / cp932 —
+        # the load fails mid-parse without an explicit `encoding="utf-8"`.
+        policy_content: dict[str, Any] = {
+            "inter_agent_safeguards": {
+                "agent_transitions": [
+                    {
+                        "message_source": "代理_alpha",
+                        "message_destination": "agent_bêta",
+                        "check_method": "regex",
+                        "pattern": r"\b(秘密|secret|geheim)\b",
+                        "violation_response": "block",
+                        "description": "Bloquer la fuite de données — 防止数据泄露",
+                    }
+                ]
+            }
+        }
+        policy_path = tmp_path / "policy.json"
+        policy_path.write_text(json.dumps(policy_content, ensure_ascii=False), encoding="utf-8")
+
+        enforcer = SafeguardEnforcer(policy=str(policy_path))
+        loaded_rules = enforcer.policy["inter_agent_safeguards"]["agent_transitions"]
+        assert loaded_rules[0]["message_source"] == "代理_alpha"
+        assert loaded_rules[0]["message_destination"] == "agent_bêta"
+        assert loaded_rules[0]["pattern"] == r"\b(秘密|secret|geheim)\b"
+        assert loaded_rules[0]["description"] == "Bloquer la fuite de données — 防止数据泄露"
+
     def test_missing_required_fields(self) -> None:
         """Test validation fails when required fields are missing."""
         invalid_policy = {"inter_agent_safeguards": {"agent_transitions": [{"message_source": "agent1"}]}}


### PR DESCRIPTION
## Why are these changes needed?

`SafeguardEnforcer._load_policy` (`autogen/agentchat/group/safeguards/enforcer.py`) loads a policy JSON file with:

```python
with open(policy) as f:
    result: dict[str, Any] = json.load(f)
```

No explicit `encoding=` is passed, so the file is decoded with Python's default text-mode encoding from `locale.getencoding()`. JSON is defined to be UTF-8 (RFC 8259 §8.1), but on platforms whose default locale codec is not UTF-8 — notably Windows, which defaults to `cp1252` / `cp932` — the read inherits the system codec instead of the format's contract.

Safeguard policies routinely carry non-ASCII content:

- localized rule descriptions
- regex `pattern` strings matching non-Latin text (CJK, diacritics)
- `message_source` / `message_destination` referencing agent names in mixed scripts

Loading such a policy on a non-UTF-8 locale raises `UnicodeDecodeError` mid-parse before `json.loads` ever sees the payload, even though the file is well-formed JSON on disk.

The same UTF-8 pin has already been applied to other ag2 file-IO sites that load JSON / text artifacts (`coding/jupyter`, `mcp/mcp_proxy`, `environments`, `beta/filesystem`, etc.) — this PR is the same fix for the safeguard policy loader.

## Related issue number

None — surfaced while auditing remaining unpinned text-IO call sites in `autogen/`. Follows the same fix shape as #2818 / #2825 / #2826 / #2827.

## Checks

- [x] I've made sure all auto checks have passed.
- [x] I've added tests (if relevant) or made sure my change didn't break any existing tests.
- [x] I've checked the documentation and made changes (in `website/`) if required.

## Validation

```
$ uv run pytest test/agentchat/group/test_safeguards.py -x -q
........................                                                 [100%]
24 passed, 7 warnings in 0.19s
$ uv run ruff check autogen/agentchat/group/safeguards/enforcer.py test/agentchat/group/test_safeguards.py
All checks passed!
$ uv run ruff format --check autogen/agentchat/group/safeguards/enforcer.py test/agentchat/group/test_safeguards.py
2 files already formatted
```

The new test (`test_policy_file_loading_handles_non_ascii_payload`) round-trips a policy carrying mixed Chinese / French metadata (`代理_alpha`, `agent_bêta`, `\b(秘密|secret|geheim)\b`, `Bloquer la fuite de données — 防止数据泄露`) through a real `tmp_path` file. Without the encoding pin this round-trip raises `UnicodeDecodeError` on Windows default locales.

## AI assistance disclosure

Per `.github/AI_POLICY.md`: this patch was drafted with AI assistance. Diff hand-reviewed; failure mode reproduced by reading the call site (`open(policy)` with no `encoding=`); test exercises both the pinned read and the non-ASCII round-trip on disk. I'm happy to expand on the rationale or revise the diff in review.