### PR TITLE
fix(captainagent): read agent library and cached config JSON as UTF-8

### DIFF
--- a/autogen/agentchat/contrib/captainagent/agent_builder.py
+++ b/autogen/agentchat/contrib/captainagent/agent_builder.py
@@ -562,7 +562,7 @@ Match roles in the role set to each expert in expert set.
         try:
             agent_library = json.loads(library_path_or_json)
         except json.decoder.JSONDecodeError:
-            with open(library_path_or_json) as f:
+            with open(library_path_or_json, encoding="utf-8") as f:
                 agent_library = json.load(f)
         except Exception as e:
             raise e
@@ -761,7 +761,7 @@ Match roles in the role set to each expert in expert set.
         # load from path.
         if filepath is not None:
             print(colored(f"Loading config from {filepath}", "green"), flush=True)
-            with open(filepath) as f:
+            with open(filepath, encoding="utf-8") as f:
                 cached_configs = json.load(f)
 
         _config_check(cached_configs)


### PR DESCRIPTION
## Why

`AgentBuilder` (`autogen/agentchat/contrib/captainagent/agent_builder.py`) loads two JSON files with a bare `open()` and no `encoding`:

- the agent library (`open(library_path_or_json)`, line ~565)
- the cached config (`open(filepath)`, line ~764)

With no explicit encoding the read uses the platform default — `cp1252` / `gbk` on Windows. Both files are JSON, which is UTF-8 by default per [RFC 8259 §8.1](https://www.rfc-editor.org/rfc/rfc8259#section-8.1), and agent libraries routinely carry non-ASCII text (localized agent names/descriptions). On a non-UTF-8 locale the load fails with `UnicodeDecodeError`.

## Change

Pin `encoding="utf-8"` on both reads. No behavior change on UTF-8 locales. Same fix already applied across other AG2 file IO.

## Validation

`python -m ast` parse clean; reads of agent-library / cached-config JSON containing non-ASCII now succeed independent of `locale.getpreferredencoding()`. Existing ASCII configs are unaffected.