### PR TITLE
fix(captainagent): read tool Python file as UTF-8 in get_full_tool_description

### DIFF
--- a/autogen/agentchat/contrib/captainagent/tool_retriever.py
+++ b/autogen/agentchat/contrib/captainagent/tool_retriever.py
@@ -277,7 +277,7 @@ def _wrap_function(func):
 @export_module("autogen.agentchat.contrib.captainagent")
 def get_full_tool_description(py_file):
     """Retrieves the function signature for a given Python file."""
-    with open(py_file) as f:
+    with open(py_file, encoding="utf-8") as f:
         code = f.read()
         exec(code)
         function_name = os.path.splitext(os.path.basename(py_file))[0]


### PR DESCRIPTION
## Why

`get_full_tool_description` (`autogen/agentchat/contrib/captainagent/tool_retriever.py`) opens the tool's Python file with a bare `open(py_file)` and no `encoding`, then reads and execs it. With no explicit encoding the read uses the platform default (`cp1252` / `gbk` on Windows). Python source files are UTF-8 by default ([PEP 263](https://peps.python.org/pep-0263/)) and tool files can contain non-ASCII characters in comments or string literals, so on a non-UTF-8 locale the read fails with `UnicodeDecodeError` before the tool can be loaded.

## Change

Pin `encoding="utf-8"` on the read so it matches Python's own source encoding default regardless of platform locale. No behavior change on UTF-8 locales.

## Validation

`python -m ast` parse clean; reading a tool file containing non-ASCII (e.g. a unicode docstring) now succeeds independent of `locale.getpreferredencoding()`.