### PR TITLE
fix(graph_rag/neo4j): read knowledge-graph text document as UTF-8

### DIFF
--- a/autogen/agentchat/contrib/graph_rag/neo4j_native_graph_query_engine.py
+++ b/autogen/agentchat/contrib/graph_rag/neo4j_native_graph_query_engine.py
@@ -199,7 +199,7 @@ class Neo4jNativeGraphQueryEngine:
         for doc in input_doc:
             if doc.doctype == DocumentType.TEXT:
                 # todo: we assume this is a path, and not URL
-                with open(doc.path_or_url) as file:  # type: ignore[arg-type]
+                with open(doc.path_or_url, encoding="utf-8") as file:  # type: ignore[arg-type]
                     text = file.read()
                 asyncio.run(self.text_kg_builder.run_async(text=text))
             elif doc.doctype == DocumentType.PDF:


### PR DESCRIPTION
## Why

`Neo4jNativeGraphQueryEngine` (`autogen/agentchat/contrib/graph_rag/neo4j_native_graph_query_engine.py`) reads each `DocumentType.TEXT` input via a bare `open(doc.path_or_url)` with no `encoding`, so the read uses the platform default (`cp1252` / `gbk` on Windows). Documents ingested into a knowledge graph are frequently non-ASCII, so on a non-UTF-8 locale the read fails with `UnicodeDecodeError` and graph construction aborts.

## Change

Pin `encoding="utf-8"` on the read so text ingestion is locale-independent. No behavior change on UTF-8 locales.

## Validation

`python -m ast` parse clean; reading a text document containing non-ASCII content now succeeds independent of `locale.getpreferredencoding()`.