### PR TITLE
fix(beta/a2a): create artifact before appending streamed text chunks (a2a-sdk 1.1.0)

### DIFF
--- a/autogen/beta/a2a/client.py
+++ b/autogen/beta/a2a/client.py
@@ -572,7 +572,8 @@ class A2AClient(LLMClient):
             state.accumulated_text += text_chunk
             state.pending_calls.extend(calls)
 
-        if a2a_event.last_chunk or not a2a_event.append:
+        # Dedup on last_chunk only; the append=False opening chunk of a stream is not yet complete.
+        if a2a_event.last_chunk:
             state.seen_artifact_ids.add(artifact.artifact_id)
 
     async def _handle_artifact_parts(

--- a/autogen/beta/a2a/executor.py
+++ b/autogen/beta/a2a/executor.py
@@ -117,12 +117,15 @@ class AgentExecutor(A2AAgentExecutorBase):
         @stream.subscribe
         async def map_ag2_to_a2a(event: BaseEvent) -> None:
             if isinstance(event, ModelMessageChunk):
+                # a2a-sdk rejects append=True before the artifact exists, so the first chunk creates it.
+                is_first_chunk = not text_pieces
                 text_pieces.append(event.content)
                 a2a_event = chunk_to_text_artifact(
                     event,
                     artifact_id=text_artifact_id,
                     task_id=task_id,
                     context_id=context_id,
+                    append=not is_first_chunk,
                 )
                 await event_queue.enqueue_event(a2a_event_to_sdk(a2a_event))
                 return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dependencies = [
 a2ui = ["jsonschema>=4.0.0,<5"]
 
 a2a = [
-    "a2a-sdk>=1.1.0,<1.2",
+    "a2a-sdk>=1.1.0,<2",
 ]
 
 ag-ui = ["ag-ui-protocol>=0.1.15,<0.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dependencies = [
 a2ui = ["jsonschema>=4.0.0,<5"]
 
 a2a = [
-    "a2a-sdk>=1.0.0,<2",
+    "a2a-sdk>=1.1.0,<1.2",
 ]
 
 ag-ui = ["ag-ui-protocol>=0.1.15,<0.2"]


### PR DESCRIPTION
## Why are these changes needed?

`a2a-sdk 1.1.0` (released 2026-05-29 ~09:34 UTC) tightened `TaskManager` artifact handling: it now **rejects a `TaskArtifactUpdateEvent` with `append=True` for an `artifact_id` it has never seen**, raising:

```
a2a.utils.errors.InvalidAgentResponseError: append=True for nonexistent artifact_id='…'.
The artifact must be created (append=False) before appending parts to it.
```

AG2's streaming executor emitted **every** text chunk with `append=True` — including the first. `a2a-sdk 1.0.x` tolerated this; `1.1.0` rejects it. Because the dependency is pinned `a2a-sdk>=1.0.0,<2` (open upper bound), CI and any fresh install now pull `1.1.0`, so **streamed A2A turns fail on every branch**, not just one PR.

Evidence this is purely an upstream SDK behavior change (not an AG2 regression):
- Main's scheduled `Core tests without LLMs` run at **2026-05-29 00:20 UTC** used `a2a-sdk 1.0.3` → `test/beta/a2a/test_lifecycle.py::test_streamed_chunks_not_duplicated_in_final_message` **passed**.
- A PR run at **19:26 UTC** the same day picked up `1.1.0` → the same test **failed** with the error above.

## What changed

- **`autogen/beta/a2a/executor.py`** — the first streamed text chunk now uses `append=False` (creating the artifact); subsequent chunks use `append=True`.
- **`autogen/beta/a2a/client.py`** — an artifact is marked fully consumed only on `last_chunk`, not on `not append`. The new `append=False` opening chunk is *not* the final one, so keying dedup off `not append` would mark the artifact "seen" after chunk one and drop every following chunk. Single-shot artifacts (tool calls, polled snapshots) already set `last_chunk=True`, so they're unaffected.
- **`pyproject.toml`** — pin `a2a-sdk` to `>=1.1.0,<1.2` (was `>=1.0.0,<2`) so a future minor can't silently break A2A again.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## Validation

Ran `test/beta/a2a/` against `a2a-sdk==1.1.0` locally — **all 119 tests pass** (the streaming test that fails on `main` against 1.1.0 now passes). No new test was added: the existing end-to-end streaming test `test_streamed_chunks_not_duplicated_in_final_message` already exercises both the server emission and client consumption paths and now covers this against the stricter SDK.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
