### PR TITLE
fix(beta): prevent crash when tool result is missing

### DIFF
--- a/autogen/beta/config/anthropic/mappers.py
+++ b/autogen/beta/config/anthropic/mappers.py
@@ -238,7 +238,7 @@ def has_file_id_references(messages: Iterable[BaseEvent]) -> bool:
                 return True
         elif isinstance(msg, ToolResultsEvent):
             for r in msg.results:
-                if any(isinstance(p, FileIdInput) for p in r.result_parts):
+                if any(isinstance(p, FileIdInput) for p in r.result.parts):
                     return True
     return False
 
@@ -347,7 +347,7 @@ def convert_messages(
                 if valid_tool_ids and r.parent_id not in valid_tool_ids:
                     continue
                 parts: list[dict[str, Any]] = []
-                for part in r.result_parts:
+                for part in r.result.parts:
                     if isinstance(part, TextInput):
                         parts.append({"type": "text", "text": part.content})
                     elif isinstance(part, DataInput):

--- a/autogen/beta/config/dashscope/mappers.py
+++ b/autogen/beta/config/dashscope/mappers.py
@@ -98,7 +98,7 @@ def convert_messages(
             for r in message.results:
                 blocks: list[dict[str, str]] = []
                 has_non_text = False
-                for part in r.result_parts:
+                for part in r.result.parts:
                     if isinstance(part, TextInput):
                         blocks.append({"text": part.content})
                     elif isinstance(part, DataInput):

--- a/autogen/beta/config/gemini/mappers.py
+++ b/autogen/beta/config/gemini/mappers.py
@@ -230,7 +230,7 @@ def convert_messages(
             for r in message.results:
                 text_chunks: list[str] = []
                 media_parts: list[types.FunctionResponsePart] = []
-                for part in r.result_parts:
+                for part in r.result.parts:
                     if isinstance(part, TextInput):
                         text_chunks.append(part.content)
                     elif isinstance(part, DataInput):

--- a/autogen/beta/config/ollama/mappers.py
+++ b/autogen/beta/config/ollama/mappers.py
@@ -112,7 +112,7 @@ def convert_messages(
         elif isinstance(message, ToolResultsEvent):
             for r in message.results:
                 parts: list[dict[str, Any]] = []
-                for part in r.result_parts:
+                for part in r.result.parts:
                     if isinstance(part, TextInput):
                         parts.append({"type": "text", "text": part.content})
                     elif isinstance(part, DataInput):

--- a/autogen/beta/config/openai/mappers.py
+++ b/autogen/beta/config/openai/mappers.py
@@ -140,7 +140,7 @@ def events_to_responses_input(
         elif isinstance(message, ToolResultsEvent):
             for r in message.results:
                 blocks: list[dict[str, Any]] = []
-                for part in r.result_parts:
+                for part in r.result.parts:
                     if isinstance(part, TextInput):
                         blocks.append({"type": "input_text", "text": part.content})
                     elif isinstance(part, DataInput):
@@ -290,7 +290,7 @@ def convert_messages(
         elif isinstance(message, ToolResultsEvent):
             for r in message.results:
                 parts: list[dict[str, Any]] = []
-                for part in r.result_parts:
+                for part in r.result.parts:
                     if isinstance(part, TextInput):
                         parts.append({"type": "text", "text": part.content})
                     elif isinstance(part, DataInput):

--- a/autogen/beta/config/xai/mappers.py
+++ b/autogen/beta/config/xai/mappers.py
@@ -296,7 +296,7 @@ def convert_messages(
 
         elif isinstance(message, ToolResultsEvent):
             for r in message.results:
-                payload = _tool_result_to_string(r.result_parts, serializer)
+                payload = _tool_result_to_string(r.result.parts, serializer)
                 result.append(tool_result(payload, tool_call_id=r.parent_id))
 
         elif isinstance(message, ModelRequest):

--- a/autogen/beta/events/tool_events.py
+++ b/autogen/beta/events/tool_events.py
@@ -124,11 +124,6 @@ class ToolResultEvent(ToolEvent):
 
     result: "ToolResult"
 
-    @property
-    def result_parts(self) -> list[Input]:
-        """Result parts, or ``[]`` when ``result`` is ``None`` (never set / lost in transit)."""
-        return self.result.parts if self.result is not None else []
-
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(parent_id={self.parent_id}, name='{self.name}', result={self.result})"
 

--- a/autogen/beta/tools/executor.py
+++ b/autogen/beta/tools/executor.py
@@ -20,7 +20,6 @@ from autogen.beta.events import (
     ToolCallsEvent,
     ToolErrorEvent,
     ToolNotFoundEvent,
-    ToolResult,
     ToolResultEvent,
     ToolResultsEvent,
 )
@@ -122,13 +121,9 @@ def _tool_not_found(known_tools: Iterable[str]) -> Callable[..., Any]:
     async def _tool_not_found(event: "ToolCallEvent", context: "Context") -> None:
         if event.name not in known_tools:
             err = ToolNotFoundError(event.name)
-            event = ToolNotFoundEvent(
-                parent_id=event.id,
-                name=event.name,
-                content=repr(err),
-                error=err,
-                result=ToolResult(repr(err)),
-            )
-            await context.send(event)
+            # Build via from_call so the event always carries a populated
+            # ``result`` (the formatted error). Constructing it by hand is what
+            # left ``result`` as ``None`` and crashed the provider mappers.
+            await context.send(ToolNotFoundEvent.from_call(event, err))
 
     return _tool_not_found

--- a/test/beta/config/anthropic/test_convert_messages.py
+++ b/test/beta/config/anthropic/test_convert_messages.py
@@ -34,11 +34,12 @@ from autogen.beta.events import (
     TextInput,
     ToolCallEvent,
     ToolCallsEvent,
+    ToolNotFoundEvent,
     ToolResultEvent,
     ToolResultsEvent,
     VideoInput,
 )
-from autogen.beta.exceptions import UnsupportedInputError
+from autogen.beta.exceptions import ToolNotFoundError, UnsupportedInputError
 from autogen.beta.files.types import FileProvider, UploadedFile
 
 
@@ -851,8 +852,22 @@ class TestUnsupportedInputs:
             )
 
 
-def test_tool_result_missing_result_does_not_crash() -> None:
-    event = ToolResultsEvent(results=[ToolResultEvent(parent_id="tc_1", name="t")])
+def test_hallucinated_tool_call_maps_with_error_text() -> None:
+    # Regression: a not-found tool call used to leave result=None and crash on r.result.parts.
+    call = ToolCallEvent(id="tc_1", name="ghost_tool")
+    event = ToolResultsEvent(results=[ToolNotFoundEvent.from_call(call, ToolNotFoundError("ghost_tool"))])
+
     result = convert_messages([event], SerializerCls)
 
-    assert result == [{"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tc_1", "content": []}]}]
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "tc_1",
+                    "content": "autogen.beta.exceptions.ToolNotFoundError: Tool `ghost_tool` not found\n",
+                }
+            ],
+        }
+    ]

--- a/test/beta/config/dashscope/test_convert_messages.py
+++ b/test/beta/config/dashscope/test_convert_messages.py
@@ -17,10 +17,12 @@ from autogen.beta.events import (
     ImageInput,
     ModelRequest,
     TextInput,
+    ToolCallEvent,
+    ToolNotFoundEvent,
     ToolResultEvent,
     ToolResultsEvent,
 )
-from autogen.beta.exceptions import UnsupportedInputError
+from autogen.beta.exceptions import ToolNotFoundError, UnsupportedInputError
 
 
 def test_audio_url_input_raises() -> None:
@@ -152,8 +154,17 @@ class TestToolResult:
             convert_messages([], [event], SerializerCls)
 
 
-def test_tool_result_missing_result_does_not_crash() -> None:
-    event = ToolResultsEvent(results=[ToolResultEvent(parent_id="tc_1", name="t")])
+def test_hallucinated_tool_call_maps_with_error_text() -> None:
+    # Regression: a not-found tool call used to leave result=None and crash on r.result.parts.
+    call = ToolCallEvent(id="tc_1", name="ghost_tool")
+    event = ToolResultsEvent(results=[ToolNotFoundEvent.from_call(call, ToolNotFoundError("ghost_tool"))])
+
     result = convert_messages([], [event], SerializerCls)
 
-    assert result == [{"role": "tool", "tool_call_id": "tc_1", "content": []}]
+    assert result == [
+        {
+            "role": "tool",
+            "tool_call_id": "tc_1",
+            "content": "autogen.beta.exceptions.ToolNotFoundError: Tool `ghost_tool` not found\n",
+        }
+    ]

--- a/test/beta/config/gemini/test_convert_messages.py
+++ b/test/beta/config/gemini/test_convert_messages.py
@@ -23,11 +23,12 @@ from autogen.beta.events import (
     TextInput,
     ToolCallEvent,
     ToolCallsEvent,
+    ToolNotFoundEvent,
     ToolResultEvent,
     ToolResultsEvent,
     VideoInput,
 )
-from autogen.beta.exceptions import UnsupportedInputError
+from autogen.beta.exceptions import ToolNotFoundError, UnsupportedInputError
 
 
 def _model_response_with_tool_call(arguments: str | None) -> ModelResponse:
@@ -488,11 +489,21 @@ class TestBuiltinToolEventReplay:
         assert result == []
 
 
-def test_tool_result_missing_result_does_not_crash() -> None:
-    event = ToolResultsEvent(results=[ToolResultEvent(parent_id="tc_1", name="t")])
+def test_hallucinated_tool_call_maps_with_error_text() -> None:
+    # Regression: a not-found tool call used to leave result=None and crash on r.result.parts.
+    call = ToolCallEvent(id="tc_1", name="ghost_tool")
+    event = ToolResultsEvent(results=[ToolNotFoundEvent.from_call(call, ToolNotFoundError("ghost_tool"))])
+
     [content] = convert_messages([event], SerializerCls)
 
     assert content.model_dump(exclude_none=True) == {
         "role": "user",
-        "parts": [{"function_response": {"name": "t", "response": {}}}],
+        "parts": [
+            {
+                "function_response": {
+                    "name": "ghost_tool",
+                    "response": {"result": "autogen.beta.exceptions.ToolNotFoundError: Tool `ghost_tool` not found\n"},
+                }
+            }
+        ],
     }

--- a/test/beta/config/ollama/test_convert_messages.py
+++ b/test/beta/config/ollama/test_convert_messages.py
@@ -20,10 +20,10 @@ from autogen.beta.events import (
     TextInput,
     ToolCallEvent,
     ToolCallsEvent,
-    ToolResultEvent,
+    ToolNotFoundEvent,
     ToolResultsEvent,
 )
-from autogen.beta.exceptions import UnsupportedInputError
+from autogen.beta.exceptions import ToolNotFoundError, UnsupportedInputError
 
 
 def _model_response_with_tool_call(arguments: str | None) -> ModelResponse:
@@ -162,8 +162,13 @@ def test_multiple_text_inputs_with_images_attach_to_last() -> None:
     ]
 
 
-def test_tool_result_missing_result_does_not_crash() -> None:
-    event = ToolResultsEvent(results=[ToolResultEvent(parent_id="tc_1", name="t")])
+def test_hallucinated_tool_call_maps_with_error_text() -> None:
+    # Regression: a not-found tool call used to leave result=None and crash on r.result.parts.
+    call = ToolCallEvent(id="tc_1", name="ghost_tool")
+    event = ToolResultsEvent(results=[ToolNotFoundEvent.from_call(call, ToolNotFoundError("ghost_tool"))])
+
     result = convert_messages([], [event], SerializerCls)
 
-    assert result == [{"role": "tool", "content": []}]
+    assert result == [
+        {"role": "tool", "content": "autogen.beta.exceptions.ToolNotFoundError: Tool `ghost_tool` not found\n"}
+    ]

--- a/test/beta/config/openai/test_convert_messages.py
+++ b/test/beta/config/openai/test_convert_messages.py
@@ -20,10 +20,12 @@ from autogen.beta.events import (
     ImageInput,
     ModelRequest,
     TextInput,
+    ToolCallEvent,
+    ToolNotFoundEvent,
     ToolResultEvent,
     ToolResultsEvent,
 )
-from autogen.beta.exceptions import UnsupportedInputError
+from autogen.beta.exceptions import ToolNotFoundError, UnsupportedInputError
 from autogen.beta.files.types import FileProvider, UploadedFile
 
 
@@ -588,18 +590,32 @@ class TestResponsesToolResult:
             events_to_responses_input([event], SerializerCls)
 
 
-def test_responses_tool_result_missing_result_does_not_crash() -> None:
-    event = ToolResultsEvent(results=[ToolResultEvent(parent_id="c1", name="t")])
-    result = events_to_responses_input([event], SerializerCls)
+def _hallucinated_tool_call() -> ToolResultsEvent:
+    # Regression fixture: a not-found tool call used to leave result=None and crash on r.result.parts.
+    call = ToolCallEvent(id="c1", name="ghost_tool")
+    return ToolResultsEvent(results=[ToolNotFoundEvent.from_call(call, ToolNotFoundError("ghost_tool"))])
 
-    assert result == [{"type": "function_call_output", "call_id": "c1", "output": []}]
+
+def test_responses_hallucinated_tool_call_maps_with_error_text() -> None:
+    result = events_to_responses_input([_hallucinated_tool_call()], SerializerCls)
+
+    assert result == [
+        {
+            "type": "function_call_output",
+            "call_id": "c1",
+            "output": "autogen.beta.exceptions.ToolNotFoundError: Tool `ghost_tool` not found\n",
+        }
+    ]
 
 
-def test_completions_tool_result_missing_result_does_not_crash() -> None:
-    event = ToolResultsEvent(results=[ToolResultEvent(parent_id="c1", name="t")])
-    result = convert_messages([], [event], SerializerCls)
+def test_completions_hallucinated_tool_call_maps_with_error_text() -> None:
+    result = convert_messages([], [_hallucinated_tool_call()], SerializerCls)
 
     assert result == [
         {"content": "", "role": "system"},
-        {"role": "tool", "tool_call_id": "c1", "content": []},
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": "autogen.beta.exceptions.ToolNotFoundError: Tool `ghost_tool` not found\n",
+        },
     ]

--- a/test/beta/config/xai/test_convert_messages.py
+++ b/test/beta/config/xai/test_convert_messages.py
@@ -23,11 +23,13 @@ from autogen.beta.events import (
     ModelRequest,
     ModelResponse,
     TextInput,
+    ToolCallEvent,
+    ToolNotFoundEvent,
     ToolResultEvent,
     ToolResultsEvent,
     VideoInput,
 )
-from autogen.beta.exceptions import UnsupportedInputError
+from autogen.beta.exceptions import ToolNotFoundError, UnsupportedInputError
 
 
 def _content_texts(msg: chat_pb2.Message) -> list[str]:
@@ -191,13 +193,16 @@ class TestToolResult:
         with pytest.raises(UnsupportedInputError, match="tool_result"):
             convert_messages([], [event], SerializerCls)
 
-    def test_missing_result_does_not_crash(self) -> None:
-        event = ToolResultsEvent(results=[ToolResultEvent(parent_id="tc_1", name="t")])
+    def test_hallucinated_tool_call_maps_with_error_text(self) -> None:
+        # Regression: a not-found tool call used to leave result=None and crash on r.result.parts.
+        call = ToolCallEvent(id="tc_1", name="ghost_tool")
+        event = ToolResultsEvent(results=[ToolNotFoundEvent.from_call(call, ToolNotFoundError("ghost_tool"))])
 
         [msg], _ = convert_messages([], [event], SerializerCls)
 
         assert msg.role == chat_pb2.ROLE_TOOL
         assert msg.tool_call_id == "tc_1"
+        assert _content_texts(msg) == ["autogen.beta.exceptions.ToolNotFoundError: Tool `ghost_tool` not found\n"]
 
 
 class TestAssistantRoundTrip:

--- a/test/beta/events/test_tool_events.py
+++ b/test/beta/events/test_tool_events.py
@@ -9,8 +9,6 @@ from autogen.beta.events import (
     ClientToolCallEvent,
     ToolCallEvent,
     ToolErrorEvent,
-    ToolResult,
-    ToolResultEvent,
 )
 
 
@@ -51,17 +49,6 @@ class TestToolErrorEventContent:
             event = ToolErrorEvent.from_call(call, e)
 
         assert "NoneType" not in event.result.parts[0].content  # type: ignore[union-attr]
-
-
-class TestResultParts:
-    def test_returns_parts_when_result_set(self) -> None:
-        event = ToolResultEvent(parent_id="tc_1", name="t", result=ToolResult("hi"))
-        assert event.result_parts == event.result.parts
-
-    def test_returns_empty_list_when_result_missing(self) -> None:
-        event = ToolResultEvent(parent_id="tc_1", name="t")
-        assert event.result is None
-        assert event.result_parts == []
 
 
 class TestSerializedArgumentsCache:

--- a/test/beta/tools/test_execution.py
+++ b/test/beta/tools/test_execution.py
@@ -288,4 +288,4 @@ async def test_unknown_tool_result_is_populated() -> None:
 
     [not_found] = [e for e in await stream.history.get_events() if isinstance(e, events.ToolNotFoundEvent)]
     assert not_found.result is not None
-    assert "missing_tool" in not_found.result_parts[0].content
+    assert "missing_tool" in not_found.result.parts[0].content


### PR DESCRIPTION
Ensure that `ToolNotFoundEvent` always contains a populated `result` by using `from_call` instead of manual construction. This prevents `NoneType` errors in provider mappers that attempt to access `r.result.parts`.

Also update mappers across all providers (Anthropic, Dashscope, Gemini, Ollama, OpenAI, and xAI) to access parts via `r.result.parts` instead of the deprecated `r.result_parts` property