### PR TITLE
fix(beta/openai): map reasoning tokens to thinking_tokens, not cache_creation

### DIFF
--- a/autogen/beta/config/openai/mappers.py
+++ b/autogen/beta/config/openai/mappers.py
@@ -504,9 +504,7 @@ def normalize_usage(usage: CompletionUsage) -> Usage:
         completion_tokens=usage.completion_tokens,
         total_tokens=usage.total_tokens,
         cache_read_input_tokens=usage.prompt_tokens_details.cached_tokens if usage.prompt_tokens_details else None,
-        cache_creation_input_tokens=usage.completion_tokens_details.reasoning_tokens
-        if usage.completion_tokens_details
-        else None,
+        thinking_tokens=usage.completion_tokens_details.reasoning_tokens if usage.completion_tokens_details else None,
     )
 
 
@@ -516,7 +514,7 @@ def normalize_responses_usage(usage: ResponseUsage) -> Usage:
         completion_tokens=usage.output_tokens,
         total_tokens=usage.total_tokens,
         cache_read_input_tokens=usage.input_tokens_details.cached_tokens,
-        cache_creation_input_tokens=usage.output_tokens_details.reasoning_tokens,
+        thinking_tokens=usage.output_tokens_details.reasoning_tokens,
     )
 
 

--- a/test/beta/config/openai/test_openai_responses_usage.py
+++ b/test/beta/config/openai/test_openai_responses_usage.py
@@ -25,7 +25,7 @@ class TestNormalizeUsage:
             completion_tokens=20,
             total_tokens=120,
             cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
+            thinking_tokens=0,
         )
 
     def test_lifts_cached_tokens(self):
@@ -42,7 +42,7 @@ class TestNormalizeUsage:
             completion_tokens=20,
             total_tokens=120,
             cache_read_input_tokens=80,
-            cache_creation_input_tokens=0,
+            thinking_tokens=0,
         )
 
     def test_lifts_reasoning_tokens(self):
@@ -54,10 +54,13 @@ class TestNormalizeUsage:
             output_tokens_details=OutputTokensDetails(reasoning_tokens=10),
         )
         result = normalize_responses_usage(usage)
+        # reasoning tokens map to thinking_tokens, NOT cache_creation_input_tokens
+        # (OpenAI has no cache-write metric, so cache_creation stays None)
         assert result == Usage(
             prompt_tokens=100,
             completion_tokens=20,
             total_tokens=120,
             cache_read_input_tokens=0,
-            cache_creation_input_tokens=10,
+            thinking_tokens=10,
         )
+        assert result.cache_creation_input_tokens is None

--- a/test/beta/config/openai/test_openai_usage.py
+++ b/test/beta/config/openai/test_openai_usage.py
@@ -4,7 +4,7 @@
 
 """Tests for OpenAI client usage normalization (cache token lifting)."""
 
-from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
+from openai.types.completion_usage import CompletionTokensDetails, CompletionUsage, PromptTokensDetails
 
 from autogen.beta.config.openai.mappers import normalize_usage
 from autogen.beta.events import Usage
@@ -45,3 +45,20 @@ class TestNormalizeUsage:
         usage = CompletionUsage(prompt_tokens=50, completion_tokens=10, total_tokens=60, prompt_tokens_details=None)
         result = normalize_usage(usage)
         assert result.cache_read_input_tokens is None
+
+    def test_lifts_reasoning_tokens(self):
+        usage = CompletionUsage(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            completion_tokens_details=CompletionTokensDetails(reasoning_tokens=15),
+        )
+        result = normalize_usage(usage)
+        # reasoning tokens map to thinking_tokens, NOT cache_creation_input_tokens
+        assert result == Usage(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            thinking_tokens=15,
+        )
+        assert result.cache_creation_input_tokens is None


### PR DESCRIPTION
## Fix

Map `reasoning_tokens` → `thinking_tokens` in both the Chat Completions and
Responses API usage normalizers. `cache_creation_input_tokens` now stays `None`
for OpenAI.