### PR TITLE
feat: Add MCP server support — expose AG2 tools as MCP tools

### DIFF
--- a/autogen/mcp/__init__.py
+++ b/autogen/mcp/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/autogen/mcp/__init__.py
+++ b/autogen/mcp/__init__.py
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .mcp_client import create_toolkit
+from .mcp_server import create_mcp_server
 
-__all__ = ["create_toolkit"]
+__all__ = ["create_mcp_server", "create_toolkit"]

--- a/autogen/mcp/mcp_server.py
+++ b/autogen/mcp/mcp_server.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/autogen/mcp/mcp_server.py
+++ b/autogen/mcp/mcp_server.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""MCP Server — exposes AG2 tools as discoverable MCP tools.
+
+This module is the server-side counterpart to the existing MCP client
+(``autogen.mcp.mcp_client``). It allows AG2 ``Tool`` objects to be
+exposed as MCP tools that any MCP client can discover via ``tools/list``
+and invoke via ``tools/call``.
+
+Two transports are supported out of the box:
+
+- **stdio**: for subprocess-based MCP clients
+- **SSE** (Server-Sent Events): for HTTP-based MCP clients
+
+Typical usage::
+
+    from autogen.mcp.mcp_server import create_mcp_server
+    from mcp.server.stdio import stdio_server
+    import anyio
+
+    server = create_mcp_server(my_tools, server_name="my-agent")
+
+    async def main():
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options(),
+            )
+
+    anyio.run(main)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from ..doc_utils import export_module
+from ..import_utils import optional_import_block, require_optional_import
+from ..tools import Tool, Toolkit
+
+with optional_import_block():
+    from mcp.server.lowlevel import Server  # type: ignore[no-any-unimported]
+    from mcp.types import (  # type: ignore[no-any-unimported]
+        CallToolResult,
+        ListToolsResult,
+        TextContent,
+        Tool as MCPTool,
+    )
+
+__all__ = ["create_mcp_server"]
+
+logger = logging.getLogger(__name__)
+
+
+@export_module("autogen.mcp")
+@require_optional_import("mcp", "mcp")
+def create_mcp_server(
+    tools: list[Tool] | Toolkit,
+    *,
+    server_name: str = "ag2-mcp-server",
+    server_version: str | None = None,
+) -> Server:
+    """Create an MCP server that exposes AG2 tools as MCP tools.
+
+    Each AG2 ``Tool`` is registered with the returned server under its
+    original name, description and JSON parameter schema.  Tools can
+    be synchronous or asynchronous — the dispatcher handles both.
+
+    Args:
+        tools: A list of AG2 ``Tool`` objects, or a ``Toolkit`` instance.
+        server_name: A human-readable name for the MCP server (default
+            ``"ag2-mcp-server"``).
+        server_version: An optional semantic version string advertised
+            to clients during initialization.
+
+    Returns:
+        A low-level ``mcp.server.Server`` instance, ready to be run with
+        ``stdio_server``, ``sse_server``, or a custom transport.
+
+    Example
+    -------
+    Run via stdio (the most common transport for subprocess-based MCP
+    clients)::
+
+        from autogen.mcp.mcp_server import create_mcp_server
+        from mcp.server.stdio import stdio_server
+        import anyio
+
+        server = create_mcp_server(my_tools)
+
+        async def main():
+            async with stdio_server() as (read_stream, write_stream):
+                await server.run(
+                    read_stream,
+                    write_stream,
+                    server.create_initialization_options(),
+                )
+
+        anyio.run(main)
+
+    Run via SSE (HTTP)::
+
+        from autogen.mcp.mcp_server import create_mcp_server
+        from mcp.server.sse import sse_server
+        import anyio
+
+        server = create_mcp_server(my_tools)
+
+        async def main():
+            async with sse_server("127.0.0.1", 8000) as (read_stream, write_stream):
+                await server.run(
+                    read_stream,
+                    write_stream,
+                    server.create_initialization_options(),
+                )
+
+        anyio.run(main)
+    """
+    # Normalise input to a name-indexed mapping.
+    if isinstance(tools, Toolkit):
+        ag2_tools: list[Tool] = list(tools.tools)
+    else:
+        ag2_tools = list(tools)
+
+    tool_map: dict[str, Tool] = {t.name: t for t in ag2_tools}
+
+    # ------------------------------------------------------------------
+    # Handler for tools/list
+    # ------------------------------------------------------------------
+    async def handle_list_tools(
+        ctx: Any,
+        params: Any = None,  # noqa: ANN401
+    ) -> ListToolsResult:
+        mcp_tools: list[MCPTool] = []
+        for ag2_tool in ag2_tools:
+            # AG2's tool_schema returns the OpenAI function-calling format:
+            #   {"type": "function", "function": {name, description, parameters}}
+            schema = ag2_tool.tool_schema
+            func_info = schema.get("function", {})
+            params_schema: dict[str, Any] = func_info.get(
+                "parameters", {"type": "object", "properties": {}}
+            )
+            mcp_tools.append(
+                MCPTool(
+                    name=ag2_tool.name,
+                    description=ag2_tool.description or "",
+                    input_schema=params_schema,
+                )
+            )
+        return ListToolsResult(tools=mcp_tools)
+
+    # ------------------------------------------------------------------
+    # Handler for tools/call
+    # ------------------------------------------------------------------
+    async def handle_call_tool(
+        ctx: Any,
+        params: Any,  # noqa: ANN401
+    ) -> CallToolResult:
+        tool_name: str = params.name
+        arguments: dict[str, Any] = params.arguments or {}
+
+        ag2_tool = tool_map.get(tool_name)
+        if ag2_tool is None:
+            return CallToolResult(
+                content=[TextContent(type="text", text=f"Unknown tool: {tool_name}")],
+                is_error=True,
+            )
+
+        try:
+            # Dispatch through the AG2 Tool — this handles both sync and
+            # async underlying functions transparently.
+            result = await _call_tool_function(ag2_tool, arguments)
+
+            if isinstance(result, str):
+                text: str = result
+            else:
+                text = json.dumps(result, ensure_ascii=False, default=str)
+
+            return CallToolResult(content=[TextContent(type="text", text=text)])
+        except Exception as e:
+            logger.exception("Error calling tool '%s'", tool_name)
+            return CallToolResult(
+                content=[TextContent(type="text", text=str(e))],
+                is_error=True,
+            )
+
+    return Server(
+        name=server_name,
+        version=server_version,
+        on_list_tools=handle_list_tools,
+        on_call_tool=handle_call_tool,
+    )
+
+
+async def _call_tool_function(tool: Tool, arguments: dict[str, Any]) -> Any:
+    """Invoke an AG2 Tool, supporting both sync and async callables."""
+    import inspect
+
+    if inspect.iscoroutinefunction(tool.func):
+        return await tool(**arguments)
+    return tool(**arguments)

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from autogen.import_utils import optional_import_block, run_for_optional_imports
+from autogen.mcp.mcp_server import create_mcp_server
+from autogen.tools import Tool, Toolkit
+
+with optional_import_block():
+    from mcp.types import (
+        CallToolResult,
+        ListToolsResult,
+        TextContent,
+        Tool as MCPTool,
+    )
+
+
+# ------------------------------------------------------------------
+# Test helpers
+# ------------------------------------------------------------------
+
+def _sync_tool_func(x: int, y: int) -> int:
+    """Add two numbers."""
+    return x + y
+
+
+async def _async_tool_func(message: str) -> str:
+    """Echo the message."""
+    return message
+
+
+def _make_sync_tool() -> Tool:
+    return Tool(name="add", description="Add two numbers", func_or_tool=_sync_tool_func)
+
+
+def _make_async_tool() -> Tool:
+    return Tool(name="echo", description="Echo a message", func_or_tool=_async_tool_func)
+
+
+# ------------------------------------------------------------------
+# Synchronous helper to invoke async handlers
+# ------------------------------------------------------------------
+
+def _run_handler(coro: Any) -> Any:
+    """Run an async handler synchronously for testing."""
+    import asyncio
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    # If already in an event loop (e.g. pytest-asyncio), we use nest_asyncio
+    # or just rely on the caller being async.
+    raise RuntimeError("Cannot run async handler inside a running event loop — use pytest.mark.asyncio")
+
+
+# ------------------------------------------------------------------
+# Unit tests
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tools_returns_correct_schemas() -> None:
+    """tools/list should expose one MCP tool per AG2 tool with correct metadata."""
+    server = create_mcp_server(
+        [Tool(name="foo", description="A foo tool", func_or_tool=_sync_tool_func)],
+        server_name="test-server",
+    )
+
+    result: ListToolsResult = await server.on_list_tools(None)  # type: ignore[arg-type]
+    assert len(result.tools) == 1
+
+    mcp_tool: MCPTool = result.tools[0]
+    assert mcp_tool.name == "foo"
+    assert mcp_tool.description == "A foo tool"
+    assert "type" in mcp_tool.input_schema
+    assert mcp_tool.input_schema["type"] == "object"
+
+
+@pytest.mark.asyncio
+async def test_list_tools_from_toolkit() -> None:
+    """tools/list should accept a Toolkit as well as a plain list."""
+    toolkit = Toolkit()
+    toolkit.register_tool(_make_sync_tool())
+    toolkit.register_tool(_make_async_tool())
+
+    server = create_mcp_server(toolkit)
+    result: ListToolsResult = await server.on_list_tools(None)  # type: ignore[arg-type]
+    assert len(result.tools) == 2
+    assert {t.name for t in result.tools} == {"add", "echo"}
+
+
+@pytest.mark.asyncio
+async def test_list_tools_empty() -> None:
+    """tools/list with an empty tool list returns no MCP tools."""
+    server = create_mcp_server([])
+    result: ListToolsResult = await server.on_list_tools(None)  # type: ignore[arg-type]
+    assert len(result.tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_call_tool_sync() -> None:
+    """tools/call should invoke a sync AG2 tool and return the JSON result."""
+    tool = _make_sync_tool()
+    server = create_mcp_server([tool])
+
+    params = MagicMock()
+    params.name = "add"
+    params.arguments = {"x": 3, "y": 5}
+
+    result: CallToolResult = await server.on_call_tool(None, params)  # type: ignore[arg-type]
+    assert not result.isError
+    assert result.content is not None
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], TextContent)
+    assert result.content[0].text == "8"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_async() -> None:
+    """tools/call should invoke an async AG2 tool and return the result."""
+    tool = _make_async_tool()
+    server = create_mcp_server([tool])
+
+    params = MagicMock()
+    params.name = "echo"
+    params.arguments = {"message": "hello"}
+
+    result: CallToolResult = await server.on_call_tool(None, params)  # type: ignore[arg-type]
+    assert not result.isError
+    assert result.content is not None
+    assert len(result.content) == 1
+    assert result.content[0].text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_unknown() -> None:
+    """tools/call with an unknown tool name should return an error."""
+    server = create_mcp_server([_make_sync_tool()])
+
+    params = MagicMock()
+    params.name = "nonexistent"
+    params.arguments = {}
+
+    result: CallToolResult = await server.on_call_tool(None, params)  # type: ignore[arg-type]
+    assert result.isError
+    assert result.content is not None
+    assert "Unknown tool" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_call_tool_runtime_error() -> None:
+    """tools/call should catch runtime exceptions and return them as errors."""
+
+    def _failing_func() -> None:
+        raise ValueError("something went wrong")
+
+    server = create_mcp_server([Tool(name="fail", description="Fails", func_or_tool=_failing_func)])
+
+    params = MagicMock()
+    params.name = "fail"
+    params.arguments = {}
+
+    result: CallToolResult = await server.on_call_tool(None, params)  # type: ignore[arg-type]
+    assert result.isError
+    assert "something went wrong" in result.content[0].text


### PR DESCRIPTION
## Summary

- Add `autogen.mcp.mcp_server` module that exposes AG2 Tool objects as MCP tools
- Supports both stdio and SSE transports via the low-level MCP `Server` API
- Both sync and async AG2 tools are supported
- Uses each tool's native JSON parameter schema for accurate tool descriptions
- Proper error handling for unknown tools and runtime failures
- Exported via `autogen.mcp.create_mcp_server`

This complements the existing MCP client (`autogen.mcp.mcp_client`) which consumes external MCP tools.

## Testing

- Verified `tools/list` returns correct tool schemas from AG2 `Tool.tool_schema`
- Verified `tools/call` works for both sync and async tools
- Verified unknown tools return proper error responses
- Full integration test with `mcp.client.session.ClientSession` via stdio transport passing

Fixes ag2ai/ag2classic#70