### PR TITLE
feat: Add MCP prompts support to MCP client

### DIFF
--- a/autogen/mcp/mcp_client.py
+++ b/autogen/mcp/mcp_client.py
@@ -23,7 +23,7 @@ from ..tools import Tool, Toolkit
 
 with optional_import_block():
     from mcp.shared.message import SessionMessage
-    from mcp.types import CallToolResult, ReadResourceResult, ResourceTemplate, TextContent
+    from mcp.types import CallToolResult, GetPromptResult, Prompt as MCPPrompt, ReadResourceResult, ResourceTemplate, TextContent
     from mcp.types import Tool as MCPTool
 
 __all__ = ["ResultSaved", "create_toolkit"]
@@ -255,15 +255,78 @@ Here is the correct format for the URI template:
 
     @classmethod
     @require_optional_import("mcp", "mcp")
+    def convert_prompt(  # type: ignore[no-any-unimported]
+        cls, prompt: Any, session: "ClientSession", **kwargs: Any
+    ) -> Tool:
+        """Convert an MCP prompt into an AG2 Tool.
+
+        Args:
+            prompt: The MCP prompt to convert.
+            session: The MCP client session.
+
+        Returns:
+            Tool: The converted AG2 Tool.
+        """
+        if not isinstance(prompt, MCPPrompt):
+            raise ValueError(f"Expected an instance of `mcp.types.Prompt`, got {type(prompt)}")
+
+        mcp_prompt: MCPPrompt = prompt  # type: ignore[no-any-unimported]
+
+        # Build argument descriptions for the docstring
+        arg_descriptions: list[str] = []
+        arg_properties: dict[str, Any] = {}
+        required_args: list[str] = []
+
+        if mcp_prompt.arguments:
+            for arg in mcp_prompt.arguments:
+                arg_descriptions.append(f"    {arg.name}: {arg.description or ''}")
+                arg_properties[arg.name] = {
+                    "type": "string",
+                    "description": arg.description or "",
+                }
+                if arg.required:
+                    required_args.append(arg.name)
+
+        arguments_description = "\n".join(arg_descriptions)
+        if arguments_description:
+            arguments_description = "\n\nArguments:\n" + arguments_description
+
+        prompt_description = f"{mcp_prompt.description or ''}{arguments_description}"
+
+        async def get_prompt(  # type: ignore[no-any-unimported]
+            **arguments: dict[str, Any],
+        ) -> "GetPromptResult":  # type: ignore[no-any-unimported]
+            result = await session.get_prompt(mcp_prompt.name, arguments)
+            return result
+
+        # Build JSON schema from prompt arguments
+        input_schema: dict[str, Any] = {
+            "type": "object",
+            "properties": arg_properties,
+        }
+        if required_args:
+            input_schema["required"] = required_args
+
+        ag2_tool = Tool(
+            name=mcp_prompt.name,
+            description=prompt_description.strip(),
+            func_or_tool=get_prompt,
+            parameters_json_schema=input_schema,
+        )
+        return ag2_tool
+
+    @classmethod
+    @require_optional_import("mcp", "mcp")
     async def load_mcp_toolkit(
         cls,
         session: "ClientSession",
         *,
         use_mcp_tools: bool,
         use_mcp_resources: bool,
+        use_mcp_prompts: bool,
         resource_download_folder: Path | None,
     ) -> Toolkit:  # type: ignore[no-any-unimported]
-        """Load all available MCP tools and convert them to AG2 Toolkit."""
+        """Load all available MCP capabilities and convert them to AG2 Toolkit."""
         all_ag2_tools: list[Tool] = []
 
         if use_mcp_tools:
@@ -282,6 +345,13 @@ Here is the correct format for the URI template:
                 for resource_template in resource_templates.resourceTemplates
             ]
             all_ag2_tools.extend(ag2_resources)
+
+        if use_mcp_prompts:
+            prompts = await session.list_prompts()
+            ag2_prompts: list[Tool] = [
+                cls.convert_prompt(prompt=prompt, session=session) for prompt in prompts.prompts
+            ]
+            all_ag2_tools.extend(ag2_prompts)
 
         return Toolkit(tools=all_ag2_tools)
 
@@ -331,6 +401,7 @@ async def create_toolkit(
     *,
     use_mcp_tools: bool = True,
     use_mcp_resources: bool = True,
+    use_mcp_prompts: bool = True,
     resource_download_folder: Path | str | None = None,
 ) -> Toolkit:  # type: ignore[no-any-unimported]
     """Create a toolkit from the MCP client session.
@@ -339,6 +410,7 @@ async def create_toolkit(
         session (ClientSession): The MCP client session.
         use_mcp_tools (bool): Whether to include MCP tools in the toolkit.
         use_mcp_resources (bool): Whether to include MCP resources in the toolkit.
+        use_mcp_prompts (bool): Whether to include MCP prompts in the toolkit.
         resource_download_folder (Optional[Union[Path, str]]): The folder to download files to.
 
     Returns:
@@ -352,6 +424,7 @@ async def create_toolkit(
         session=session,
         use_mcp_tools=use_mcp_tools,
         use_mcp_resources=use_mcp_resources,
+        use_mcp_prompts=use_mcp_prompts,
         resource_download_folder=resource_download_folder,
     )
 

--- a/test/mcp/prompts_server.py
+++ b/test/mcp/prompts_server.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2023 - 2025, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A test MCP server that exposes prompts for testing."""
+
+from mcp.server import Server, ServerRequestContext
+from mcp.server.stdio import stdio_server
+from mcp.types import (
+    GetPromptRequestParams,
+    GetPromptResult,
+    ListPromptsResult,
+    PaginatedRequestParams,
+    Prompt,
+    PromptArgument,
+    PromptMessage,
+    TextContent,
+)
+
+
+def create_prompts_server() -> Server:
+    """Create an MCP server with test prompts."""
+
+    async def handle_list_prompts(
+        _context: ServerRequestContext,
+        _params: PaginatedRequestParams | None,
+    ) -> ListPromptsResult:
+        return ListPromptsResult(
+            prompts=[
+                Prompt(
+                    name="greeting",
+                    description="A simple greeting prompt",
+                ),
+                Prompt(
+                    name="echo",
+                    description="Echo a user-provided message",
+                    arguments=[
+                        PromptArgument(
+                            name="message",
+                            description="The message to echo",
+                            required=True,
+                        ),
+                    ],
+                ),
+                Prompt(
+                    name="code_review",
+                    description="Review code with optional language specification",
+                    arguments=[
+                        PromptArgument(
+                            name="code",
+                            description="The code to review",
+                            required=True,
+                        ),
+                        PromptArgument(
+                            name="language",
+                            description="The programming language",
+                            required=False,
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    async def handle_get_prompt(
+        _context: ServerRequestContext,
+        params: GetPromptRequestParams,
+    ) -> GetPromptResult:
+        if params.name == "greeting":
+            return GetPromptResult(
+                description="A greeting",
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text="Hello! How can I help you today?",
+                        ),
+                    ),
+                ],
+            )
+        elif params.name == "echo":
+            message = (params.arguments or {}).get("message", "")
+            return GetPromptResult(
+                description=f"Echo: {message}",
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text=f"Echoing: {message}",
+                        ),
+                    ),
+                ],
+            )
+        elif params.name == "code_review":
+            code = (params.arguments or {}).get("code", "")
+            language = (params.arguments or {}).get("language", "unknown")
+            return GetPromptResult(
+                description=f"Code review for {language}",
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text=f"Please review this {language} code:\n\n```{language}\n{code}\n```",
+                        ),
+                    ),
+                ],
+            )
+        else:
+            raise ValueError(f"Unknown prompt: {params.name}")
+
+    server = Server(
+        "test-prompts-server",
+        on_list_prompts=handle_list_prompts,
+        on_get_prompt=handle_get_prompt,
+    )
+
+    return server
+
+
+async def main() -> None:
+    """Run the prompts test server over stdio."""
+    server = create_prompts_server()
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
+
+
+if __name__ == "__main__":
+    import anyio
+
+    anyio.run(main)

--- a/test/mcp/test_mcp.py
+++ b/test/mcp/test_mcp.py
@@ -18,6 +18,7 @@ from autogen.import_utils import optional_import_block, run_for_optional_imports
 from autogen.mcp.mcp_client import (
     DEFAULT_HTTP_REQUEST_TIMEOUT,
     DEFAULT_SSE_EVENT_READ_TIMEOUT,
+    MCPClient,
     MCPClientSessionManager,
     ResultSaved,
     SseConfig,
@@ -29,7 +30,7 @@ from test.credentials import Credentials
 with optional_import_block():
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
-    from mcp.types import ReadResourceResult, TextResourceContents
+    from mcp.types import GetPromptResult, Prompt, PromptArgument, ReadResourceResult, TextResourceContents
 
 
 class TestMCPClient:
@@ -215,6 +216,216 @@ class TestMCPClient:
             await result.process()
             summary = await result.summary
             assert "6912" in summary
+
+
+class TestMCPPrompts:
+    """Tests for MCP prompts support."""
+
+    @pytest.fixture
+    def prompts_server_params(self) -> "StdioServerParameters":  # type: ignore[no-any-unimported]
+        server_file = Path(__file__).parent / "prompts_server.py"
+        return StdioServerParameters(
+            command="python3",
+            args=[str(server_file)],
+        )
+
+    @pytest.mark.asyncio
+    async def test_prompts_list_and_get(self, prompts_server_params: "StdioServerParameters") -> None:  # type: ignore[no-any-unimported]
+        """Test that the prompts server provides prompts and get_prompt works."""
+        import anyio
+        from anyio import BrokenResourceError
+
+        try:
+            async with (
+                stdio_client(prompts_server_params) as (read, write),
+                ClientSession(read, write, read_timeout_seconds=timedelta(seconds=30)) as session,
+            ):
+                await session.initialize()
+                result = await session.list_prompts()
+                prompt_names = [p.name for p in result.prompts]
+                assert "greeting" in prompt_names
+                assert "echo" in prompt_names
+                assert "code_review" in prompt_names
+
+                # Verify echo prompt has arguments
+                for p in result.prompts:
+                    if p.name == "echo":
+                        assert p.arguments is not None
+                        assert p.arguments[0].name == "message"
+                        assert p.arguments[0].required is True
+
+                # Get prompts and verify content
+                greeting = await session.get_prompt("greeting")
+                assert len(greeting.messages) == 1
+
+                echo = await session.get_prompt("echo", {"message": "test"})
+                assert "test" in echo.messages[0].content.text
+
+                review = await session.get_prompt(
+                    "code_review", {"code": "print(1)", "language": "python"}
+                )
+                assert "python" in review.messages[0].content.text
+        except BaseExceptionGroup as eg:
+            # Filter out BrokenResourceError during cleanup (MCP SDK quirk)
+            remaining = [
+                e
+                for e in eg.exceptions
+                if not (
+                    isinstance(e, BrokenResourceError)
+                    or (
+                        hasattr(e, "exceptions")
+                        and all(isinstance(x, BrokenResourceError) for x in e.exceptions)
+                    )
+                )
+            ]
+            if remaining:
+                raise BaseExceptionGroup("remaining errors", remaining)
+
+    @pytest.mark.asyncio
+    async def test_convert_prompt(self) -> None:  # type: ignore[no-any-unimported]
+        """Test converting an MCP prompt to an AG2 Tool using a mock session."""
+        from mcp.types import PromptMessage, TextContent
+
+        mock_session = AsyncMock()
+        mock_get_prompt = AsyncMock(
+            return_value=GetPromptResult(
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(type="text", text="Echoing: hello world"),
+                    )
+                ]
+            )
+        )
+        mock_session.get_prompt = mock_get_prompt
+
+        mcp_prompt = Prompt(
+            name="test_echo",
+            description="Echo a message",
+            arguments=[
+                PromptArgument(name="message", description="The message to echo", required=True),
+            ],
+        )
+
+        tool = MCPClient.convert_prompt(prompt=mcp_prompt, session=mock_session)
+
+        assert tool.name == "test_echo"
+        assert "Echo a message" in tool.description
+
+        # Verify the function schema (from parameters_json_schema)
+        func_schema = tool._func_schema  # type: ignore[attr-defined]
+        assert func_schema is not None
+        assert func_schema["function"]["name"] == "test_echo"
+        assert "message" in func_schema["function"]["parameters"]["properties"]
+
+        # Call the tool
+        result = await tool(message="hello world")
+        mock_get_prompt.assert_called_once_with("test_echo", {"message": "hello world"})
+
+    @pytest.mark.asyncio
+    async def test_convert_prompt_no_args(self) -> None:  # type: ignore[no-any-unimported]
+        """Test converting a prompt without arguments."""
+        mock_session = AsyncMock()
+
+        mcp_prompt = Prompt(
+            name="simple_greeting",
+            description="A greeting prompt",
+        )
+
+        tool = MCPClient.convert_prompt(prompt=mcp_prompt, session=mock_session)
+
+        assert tool.name == "simple_greeting"
+        assert "A greeting prompt" in tool.description
+
+        # Should have empty properties since no args
+        assert tool._func_schema["function"]["parameters"]["properties"] == {}  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_convert_prompt_invalid_type(self) -> None:  # type: ignore[no-any-unimported]
+        """Test that convert_prompt raises ValueError for non-Prompt types."""
+        mock_session = AsyncMock()
+
+        with pytest.raises(ValueError, match="Expected an instance of"):
+            MCPClient.convert_prompt(prompt="not_a_prompt", session=mock_session)
+
+    @pytest.mark.asyncio
+    async def test_prompts_in_toolkit(self) -> None:  # type: ignore[no-any-unimported]
+        """Test that prompts are included in the toolkit via load_mcp_toolkit."""
+        mock_session = AsyncMock()
+        mock_session.list_prompts = AsyncMock(
+            return_value=type(
+                "ListPromptsResult",
+                (),
+                {
+                    "prompts": [
+                        Prompt(name="prompt_a", description="Prompt A"),
+                        Prompt(name="prompt_b", description="Prompt B"),
+                    ]
+                },
+            )()
+        )
+
+        toolkit = await MCPClient.load_mcp_toolkit(
+            session=mock_session,
+            use_mcp_tools=False,
+            use_mcp_resources=False,
+            use_mcp_prompts=True,
+            resource_download_folder=None,
+        )
+
+        assert len(toolkit) == 2
+        assert toolkit.get_tool("prompt_a") is not None
+        assert toolkit.get_tool("prompt_b") is not None
+
+    @pytest.mark.asyncio
+    async def test_prompts_disabled(self) -> None:  # type: ignore[no-any-unimported]
+        """Test that prompts can be excluded from the toolkit."""
+        mock_session = AsyncMock()
+
+        toolkit = await MCPClient.load_mcp_toolkit(
+            session=mock_session,
+            use_mcp_tools=False,
+            use_mcp_resources=False,
+            use_mcp_prompts=False,
+            resource_download_folder=None,
+        )
+
+        assert len(toolkit) == 0
+        # list_prompts should not have been called
+        mock_session.list_prompts.assert_not_called()
+
+
+    @pytest.mark.asyncio
+    async def test_prompts_in_full_toolkit(self, prompts_server_params: "StdioServerParameters") -> None:  # type: ignore[no-any-unimported]
+        """Test that prompts are included alongside tools and resources."""
+        import anyio
+        from anyio import BrokenResourceError
+
+        try:
+            async with (
+                stdio_client(prompts_server_params) as (read, write),
+                ClientSession(read, write, read_timeout_seconds=timedelta(seconds=30)) as session,
+            ):
+                await session.initialize()
+                # The prompts server has no tools/resources, so with all enabled
+                # we should still get only prompts
+                toolkit = await create_toolkit(session=session)
+                assert len(toolkit) == 3
+        except BaseExceptionGroup as eg:
+            # Filter out BrokenResourceError during cleanup (MCP SDK quirk)
+            remaining = [
+                e
+                for e in eg.exceptions
+                if not (
+                    isinstance(e, BrokenResourceError)
+                    or (
+                        hasattr(e, "exceptions")
+                        and all(isinstance(x, BrokenResourceError) for x in e.exceptions)
+                    )
+                )
+            ]
+            if remaining:
+                raise BaseExceptionGroup("remaining errors", remaining)
 
 
 class MockClientSession:


### PR DESCRIPTION
## Summary

- Extend MCP client to surface MCP server prompts as AG2 toolkit objects
- Follows the same pattern as existing MCP tools and resources integration
- All existing functionality remains backward-compatible (prompts enabled by default)

## Changes

- **autogen/mcp/mcp_client.py**: Added `convert_prompt()` classmethod, `use_mcp_prompts` parameter to `load_mcp_toolkit()` and `create_toolkit()`
- **test/mcp/prompts_server.py**: New test MCP server exposing three prompt templates (greeting, echo, code_review)
- **test/mcp/test_mcp.py**: 7 new test cases covering prompt conversion, toolkit integration, and server interaction

Fixes ag2ai/ag2classic#67