### PR TITLE
chore: fix typos in code and docstrings (INEGER, OepnAI, GrapStoreQueryResult, GraphRagCapbility)

### DIFF
--- a/autogen/agentchat/contrib/graph_rag/graph_rag_capability.py
+++ b/autogen/agentchat/contrib/graph_rag/graph_rag_capability.py
@@ -29,7 +29,7 @@ class GraphRagCapability(AgentCapability):
         max_consecutive_auto_reply=3,
         ...
     )
-    graph_rag_capability = GraphRagCapbility(graph_query_engine)
+    graph_rag_capability = GraphRagCapability(graph_query_engine)
     graph_rag_capability.add_to_agent(graph_rag_agent)
 
     user_proxy = UserProxyAgent(

--- a/autogen/agentchat/contrib/graph_rag/neo4j_graph_query_engine.py
+++ b/autogen/agentchat/contrib/graph_rag/neo4j_graph_query_engine.py
@@ -176,7 +176,7 @@ class Neo4jGraphQueryEngine:
             **kwargs: additional keyword arguments.
 
         Returns:
-            A GrapStoreQueryResult object containing the answer and related triplets.
+            A GraphStoreQueryResult object containing the answer and related triplets.
         """
         if not hasattr(self, "index"):
             raise ValueError("Property graph index is not created.")

--- a/autogen/logger/sqlite_logger.py
+++ b/autogen/logger/sqlite_logger.py
@@ -96,7 +96,7 @@ class SqliteLogger(BaseLogger):
                     source_name TEXT,
                     request TEXT,
                     response TEXT,
-                    is_cached INEGER,
+                    is_cached INTEGER,
                     cost REAL,
                     start_time DATETIME DEFAULT CURRENT_TIMESTAMP,
                     end_time DATETIME DEFAULT CURRENT_TIMESTAMP)

--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -199,7 +199,7 @@ def get_config_list(
         api_version (str, optional): The api version for openai api calls.
 
     Returns:
-        list: A list of configs for OepnAI API calls.
+        list: A list of configs for OpenAI API calls.
 
     Example:
     ```python


### PR DESCRIPTION
## Summary

Four typos surfaced by running the repo's own `_typos.toml` config. One is a real (though benign-in-practice) bug, the other three are visible to users in docstring snippets.

## Changes

- `autogen/logger/sqlite_logger.py`: `INEGER` -> `INTEGER` in the `chat_completions` `CREATE TABLE`. SQLite type-affinity rules map any column type containing `INT` to INTEGER affinity; `INEGER` falls to NUMERIC affinity instead, so `is_cached` was silently stored as NUMERIC rather than the intended INTEGER. Functionally tolerant (NUMERIC accepts 0/1) but not what the schema is supposed to declare.
- `autogen/oai/openai_utils.py`: `OepnAI` -> `OpenAI` in the `get_config_list` docstring.
- `autogen/agentchat/contrib/graph_rag/neo4j_graph_query_engine.py`: `GrapStoreQueryResult` -> `GraphStoreQueryResult` in the `query` docstring; now matches the actual return type.
- `autogen/agentchat/contrib/graph_rag/graph_rag_capability.py`: `GraphRagCapbility` -> `GraphRagCapability` in the class-level usage example so the copy-pasted snippet actually resolves.

## Test plan

- [x] `typos` (repo `_typos.toml` config) clean post-change.
- [x] Changed files compile (`py_compile`).
- [x] Pre-commit (ruff, mypy, codespell) green for the changed files.

## Attribution

These typos were originally surfaced by @Pablosinyores in #2908, which was closed because the CLA was not signed. This PR carries the fixes forward so they aren't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)