### PR TITLE
fix(beta/a2a): validate A2A protocol version during connection

### DIFF
--- a/autogen/beta/a2a/_session.py
+++ b/autogen/beta/a2a/_session.py
@@ -9,7 +9,7 @@ from typing import Any
 from a2a.client import A2ACardResolver, Client
 
 from .config import A2AConfig
-from .transports._http import make_a2a_client, make_httpx_client, select_transport
+from .transports._http import make_a2a_client, make_httpx_client, select_interface, validate_protocol_version
 
 
 def with_tenant(config: A2AConfig, override: str | None, **kwargs: Any) -> dict[str, Any]:
@@ -44,7 +44,8 @@ async def open_session(config: A2AConfig) -> AsyncIterator[Client]:
             config.preset_card
             or await A2ACardResolver(httpx_client=httpx_client, base_url=config.card_url).get_agent_card()
         )
-        transport = select_transport(card, url=config.card_url, prefer=config.prefer)
+        iface, transport = select_interface(card, url=config.card_url, prefer=config.prefer)
+        validate_protocol_version(iface, url=config.card_url, transport=transport)
         sdk = make_a2a_client(
             card=card,
             httpx_client=httpx_client,

--- a/autogen/beta/a2a/client.py
+++ b/autogen/beta/a2a/client.py
@@ -79,7 +79,7 @@ from .mappers import (
     payload_to_call,
 )
 from .transports import TransportName
-from .transports._http import make_a2a_client, make_httpx_client, select_transport
+from .transports._http import make_a2a_client, make_httpx_client, select_interface, validate_protocol_version
 
 if TYPE_CHECKING:
     import grpc.aio
@@ -278,7 +278,8 @@ class A2AClient(LLMClient):
             self._agent_card = await A2ACardResolver(
                 httpx_client=self._httpx_client, base_url=self._card_url
             ).get_agent_card()
-        transport = select_transport(self._agent_card, url=self._card_url, prefer=self._prefer)
+        iface, transport = select_interface(self._agent_card, url=self._card_url, prefer=self._prefer)
+        validate_protocol_version(iface, url=self._card_url, transport=transport)
         self._sdk_client = make_a2a_client(
             card=self._agent_card,
             httpx_client=self._httpx_client,

--- a/autogen/beta/a2a/errors.py
+++ b/autogen/beta/a2a/errors.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from a2a.types import Task, TaskState
+from a2a.utils.constants import PROTOCOL_VERSION_1_0
 
 
 class A2AError(Exception):
@@ -18,6 +19,29 @@ class A2AClientToolsNotSupportedError(A2AError):
 
 class A2AInvalidCardError(A2AError):
     """Raised when an ``AgentCard`` is missing data required to connect."""
+
+
+class A2AIncompatibleProtocolVersionError(A2AError):
+    """Raised when the interface AG2 selected on an ``AgentCard`` advertises an
+    A2A protocol version older than 1.0.
+
+    The 1.0 protocol is not backwards-compatible with the earlier 0.x drafts
+    (see https://a2a-protocol.org/latest/announcing-1.0/), so AG2 refuses to
+    connect rather than silently negotiating a session that fails later with
+    opaque RPC-level errors. A missing or unparsable ``protocol_version`` is
+    treated as compatible — it is an optional field and the A2A SDK itself
+    defaults it to the current version.
+    """
+
+    def __init__(self, *, url: str, transport: str, protocol_version: str) -> None:
+        self.url = url
+        self.transport = transport
+        self.protocol_version = protocol_version
+        super().__init__(
+            f"AgentCard at {url!r} declares an incompatible A2A protocol version "
+            f"{protocol_version!r} for transport {transport!r}; AG2 requires "
+            f">= {PROTOCOL_VERSION_1_0} (see https://a2a-protocol.org/latest/announcing-1.0/)."
+        )
 
 
 class A2AReconnectError(A2AError):

--- a/autogen/beta/a2a/transports/_http.py
+++ b/autogen/beta/a2a/transports/_http.py
@@ -9,9 +9,11 @@ from typing import TYPE_CHECKING
 import httpx
 from a2a.client import Client, ClientCallInterceptor, ClientConfig, ClientFactory
 from a2a.client.client_factory import TransportProtocol
-from a2a.types import AgentCard
+from a2a.types import AgentCard, AgentInterface
+from a2a.utils.constants import PROTOCOL_VERSION_1_0
+from packaging.version import InvalidVersion, Version
 
-from ..errors import A2AInvalidCardError
+from ..errors import A2AIncompatibleProtocolVersionError, A2AInvalidCardError
 from . import TransportName
 from .grpc import default_grpc_channel_factory
 
@@ -34,11 +36,18 @@ def binding_to_transport(binding: str) -> TransportName | None:
     return _BINDING_TO_TRANSPORT.get(binding)
 
 
-def select_transport(card: AgentCard, *, url: str, prefer: TransportName | None) -> TransportName:
-    """Pick a transport from ``card.supported_interfaces``.
+def select_interface(
+    card: AgentCard, *, url: str, prefer: TransportName | None
+) -> tuple[AgentInterface, TransportName]:
+    """Pick the ``AgentInterface`` AG2 will connect through, with its transport.
 
     Resolution: 1) ``prefer`` matches a declared binding (raise if absent);
     2) interface whose ``url`` matches ``url``; 3) first listed interface.
+
+    Returning the interface itself (not just the transport name) lets the
+    caller validate the *exact* interface that will be used — when a card
+    declares two interfaces with the same binding, the first-by-binding one
+    is not necessarily the one ``url`` resolution would select.
     """
     interfaces = list(card.supported_interfaces)
     if not interfaces:
@@ -46,9 +55,8 @@ def select_transport(card: AgentCard, *, url: str, prefer: TransportName | None)
 
     if prefer is not None:
         for iface in interfaces:
-            transport = binding_to_transport(iface.protocol_binding)
-            if transport == prefer:
-                return transport
+            if binding_to_transport(iface.protocol_binding) == prefer:
+                return iface, prefer
         raise A2AInvalidCardError(
             f"AgentCard at {url!r} does not declare prefer={prefer!r}; "
             f"available: {[iface.protocol_binding for iface in interfaces]}",
@@ -58,7 +66,7 @@ def select_transport(card: AgentCard, *, url: str, prefer: TransportName | None)
         if iface.url == url:
             transport = binding_to_transport(iface.protocol_binding)
             if transport is not None:
-                return transport
+                return iface, transport
 
     first = interfaces[0]
     transport = binding_to_transport(first.protocol_binding)
@@ -66,7 +74,31 @@ def select_transport(card: AgentCard, *, url: str, prefer: TransportName | None)
         raise A2AInvalidCardError(
             f"AgentCard at {url!r} declares unsupported binding {first.protocol_binding!r}",
         )
-    return transport
+    return first, transport
+
+
+def validate_protocol_version(iface: AgentInterface, *, url: str, transport: TransportName) -> None:
+    """Raise ``A2AIncompatibleProtocolVersionError`` if ``iface`` advertises an
+    A2A protocol version older than 1.0.
+
+    A2A v1.0 is a breaking change vs. the 0.x
+    (see https://a2a-protocol.org/latest/announcing-1.0/), so we refuse pre-1.0
+    interfaces at connect time rather than letting them surface as obscure
+    RPC failures later.
+
+    An empty / missing / unparsable ``protocol_version`` is treated as
+    compatible: the field is optional and the A2A SDK defaults it to the
+    current version, so rejecting it would break spec-conforming 1.0 servers.
+    """
+    raw = iface.protocol_version
+    if not raw:
+        return
+    try:
+        version = Version(raw)
+    except InvalidVersion:
+        return
+    if version < Version(PROTOCOL_VERSION_1_0):
+        raise A2AIncompatibleProtocolVersionError(url=url, transport=transport, protocol_version=raw)
 
 
 def make_httpx_client(

--- a/test/beta/a2a/test_protocol_version.py
+++ b/test/beta/a2a/test_protocol_version.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for issue #2904 — beta A2A must reject AgentCards whose
+selected interface advertises an A2A protocol version < 1.0, while still
+accepting interfaces that omit the optional ``protocol_version`` field."""
+
+import pytest
+from a2a.client.client_factory import TransportProtocol
+from a2a.types import AgentCapabilities, AgentCard, AgentInterface
+from a2a.utils.constants import PROTOCOL_VERSION_CURRENT
+
+from autogen.beta import Agent
+from autogen.beta.a2a import A2AConfig
+from autogen.beta.a2a.errors import A2AIncompatibleProtocolVersionError
+from autogen.beta.a2a.transports._http import select_interface, validate_protocol_version
+
+
+def _iface(*, url: str, version: str, binding: str = TransportProtocol.JSONRPC.value) -> AgentInterface:
+    return AgentInterface(url=url, protocol_binding=binding, protocol_version=version)
+
+
+def _card(*interfaces: AgentInterface) -> AgentCard:
+    return AgentCard(
+        name="t",
+        description="",
+        version="1.0.0",
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+        capabilities=AgentCapabilities(),
+        skills=[],
+        supported_interfaces=list(interfaces),
+    )
+
+
+class TestValidateProtocolVersion:
+    @pytest.mark.parametrize(
+        "version",
+        ["1.0", "1.0.0", "2.5", PROTOCOL_VERSION_CURRENT],
+    )
+    def test_accepts_compatible(self, version: str) -> None:
+        iface = _iface(url="http://example", version=version)
+        validate_protocol_version(iface, url="http://example", transport="jsonrpc")
+
+    @pytest.mark.parametrize(
+        "version",
+        ["", "garbage", "not-a-version"],
+    )
+    def test_accepts_empty_or_unparsable(self, version: str) -> None:
+        # The field is optional; the A2A SDK defaults a missing/unknown version
+        # to the current one, so we must not reject these as incompatible.
+        iface = _iface(url="http://example", version=version)
+        validate_protocol_version(iface, url="http://example", transport="jsonrpc")
+
+    @pytest.mark.parametrize("version", ["0.3", "0.9", "0.3.0"])
+    def test_rejects_legacy(self, version: str) -> None:
+        iface = _iface(url="http://example", version=version)
+        with pytest.raises(A2AIncompatibleProtocolVersionError) as exc:
+            validate_protocol_version(iface, url="http://example", transport="jsonrpc")
+        assert exc.value.protocol_version == version
+        assert exc.value.transport == "jsonrpc"
+        assert exc.value.url == "http://example"
+
+
+class TestSelectInterface:
+    def test_prefer_selects_matching_binding(self) -> None:
+        card = _card(
+            _iface(url="http://jsonrpc", version="1.0"),
+            _iface(url="http://grpc", version="1.0", binding=TransportProtocol.GRPC.value),
+        )
+        iface, transport = select_interface(card, url="http://jsonrpc", prefer="grpc")
+        assert transport == "grpc"
+        assert iface.url == "http://grpc"
+
+    def test_url_match_picks_exact_interface_among_same_binding(self) -> None:
+        # Two JSON-RPC interfaces: a legacy one and a current one. URL resolution
+        # must pick the interface matching the connect URL, not the first by
+        # binding — otherwise validation would inspect the wrong interface.
+        legacy = _iface(url="http://legacy", version="0.3")
+        current = _iface(url="http://current", version="1.0")
+        card = _card(legacy, current)
+
+        iface, transport = select_interface(card, url="http://current", prefer=None)
+        assert iface.url == "http://current"
+        # The selected (current) interface validates cleanly even though a
+        # legacy interface is listed first.
+        validate_protocol_version(iface, url="http://current", transport=transport)
+
+    def test_url_match_to_legacy_interface_is_rejected(self) -> None:
+        legacy = _iface(url="http://legacy", version="0.3")
+        current = _iface(url="http://current", version="1.0")
+        card = _card(legacy, current)
+
+        iface, transport = select_interface(card, url="http://legacy", prefer=None)
+        assert iface.url == "http://legacy"
+        with pytest.raises(A2AIncompatibleProtocolVersionError):
+            validate_protocol_version(iface, url="http://legacy", transport=transport)
+
+
+@pytest.mark.asyncio
+async def test_ask_raises_on_legacy_card() -> None:
+    card = _card(_iface(url="http://legacy", version="0.3"))
+    agent = Agent(
+        "client-agent",
+        config=A2AConfig(card_url="http://legacy", preset_card=card),
+    )
+    with pytest.raises(A2AIncompatibleProtocolVersionError) as exc:
+        await agent.ask("hello")
+    assert exc.value.protocol_version == "0.3"


### PR DESCRIPTION
## Summary

Closes #2904.

A2A v1.0 is a breaking change vs. the 0.x drafts (see
https://a2a-protocol.org/latest/announcing-1.0/). Today, opening a connection
against a server whose selected interface still advertises a `protocol_version`
of 0.x silently negotiates a session, and the incompatibility surfaces later as
opaque RPC-level errors. This PR surfaces it at **connect time** with a clear,
actionable exception.

In a2a-sdk 1.x the top-level `AgentCard.protocol_version` is gone — the version
now lives per-interface on `AgentInterface.protocol_version` — so the check is
applied to the specific interface AG2 will actually use.