### PR TITLE
fix(test): skip TinyFish tests when tinyfish is not installed

### DIFF
--- a/test/tools/experimental/tinyfish/test_tinyfish.py
+++ b/test/tools/experimental/tinyfish/test_tinyfish.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from autogen.import_utils import run_for_optional_imports
 from autogen.tools.experimental.tinyfish import TinyFishFetchTool, TinyFishSearchTool, TinyFishTool, tinyfish_tool
 
 
@@ -125,6 +126,7 @@ class TestTinyFishTool:
         assert result["data"]["status"] == "no_result"
 
 
+@run_for_optional_imports(["tinyfish"], "tinyfish")
 class TestTinyFishExecutionHelpers:
     """Test TinyFish SDK response mapping helpers."""
 


### PR DESCRIPTION
## Why are these changes needed?

Skip TinyFish tests when the package isn't installed, causes non-relevant test suite to fail otherwise.

## Related issue number

N/A

## Checks

- [] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
