### PR TITLE
fix(beta/network): make hub envelope ids strictly monotonic

### DIFF
--- a/autogen/beta/network/hub/core.py
+++ b/autogen/beta/network/hub/core.py
@@ -69,7 +69,7 @@ from ..errors import (
     ProtocolError,
 )
 from ..identity import ObservedStat, Passport, Resume
-from ..ids import make_id
+from ..ids import _MonotonicIds, make_id
 from ..remote import RemoteAgentProxy
 from ..rule import Rule, parse_duration
 from ..transport.frames import (
@@ -267,9 +267,19 @@ class Hub:
         # reconnect with ``HelloFrame.since_envelope_id`` set, the hub
         # replays, per channel, every dispatched envelope whose id sorts
         # strictly above ``max(channel_cursor, since_envelope_id)``.
-        # Envelope ids are UUID7, so lexicographic compare matches
+        # Envelope ids come from ``self._mint_envelope_id`` (strictly
+        # monotonic, time-ordered), so lexicographic compare matches
         # dispatch ordering within a channel.
         self._inbox_cursors: dict[str, dict[str, str]] = {}
+
+        # Strictly-monotonic source for envelope ids. The cursor and
+        # replay above rely on per-channel WAL order == sort order, but
+        # ``time.time_ns`` can repeat within a tick on coarse-resolution
+        # clocks (Windows ~15 ms), so a plain ``make_id`` would sort two
+        # same-tick envelopes by their random suffix — non-deterministically.
+        # This clamps each id strictly above the last so sort order always
+        # tracks mint order. State is per-hub (no shared global counter).
+        self._mint_envelope_id = _MonotonicIds()
 
         # Federation dispatch registry keyed by ``proxy.scheme``. When
         # a recipient passport has ``effective_kind == "remote_agent"``
@@ -1789,7 +1799,7 @@ class Hub:
                 )
             adapter.validate_send(metadata, envelope, state)
 
-            envelope.envelope_id = make_id()
+            envelope.envelope_id = self._mint_envelope_id()
             envelope.created_at = self._clock()
 
             await self._wal_append(envelope)
@@ -2532,9 +2542,12 @@ class Hub:
                 event_type=event_type,
                 event_data={"reason": reason, "channel_id": channel_id},
             )
-            close_envelope.envelope_id = make_id()
-            close_envelope.created_at = self._clock()
+            # Mint inside the WAL lock so the id is assigned in append
+            # order — otherwise a concurrent send on this channel could
+            # mint a later id but append it first, breaking sort order.
             async with self._wal_lock(channel_id):
+                close_envelope.envelope_id = self._mint_envelope_id()
+                close_envelope.created_at = self._clock()
                 await self._wal_append(close_envelope)
             await self._dispatch(close_envelope, metadata)
             kind_label = "expired" if new_state == ChannelState.EXPIRED else "closed"

--- a/autogen/beta/network/ids.py
+++ b/autogen/beta/network/ids.py
@@ -4,9 +4,17 @@
 
 """Identifier helpers for the network layer.
 
-:func:`make_id` returns time-ordered 32-char hex ids so the delivery
-cursor and reconnect replay can compare them by sort order identically
-on every supported runtime.
+:func:`make_id` returns 32-char hex ids whose leading 8 bytes are the
+wall-clock time, so they are *best-effort* time-ordered: unique and
+roughly sortable, but two ids minted within one clock tick are ordered
+only by their random suffix (``time.time_ns`` has coarse resolution on
+some runtimes — notably Windows, at ~15 ms).
+
+Where strict creation-order sorting is a correctness requirement — the
+delivery cursor and reconnect replay compare envelope ids by sort order —
+use :class:`_MonotonicIds`, which clamps each timestamp to strictly above
+the previous one (the UUIDv7 monotonicity guarantee). The hub owns one
+per instance and mints every envelope id through it.
 
 Also exposes :func:`parse_hub_urn` — the canonical helper for splitting
 ``hub://<hub_id>/<agent_id>`` URNs into their parts. Non-URN inputs
@@ -15,6 +23,7 @@ without branching on shape.
 """
 
 import os
+import threading
 import time
 
 __all__ = ("make_id", "parse_hub_urn")
@@ -24,16 +33,57 @@ _HUB_URN_PREFIX = "hub://"
 
 
 def make_id() -> str:
-    """Return a fresh time-ordered identifier as a 32-char hex string.
+    """Return a fresh, best-effort time-ordered 32-char hex string.
 
-    The leading 8 bytes are the big-endian nanosecond wall clock, so the
-    hex sorts lexicographically in creation order; the trailing 8 bytes
-    are random for uniqueness. The delivery cursor and reconnect replay
-    compare ids by sort order, so this ordering has to hold on every
-    supported runtime — ``uuid.uuid7`` exists only on 3.14+ and
-    ``uuid.uuid4`` is unordered, so neither is a portable basis.
+    The leading 8 bytes are the big-endian nanosecond wall clock; the
+    trailing 8 bytes are random for uniqueness. Two ids minted in the same
+    clock tick share the time prefix and so sort only by their random
+    suffix — fine for ids that need only uniqueness (agent, channel,
+    endpoint, request). Anything that must sort in *strict* creation order
+    — envelope ids, which the delivery cursor and reconnect replay compare
+    by sort order — must come from :class:`_MonotonicIds` instead.
+
+    (``uuid.uuid7`` would give strict ordering but exists only on 3.14+,
+    and ``uuid.uuid4`` is unordered, so neither is a portable basis.)
     """
     return time.time_ns().to_bytes(8, "big").hex() + os.urandom(8).hex()
+
+
+class _MonotonicIds:
+    """Callable returning strictly-monotonic, time-ordered ids.
+
+    Each id has the same shape as :func:`make_id` — an 8-byte big-endian
+    timestamp plus 8 random bytes — but consecutive calls are guaranteed
+    to sort in call order even when the wall clock does not advance between
+    them. Each timestamp is clamped to strictly above the previous one (the
+    UUIDv7 monotonicity guarantee); that is what makes the result a safe
+    basis for the delivery cursor and reconnect replay, which compare
+    envelope ids by sort order. As a side benefit it is also robust to the
+    wall clock stepping *backwards* (NTP slew), which a plain timestamp is
+    not.
+
+    State is per-instance, so each owner (e.g. a ``Hub``) gets an isolated
+    sequence — there is no shared process-global counter, so separate
+    owners never perturb one another's ordering and nothing leaks across
+    them (or across tests). The lock keeps the read-modify-write atomic if
+    an instance is ever called off the event loop (e.g. from a worker
+    thread); the critical section is a few arithmetic ops and holds no
+    ``await``, so it never stalls the loop. Envelope minting already runs
+    under the hub's per-channel WAL lock on a single event loop, so this
+    lock is defense-in-depth rather than a load-bearing guard.
+    """
+
+    def __init__(self) -> None:
+        self._last_ns = 0
+        self._lock = threading.Lock()
+
+    def __call__(self) -> str:
+        with self._lock:
+            ns = time.time_ns()
+            if ns <= self._last_ns:
+                ns = self._last_ns + 1
+            self._last_ns = ns
+        return ns.to_bytes(8, "big").hex() + os.urandom(8).hex()
 
 
 def parse_hub_urn(s: str) -> tuple[str | None, str]:

--- a/test/beta/network/test_at_least_once.py
+++ b/test/beta/network/test_at_least_once.py
@@ -21,6 +21,7 @@ Two test patterns coexist here:
 
 import asyncio
 import json
+from unittest import mock
 
 import pytest
 
@@ -157,6 +158,46 @@ class TestReceiptCursorAdvance:
             await alice_hc.close()
             await bob_hc.close()
             await hub.close()
+
+    @pytest.mark.asyncio
+    async def test_cursor_tracks_wal_head_when_clock_does_not_advance(self) -> None:
+        """Regression: envelope ids must sort in WAL-append order even when
+        the wall clock does not advance between mints — coarse-resolution
+        timers (Windows ~15 ms) or many envelopes inside one tick. The hub
+        mints through a strictly-monotonic source, so the cursor follows the
+        WAL head instead of landing on whichever same-tick envelope drew the
+        largest random suffix. Frozen here (the worst case of a coarse clock)
+        so the assertion would fail ~always without strict monotonicity."""
+        with mock.patch("autogen.beta.network.ids.time") as fake_time:
+            fake_time.time_ns.return_value = 1_700_000_000_000_000_000
+
+            hub = await _new_hub()
+            link = LocalLink(hub)
+            alice_hc = HubClient(link, hub=hub)
+            bob_hc = HubClient(link, hub=hub)
+            alice = await alice_hc.register(_agent("alice"), Passport(name="alice"), Resume())
+            bob = await bob_hc.register(_agent("bob"), Passport(name="bob"), Resume())
+
+            try:
+                # conversation channel: no turn-taking, so one sender may
+                # post many envelopes back-to-back (all within the frozen tick).
+                channel = await alice.open(type="conversation", target=["bob"])
+                for i in range(20):
+                    await channel.send(f"msg {i}")
+                await wait_for_text_count(hub, channel.channel_id, 20)
+
+                wal = await hub.read_wal(channel.channel_id)
+                env_ids = [e.envelope_id for e in wal]
+                assert env_ids == sorted(env_ids)  # sort order == append order
+                assert len(set(env_ids)) == len(env_ids)  # all unique
+
+                last_text = [e for e in wal if e.event_type == EV_TEXT][-1]
+                await _await_cursor(hub, bob.agent_id, channel.channel_id, lambda c: c == last_text.envelope_id)
+                assert hub.inbox_cursor(bob.agent_id, channel.channel_id) == last_text.envelope_id
+            finally:
+                await alice_hc.close()
+                await bob_hc.close()
+                await hub.close()
 
     @pytest.mark.asyncio
     async def test_ack_is_monotonic_under_out_of_order_receipts(self) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The network hub's per-`(agent, channel)` delivery cursor and reconnect replay compare envelope ids **lexicographically**, so envelope ids must sort in creation order. `make_id()` builds an id as `time.time_ns()` (8 bytes, big-endian) + 8 random bytes, which only sorts by creation order while the wall clock strictly advances.

On coarse-resolution clocks (Windows, ~15 ms) two envelopes minted in the same tick share the 8-byte time prefix and then sort only by their random suffix — non-deterministically. As a result the cursor can advance to the wrong envelope, and reconnect replay can skip or re-send messages. The failure is Windows-only and intermittent (it depends on whether two posts land in the same clock tick); Linux/macOS have nanosecond-resolution clocks, so consecutive `make_id()` calls almost always advance.

**Fix:** add `_MonotonicIds`, a per-`Hub` callable that clamps each timestamp to strictly above the previous one (the UUIDv7 monotonicity guarantee), and mint every envelope id through it.

- State is **per-instance** (no module global) and lock-guarded, so separate hubs/tests never share a counter — no cross-test, fork, or cross-instance coupling.
- Channel-close envelopes are now minted **inside** the WAL lock so their id is assigned in append order (previously minted *before* acquiring the lock — a latent ordering hazard).
- As a side benefit, ordering now also survives a backwards wall-clock step (NTP slew), which the old scheme did not.
- Corrected the stale "Envelope ids are UUID7" comment and the over-promising `make_id` docstring.

Other ids (`agent` / `channel` / `endpoint` / `request`) keep the lightweight `make_id` — only envelope ids require strict ordering.

### Validation

- **New regression test** `test_cursor_tracks_wal_head_when_clock_does_not_advance`: freezes the id clock (worst case of a coarse timer), posts 20 messages in a single tick (≈24 envelopes with channel setup), and asserts the WAL stays sorted and the cursor tracks the head. It **fails 5/5 runs without the fix** and passes deterministically with it.
- Full `test/beta/network/` suite: **450 passed**.
- `ruff check` clean on all changed files.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [ ] I understand the changes in this PR and can explain them in my own words.
- [ ] I have verified that the PR description accurately reflects the actual diff.
- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
