### PR TITLE
fix: preserve parameters_json_schema through tool registration and recreation

### DIFF
--- a/autogen/agentchat/contrib/swarm_agent.py
+++ b/autogen/agentchat/contrib/swarm_agent.py
@@ -355,10 +355,18 @@ def _change_tool_context_variables_to_depends(
         description = current_tool._description
         agent.remove_tool_for_llm(current_tool)
 
+        # Preserve parameters_json_schema from the original tool
+        parameters_json_schema = (
+            current_tool._func_schema["function"]["parameters"] if current_tool._func_schema else None
+        )
+
         # Recreate the tool without the context_variables parameter
         tool_func = _modify_context_variables_param(current_tool._func, context_variables)
         tool_func = inject_params(tool_func)
-        new_tool = ConversableAgent._create_tool_if_needed(func_or_tool=tool_func, name=name, description=description)
+        new_tool = ConversableAgent._create_tool_if_needed(
+            func_or_tool=tool_func, name=name, description=description,
+            parameters_json_schema=parameters_json_schema,
+        )
 
         # Re-register with the agent
         agent.register_for_llm()(new_tool)

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -3952,15 +3952,16 @@ class ConversableAgent(LLMAgent):
         func_or_tool: F | Tool,
         name: str | None,
         description: str | None,
+        parameters_json_schema: dict[str, Any] | None = None,
     ) -> Tool:
         if isinstance(func_or_tool, Tool):
             tool: Tool = func_or_tool
-            # create new tool object if name or description is not None
-            if name or description:
-                tool = Tool(func_or_tool=tool, name=name, description=description)
+            # create new tool object if name, description, or schema is overridden
+            if name or description or parameters_json_schema:
+                tool = Tool(func_or_tool=tool, name=name, description=description, parameters_json_schema=parameters_json_schema)
         elif inspect.isfunction(func_or_tool):
             function: Callable[..., Any] = func_or_tool
-            tool = Tool(func_or_tool=function, name=name, description=description)
+            tool = Tool(func_or_tool=function, name=name, description=description, parameters_json_schema=parameters_json_schema)
         else:
             raise TypeError(f"'func_or_tool' must be a function or a Tool object, got '{type(func_or_tool)}' instead.")
         return tool

--- a/autogen/agentchat/group/group_tool_executor.py
+++ b/autogen/agentchat/group/group_tool_executor.py
@@ -140,10 +140,20 @@ class GroupToolExecutor(ConversableAgent):
             name = current_tool._name
             description = current_tool._description
 
+            # Preserve parameters_json_schema from the original tool
+            parameters_json_schema = (
+                current_tool._func_schema["function"]["parameters"] if current_tool._func_schema else None
+            )
+
             # Recreate the tool without the context_variables parameter
             tool_func = self._modify_context_variables_param(tool_func, context_variables)
             tool_func = inject_params(tool_func)
-            return ConversableAgent._create_tool_if_needed(func_or_tool=tool_func, name=name, description=description)
+            return ConversableAgent._create_tool_if_needed(
+                func_or_tool=tool_func,
+                name=name,
+                description=description,
+                parameters_json_schema=parameters_json_schema,
+            )
         return None
 
     def _change_tool_context_variables_to_depends(

--- a/autogen/tools/tool.py
+++ b/autogen/tools/tool.py
@@ -61,18 +61,31 @@ class Tool:
                 f"Parameter 'func_or_tool' must be a function, method or a Tool instance, it is '{type(func_or_tool)}' instead."
             )
 
-        self._func_schema = (
-            {
+        # Build _func_schema from parameters_json_schema if provided;
+        # when constructing from an existing Tool, propagate its _func_schema
+        # unless explicitly overridden.
+        if parameters_json_schema:
+            self._func_schema = {
                 "type": "function",
                 "function": {
-                    "name": name,
-                    "description": description,
+                    "name": self._name,
+                    "description": self._description,
                     "parameters": parameters_json_schema,
                 },
             }
-            if parameters_json_schema
-            else None
-        )
+        elif isinstance(func_or_tool, Tool) and func_or_tool._func_schema is not None:
+            # Propagate the parent tool's schema (updated with new name/description if overridden)
+            parent_schema = func_or_tool._func_schema["function"]
+            self._func_schema = {
+                "type": "function",
+                "function": {
+                    "name": self._name,
+                    "description": self._description,
+                    "parameters": parent_schema["parameters"],
+                },
+            }
+        else:
+            self._func_schema = None
 
     @property
     def name(self) -> str:
@@ -97,6 +110,10 @@ class Tool:
         """
         if self._func_schema:
             agent.update_tool_signature(self._func_schema, is_remove=False)
+            # Ensure the tool is tracked in agent._tools so that
+            # agent.tools (used by GroupToolExecutor, swarm, etc.) can see it.
+            if self not in agent._tools:
+                agent._tools.append(self)
         else:
             agent.register_for_llm()(self)
 


### PR DESCRIPTION
## What

Fix two interrelated bugs where `parameters_json_schema` is lost or causes tools to be invisible during GroupChat and swarm registration.

## Bug 1: `_func_schema` bypasses `agent._tools`

When `parameters_json_schema` is provided, `Tool.register_for_llm` calls `agent.update_tool_signature()` directly instead of going through the decorator path. This skips `self._tools.append(tool)`, making the tool invisible to `agent.tools` — which GroupToolExecutor and swarm iterate to find and swap `context_variables` to `Depends`.

**Fix:** After `update_tool_signature`, also append to `agent._tools` if not already present.

## Bug 2: `parameters_json_schema` lost during tool recreation

When `make_tool_copy_with_context_variables` recreates a tool (to swap `context_variables` to `Depends`), it passes a raw function to `_create_tool_if_needed` without forwarding the original `parameters_json_schema`.

**Fix:** Extract `parameters_json_schema` from `current_tool._func_schema` and forward it through `_create_tool_if_needed` → `Tool.__init__`.

## Files Changed

- `autogen/tools/tool.py`: Propagate `_func_schema` when constructing from existing Tool; add to `agent._tools` in `_func_schema` path
- `autogen/agentchat/conversable_agent.py`: `_create_tool_if_needed` accepts `parameters_json_schema`
- `autogen/agentchat/group/group_tool_executor.py`: Preserve `parameters_json_schema` in `make_tool_copy_with_context_variables`
- `autogen/agentchat/contrib/swarm_agent.py`: Same fix for `_change_tool_context_variables_to_depends`

Fixes ag2ai/ag2classic#44