### PR TITLE
feat: add message_filter to GroupChat for selective message delivery

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -175,6 +175,7 @@ class GroupChat:
     select_speaker_auto_llm_config: LLMConfig | dict[str, Any] | Literal[False] | None = None
     role_for_select_speaker_messages: str | None = "system"
     eligibility_policies: list[AgentEligibilityPolicy] = field(default_factory=list)
+    message_filter: Callable[[dict[str, Any], str, "Agent"], bool] | None = None
 
     _VALID_SPEAKER_SELECTION_METHODS = ["auto", "manual", "random", "round_robin"]
     _VALID_SPEAKER_TRANSITIONS_TYPE = ["allowed", "disallowed", None]
@@ -317,6 +318,10 @@ class GroupChat:
                     f"eligibility_policies[{i}] does not implement AgentEligibilityPolicy "
                     f"(missing is_eligible method). Got {type(policy).__name__}."
                 )
+
+        # Validate message_filter
+        if self.message_filter is not None and not callable(self.message_filter):
+            raise ValueError(f"message_filter must be a callable or None, got {type(self.message_filter).__name__}.")
 
     def _apply_eligibility_policies(
         self,
@@ -1179,6 +1184,16 @@ class GroupChat:
                 return reply
         return None
 
+    def _should_deliver_message(self, message: dict[str, Any], sender_name: str, receiver: "Agent") -> bool:
+        """Check whether a message should be delivered to a receiver during broadcast.
+
+        Uses the user-provided ``message_filter`` callable if configured.
+        Returns ``True`` (deliver) when no filter is set.
+        """
+        if self.message_filter is None:
+            return True
+        return self.message_filter(message, sender_name, receiver)
+
 
 @export_module("autogen")
 class GroupChatManager(ConversableAgent):
@@ -1334,7 +1349,7 @@ class GroupChatManager(ConversableAgent):
             groupchat.append(message, speaker)
             # broadcast the message to all agents except the speaker
             for agent in groupchat.agents:
-                if agent != speaker:
+                if agent != speaker and groupchat._should_deliver_message(message, speaker.name, agent):
                     inter_reply = groupchat._run_inter_agent_guardrails(
                         src_agent_name=speaker.name,
                         dst_agent_name=agent.name,
@@ -1473,7 +1488,7 @@ class GroupChatManager(ConversableAgent):
 
             # broadcast the message to all agents except the speaker
             for agent in groupchat.agents:
-                if agent != speaker:
+                if agent != speaker and groupchat._should_deliver_message(message, speaker.name, agent):
                     await self.a_send(message, agent, request_reply=False, silent=True)
             if i == groupchat.max_round - 1:
                 # the last round

--- a/test/agentchat/test_groupchat.py
+++ b/test/agentchat/test_groupchat.py
@@ -2402,3 +2402,96 @@ def test_groupchatmanager_no_llm_config():
         ),
     ):
         agent_a.initiate_chat(manager, message="Hello")
+
+
+# -----------------------------------------------------------------------------
+# Tests: message_filter
+# -----------------------------------------------------------------------------
+
+
+def test_message_filter_none_delivers_all():
+    """Default (no filter) should deliver messages to all agents."""
+    agent_a = autogen.ConversableAgent("A", llm_config=False, human_input_mode="NEVER")
+    agent_b = autogen.ConversableAgent("B", llm_config=False, human_input_mode="NEVER")
+    agent_c = autogen.ConversableAgent("C", llm_config=False, human_input_mode="NEVER")
+
+    gc = GroupChat(agents=[agent_a, agent_b, agent_c], messages=[], max_round=2, speaker_selection_method="round_robin")
+    assert gc.message_filter is None
+    # _should_deliver_message should always return True when no filter
+    assert gc._should_deliver_message({"content": "hi"}, "A", agent_b) is True
+    assert gc._should_deliver_message({"content": "hi"}, "A", agent_c) is True
+
+
+def test_message_filter_blocks_irrelevant_messages():
+    """message_filter should prevent delivery to filtered-out agents."""
+    agent_a = autogen.ConversableAgent("A", llm_config=False, human_input_mode="NEVER")
+    agent_b = autogen.ConversableAgent("B", llm_config=False, human_input_mode="NEVER")
+    agent_c = autogen.ConversableAgent("C", llm_config=False, human_input_mode="NEVER")
+
+    # Only deliver messages from A to B, and from B to A; C never receives anything
+    def my_filter(message, sender_name, receiver):
+        if receiver.name == "C":
+            return False
+        return True
+
+    gc = GroupChat(
+        agents=[agent_a, agent_b, agent_c],
+        messages=[],
+        max_round=2,
+        speaker_selection_method="round_robin",
+        message_filter=my_filter,
+    )
+
+    msg = {"content": "hello from A", "name": "A"}
+    assert gc._should_deliver_message(msg, "A", agent_b) is True
+    assert gc._should_deliver_message(msg, "A", agent_c) is False
+    assert gc._should_deliver_message(msg, "B", agent_a) is True
+    assert gc._should_deliver_message(msg, "B", agent_c) is False
+
+
+def test_message_filter_selective_by_sender():
+    """message_filter can route messages based on sender name."""
+    agent_coder = autogen.ConversableAgent("Coder", llm_config=False, human_input_mode="NEVER")
+    agent_reviewer = autogen.ConversableAgent("Reviewer", llm_config=False, human_input_mode="NEVER")
+    agent_writer = autogen.ConversableAgent("Writer", llm_config=False, human_input_mode="NEVER")
+
+    # Coder's messages only go to Reviewer; Writer's messages only go to Coder
+    def route_filter(message, sender_name, receiver):
+        if sender_name == "Coder" and receiver.name == "Reviewer":
+            return True
+        if sender_name == "Writer" and receiver.name == "Coder":
+            return True
+        return False
+
+    gc = GroupChat(
+        agents=[agent_coder, agent_reviewer, agent_writer],
+        messages=[],
+        max_round=2,
+        speaker_selection_method="round_robin",
+        message_filter=route_filter,
+    )
+
+    coder_msg = {"content": "code", "name": "Coder"}
+    assert gc._should_deliver_message(coder_msg, "Coder", agent_reviewer) is True
+    assert gc._should_deliver_message(coder_msg, "Coder", agent_writer) is False
+
+    writer_msg = {"content": "docs", "name": "Writer"}
+    assert gc._should_deliver_message(writer_msg, "Writer", agent_coder) is True
+    assert gc._should_deliver_message(writer_msg, "Writer", agent_reviewer) is False
+
+
+def test_message_filter_validation():
+    """message_filter must be callable or None."""
+    agent = autogen.ConversableAgent("A", llm_config=False, human_input_mode="NEVER")
+
+    # None is fine
+    gc = GroupChat(agents=[agent], messages=[], message_filter=None)
+    assert gc.message_filter is None
+
+    # Callable is fine
+    gc = GroupChat(agents=[agent], messages=[], message_filter=lambda m, s, r: True)
+    assert callable(gc.message_filter)
+
+    # Non-callable raises
+    with pytest.raises(ValueError, match="message_filter must be a callable or None"):
+        GroupChat(agents=[agent], messages=[], message_filter="not_callable")


### PR DESCRIPTION
## What

Add a `message_filter` parameter to `GroupChat` that allows users to control which agents receive each message during broadcast. Currently, every agent receives ALL messages in the group chat, even irrelevant ones.

## Problem

In `GroupChat.run_chat()`, the broadcast loop sends every message to every agent unconditionally. This means:
- Agents accumulate irrelevant context, wasting tokens
- LLM may be confused by unrelated conversation threads
- No way to scope message delivery per agent

## Solution

Add `message_filter: Callable[[dict, str, Agent], bool] | None` to `GroupChat`.

- **Default `None`**: no filtering, all messages delivered (backward-compatible)
- **Custom callable**: `(message, sender_name, receiver_agent) -> bool` — return `True` to deliver, `False` to skip

Applied in both `run_chat()` and `a_run_chat()` broadcast loops.

## Usage

```python
def my_filter(message, sender_name, receiver):
    # Only deliver messages that mention the receiver
    return receiver.name in message.get("content", "")

gc = GroupChat(
    agents=[coder, reviewer, writer],
    message_filter=my_filter,
)
```

Fixes ag2ai/ag2classic#17