### PR TITLE
fix: disable JS minification to restore docs search bar

### DIFF
--- a/website/mkdocs/mkdocs.yml
+++ b/website/mkdocs/mkdocs.yml
@@ -118,7 +118,7 @@ plugins:
       nav_file: SUMMARY.md
   - minify:
       minify_html: true
-      minify_js: true
+      minify_js: false
       minify_css: true
       htmlmin_opts:
         remove_comments: true


### PR DESCRIPTION
Fixes ag2ai/ag2classic#15. The mkdocs-minify-plugin minify_js:true corrupts the Material theme search worker (lunr.js), breaking the search bar in local docs. Set minify_js to false.