### PR TITLE
fix: prevent Event loop is closed error in browser_use tool calls

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -2711,8 +2711,20 @@ class ConversableAgent(LLMAgent):
         def runner():
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-            result["value"] = loop.run_until_complete(coro)
-            loop.close()
+            try:
+                result["value"] = loop.run_until_complete(coro)
+            finally:
+                # Cancel and drain any pending tasks (e.g. Playwright browser
+                # shutdown, httpx connection cleanup) before closing the loop.
+                # Without this, async libraries that schedule deferred cleanup
+                # via __del__ or weakref finalizers raise
+                # "RuntimeError: Event loop is closed" on subsequent calls.
+                pending = asyncio.all_tasks(loop)
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+                loop.close()
 
         t = threading.Thread(target=runner)
         t.start()

--- a/autogen/tools/experimental/browser_use/browser_use.py
+++ b/autogen/tools/experimental/browser_use/browser_use.py
@@ -127,15 +127,25 @@ class BrowserUseTool(Tool):
                 controller=BrowserUseTool._get_controller(llm_config),
                 **agent_kwargs,
             )
-            result = await agent.run(max_steps=max_steps)
-            extracted_content = [
-                ExtractedContent(content=content, url=url)
-                for content, url in zip(result.extracted_content(), result.urls())
-            ]
-            return BrowserUseResult(
-                extracted_content=extracted_content,
-                final_result=result.final_result(),
-            )
+            try:
+                result = await agent.run(max_steps=max_steps)
+                extracted_content = [
+                    ExtractedContent(content=content, url=url)
+                    for content, url in zip(result.extracted_content(), result.urls())
+                ]
+                return BrowserUseResult(
+                    extracted_content=extracted_content,
+                    final_result=result.final_result(),
+                )
+            finally:
+                # Ensure the browser session is properly closed before the
+                # event loop is destroyed.  Without this, Playwright's async
+                # cleanup (__del__, weakref finalizers) fires on a closed loop
+                # and raises "RuntimeError: Event loop is closed".
+                try:
+                    await browser.close()
+                except Exception:
+                    pass  # best-effort cleanup
 
         super().__init__(
             name="browser_use",


### PR DESCRIPTION
Fixes ag2ai/ag2classic#41. Two changes: (1) _run_async_in_thread drains pending async tasks before closing the event loop, (2) browser_use adds try/finally with await browser.close() to properly shut down BrowserSession before loop destruction.