### PR TITLE
fix: add .clabot config to exclude bot accounts from CLA check

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,0 +1,6 @@
+{
+  "signatures": [],
+  "ignore": [
+    "[bot]"
+  ]
+}


### PR DESCRIPTION
Fixes ag2ai/ag2classic#19. Bot accounts like joggrbot[bot] cannot sign the CLA. Add .clabot config with ignore pattern [bot] to skip all GitHub bot accounts.