### PR TITLE
fix: correct Gemini client bugs and documentation

### DIFF
--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -307,12 +307,21 @@ class GeminiClient:
         tool_config = params.get("tool_config")
         include_thoughts = params.get("include_thoughts")
         thinking_budget = params.get("thinking_budget")
-        # Note: thinking_level is defined in GeminiLLMConfigEntry but not yet supported
-        # by google.genai.types.ThinkingConfig. Kept in config for forward compatibility.
-        thinking_config = ThinkingConfig(
-            include_thoughts=include_thoughts,
-            thinking_budget=thinking_budget,
-        )
+        thinking_level = params.get("thinking_level")
+
+        # Only create ThinkingConfig when at least one thinking parameter is set,
+        # to avoid sending an empty config to models that don't support thinking.
+        thinking_config = None
+        if include_thoughts is not None or thinking_budget is not None or thinking_level is not None:
+            tc_kwargs: dict[str, Any] = {}
+            if include_thoughts is not None:
+                tc_kwargs["include_thoughts"] = include_thoughts
+            if thinking_budget is not None:
+                tc_kwargs["thinking_budget"] = thinking_budget
+            if thinking_level is not None:
+                # Normalize to lowercase to match the google-genai SDK expectation
+                tc_kwargs["thinking_level"] = thinking_level.lower() if isinstance(thinking_level, str) else thinking_level
+            thinking_config = ThinkingConfig(**tc_kwargs)
         generation_config = {
             gemini_term: params[autogen_term]
             for autogen_term, gemini_term in self.PARAMS_MAPPING.items()
@@ -369,7 +378,7 @@ class GeminiClient:
                 system_instruction=system_instruction,
                 tools=tools,
                 tool_config=tool_config,
-                thinking_config=thinking_config if thinking_config is not None else None,
+                thinking_config=thinking_config,
                 **generation_config,
             )
             chat = client.chats.create(model=model_name, config=generate_content_config, history=gemini_messages[:-1])
@@ -414,7 +423,18 @@ class GeminiClient:
                 raise ValueError(
                     f"Unexpected number of candidates in the response. Expected 1, got {len(response.candidates)}"
                 )
-            parts = response.candidates[0].content.parts
+            if response.candidates[0].finish_reason and response.candidates[0].finish_reason.name == "RECITATION":
+                parts = [VertexAIPart.from_text("Unsuccessful Finish Reason: RECITATION")]
+                error_finish_reason = "content_filter"
+            elif not response.candidates[0].content or not response.candidates[0].content.parts:
+                parts = [
+                    VertexAIPart.from_text(
+                        f"Unsuccessful Finish Reason: ({str(response.candidates[0].finish_reason)}) NO CONTENT RETURNED"
+                    )
+                ]
+                error_finish_reason = "content_filter"
+            else:
+                parts = response.candidates[0].content.parts
         else:
             raise ValueError(f"Unexpected response type: {type(response)}")
 
@@ -591,8 +611,8 @@ class GeminiClient:
         if messages is None or len(messages) == 0 or messages[0].get("role") != "system":
             return None
 
-        message = messages.pop(0)
-        content = message["content"]
+        message = messages[0]
+        content = message.get("content")
 
         # Multi-model uses a list of dictionaries as content with text for the system message
         # Otherwise normal agents will have strings as content
@@ -751,6 +771,9 @@ class GeminiClient:
         """
         rst = []
         for message in messages:
+            # Skip system messages - they are extracted separately as system_instruction
+            if message.get("role") == "system":
+                continue
             parts, part_type = self._oai_content_to_gemini_content(message)
             role = "user" if message.get("role", "user") in ["user", "system"] else "model"
 
@@ -936,7 +959,7 @@ class GeminiClient:
         function_declaration = FunctionDeclaration()
         function_declaration.name = tool["function"]["name"]
         function_declaration.description = tool["function"]["description"]
-        if len(tool["function"]["parameters"]["properties"]) != 0:
+        if tool["function"]["parameters"].get("properties"):
             function_declaration.parameters = GeminiClient._create_gemini_function_declaration_schema(
                 copy.deepcopy(tool["function"]["parameters"])
             )

--- a/notebook/agentchat_gemini_thinking_config_example.ipynb
+++ b/notebook/agentchat_gemini_thinking_config_example.ipynb
@@ -52,13 +52,7 @@
    "cell_type": "markdown",
    "id": "2",
    "metadata": {},
-   "source": [
-    "## AG2 now supports Google Gemini's `ThinkingConfig`\n",
-    "ThinkConfig has three configuration, which are configured through LLMConfig item parameters:\n",
-    "- `thinking budget`: Indicates the thinking budget in tokens. 0 is DISABLED. -1 is AUTOMATIC. The default values and allowed ranges are model dependent.\n",
-    "- `thinking level`: The level of thoughts tokens that the model should generate.\n",
-    "- `include_thoughts`: Indicates whether to include thoughts in the response. If true, thoughts are returned only if the model supports thought and thoughts are available."
-   ]
+   "source": "## AG2 now supports Google Gemini's `ThinkingConfig`\nThinkingConfig has three configuration options, which are configured through LLMConfig item parameters:\n- `thinking_budget`: Indicates the thinking budget in tokens. 0 is DISABLED. -1 is AUTOMATIC. The default values and allowed ranges are model dependent.\n- `thinking_level`: The level of thoughts tokens that the model should generate.\n- `include_thoughts`: Indicates whether to include thoughts in the response. If true, thoughts are returned only if the model supports thought and thoughts are available."
   },
   {
    "cell_type": "code",
@@ -126,10 +120,7 @@
    "cell_type": "markdown",
    "id": "6",
    "metadata": {},
-   "source": [
-    "## Vary `thinking_level`\n",
-    "You can set `thinking_level` to \"low\" or \"high\" (which is the default for `gemini-3-pro-preview`) for `gemini-3-pro-preview` or `gemini-3-flash-preview`. `gemini-3-flash-preview` also supports \"medium\" or \"minimal\" (similar to no thinking). These settings will indicate to the model if it allowed to do a lot of thinking. Since the thinking process stays dynamic, `high` doesn't mean it will always use a lot of token in its thinking phase, just that it's allowed to."
-   ]
+   "source": "## Vary `thinking_level`\nYou can set `thinking_level` to \"low\" or \"high\" (which is the default for `gemini-3-pro-preview`) for `gemini-3-pro-preview` or `gemini-3-flash-preview`. `gemini-3-flash-preview` also supports \"medium\" or \"minimal\" (similar to no thinking). These settings will indicate to the model if it is allowed to do a lot of thinking. Since the thinking process stays dynamic, `high` doesn't mean it will always use a lot of token in its thinking phase, just that it's allowed to."
   },
   {
    "cell_type": "code",

--- a/website/docs/user-guide/models/google-gemini.mdx
+++ b/website/docs/user-guide/models/google-gemini.mdx
@@ -199,7 +199,7 @@ for event in response.events:
 
 ## Gemini vision example
 
-Gemini's models have vision capabilitiesso we can create multimodal agents.
+Gemini's models have vision capabilities so we can create multimodal agents.
 
 Here, we ask a question about
 ![Coding Example](./assets/chat-example.png)
@@ -263,22 +263,37 @@ In summary, the image depicts a typical chat interface used for customer support
 
 ## ThinkingConfig
 
-ThinkingConfig has two configuration options:
+ThinkingConfig has three configuration options:
 
 - `thinking_budget`: Indicates the thinking budget in tokens. 0 is DISABLED. -1 is AUTOMATIC. The default values and allowed ranges are model dependent.
 The ranges can be found here: [thinking budget ranges](https://ai.google.dev/gemini-api/docs/thinking#:~:text=The%20following%20are%20thinkingBudget%20configuration%20details%20for%20each%20model%20type.%20You%20can%20disable%20thinking%20by%20setting%20thinkingBudget%20to%200.%20Setting%20the%20thinkingBudget%20to%20%2D1%20turns%20on%20dynamic%20thinking%2C%20meaning%20the%20model%20will%20adjust%20the%20budget%20based%20on%20the%20complexity%20of%20the%20request.)
+- `thinking_level`: The level of thinking tokens that the model should generate. Supported values are "high", "medium", "low", and "minimal". Use with Gemini 3 models (`gemini-3-pro-preview`, `gemini-3-flash-preview`).
 - `include_thoughts`: Indicates whether to include thoughts in the response. If true, thoughts are returned only if the model supports thought and thoughts are available.
 
-Note: `thinking_level` is accepted in the configuration for forward compatibility but is not yet supported by the Google GenAI SDK.
-
 ```python
-# example configuration for ThinkingConfig Support (AI Studio)
+# example configuration for ThinkingConfig with thinking_budget (Gemini 2.5 series)
 llm_config = LLMConfig(
     config_list={
         "model": "gemini-2.5-flash",
         "api_type": "google",
         "api_key": "your-google-gemini-api-key",
         "thinking_budget": -1,  # -1 = AUTOMATIC, 0 = DISABLED
+        "include_thoughts": True,
+    }
+)
+
+agent = ConversableAgent(name="agent", description="you are a helpful assistant", llm_config=llm_config)
+response = agent.run(message=prompt, max_turns=2).process()
+```
+
+```python
+# example configuration for ThinkingConfig with thinking_level (Gemini 3 series)
+llm_config = LLMConfig(
+    config_list={
+        "model": "gemini-3-flash-preview",
+        "api_type": "google",
+        "api_key": "your-google-gemini-api-key",
+        "thinking_level": "high",  # "high", "medium", "low", or "minimal"
         "include_thoughts": True,
     }
 )

--- a/website/docs/user-guide/models/google-gemini.mdx
+++ b/website/docs/user-guide/models/google-gemini.mdx
@@ -59,14 +59,15 @@ Sample OAI_CONFIG_LIST
     },
     {
         "model": "gemini-2.5-pro",
+        "api_key": "your Google's GenAI Key goes here",
         "api_type": "google"
     },
     {
-        "model": "gemini-3.1-pro-preview",
+        "model": "gemini-2.5-pro",
         "project_id": "your-awesome-google-cloud-project-id",
         "location": "us-west1",
         "google_application_credentials": "your-google-service-account-key.json",
-        "api_type": "google"
+        "api_type": "google_vertex"
     }
 ]
 ```
@@ -87,14 +88,9 @@ from autogen.code_utils import content_str
 seed = 42  # for caching, use None for no caching
 llm_config = LLMConfig(
     config_list={
-        "model": "gemini-3.1-pro-preview",
+        "model": "gemini-2.5-flash",
         "api_type": "google",
-        "project_id": "your-awesome-google-cloud-project-id",
-        "location": "us-west1",
-        "google_application_credentials": "your-google-service-account-key.json",
-        "api_key": api_key,
-        "thinking_level": "High",
-        "include_thoughts": True,
+        "api_key": "your-google-gemini-api-key",
     }
 )
 
@@ -218,19 +214,14 @@ llm_config = LLMConfig(
     config_list={
         "model": "gemini-2.5-flash",
         "api_type": "google",
-        "project_id": "your-awesome-google-cloud-project-id",
-        "location": "us-west1",
-        "google_application_credentials": "your-google-service-account-key.json",
-        "api_key": api_key,
-        "thinking_budget": -1, # '-1' means AUTOMATIC Gemini adjusts based on complexity of tasks
-        "include_thoughts": True,
+        "api_key": "your-google-gemini-api-key",
     }
 )
 
 image_agent = MultimodalConversableAgent(
     "Gemini Vision",
     max_consecutive_auto_reply=1,
-    llm_config=llm_config_gemini_vision,
+    llm_config=llm_config,
 )
 
 user_proxy = UserProxyAgent("user_proxy", human_input_mode="NEVER", max_consecutive_auto_reply=0)
@@ -272,25 +263,22 @@ In summary, the image depicts a typical chat interface used for customer support
 
 ## ThinkingConfig
 
-ThinkConfig has three configuration:
+ThinkingConfig has two configuration options:
 
-- `thinking budget`: Indicates the thinking budget in tokens. 0 is DISABLED. -1 is AUTOMATIC. The default values and allowed ranges are model dependent.
-the ranges can be found here: [thinking budget ranges](https://ai.google.dev/gemini-api/docs/thinking#:~:text=The%20following%20are%20thinkingBudget%20configuration%20details%20for%20each%20model%20type.%20You%20can%20disable%20thinking%20by%20setting%20thinkingBudget%20to%200.%20Setting%20the%20thinkingBudget%20to%20%2D1%20turns%20on%20dynamic%20thinking%2C%20meaning%20the%20model%20will%20adjust%20the%20budget%20based%20on%20the%20complexity%20of%20the%20request.)
-- `thinking level`: The level of thoughts tokens that the model should generate.
+- `thinking_budget`: Indicates the thinking budget in tokens. 0 is DISABLED. -1 is AUTOMATIC. The default values and allowed ranges are model dependent.
+The ranges can be found here: [thinking budget ranges](https://ai.google.dev/gemini-api/docs/thinking#:~:text=The%20following%20are%20thinkingBudget%20configuration%20details%20for%20each%20model%20type.%20You%20can%20disable%20thinking%20by%20setting%20thinkingBudget%20to%200.%20Setting%20the%20thinkingBudget%20to%20%2D1%20turns%20on%20dynamic%20thinking%2C%20meaning%20the%20model%20will%20adjust%20the%20budget%20based%20on%20the%20complexity%20of%20the%20request.)
 - `include_thoughts`: Indicates whether to include thoughts in the response. If true, thoughts are returned only if the model supports thought and thoughts are available.
 
+Note: `thinking_level` is accepted in the configuration for forward compatibility but is not yet supported by the Google GenAI SDK.
+
 ```python
-# example configuration for ThinkingConfig Support
+# example configuration for ThinkingConfig Support (AI Studio)
 llm_config = LLMConfig(
     config_list={
-        "model": "gemini-3.1-pro-preview",
+        "model": "gemini-2.5-flash",
         "api_type": "google",
-        "project_id": "your-awesome-google-cloud-project-id",
-        "location": "us-west1",
-        "google_application_credentials": "your-google-service-account-key.json",
-        "api_key": api_key,
-        # "thinking_budget": 10000,
-        "thinking_level": "High", # Use the thinkingLevel parameter with Gemini 3 Pro. While thinkingBudget is accepted for backwards compatibility, using it with Gemini 3 Pro is recommended
+        "api_key": "your-google-gemini-api-key",
+        "thinking_budget": -1,  # -1 = AUTOMATIC, 0 = DISABLED
         "include_thoughts": True,
     }
 )


### PR DESCRIPTION
## Changes

### Bug Fixes in `autogen/oai/gemini.py`

1. **Fix `thinking_level` silently ignored** (critical): The `thinking_level` parameter was defined in `GeminiLLMConfigEntry` but never passed to `ThinkingConfig`. Users following the notebook would believe they were controlling thinking level when the parameter was completely ignored. Now properly passed with lowercase normalization to match the SDK expectation.

2. **Fix `ThinkingConfig` always created even when unused**: Previously an empty `ThinkingConfig` was sent on every request, which could cause unexpected behavior with models that do not support thinking. Now only created when at least one thinking parameter is set.

3. **Fix `_extract_system_instruction` mutating caller list**: Changed `messages.pop(0)` to `messages[0]` and added system message skipping in `_oai_messages_to_gemini_messages` to avoid processing system messages twice.

4. **Fix `_create_gemini_function_declaration` crash on no-parameter functions**: Functions with zero arguments (no `properties` key) caused a `KeyError`. Changed to use `.get("properties")`.

5. **Add error handling for VertexAI path**: Added RECITATION and null content checks matching the non-VertexAI path, preventing `AttributeError` on edge cases.

### Documentation Fixes

- Fixed typos in `notebook/agentchat_gemini_thinking_config_example.ipynb` (`ThinkConfig` -> `ThinkingConfig`, grammar fix)
- Updated `website/docs/user-guide/models/google-gemini.mdx` ThinkingConfig section to include `thinking_level` as a supported option and added Gemini 3 example

Closes ag2ai/ag2classic#45