### PR TITLE
feat: add anybrowse_web_fetch tool to CaptainAgent

### DIFF
--- a/autogen/agentchat/contrib/captainagent/tools/information_retrieval/anybrowse_web_fetch.py
+++ b/autogen/agentchat/contrib/captainagent/tools/information_retrieval/anybrowse_web_fetch.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+def anybrowse_web_fetch(url, api_key=None):
+    """Fetch a web page and convert it to clean Markdown using anybrowse.
+
+    Handles JavaScript-heavy sites, Cloudflare-protected pages, and PDFs
+    by rendering with a real Chrome browser. Returns LLM-ready Markdown.
+
+    Free tier: 10 calls/day without signup, 50 calls/day with free account.
+    Get an API key at https://anybrowse.dev/signup.
+
+    Args:
+        url (str): The URL to fetch and convert to Markdown.
+        api_key (str, optional): anybrowse API key. If not provided,
+            reads from ANYBROWSE_API_KEY environment variable. Not required
+            for the free tier (10 calls/day).
+
+    Returns:
+        str: The page content as clean Markdown, or an error message.
+    """
+    import json
+    import os
+
+    import requests
+
+    api_key = api_key or os.getenv("ANYBROWSE_API_KEY")
+
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    payload = {"url": url}
+
+    try:
+        response = requests.post(
+            "https://anybrowse.dev/scrape",
+            headers=headers,
+            data=json.dumps(payload),
+            timeout=60,
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        if result.get("status") == "ok" and result.get("markdown"):
+            title = result.get("title", url)
+            return f"# {title}\n\n{result['markdown']}"
+        else:
+            return f"Error: {result.get('error', 'Unknown error from anybrowse')}"
+
+    except requests.exceptions.Timeout:
+        return f"Error: Request timed out while fetching {url}"
+    except requests.exceptions.HTTPError as e:
+        if e.response.status_code == 429:
+            return "Error: Rate limit exceeded. Sign up at https://anybrowse.dev/signup for more calls."
+        return f"Error: HTTP {e.response.status_code} - {e.response.text}"
+    except Exception as e:
+        return f"Error fetching {url}: {e!s}"

--- a/autogen/agentchat/contrib/captainagent/tools/tool_description.tsv
+++ b/autogen/agentchat/contrib/captainagent/tools/tool_description.tsv
@@ -32,3 +32,4 @@ docid	document_content
 31	information_retrieval get_youtube_caption Retrieves the captions for a YouTube video.
 32	information_retrieval youtube_download Downloads a YouTube video and returns the download link.
 33	information_retrieval get_wikipedia_text Retrieves the text content of a Wikipedia page. It does not support tables and other complex formatting.
+34	information_retrieval anybrowse_web_fetch Fetch a web page and convert it to clean Markdown. Handles JavaScript-heavy sites, Cloudflare-protected pages, and PDFs using a real Chrome browser.

--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -1050,11 +1050,13 @@ class OpenAIWrapper:
 
                 client = self._create_v2_client(V2Client, openai_config, response_format)
             elif api_type is not None and api_type.startswith("responses"):
-                # OpenAI Responses API (stateful). Reuse the same OpenAI SDK but call the `/responses` endpoint via the new client.
+                # OpenAI Responses API. Reuse the same OpenAI SDK but call the `/responses` endpoint via the new client.
+                use_response_state = config.get("use_response_state", False)
+
                 @require_optional_import("openai>=2.30.0", "openai")
                 def create_responses_client() -> OpenAI:
                     client = OpenAI(**openai_config)
-                    self._clients.append(OpenAIResponsesClient(client, response_format=response_format))  # type: ignore[arg-type]
+                    self._clients.append(OpenAIResponsesClient(client, response_format=response_format, use_response_state=use_response_state))  # type: ignore[arg-type]
                     return client
 
                 client = create_responses_client()
@@ -1618,22 +1620,26 @@ class OpenAIResponsesEntryDict(LLMConfigEntryDict, total=False):
 
     tool_choice: Literal["none", "auto", "required"] | None
     built_in_tools: list[Literal["web_search", "image_generation", "apply_patch", "shell"]] | None
+    use_response_state: bool
 
 
 class OpenAIResponsesLLMConfigEntry(OpenAILLMConfigEntry):
-    """LLMConfig entry for the OpenAI Responses API (stateful, tool-enabled).
+    """LLMConfig entry for the OpenAI Responses API.
+
+    Supports both stateless (default) and stateful modes.  Stateless sends the
+    full message context each turn for reproducibility; stateful chains
+    responses via ``previous_response_id`` on the server side.
 
     This reuses all the OpenAI fields but changes *api_type* so the wrapper can
-    route traffic to the `client.responses` endpoint instead of
-    `chat.completions`.  It inherits everything else – including reasoning
-    fields – from *OpenAILLMConfigEntry* so users can simply set
+    route traffic to the ``client.responses`` endpoint instead of
+    ``chat.completions``.
 
     ```python
     {
-        "api_type": "responses_v2",  # <-- key differentiator
-        "model": "o3",  # reasoning model
-        "reasoning_effort": "medium",  # low / medium / high
-        "stream": True,
+        "api_type": "responses",
+        "model": "gpt-4o",
+        "use_response_state": False,  # default; set True for stateful threading
+        "built_in_tools": ["web_search"],
     }
     ```
     """
@@ -1649,6 +1655,7 @@ class OpenAIResponsesLLMConfigEntry(OpenAILLMConfigEntry):
     denied_commands: list[str] | None = None
     enable_command_filtering: bool = True
     dangerous_patterns: list[tuple[str, str]] | None = None
+    use_response_state: bool = False
 
     def create_client(self) -> ModelClient:  # pragma: no cover
         raise NotImplementedError("Handled via OpenAIWrapper._register_default_client")

--- a/autogen/oai/openai_responses.py
+++ b/autogen/oai/openai_responses.py
@@ -180,6 +180,7 @@ class OpenAIResponsesClient:
         self,
         client: "OpenAI",
         response_format: BaseModel | dict[str, Any] | None = None,
+        use_response_state: bool = False,
     ):
         self._oai_client = client  # plain openai.OpenAI instance
         self.response_format = response_format  # kept for parity but unused for now
@@ -194,8 +195,20 @@ class OpenAIResponsesClient:
         }
         self.previous_response_id = None
 
+        # Stateful mode: when True, chains responses via previous_response_id.
+        # Default is False (stateless) for reproducibility and GroupChat safety.
+        self.use_response_state = use_response_state
+
         # Image costs are calculated manually (rather than off returned information)
         self.image_costs = 0
+
+    def reset_state(self) -> None:
+        """Reset the conversation state (previous_response_id).
+
+        Call this to start a new conversation thread when using stateful mode,
+        or to clear stale state between independent interactions.
+        """
+        self.previous_response_id = None
 
     # ------------------------------------------------------------------ helpers
     # responses objects embed usage similarly to chat completions
@@ -823,11 +836,20 @@ class OpenAIResponsesClient:
 
         If the caller provided a classic *messages* array we convert it to the
         *input* format expected by the Responses API.
+
+        Stateful behavior is controlled by ``use_response_state``:
+        - Per-call override: pass ``use_response_state`` in *params*
+        - Instance default: set on ``__init__`` or assign to the attribute
+        When *False* (default), ``previous_response_id`` is never injected and
+        each request is fully self-contained (stateless).
         """
         params = params.copy()
 
         # Import here to avoid circular import
         from autogen.tools.experimental.shell import ShellExecutor
+
+        # Determine stateful mode: per-call param overrides instance attribute
+        use_state = params.pop("use_response_state", self.use_response_state)
 
         image_generation_tool_params = {"type": "image_generation"}
         web_search_tool_params = {"type": "web_search"}
@@ -848,40 +870,31 @@ class OpenAIResponsesClient:
         if dangerous_patterns is None:
             dangerous_patterns = ShellExecutor.DEFAULT_DANGEROUS_PATTERNS
 
-        if self.previous_response_id is not None and "previous_response_id" not in params:
+        # Only chain previous response when stateful mode is enabled
+        if use_state and self.previous_response_id is not None and "previous_response_id" not in params:
             params["previous_response_id"] = self.previous_response_id
 
-        # Check previous response for apply_patch_call items that need outputs
-        previous_apply_patch_calls = {}
-        if self.previous_response_id is not None:
+        # Check previous response for pending built-in tool calls (apply_patch, shell)
+        # that need outputs. Combined into a single retrieval to avoid duplicate API calls.
+        previous_apply_patch_calls: dict[str, Any] = {}
+        previous_shell_calls: dict[str, Any] = {}
+        if use_state and self.previous_response_id is not None:
             try:
                 previous_response = self._oai_client.responses.retrieve(self.previous_response_id)
                 previous_output = getattr(previous_response, "output", [])
                 for item in previous_output:
                     if hasattr(item, "model_dump"):
                         item = item.model_dump()
-                    if item.get("type") == "apply_patch_call":
-                        call_id = item.get("call_id")
-                        if call_id:
-                            previous_apply_patch_calls[call_id] = item
+                    item_type = item.get("type")
+                    call_id = item.get("call_id")
+                    if not call_id:
+                        continue
+                    if item_type == "apply_patch_call":
+                        previous_apply_patch_calls[call_id] = item
+                    elif item_type == "shell_call":
+                        previous_shell_calls[call_id] = item
             except Exception as e:
-                logger.debug(f"[apply_patch] Could not retrieve previous response: {e}")
-
-        # Check previous response for shell_call items that need outputs
-        previous_shell_calls = {}
-        if self.previous_response_id is not None:
-            try:
-                previous_response = self._oai_client.responses.retrieve(self.previous_response_id)
-                previous_output = getattr(previous_response, "output", [])
-                for item in previous_output:
-                    if hasattr(item, "model_dump"):
-                        item = item.model_dump()
-                    if item.get("type") == "shell_call":
-                        call_id = item.get("call_id")
-                        if call_id:
-                            previous_shell_calls[call_id] = item
-            except Exception as exc:  # pragma: no cover - retrieval best-effort
-                logger.debug("[shell] Could not inspect previous response: %s", exc)
+                logger.debug(f"Could not retrieve previous response for tool calls: {e}")
 
         # Back-compat: transform messages → input if needed ------------------
         if "messages" in params and "input" not in params:
@@ -978,12 +991,14 @@ class OpenAIResponsesClient:
                         return self._oai_client.responses.create(**kwargs)
 
             response = _create_or_parse(**params)
-            self.previous_response_id = response.id
+            if use_state:
+                self.previous_response_id = response.id
             return response
         # No structured output
         params = self._parse_params(params)
         response = self._oai_client.responses.create(**params)
-        self.previous_response_id = response.id
+        if use_state:
+            self.previous_response_id = response.id
         # Accumulate image costs
         self._add_image_cost(response)
         return response

--- a/test/oai/test_responses_client.py
+++ b/test/oai/test_responses_client.py
@@ -2924,3 +2924,167 @@ def test_shell_tool_convert_messages_to_input_filters_tool_responses_for_process
 
     # Tool response should be filtered out
     assert len(input_items) == 0
+
+
+# -----------------------------------------------------------------------------
+# Tests: use_response_state / reset_state
+# -----------------------------------------------------------------------------
+
+
+def test_stateless_by_default(mocked_openai_client):
+    """Client should be stateless by default (use_response_state=False)."""
+    client = OpenAIResponsesClient(mocked_openai_client)
+    assert client.use_response_state is False
+    assert client.previous_response_id is None
+
+
+def test_stateful_mode_via_init(mocked_openai_client):
+    """use_response_state=True enables stateful chaining."""
+    client = OpenAIResponsesClient(mocked_openai_client, use_response_state=True)
+    assert client.use_response_state is True
+
+
+def test_stateless_does_not_inject_previous_response_id(mocked_openai_client):
+    """In stateless mode, previous_response_id should NOT be injected into params."""
+    mocked_openai_client.responses.create.return_value = _FakeResponse(output=[], usage=_FakeUsage(
+        input_tokens=10, output_tokens=5, total_tokens=15,
+        output_tokens_details={"reasoning_tokens": 0},
+    ))
+
+    client = OpenAIResponsesClient(mocked_openai_client, use_response_state=False)
+    # Simulate a prior response having set the id
+    client.previous_response_id = "resp_old_123"
+
+    client.create(params={"messages": [{"role": "user", "content": "Hello"}]})
+
+    call_kwargs = mocked_openai_client.responses.create.call_args[1]
+    assert "previous_response_id" not in call_kwargs
+
+
+def test_stateful_injects_previous_response_id(mocked_openai_client):
+    """In stateful mode, previous_response_id should be injected into params."""
+    resp1 = _FakeResponse(output=[], usage=_FakeUsage(
+        input_tokens=10, output_tokens=5, total_tokens=15,
+        output_tokens_details={"reasoning_tokens": 0},
+    ))
+    resp1.id = "resp_001"
+    resp2 = _FakeResponse(output=[], usage=_FakeUsage(
+        input_tokens=10, output_tokens=5, total_tokens=15,
+        output_tokens_details={"reasoning_tokens": 0},
+    ))
+    resp2.id = "resp_002"
+    mocked_openai_client.responses.create.side_effect = [resp1, resp2]
+
+    client = OpenAIResponsesClient(mocked_openai_client, use_response_state=True)
+    client.create(params={"messages": [{"role": "user", "content": "Hello"}]})
+    assert client.previous_response_id == "resp_001"
+
+    # Second call should inject the previous id
+    client.create(params={"messages": [{"role": "user", "content": "Follow up"}]})
+    call_kwargs = mocked_openai_client.responses.create.call_args[1]
+    assert call_kwargs.get("previous_response_id") == "resp_001"
+
+
+def test_stateless_does_not_update_previous_response_id(mocked_openai_client):
+    """In stateless mode, previous_response_id should NOT be updated after create."""
+    resp = _FakeResponse(output=[], usage=_FakeUsage(
+        input_tokens=10, output_tokens=5, total_tokens=15,
+        output_tokens_details={"reasoning_tokens": 0},
+    ))
+    resp.id = "resp_new"
+    mocked_openai_client.responses.create.return_value = resp
+
+    client = OpenAIResponsesClient(mocked_openai_client, use_response_state=False)
+    client.create(params={"messages": [{"role": "user", "content": "Hello"}]})
+
+    assert client.previous_response_id is None
+
+
+def test_per_call_use_response_state_override(mocked_openai_client):
+    """Per-call use_response_state overrides the instance default."""
+    resp = _FakeResponse(output=[], usage=_FakeUsage(
+        input_tokens=10, output_tokens=5, total_tokens=15,
+        output_tokens_details={"reasoning_tokens": 0},
+    ))
+    resp.id = "resp_override"
+    mocked_openai_client.responses.create.return_value = resp
+
+    # Instance is stateless, but per-call enables stateful
+    client = OpenAIResponsesClient(mocked_openai_client, use_response_state=False)
+    client.create(params={
+        "messages": [{"role": "user", "content": "Hello"}],
+        "use_response_state": True,
+    })
+
+    assert client.previous_response_id == "resp_override"
+
+
+def test_reset_state_clears_previous_response_id(mocked_openai_client):
+    """reset_state() should clear previous_response_id."""
+    client = OpenAIResponsesClient(mocked_openai_client, use_response_state=True)
+    client.previous_response_id = "resp_stale"
+    client.reset_state()
+    assert client.previous_response_id is None
+
+
+def test_reset_state_allows_new_conversation(mocked_openai_client):
+    """After reset_state(), the next call should NOT chain the old response."""
+    resp1 = _FakeResponse(output=[], usage=_FakeUsage(
+        input_tokens=10, output_tokens=5, total_tokens=15,
+        output_tokens_details={"reasoning_tokens": 0},
+    ))
+    resp1.id = "resp_before_reset"
+    resp2 = _FakeResponse(output=[], usage=_FakeUsage(
+        input_tokens=10, output_tokens=5, total_tokens=15,
+        output_tokens_details={"reasoning_tokens": 0},
+    ))
+    resp2.id = "resp_after_reset"
+    mocked_openai_client.responses.create.side_effect = [resp1, resp2]
+
+    client = OpenAIResponsesClient(mocked_openai_client, use_response_state=True)
+    client.create(params={"messages": [{"role": "user", "content": "First turn"}]})
+    assert client.previous_response_id == "resp_before_reset"
+
+    client.reset_state()
+    assert client.previous_response_id is None
+
+    # Next call should NOT inject previous_response_id
+    client.create(params={"messages": [{"role": "user", "content": "New conversation"}]})
+    call_kwargs = mocked_openai_client.responses.create.call_args[1]
+    assert "previous_response_id" not in call_kwargs
+    assert client.previous_response_id == "resp_after_reset"
+
+
+def test_stateful_combined_retrieval_for_tool_calls(mocked_openai_client):
+    """Stateful mode retrieves previous response once for both apply_patch and shell calls."""
+    apply_patch_item = MagicMock()
+    apply_patch_item.model_dump.return_value = {
+        "type": "apply_patch_call",
+        "call_id": "call_patch_1",
+        "status": "completed",
+    }
+    shell_item = MagicMock()
+    shell_item.model_dump.return_value = {
+        "type": "shell_call",
+        "call_id": "call_shell_1",
+        "status": "completed",
+    }
+
+    prev_response = MagicMock()
+    prev_response.output = [apply_patch_item, shell_item]
+    mocked_openai_client.responses.retrieve.return_value = prev_response
+
+    new_response = _FakeResponse(output=[], usage=_FakeUsage(
+        input_tokens=10, output_tokens=5, total_tokens=15,
+        output_tokens_details={"reasoning_tokens": 0},
+    ))
+    new_response.id = "resp_new"
+    mocked_openai_client.responses.create.return_value = new_response
+
+    client = OpenAIResponsesClient(mocked_openai_client, use_response_state=True)
+    client.previous_response_id = "resp_old"
+
+    client.create(params={"input": [{"role": "user", "content": [{"type": "input_text", "text": "go"}]}]})
+
+    # Should have retrieved the previous response exactly once
+    mocked_openai_client.responses.retrieve.assert_called_once_with("resp_old")


### PR DESCRIPTION
Add anybrowse as an information retrieval tool for CaptainAgent workflows.

## Changes
- New tool: `anybrowse_web_fetch.py` in `tools/information_retrieval/`
- Updated `tool_description.tsv` with tool description

## What it does
Converts any URL to clean, LLM-ready Markdown using a real Chrome browser. Handles JavaScript-heavy sites, Cloudflare-protected pages, and PDFs.

## Free tier
- 10 calls/day without signup
- 50 calls/day with free account at https://anybrowse.dev/signup

Fixes ag2ai/ag2classic#6