### PR TITLE
feat: add TWZRD Agent Intel MCP notebook — Solana x402 agent trust scoring

### DIFF
--- a/notebook/agentchat_mcp_twzrd_trust.ipynb
+++ b/notebook/agentchat_mcp_twzrd_trust.ipynb
@@ -1,0 +1,201 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Agent Trust Verification with AG2 and TWZRD Agent Intel MCP\n",
+    "\n",
+    "This notebook shows how to connect AG2 agents to the [TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server\n",
+    "to score Solana AI agent wallets before authorizing x402 micropayments.\n",
+    "\n",
+    "**TWZRD Agent Intel** is a zero-install MCP server accessible via streamable-HTTP:\n",
+    "- `score_agent(wallet)` \u2014 on-chain trust score 0\u20131 (free)\n",
+    "- `preflight_check(wallet)` \u2014 full pre-payment due diligence (free)\n",
+    "- `get_trust_receipt(wallet)` \u2014 signed trust receipt via HTTP 402 (paid)\n",
+    "\n",
+    "No server to run locally. No API key required for the free tools.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install Dependencies\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install required packages\n",
+    "# pip install ag2 mcp nest_asyncio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports and Setup\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import os\n",
+    "\n",
+    "import nest_asyncio\n",
+    "from mcp import ClientSession\n",
+    "from mcp.client.streamable_http import streamablehttp_client\n",
+    "\n",
+    "from autogen import ConversableAgent, LLMConfig\n",
+    "from autogen.mcp import create_toolkit\n",
+    "\n",
+    "nest_asyncio.apply()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure LLM\n",
+    "\n",
+    "Set your API key. The example uses OpenAI but any AG2-supported model works.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OPENAI_API_KEY = os.getenv(\"OPENAI_API_KEY\", \"your-api-key-here\")\n",
+    "\n",
+    "llm_config = LLMConfig(\n",
+    "    config_list=[\n",
+    "        {\n",
+    "            \"model\": \"gpt-4o-mini\",\n",
+    "            \"api_type\": \"openai\",\n",
+    "            \"api_key\": OPENAI_API_KEY,\n",
+    "        }\n",
+    "    ],\n",
+    "    temperature=0.3,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connect to TWZRD Agent Intel MCP\n",
+    "\n",
+    "The TWZRD Agent Intel server uses the **streamable-HTTP** MCP transport.\n",
+    "We connect directly using `mcp.client.streamable_http` and wrap tools with `create_toolkit`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Target wallet to score (a known active Solana agent)\n",
+    "WALLET = \"D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi\"\n",
+    "\n",
+    "\n",
+    "async def run_trust_check():\n",
+    "    \"\"\"Connect to TWZRD Agent Intel MCP and run a trust check with AG2.\"\"\"\n",
+    "\n",
+    "    async with streamablehttp_client(\"https://intel.twzrd.xyz/mcp\") as (read, write, _):\n",
+    "        async with ClientSession(read, write) as session:\n",
+    "            await session.initialize()\n",
+    "\n",
+    "            # Wrap MCP tools as AG2-compatible tools\n",
+    "            toolkit = await create_toolkit(session=session)\n",
+    "\n",
+    "            # AG2 agent that uses TWZRD tools\n",
+    "            trust_agent = ConversableAgent(\n",
+    "                name=\"TrustAnalyst\",\n",
+    "                llm_config=llm_config,\n",
+    "                system_message=(\n",
+    "                    \"You are a Solana agent trust analyst. \"\n",
+    "                    \"Use the available MCP tools to score a wallet and provide \"\n",
+    "                    \"an APPROVE or REJECT recommendation for x402 payments.\"\n",
+    "                ),\n",
+    "            )\n",
+    "\n",
+    "            # Register TWZRD tools on the agent\n",
+    "            toolkit.register_for_llm(trust_agent)\n",
+    "            toolkit.register_for_execution(trust_agent)\n",
+    "\n",
+    "            # Orchestrator that drives the conversation\n",
+    "            orchestrator = ConversableAgent(\n",
+    "                name=\"Orchestrator\",\n",
+    "                llm_config=False,\n",
+    "                human_input_mode=\"NEVER\",\n",
+    "                max_consecutive_auto_reply=1,\n",
+    "            )\n",
+    "\n",
+    "            # Run the trust check\n",
+    "            await orchestrator.a_initiate_chat(\n",
+    "                trust_agent,\n",
+    "                message=(\n",
+    "                    f\"Score this Solana agent wallet: {WALLET}\\n\"\n",
+    "                    \"1. Call score_agent to get the trust score\\n\"\n",
+    "                    \"2. Call preflight_check for full due diligence\\n\"\n",
+    "                    \"3. Return APPROVE or REJECT with reasoning\"\n",
+    "                ),\n",
+    "                max_turns=3,\n",
+    "            )\n",
+    "\n",
+    "\n",
+    "asyncio.run(run_trust_check())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Expected Output\n",
+    "\n",
+    "The `TrustAnalyst` agent will:\n",
+    "1. Call `score_agent` \u2192 receive trust score (0\u20131) and payment history\n",
+    "2. Call `preflight_check` \u2192 receive full due diligence report\n",
+    "3. Return a structured `APPROVE` or `REJECT` recommendation\n",
+    "\n",
+    "Example output:\n",
+    "```\n",
+    "Wallet: D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi\n",
+    "Trust Score: 0.85\n",
+    "Prior x402 Payments: 48\n",
+    "Recommendation: APPROVE \u2014 High repeat-payment agent with 48 confirmed transactions\n",
+    "```\n",
+    "\n",
+    "## Links\n",
+    "\n",
+    "- TWZRD Agent Intel: https://intel.twzrd.xyz\n",
+    "- MCP endpoint: `https://intel.twzrd.xyz/mcp`\n",
+    "- x402 protocol: https://x402.org\n"
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
## What This Adds

`notebook/agentchat_mcp_twzrd_trust.ipynb` — a new MCP notebook demonstrating how AG2 agents can use the [TWZRD Agent Intel](https://intel.twzrd.xyz) server to score Solana AI agent wallets before authorizing x402 micropayments.

This follows the same pattern as the existing `agentchat_mcp_arxiv.ipynb` and `agentchat_mcp_wikipedia.ipynb` notebooks, but uses a **zero-install remote MCP server** via the streamable-HTTP transport rather than a locally-run server.

## Why It's Useful

x402 is an emerging HTTP payment protocol for autonomous AI agents. Before an agent accepts payment from another agent, it needs to assess the payer's trustworthiness. TWZRD Agent Intel provides this in a single MCP call — free, no registration, no local setup:

```python
async with streamablehttp_client("https://intel.twzrd.xyz/mcp") as (read, write, _):
    async with ClientSession(read, write) as session:
        await session.initialize()
        toolkit = await create_toolkit(session=session)
        # Use toolkit with any ConversableAgent
```

## Tools Available

| Tool | Description | Cost |
|------|-------------|------|
| `score_agent(wallet)` | On-chain trust score 0–1 | Free |
| `preflight_check(wallet)` | Full pre-payment check | Free |
| `get_trust_receipt(wallet)` | Signed receipt (HTTP 402) | Paid |

The notebook only uses the free tools — no API key or USDC balance needed.

## Key Difference from Other MCP Notebooks

- `agentchat_mcp_arxiv.ipynb` / `agentchat_mcp_wikipedia.ipynb` use **stdio** (local subprocess) or **SSE** (local server) transport
- This notebook uses `mcp.client.streamable_http` to connect to a **remote public MCP server** directly — no local server to start