### PR TITLE
docs(beta): AI coding agent documentation support

### DIFF
--- a/.github/workflows/build-mkdocs.yml
+++ b/.github/workflows/build-mkdocs.yml
@@ -43,6 +43,13 @@ jobs:
       - name: Verify the build
         run: |
           ls -la ./website/mkdocs/site
+          # Ensure the Beta-scoped llms.txt files were generated and copied into the site.
+          for f in llms.txt llms-full.txt; do
+            if [ ! -s "./website/mkdocs/site/$f" ]; then
+              echo "::error::Expected non-empty ./website/mkdocs/site/$f (llms.txt generation failed)"
+              exit 1
+            fi
+          done
         working-directory: .
 
       - name: Configure Git user

--- a/website/docs/beta/agents.mdx
+++ b/website/docs/beta/agents.mdx
@@ -129,3 +129,6 @@ reply = await agent.ask(
     stream=stream
 )
 ```
+
+!!! tip "Building with an AI coding assistant?"
+    See [Coding with AI Assistants](/docs/beta/coding_with_ai) to set up Claude Code, Cursor, Copilot, or another assistant with AG2 Beta skills and project rules so it writes against the current `autogen.beta` API.

--- a/website/docs/beta/coding_with_ai.mdx
+++ b/website/docs/beta/coding_with_ai.mdx
@@ -1,0 +1,135 @@
+---
+title: "Coding with AI Assistants"
+sidebarTitle: "AI Coding Assistants"
+---
+
+Set up your AI coding assistant (Claude Code, Cursor, Copilot, Codex, Windsurf, or any agent) so it can build **AG2 Beta** apps with you using current, accurate APIs instead of guessing at outdated `autogen` patterns.
+
+!!! tip "Point your agent at this page"
+    Most coding agents can read a URL. Paste this page's link into your assistant and ask it to follow the setup — it can install the AG2 skills and configure itself. Everything below is written to be runnable copy-paste.
+
+## Why this matters
+
+AG2 Beta (`autogen.beta`) is a new, async, protocol-driven API. Models were largely trained on the older `autogen` / `pyautogen` surface, so out of the box an assistant will reach for stale patterns — synchronous `ConversableAgent`, `initiate_chat`, and the like. The setup on this page gives your assistant three things it otherwise lacks: **AG2-specific skills**, a **Beta-only docs reference**, and **project rules** that keep it on the Beta API.
+
+!!! warning "Beta only"
+    This page targets `autogen.beta`. The pre-Beta API is being retired at v1.0 — point your assistant at the Beta docs and skills, not legacy `autogen` examples it may have memorized.
+
+## Step 1 — Install the AG2 Skills (start here)
+
+[ag2-skills](https://github.com/ag2ai/ag2-skills){.external-link target="_blank"} is a catalog of [Agent Skills](https://agentskills.io/){.external-link target="_blank"} — on-demand instruction packs that teach an assistant how to build with AG2 Beta. Each skill loads only its name and description (~100 tokens) until it's relevant, then pulls in the full recipe. Skills cover quickstart, custom tools, the multi-agent network, middleware, memory, structured output, evaluation, and more.
+
+The fastest path uses the [`skills` CLI](https://skills.sh){.external-link target="_blank"}:
+
+<Tabs>
+  <Tab title="All skills">
+```bash
+# Install the full AG2 Beta skill catalog
+npx skills add ag2ai/ag2-skills
+```
+  </Tab>
+
+  <Tab title="One skill">
+```bash
+# Install just the quickstart (good first taste)
+npx skills add ag2ai/ag2-skills@ag2-quickstart
+```
+  </Tab>
+
+  <Tab title="Manual (Claude Code)">
+```bash
+# Clone and copy individual skills into your user skills directory
+git clone https://github.com/ag2ai/ag2-skills.git
+cp -r ag2-skills/skills/ag2-overview   ~/.claude/skills/
+cp -r ag2-skills/skills/ag2-quickstart ~/.claude/skills/
+```
+  </Tab>
+</Tabs>
+
+!!! tip "Where to start"
+    After installing, tell your assistant to load **`ag2-overview`** (a map of AG2 Beta capabilities) and **`ag2-quickstart`** (a minimal working agent). From there it can pull in the specific skill it needs — for example `ag2-add-custom-tool` or `ag2-network-quickstart`.
+
+## Step 2 — Point your assistant at the Beta docs
+
+Skills teach patterns; the docs keep your assistant honest about the *exact* current signatures. The biggest risk is your assistant falling back on the **classic** `autogen` API it was trained on (`ConversableAgent`, `initiate_chat`, `GroupChat`) — all retired at v1.0. Give it Beta-only ground truth:
+
+- **Beta `llms.txt`:** [`https://docs.ag2.ai/latest/llms.txt`](https://docs.ag2.ai/latest/llms.txt){.external-link target="_blank"} — a machine-readable index of the Beta docs following the [llms.txt standard](https://llmstxt.org/){.external-link target="_blank"}, plus [`llms-full.txt`](https://docs.ag2.ai/latest/llms-full.txt){.external-link target="_blank"} for the entire Beta docs in one file. Both are Beta-scoped, so they never point your agent at the classic API.
+- **Live Beta docs:** [`https://docs.ag2.ai/latest/docs/beta/`](https://docs.ag2.ai/latest/docs/beta/){.external-link target="_blank"} — point your agent at this section (most assistants can fetch a URL).
+- **Beta docs source (Markdown):** [`ag2ai/ag2/website/docs/beta`](https://github.com/ag2ai/ag2/tree/main/website/docs/beta){.external-link target="_blank"} — the raw `.mdx` your agent can read directly from GitHub.
+
+Then anchor your prompt: *"Build with `autogen.beta` only. If a signature is unfamiliar, check the Beta docs before writing code — do not use the classic `autogen` API."*
+
+!!! warning "Be careful with generic docs indexers for AG2 right now"
+    Third-party docs-MCP servers and code indexers typically ingest the **entire** `ag2` repository, which is still dominated by the classic API. Pointed at AG2 today they surface `ConversableAgent` / `initiate_chat` examples — the opposite of what you want for Beta. Until a Beta-scoped index exists, rely on the AG2 Skills and the Beta docs links above, which are Beta-only by construction.
+
+## Step 3 — Add project rules to your repo
+
+A rules file pins AG2 Beta conventions for every session in your project. The open [AGENTS.md](https://agents.md/){.external-link target="_blank"} standard is read by Cursor, Copilot, Codex, Gemini CLI, Windsurf, and others; Claude Code reads `CLAUDE.md`. Drop one (or both — a symlink works) at your repo root:
+
+```markdown
+# AGENTS.md
+
+This project is built on **AG2 Beta** (`autogen.beta`). Follow these rules.
+
+## API surface
+- Import only from `autogen.beta` and its submodules (`autogen.beta.config`,
+  `autogen.beta.tools`, ...). Do NOT use the legacy `autogen` / `pyautogen`
+  API (`ConversableAgent`, `initiate_chat`) — it is retired at v1.0.
+- Agents are async. Use `await agent.ask(...)` and `await reply.ask(...)`.
+
+## Conventions
+- Do not use `from __future__ import annotations`.
+- Public signatures accept `str | os.PathLike[str]`; use `pathlib.Path` internally.
+- Prefer top-level imports; no imports inside functions.
+
+## Docs & skills
+- Install AG2 skills: `npx skills add ag2ai/ag2-skills`.
+- Beta docs index (Beta-only): https://docs.ag2.ai/latest/llms.txt
+- When unsure of a signature, check the Beta docs before writing code.
+- Do NOT trust generic docs indexers — they surface the retired classic API.
+```
+
+<Tabs>
+  <Tab title="Claude Code">
+```bash
+# Claude Code reads CLAUDE.md — symlink it to a single source of truth
+ln -s AGENTS.md CLAUDE.md
+```
+  </Tab>
+
+  <Tab title="Cursor">
+```bash
+# Cursor reads AGENTS.md, or project rules under .cursor/rules/
+mkdir -p .cursor/rules
+cp AGENTS.md .cursor/rules/ag2-beta.md
+```
+  </Tab>
+
+  <Tab title="Copilot">
+```bash
+# GitHub Copilot reads .github/copilot-instructions.md
+mkdir -p .github
+cp AGENTS.md .github/copilot-instructions.md
+```
+  </Tab>
+</Tabs>
+
+## Per-tool summary
+
+| Assistant | Skills | Beta docs | Project rules |
+|---|---|---|---|
+| **Claude Code** | `npx skills add ag2ai/ag2-skills` or copy to `~/.claude/skills/` | point at `llms.txt` | `CLAUDE.md` (symlink to `AGENTS.md`) |
+| **Cursor** | `npx skills add ag2ai/ag2-skills` | point at `llms.txt` | `AGENTS.md` or `.cursor/rules/` |
+| **Copilot / Codex / Windsurf** | `npx skills add ag2ai/ag2-skills` | point at `llms.txt` | `AGENTS.md` (Copilot: `.github/copilot-instructions.md`) |
+| **Any agent** | paste `SKILL.md` contents into context | hand it `llms-full.txt` | paste the rules above into your prompt |
+
+## Tips & caveats
+
+- **Start from the quickstart.** Have your assistant scaffold from `ag2-quickstart` rather than inventing structure — see [Agent Communication](/docs/beta/agents) and [Model Configuration](/docs/beta/model_configuration).
+- **Prefer the documented high-level API** (`autogen.beta`, `autogen.beta.tools`, `autogen.beta.config`) over reaching into internals.
+- **Always review generated code.** Models still drift toward legacy `autogen` patterns; verify imports come from `autogen.beta` and that calls are `await`ed.
+- **Verify signatures against the Beta docs.** If a generated API looks unfamiliar, have the assistant confirm it against the [Beta docs](https://docs.ag2.ai/latest/docs/beta/){.external-link target="_blank"} before trusting it.
+- **Run the tests.** AG2 is async throughout — encourage your assistant to write and run [tests](/docs/beta/testing) with `TestConfig` instead of hitting a live model.
+
+!!! note "Going further"
+    The skill catalog mirrors these docs section-for-section — `ag2-network-quickstart` for [multi-agent networks](/docs/beta/network/overview), `ag2-structured-output` for [typed responses](/docs/beta/structured_output), `ag2-evaluation` for the [eval framework](/docs/beta/evaluation/evaluation), and more. Install the set once and your assistant can pull in whichever it needs.

--- a/website/docs/beta/coding_with_ai.mdx
+++ b/website/docs/beta/coding_with_ai.mdx
@@ -3,21 +3,23 @@ title: "Coding with AI Assistants"
 sidebarTitle: "AI Coding Assistants"
 ---
 
-Set up your AI coding assistant (Claude Code, Cursor, Copilot, Codex, Windsurf, or any agent) so it can build **AG2 Beta** apps with you using current, accurate APIs instead of guessing at outdated `autogen` patterns.
+Set up your AI coding assistant (Claude Code, Cursor, Copilot, Codex, Windsurf, or any agent) so it can build **AG2 Beta** apps with you using current, accurate APIs and examples.
 
 !!! tip "Point your agent at this page"
-    Most coding agents can read a URL. Paste this page's link into your assistant and ask it to follow the setup — it can install the AG2 skills and configure itself. Everything below is written to be runnable copy-paste.
+    Paste this page's link into your assistant and ask it to follow the setup. It can install the AG2 skills and configure itself. Everything below is written to be runnable copy-paste.
 
 ## Why this matters
 
-AG2 Beta (`autogen.beta`) is a new, async, protocol-driven API. Models were largely trained on the older `autogen` / `pyautogen` surface, so out of the box an assistant will reach for stale patterns — synchronous `ConversableAgent`, `initiate_chat`, and the like. The setup on this page gives your assistant three things it otherwise lacks: **AG2-specific skills**, a **Beta-only docs reference**, and **project rules** that keep it on the Beta API.
+AG2 Beta (`autogen.beta`) is a new, async, protocol-driven API. Models were largely trained on the older `autogen` / `pyautogen` surface, so out of the box an assistant will reach for stale patterns such as synchronous `ConversableAgent`, `initiate_chat`, and the like. The setup on this page gives your assistant three things it otherwise lacks: **AG2-specific skills**, a **Beta-only docs reference**, and **project rules** that keep it on the Beta API.
 
 !!! warning "Beta only"
-    This page targets `autogen.beta`. The pre-Beta API is being retired at v1.0 — point your assistant at the Beta docs and skills, not legacy `autogen` examples it may have memorized.
+    This page targets `autogen.beta`. The pre-Beta API (known as the classic API) is being retired at v1.0, so point your assistant at the Beta docs and skills, not legacy `autogen` examples it may have memorized.
 
-## Step 1 — Install the AG2 Skills (start here)
+## Step 1: Install the AG2 Skills
 
-[ag2-skills](https://github.com/ag2ai/ag2-skills){.external-link target="_blank"} is a catalog of [Agent Skills](https://agentskills.io/){.external-link target="_blank"} — on-demand instruction packs that teach an assistant how to build with AG2 Beta. Each skill loads only its name and description (~100 tokens) until it's relevant, then pulls in the full recipe. Skills cover quickstart, custom tools, the multi-agent network, middleware, memory, structured output, evaluation, and more.
+The most critical and dev-accelerating step.
+
+[ag2-skills](https://github.com/ag2ai/ag2-skills){.external-link target="_blank"} is a catalog of [Agent Skills](https://agentskills.io/){.external-link target="_blank"}, on-demand instruction packs that teach an assistant how to build with AG2 Beta. Each skill loads only its name and description until it's relevant, then pulls in the full recipe. Skills cover quickstart, custom tools, the multi-agent network, middleware, memory, structured output, evaluation, and more.
 
 The fastest path uses the [`skills` CLI](https://skills.sh){.external-link target="_blank"}:
 
@@ -47,24 +49,24 @@ cp -r ag2-skills/skills/ag2-quickstart ~/.claude/skills/
 </Tabs>
 
 !!! tip "Where to start"
-    After installing, tell your assistant to load **`ag2-overview`** (a map of AG2 Beta capabilities) and **`ag2-quickstart`** (a minimal working agent). From there it can pull in the specific skill it needs — for example `ag2-add-custom-tool` or `ag2-network-quickstart`.
+    After installing, tell your assistant to load **`ag2-overview`** (a map of AG2 Beta capabilities) and **`ag2-quickstart`** (a minimal working agent). From there it can pull in the specific skill it needs, such as `ag2-add-custom-tool` or `ag2-network-quickstart`.
 
-## Step 2 — Point your assistant at the Beta docs
+## Step 2: Point your assistant at the Beta docs
 
-Skills teach patterns; the docs keep your assistant honest about the *exact* current signatures. The biggest risk is your assistant falling back on the **classic** `autogen` API it was trained on (`ConversableAgent`, `initiate_chat`, `GroupChat`) — all retired at v1.0. Give it Beta-only ground truth:
+Skills teach patterns; the docs keep your assistant honest about the *exact* current signatures. The biggest risk is your assistant falling back on the **classic** `autogen` API it was trained on (`ConversableAgent`, `initiate_chat`, `GroupChat`) — all retiring at v1.0. Give it Beta-only ground truth:
 
-- **Beta `llms.txt`:** [`https://docs.ag2.ai/latest/llms.txt`](https://docs.ag2.ai/latest/llms.txt){.external-link target="_blank"} — a machine-readable index of the Beta docs following the [llms.txt standard](https://llmstxt.org/){.external-link target="_blank"}, plus [`llms-full.txt`](https://docs.ag2.ai/latest/llms-full.txt){.external-link target="_blank"} for the entire Beta docs in one file. Both are Beta-scoped, so they never point your agent at the classic API.
-- **Live Beta docs:** [`https://docs.ag2.ai/latest/docs/beta/`](https://docs.ag2.ai/latest/docs/beta/){.external-link target="_blank"} — point your agent at this section (most assistants can fetch a URL).
+- **Live Beta docs:** [`https://docs.ag2.ai/latest/docs/beta/agents/`](https://docs.ag2.ai/latest/docs/beta/agents/){.external-link target="_blank"} — point your agent at this section (most assistants can fetch a URL).
 - **Beta docs source (Markdown):** [`ag2ai/ag2/website/docs/beta`](https://github.com/ag2ai/ag2/tree/main/website/docs/beta){.external-link target="_blank"} — the raw `.mdx` your agent can read directly from GitHub.
+- **Beta `llms.txt`:** [`https://docs.ag2.ai/latest/llms.txt`](https://docs.ag2.ai/latest/llms.txt){.external-link target="_blank"} — a machine-readable index of the Beta docs following the [llms.txt standard](https://llmstxt.org/){.external-link target="_blank"}, plus [`llms-full.txt`](https://docs.ag2.ai/latest/llms-full.txt){.external-link target="_blank"} for the entire Beta docs in one file. Both are Beta-scoped, so they never point your agent at the classic API.
 
 Then anchor your prompt: *"Build with `autogen.beta` only. If a signature is unfamiliar, check the Beta docs before writing code — do not use the classic `autogen` API."*
 
 !!! warning "Be careful with generic docs indexers for AG2 right now"
-    Third-party docs-MCP servers and code indexers typically ingest the **entire** `ag2` repository, which is still dominated by the classic API. Pointed at AG2 today they surface `ConversableAgent` / `initiate_chat` examples — the opposite of what you want for Beta. Until a Beta-scoped index exists, rely on the AG2 Skills and the Beta docs links above, which are Beta-only by construction.
+    Third-party docs-MCP servers and code indexers typically ingest the **entire** `ag2` repository, which still has the classic API. Pointed at AG2 today they surface `ConversableAgent` / `initiate_chat` examples — the opposite of what you want for Beta. Until a Beta-scoped index exists, rely on the AG2 Skills and the Beta docs links above, which are Beta-only by construction.
 
-## Step 3 — Add project rules to your repo
+## Step 3: Add project rules to your repo
 
-A rules file pins AG2 Beta conventions for every session in your project. The open [AGENTS.md](https://agents.md/){.external-link target="_blank"} standard is read by Cursor, Copilot, Codex, Gemini CLI, Windsurf, and others; Claude Code reads `CLAUDE.md`. Drop one (or both — a symlink works) at your repo root:
+A rules file pins AG2 Beta conventions for every session in your project. The open [AGENTS.md](https://agents.md/){.external-link target="_blank"} standard is read by Cursor, Copilot, Codex, Gemini CLI, Windsurf, and others; Claude Code reads `CLAUDE.md`. Drop one (or both, a symlink works) at your repo root:
 
 ```markdown
 # AGENTS.md
@@ -83,8 +85,8 @@ This project is built on **AG2 Beta** (`autogen.beta`). Follow these rules.
 - Prefer top-level imports; no imports inside functions.
 
 ## Docs & skills
-- Install AG2 skills: `npx skills add ag2ai/ag2-skills`.
-- Beta docs index (Beta-only): https://docs.ag2.ai/latest/llms.txt
+- Install and use the AG2 skills: `npx skills add ag2ai/ag2-skills`.
+- Beta docs: https://docs.ag2.ai/latest/docs/beta/agents/ (machine-readable index at /latest/llms.txt).
 - When unsure of a signature, check the Beta docs before writing code.
 - Do NOT trust generic docs indexers — they surface the retired classic API.
 ```
@@ -118,17 +120,16 @@ cp AGENTS.md .github/copilot-instructions.md
 
 | Assistant | Skills | Beta docs | Project rules |
 |---|---|---|---|
-| **Claude Code** | `npx skills add ag2ai/ag2-skills` or copy to `~/.claude/skills/` | point at `llms.txt` | `CLAUDE.md` (symlink to `AGENTS.md`) |
-| **Cursor** | `npx skills add ag2ai/ag2-skills` | point at `llms.txt` | `AGENTS.md` or `.cursor/rules/` |
-| **Copilot / Codex / Windsurf** | `npx skills add ag2ai/ag2-skills` | point at `llms.txt` | `AGENTS.md` (Copilot: `.github/copilot-instructions.md`) |
-| **Any agent** | paste `SKILL.md` contents into context | hand it `llms-full.txt` | paste the rules above into your prompt |
+| **Claude Code** | `npx skills add ag2ai/ag2-skills` or copy to `~/.claude/skills/` | point at the docs URL | `CLAUDE.md` (symlink to `AGENTS.md`) |
+| **Cursor** | `npx skills add ag2ai/ag2-skills` | point at the docs URL | `AGENTS.md` or `.cursor/rules/` |
+| **Copilot / Codex / Windsurf** | `npx skills add ag2ai/ag2-skills` | point at the docs URL | `AGENTS.md` (Copilot: `.github/copilot-instructions.md`) |
+| **Any agent** | paste `SKILL.md` contents into context | paste the docs (or `llms-full.txt`) | paste the rules above into your prompt |
 
 ## Tips & caveats
 
 - **Start from the quickstart.** Have your assistant scaffold from `ag2-quickstart` rather than inventing structure — see [Agent Communication](/docs/beta/agents) and [Model Configuration](/docs/beta/model_configuration).
 - **Prefer the documented high-level API** (`autogen.beta`, `autogen.beta.tools`, `autogen.beta.config`) over reaching into internals.
 - **Always review generated code.** Models still drift toward legacy `autogen` patterns; verify imports come from `autogen.beta` and that calls are `await`ed.
-- **Verify signatures against the Beta docs.** If a generated API looks unfamiliar, have the assistant confirm it against the [Beta docs](https://docs.ag2.ai/latest/docs/beta/){.external-link target="_blank"} before trusting it.
 - **Run the tests.** AG2 is async throughout — encourage your assistant to write and run [tests](/docs/beta/testing) with `TestConfig` instead of hitting a live model.
 
 !!! note "Going further"

--- a/website/docs/beta/motivation.mdx
+++ b/website/docs/beta/motivation.mdx
@@ -79,6 +79,9 @@ When you `pip install ag2`, this will include the current **AG2 Beta** release u
 
 If you want the most up-to-date version, use the `main` branch. To see current work in progress, view the [GitHub repository](https://github.com/ag2ai/ag2/issues?q=state%3Aopen%20label%3Abeta) for PRs with the `beta` label.
 
+!!! tip "Using an AI coding assistant?"
+    If you build with Claude Code, Cursor, Copilot, or another AI coding assistant, see [Coding with AI Assistants](/docs/beta/coding_with_ai) to set it up with AG2 Beta skills and project rules so it writes against the current `autogen.beta` API.
+
 See the following pages for walkthroughs of the new **AG2 Beta** API.
 
 ## Current Focus Areas

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -519,6 +519,7 @@
         },
         "docs/beta/ag2_compatibility",
         "docs/beta/roadmap",
+        "docs/beta/coding_with_ai",
         "docs/beta/contribution_policy",
         {
           "group": "Code Examples",

--- a/website/mkdocs/.gitignore
+++ b/website/mkdocs/.gitignore
@@ -1,4 +1,6 @@
 /site
 /docs/assets/**
 /docs/snippets/**
+/docs/llms.txt
+/docs/llms-full.txt
 /data/notebooks_metadata.yml

--- a/website/mkdocs/_website/generate_mkdocs.py
+++ b/website/mkdocs/_website/generate_mkdocs.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from autogen.import_utils import optional_import_block, require_optional_import
 
+from .llms_txt import generate_llms_txt
 from .notebook_processor import (
     create_base_argument_parser,
     process_notebooks_core,
@@ -1335,6 +1336,9 @@ def main(force: bool) -> None:
 
     process_blog_files(mkdocs_output_dir, authors_yml_path, snippets_dir_path)
     generate_mkdocs_navigation(website_dir, mkdocs_root_dir, nav_exclusions)
+
+    # Generate Beta-scoped llms.txt / llms-full.txt (https://llmstxt.org/) at the site root.
+    generate_llms_txt(website_dir, mkdocs_docs_dir)
 
     if args.website_build_directory is None:
         args.website_build_directory = mkdocs_output_dir

--- a/website/mkdocs/_website/llms_txt.py
+++ b/website/mkdocs/_website/llms_txt.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2023 - 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate Beta-scoped ``llms.txt`` and ``llms-full.txt`` files.
+
+The output follows the https://llmstxt.org/ specification:
+
+- a single H1 with the project name,
+- a blockquote summary,
+- zero or more free-form markdown sections with details,
+- zero or more H2 "file list" sections whose items are ``[name](url)`` links with
+  an optional ``: description`` suffix,
+- an optional H2 section literally titled "Optional" holding links that may be
+  skipped when a shorter context is needed.
+
+Scope is intentionally limited to ``docs/beta/**`` so coding assistants are never
+fed the classic ``autogen`` API (retired at v1.0).
+"""
+
+import json
+import re
+from pathlib import Path
+
+from autogen.import_utils import optional_import_block, require_optional_import
+
+with optional_import_block():
+    import yaml
+    from jinja2 import Template
+
+BASE_URL = "https://docs.ag2.ai/latest"
+
+PROJECT_TITLE = "AG2 Beta"
+
+SUMMARY = (
+    "AG2 Beta (`autogen.beta`) is an async, protocol-driven Python framework for building "
+    "AI agents — covering agents, tools, multi-agent networks, structured output, memory, "
+    "and evaluation. This file indexes the Beta documentation for LLMs and coding assistants."
+)
+
+# Free-form details paragraph(s) emitted after the blockquote.
+DETAILS = (
+    "Build with `autogen.beta` only. The classic `autogen` API (`ConversableAgent`, "
+    "`initiate_chat`, `GroupChat`) is retired at v1.0 — do not use it. For ready-made "
+    "setup, install the AG2 Skills with `npx skills add ag2ai/ag2-skills`."
+)
+
+# Heading used for the standalone (non-grouped) Beta pages.
+DEFAULT_SECTION = "Documentation"
+
+# Capitalization fixes when deriving a title from a filename.
+_TITLE_KEYWORDS = {
+    "Ag2": "AG2",
+    "Rag": "RAG",
+    "Llm": "LLM",
+    "Ai": "AI",
+    "Mcp": "MCP",
+    "Hitl": "HITL",
+    "Ui": "UI",
+    "A2A": "A2A",
+    "Stt": "STT",
+    "Tts": "TTS",
+}
+
+_MAX_DESCRIPTION = 200
+
+# Typographic punctuation that adds no value in a plain-text file meant for machine
+# ingestion, and which renders as mojibake (``â€``…) in non-UTF-8 viewers. Mapped to
+# ASCII. Meaningful symbols (box-drawing diagrams, checkmarks, math) are left untouched.
+_PUNCT_TABLE = {
+    ord("—"): "-",  # — em dash
+    ord("–"): "-",  # – en dash
+    ord("−"): "-",  # − minus sign
+    ord("…"): "...",  # … ellipsis
+    ord("‘"): "'",  # ' left single quote
+    ord("’"): "'",  # ' right single quote
+    ord("“"): '"',  # " left double quote
+    ord("”"): '"',  # " right double quote
+    ord(" "): " ",  # non-breaking space
+    ord("·"): "-",  # · middle dot
+    ord("›"): ">",  # › single right angle quote
+    ord("→"): "->",  # → rightwards arrow
+    ord("←"): "<-",  # ← leftwards arrow
+    ord("↔"): "<->",  # ↔ left-right arrow
+    ord("⇒"): "=>",  # ⇒ rightwards double arrow
+}
+
+
+def _normalize_punctuation(text: str) -> str:
+    """Replace noisy typographic punctuation with ASCII equivalents."""
+    return text.translate(_PUNCT_TABLE)
+
+
+def _format_title_from_filename(stem: str) -> str:
+    words = stem.replace("-", " ").replace("_", " ").title().split()
+    return " ".join(_TITLE_KEYWORDS.get(word, word) for word in words)
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Return ``(frontmatter_dict, body)`` for a Markdown document."""
+    match = re.match(r"^---\n(.*?)\n---\n?", text, re.DOTALL)
+    if not match:
+        return {}, text
+    try:
+        frontmatter = yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError:
+        frontmatter = {}
+    return frontmatter, text[match.end() :]
+
+
+def _page_title(frontmatter: dict[str, str], stem: str) -> str:
+    return frontmatter.get("title") or frontmatter.get("sidebarTitle") or _format_title_from_filename(stem)
+
+
+def _clean_inline(text: str) -> str:
+    """Strip Markdown adornments so a line reads as plain prose."""
+    text = re.sub(r"\{\.external-link[^}]*\}", "", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)  # links -> link text
+    text = text.replace("#!python ", "")
+    # Drop inline-code ticks and bold/italic asterisks, but keep underscores so code
+    # identifiers like ``on_tool_execution`` survive intact.
+    text = re.sub(r"[`*]+", "", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _description(body: str) -> str:
+    """Extract a one-line description from the first prose paragraph of a page."""
+    body = re.sub(r"^\s*#\s+.*\n", "", body, count=1)  # drop a leading H1 if present
+
+    paragraph: list[str] = []
+    in_code = False
+    for line in body.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code = not in_code
+            continue
+        if in_code:
+            continue
+        if not stripped:
+            if paragraph:
+                break
+            continue
+        # Skip structural / non-prose lines until real prose starts.
+        if stripped.startswith(("#", "<", "!!!", "===", "|", ">", "-", "*", "import ", "from ")):
+            if paragraph:
+                break
+            continue
+        paragraph.append(stripped)
+
+    text = _clean_inline(" ".join(paragraph))
+    if len(text) > _MAX_DESCRIPTION:
+        text = text[:_MAX_DESCRIPTION].rsplit(" ", 1)[0].rstrip(",.;:") + "…"
+    return text
+
+
+def _clean_for_full(body: str) -> str:
+    """Tidy a page body for inclusion in ``llms-full.txt``."""
+    # Reduce code-fence info strings to just the language (drop linenums/hl_lines).
+    body = re.sub(r"^(```[a-zA-Z0-9_+-]*)[^\n]*$", r"\1", body, flags=re.MULTILINE)
+    body = re.sub(r"\{\.external-link[^}]*\}", "", body)
+    body = body.replace("#!python ", "")
+    return body.strip()
+
+
+def _flatten_pages(group: dict) -> list[str]:
+    """Return all leaf page paths within a (possibly nested) navigation group."""
+    pages: list[str] = []
+    for page in group["pages"]:
+        if isinstance(page, str):
+            pages.append(page)
+        else:
+            pages.extend(_flatten_pages(page))
+    return pages
+
+
+def _iter_sections(beta_group: dict) -> list[tuple[str, list[str]]]:
+    """Split the Beta nav into ``(section_title, page_paths)`` pairs, preserving order."""
+    sections: list[tuple[str, list[str]]] = []
+    standalone: list[str] = []
+    for page in beta_group["pages"]:
+        if isinstance(page, str):
+            standalone.append(page)
+        else:
+            sections.append((page["group"], _flatten_pages(page)))
+    if standalone:
+        sections.insert(0, (DEFAULT_SECTION, standalone))
+    return sections
+
+
+def _load_page(page_path: str, site_root: Path) -> tuple[str, str, str] | None:
+    """Return ``(title, description, cleaned_body)`` for a Beta page, or ``None`` if missing."""
+    md_file = site_root / f"{page_path}.md"
+    if not md_file.is_file():
+        return None
+    frontmatter, body = _split_frontmatter(md_file.read_text(encoding="utf-8"))
+    title = _page_title(frontmatter, Path(page_path).stem)
+    return title, _description(body), _clean_for_full(body)
+
+
+def _render_index(sections: list[tuple[str, list[str]]], pages: dict[str, tuple[str, str, str]]) -> str:
+    lines = [f"# {PROJECT_TITLE}", "", f"> {SUMMARY}", "", DETAILS, ""]
+    for section_title, page_paths in sections:
+        entries = []
+        for page_path in page_paths:
+            loaded = pages.get(page_path)
+            if loaded is None:
+                continue
+            title, description, _ = loaded
+            url = f"{BASE_URL}/{page_path}/"
+            entries.append(f"- [{title}]({url})" + (f": {description}" if description else ""))
+        if entries:
+            lines.append(f"## {section_title}")
+            lines.append("")
+            lines.extend(entries)
+            lines.append("")
+
+    lines.append("## Optional")
+    lines.append("")
+    lines.append(
+        f"- [llms-full.txt]({BASE_URL}/llms-full.txt): The entire Beta documentation concatenated into a single file."
+    )
+    lines.append(
+        "- [AG2 Skills](https://github.com/ag2ai/ag2-skills): Installable Agent Skills that "
+        "teach coding assistants the Beta API."
+    )
+    lines.append("")
+    return _normalize_punctuation("\n".join(lines))
+
+
+def _render_full(sections: list[tuple[str, list[str]]], pages: dict[str, tuple[str, str, str]]) -> str:
+    lines = [
+        f"# {PROJECT_TITLE} — Full Documentation",
+        "",
+        f"> {SUMMARY}",
+        "",
+        DETAILS,
+        "",
+    ]
+    for _, page_paths in sections:
+        for page_path in page_paths:
+            loaded = pages.get(page_path)
+            if loaded is None:
+                continue
+            title, _, body = loaded
+            url = f"{BASE_URL}/{page_path}/"
+            lines.append("---")
+            lines.append("")
+            lines.append(f"# {title}")
+            lines.append("")
+            lines.append(f"Source: {url}")
+            lines.append("")
+            lines.append(body)
+            lines.append("")
+    return _normalize_punctuation("\n".join(lines))
+
+
+@require_optional_import(["yaml", "jinja2"], "docs")
+def generate_llms_txt(website_dir: Path, site_root: Path) -> None:
+    """Write ``llms.txt`` and ``llms-full.txt`` to ``site_root`` from the Beta docs.
+
+    Args:
+        website_dir: The ``website/`` directory (holds ``mint-json-template.json.jinja``).
+        site_root: The MkDocs ``docs_dir`` (``website/mkdocs/docs``); files written here
+            are served at the site root, e.g. ``https://docs.ag2.ai/latest/llms.txt``.
+    """
+    template_path = website_dir / "mint-json-template.json.jinja"
+    navigation = json.loads(Template(template_path.read_text(encoding="utf-8")).render())["navigation"]
+    beta_group = next((group for group in navigation if group["group"] == "Beta"), None)
+    if beta_group is None:
+        # Fail loudly rather than silently shipping no llms.txt — the most likely cause is
+        # the "Beta" navigation group being renamed in mint-json-template.json.jinja.
+        raise RuntimeError("Could not find the 'Beta' navigation group; llms.txt was not generated.")
+
+    sections = _iter_sections(beta_group)
+    pages: dict[str, tuple[str, str, str]] = {}
+    for _, page_paths in sections:
+        for page_path in page_paths:
+            loaded = _load_page(page_path, site_root)
+            if loaded is not None:
+                pages[page_path] = loaded
+
+    if not pages:
+        # The Beta docs were not converted to Markdown before this step ran.
+        raise RuntimeError(f"No Beta pages found under {site_root / 'docs' / 'beta'}; llms.txt was not generated.")
+
+    (site_root / "llms.txt").write_text(_render_index(sections, pages), encoding="utf-8")
+    (site_root / "llms-full.txt").write_text(_render_full(sections, pages), encoding="utf-8")


### PR DESCRIPTION
## Why are these changes needed?

To support AI coding assistants, such as Claude Code, Codex, Cursor, this adds documentation that they can read and files they can read (e.g. llms.txt and llms-full.txt) to get started. It also includes directions on installing the AG2 skills from https://github.com/ag2ai/ag2-skills.

Adds generation of llms.txt and llms-full.txt which can be used by coding agents / LLMs. [Link](https://llmstxt.org/)

This is beta-specific.

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
