### PR TITLE
fix(test): improve asyncio.sleep use reliability

### DIFF
--- a/test/beta/network/test_observability.py
+++ b/test/beta/network/test_observability.py
@@ -338,9 +338,10 @@ async def test_handler_exception_does_not_crash_channel() -> None:
     channel = await alice.open(type="conversation", target="bob")
     await channel.send("hello bob")
 
-    # Yield so receive-loop dispatches the inbound and the default
-    # handler runs through agent.ask (which raises).
-    await asyncio.sleep(0.1)
+    for _ in range(200):
+        if listener.turn_failed:
+            break
+        await asyncio.sleep(0.01)
 
     assert listener.turn_failed, "expected on_turn_failed to fire"
     # Subsequent send still works — channel survived the crash.
@@ -592,7 +593,10 @@ async def test_widened_trap_catches_pre_ask_failures() -> None:
 
     channel = await alice.open(type="conversation", target="bob")
     await channel.send("hi bob")
-    await asyncio.sleep(0.1)
+    for _ in range(200):
+        if listener.turn_failed:
+            break
+        await asyncio.sleep(0.01)
 
     assert listener.turn_failed, "view.project crash should fire on_turn_failed"
     # Channel survives — subsequent send still works.

--- a/test/beta/tools/test_background.py
+++ b/test/beta/tools/test_background.py
@@ -27,8 +27,12 @@ class TestBackgroundDelivery:
 
         @tool
         async def wait_for_bg(ctx: Context) -> str:
-            """Yield until the background subagent has appended to the inbox."""
-            for _ in range(200):
+            """Yield until the background subagent's message has been drained."""
+            for _ in range(300):
+                events = list(await ctx.stream.history.get_events())
+                drained = [e for e in events if isinstance(e, DrainedModelRequest)]
+                if any("Research findings." in p.content for r in drained for p in r.parts if hasattr(p, "content")):
+                    return "ok"
                 if ctx.pending_messages:
                     return "ok"
                 await asyncio.sleep(0.01)


### PR DESCRIPTION
## Why are these changes needed?

The Background agent test `test_delivery_via_enqueue` isn't reliable on the GitHub runner, likely due to some kind of resource contention.

`test_delivery_via_enqueue` verifies that a background agent's result reaches the orchestrator's LLM before the final reply. The `wait_for_bg` tool polls two signals, `ctx.pending_messages` (not yet drained) and `DrainedModelRequest` in stream history (already drained) - because `_call_client` drains the inbox before each LLM call, meaning the message can disappear from `pending_messages` before `wait_for_bg` runs. Both checks together cover both timing orderings of the asyncio race.

Similarly, the Network had two tests which relied on `asyncio.sleep` and have now been updated to be more deterministic.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
