### PR TITLE
Docs: Add TealTiger governance integration example

### DIFF
--- a/website/docs/ecosystem/tealtiger.mdx
+++ b/website/docs/ecosystem/tealtiger.mdx
@@ -4,7 +4,8 @@ title: TealTiger
 
 # TealTiger Governance Integration
 
-![TealTiger](./img/ecosystem-tealtiger.png)
+![TealTiger](https://raw.githubusercontent.com/agentguard-ai/tealtiger/main/.github/logo/tealtiger-logo-256.png)
+
 
 [TealTiger](https://github.com/agentguard-ai/tealtiger) provides deterministic governance for AG2 agents via the `register_reply` interceptor mechanism. No LLM in the governance path — all policy evaluation is deterministic with <5ms overhead.
 

--- a/website/docs/ecosystem/tealtiger.mdx
+++ b/website/docs/ecosystem/tealtiger.mdx
@@ -1,0 +1,135 @@
+
+# TealTiger Governance Integration
+
+[TealTiger](https://github.com/agentguard-ai/tealtiger) provides deterministic governance for AG2 agents via the `register_reply` interceptor mechanism. No LLM in the governance path — all policy evaluation is deterministic with <5ms overhead.
+
+## Installation
+
+```bash
+pip install ag2-tealtiger
+```
+
+## Quick Start
+
+### Zero-Config Observe Mode
+
+Track cost, PII, and tool usage across all agents with zero configuration:
+
+```python
+from ag2_tealtiger import TealTigerGuard
+
+# Observe everything, block nothing
+guard = TealTigerGuard()
+guard.attach(my_agent)
+
+# After some tool calls...
+for entry in guard.audit_trail:
+    print(f"{entry.agent_id}: {entry.tool_name} → {entry.action} (cost: ${entry.cost_tracked:.4f})")
+```
+
+### Policy Enforcement
+
+```python
+from ag2_tealtiger import TealTigerGuard, GovernanceMode
+
+guard = TealTigerGuard(engine=my_engine, mode=GovernanceMode.ENFORCE)
+guard.attach(agent)
+
+# Tool calls are now evaluated against policies
+# DENY blocks with structured denial message visible in conversation
+# ALLOW passes through transparently
+```
+
+### ConversableAgent Subclass
+
+```python
+from ag2_tealtiger import TealTigerAuditAgent
+
+# Zero-config — governance built in
+agent = TealTigerAuditAgent(name="coder")
+
+# With policy engine
+agent = TealTigerAuditAgent(
+    name="executor",
+    engine=my_engine,
+    mode=GovernanceMode.ENFORCE,
+    budget_limit=5.0,  # Per-agent cost ceiling
+)
+```
+
+### Governed GroupChat
+
+```python
+from ag2_tealtiger import GovernedGroupChat, TealTigerGuard, GovernanceMode
+
+guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
+
+# Attach guard to all agents
+for agent in [coder, reviewer, executor]:
+    guard.attach(agent)
+
+# Speaker selection respects governance
+group_chat = GovernedGroupChat(agents=[coder, reviewer, executor], guard=guard)
+speaker = group_chat.select_speaker(last_speaker=coder)
+
+# Frozen agents skipped (no engine call)
+# Over-budget agents skipped (no engine call)
+# Policy-denied agents skipped to next candidate
+# ALL_SPEAKERS_DENIED terminates the round safely
+```
+
+## Per-Agent Kill Switch
+
+```python
+# Freeze mid-conversation — blocks ALL actions regardless of mode
+guard.freeze("dangerous_agent")
+
+# Other agents continue normally
+speaker = group_chat.select_speaker(last_speaker=coder)  # Skips frozen agent
+
+# Unfreeze to restore
+guard.unfreeze("dangerous_agent")
+```
+
+## Budget Enforcement
+
+```python
+guard.set_budget("expensive_agent", limit=5.0)
+
+# After cumulative cost exceeds limit:
+# - ENFORCE: blocks with BUDGET_EXCEEDED
+# - 80% warning emitted at threshold
+# - Reset: guard.reset_budget("expensive_agent")
+```
+
+## REFER Escalation
+
+```python
+# When TealEngine returns REFER, action is suspended (not terminated)
+# GroupChat continues with remaining agents
+# Resolve later:
+guard.resolve_refer(decision_id, resolution="ALLOW", approval_id="reviewer-123")
+```
+
+## Features
+
+| Feature | Observe | Monitor | Enforce |
+|---------|:-------:|:-------:|:-------:|
+| Cost tracking per agent | ✅ | ✅ | ✅ |
+| PII detection in tool args | ✅ | ✅ | ✅ |
+| Structured audit (TEEC namespace) | ✅ | ✅ | ✅ |
+| Per-agent freeze/unfreeze | ✅ | ✅ | ✅ |
+| Policy evaluation | — | ✅ (log) | ✅ (block) |
+| Budget enforcement | — | ✅ (log) | ✅ (block) |
+| REFER escalation | — | ✅ | ✅ |
+| Inter-agent message governance | ✅ | ✅ | ✅ |
+| Governed speaker selection | ✅ | ✅ | ✅ |
+| JSONL audit export | ✅ | ✅ | ✅ |
+
+## Links
+
+- **PyPI:** [ag2-tealtiger](https://pypi.org/project/ag2-tealtiger/)
+- **Source:** [github.com/agentguard-ai/tealtiger/packages/ag2-tealtiger](https://github.com/agentguard-ai/tealtiger/tree/main/packages/ag2-tealtiger)
+- **Examples:** [Zero-config](https://github.com/agentguard-ai/tealtiger/blob/main/packages/ag2-tealtiger/examples/zero_config_observe.py) | [Policy enforcement](https://github.com/agentguard-ai/tealtiger/blob/main/packages/ag2-tealtiger/examples/policy_enforcement.py) | [Governed GroupChat](https://github.com/agentguard-ai/tealtiger/blob/main/packages/ag2-tealtiger/examples/governed_groupchat.py)
+- **License:** Apache-2.0
+```

--- a/website/docs/ecosystem/tealtiger.mdx
+++ b/website/docs/ecosystem/tealtiger.mdx
@@ -6,14 +6,15 @@ title: TealTiger
 
 ![TealTiger](https://raw.githubusercontent.com/agentguard-ai/tealtiger/main/.github/logo/tealtiger-logo-256.png)
 
-
 [TealTiger](https://github.com/agentguard-ai/tealtiger) provides deterministic governance for AG2 agents via the `register_reply` interceptor mechanism. No LLM in the governance path — all policy evaluation is deterministic with <5ms overhead.
 
 ## Installation
 
 ```bash
-pip install ag2-tealtiger
+pip install "ag2-tealtiger>=0.1.0"
 ```
+
+**Compatibility:** AG2 `>=0.6.0,<1.0`
 
 ## Quick Start
 

--- a/website/docs/ecosystem/tealtiger.mdx
+++ b/website/docs/ecosystem/tealtiger.mdx
@@ -1,5 +1,10 @@
+---
+title: TealTiger
+---
 
 # TealTiger Governance Integration
+
+![TealTiger](./img/ecosystem-tealtiger.png)
 
 [TealTiger](https://github.com/agentguard-ai/tealtiger) provides deterministic governance for AG2 agents via the `register_reply` interceptor mechanism. No LLM in the governance path — all policy evaluation is deterministic with <5ms overhead.
 
@@ -31,8 +36,15 @@ for entry in guard.audit_trail:
 
 ```python
 from ag2_tealtiger import TealTigerGuard, GovernanceMode
+from tealtiger import TealEngine
 
-guard = TealTigerGuard(engine=my_engine, mode=GovernanceMode.ENFORCE)
+engine = TealEngine(policies=[
+    {"type": "cost_limit", "max_per_session": 5.00},
+    {"type": "pii_block", "categories": ["ssn", "credit_card"]},
+    {"type": "tool_allowlist", "allowed": ["web_search", "read_file"]},
+])
+
+guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
 guard.attach(agent)
 
 # Tool calls are now evaluated against policies
@@ -43,18 +55,22 @@ guard.attach(agent)
 ### ConversableAgent Subclass
 
 ```python
-from ag2_tealtiger import TealTigerAuditAgent
+from ag2_tealtiger import TealTigerAuditAgent, GovernanceMode
 
 # Zero-config — governance built in
 agent = TealTigerAuditAgent(name="coder")
 
-# With policy engine
+# With policy engine and budget
 agent = TealTigerAuditAgent(
     name="executor",
     engine=my_engine,
     mode=GovernanceMode.ENFORCE,
-    budget_limit=5.0,  # Per-agent cost ceiling
+    budget_limit=5.0,
 )
+
+# Access governance state
+print(agent.audit_trail)
+print(agent.summary)
 ```
 
 ### Governed GroupChat
@@ -64,11 +80,9 @@ from ag2_tealtiger import GovernedGroupChat, TealTigerGuard, GovernanceMode
 
 guard = TealTigerGuard(engine=engine, mode=GovernanceMode.ENFORCE)
 
-# Attach guard to all agents
 for agent in [coder, reviewer, executor]:
     guard.attach(agent)
 
-# Speaker selection respects governance
 group_chat = GovernedGroupChat(agents=[coder, reviewer, executor], guard=guard)
 speaker = group_chat.select_speaker(last_speaker=coder)
 
@@ -85,9 +99,9 @@ speaker = group_chat.select_speaker(last_speaker=coder)
 guard.freeze("dangerous_agent")
 
 # Other agents continue normally
-speaker = group_chat.select_speaker(last_speaker=coder)  # Skips frozen agent
+speaker = group_chat.select_speaker(last_speaker=coder)
 
-# Unfreeze to restore
+# Unfreeze to restore normal governance
 guard.unfreeze("dangerous_agent")
 ```
 
@@ -104,11 +118,34 @@ guard.set_budget("expensive_agent", limit=5.0)
 
 ## REFER Escalation
 
+For multi-agent scenarios where binary ALLOW/DENY isn't enough:
+
 ```python
 # When TealEngine returns REFER, action is suspended (not terminated)
 # GroupChat continues with remaining agents
+# The escalation receipt contains full context for a human reviewer
+
 # Resolve later:
 guard.resolve_refer(decision_id, resolution="ALLOW", approval_id="reviewer-123")
+```
+
+## Inter-Agent Message Governance
+
+```python
+# Messages between agents are also governed
+# Frozen sender → blocked regardless of mode
+# Policy-denied message → blocked in ENFORCE, logged in MONITOR
+# Each message gets its own decision_id (independent from tool governance)
+```
+
+## Audit Trail Export
+
+```python
+# Export full governance audit as JSONL
+entries_written = guard.export_audit_trail("audit.jsonl")
+
+# Each line contains: agent_id, tool_name, action, risk_score,
+# reason_codes, evaluation_time_ms, TEEC correlation context
 ```
 
 ## Features
@@ -117,14 +154,31 @@ guard.resolve_refer(decision_id, resolution="ALLOW", approval_id="reviewer-123")
 |---------|:-------:|:-------:|:-------:|
 | Cost tracking per agent | ✅ | ✅ | ✅ |
 | PII detection in tool args | ✅ | ✅ | ✅ |
-| Structured audit (TEEC namespace) | ✅ | ✅ | ✅ |
+| Structured audit entries (TEEC) | ✅ | ✅ | ✅ |
+| Correlation IDs (UUID v4) | ✅ | ✅ | ✅ |
 | Per-agent freeze/unfreeze | ✅ | ✅ | ✅ |
 | Policy evaluation | — | ✅ (log) | ✅ (block) |
 | Budget enforcement | — | ✅ (log) | ✅ (block) |
 | REFER escalation | — | ✅ | ✅ |
 | Inter-agent message governance | ✅ | ✅ | ✅ |
 | Governed speaker selection | ✅ | ✅ | ✅ |
+| Decision receipt expiry | — | ✅ | ✅ |
 | JSONL audit export | ✅ | ✅ | ✅ |
+
+## Governance Modes
+
+- **OBSERVE** — Zero-config default. Track everything, block nothing. Build behavioral baseline.
+- **MONITOR** — Evaluate policies, log decisions, allow all through. See what would be blocked.
+- **ENFORCE** — Evaluate policies, block denied actions. Production mode.
+
+## Error Handling
+
+| Scenario | ENFORCE | MONITOR/OBSERVE |
+|----------|---------|-----------------|
+| Engine returns DENY | Block + denial message | Log + allow |
+| Engine throws exception | Fail-closed (deny) | Fail-open (allow) |
+| Agent frozen | Block (always) | Block (always) |
+| Budget exceeded | Block | Log + allow |
 
 ## Links
 
@@ -132,4 +186,4 @@ guard.resolve_refer(decision_id, resolution="ALLOW", approval_id="reviewer-123")
 - **Source:** [github.com/agentguard-ai/tealtiger/packages/ag2-tealtiger](https://github.com/agentguard-ai/tealtiger/tree/main/packages/ag2-tealtiger)
 - **Examples:** [Zero-config](https://github.com/agentguard-ai/tealtiger/blob/main/packages/ag2-tealtiger/examples/zero_config_observe.py) | [Policy enforcement](https://github.com/agentguard-ai/tealtiger/blob/main/packages/ag2-tealtiger/examples/policy_enforcement.py) | [Governed GroupChat](https://github.com/agentguard-ai/tealtiger/blob/main/packages/ag2-tealtiger/examples/governed_groupchat.py)
 - **License:** Apache-2.0
-```
+- **Feature Request:** [#2942](https://github.com/ag2ai/ag2/issues/2942)


### PR DESCRIPTION
## Why are these changes needed?

Adds an ecosystem documentation page for [TealTiger](https://github.com/agentguard-ai/tealtiger) — an open-source (Apache-2.0) deterministic governance layer for AG2 agents.

**What TealTiger provides for AG2 users:**
- **Tool authorization** — Per-agent tool allowlists enforced via `register_reply` interception
- **Cost control** — Per-agent budget limits with automatic denial when exceeded (80% warning threshold)
- **Kill switch** — `freeze(agent_id)` halts one agent mid-GroupChat without stopping others
- **Audit trail** — Structured evidence (correlation IDs, decision receipts) for compliance
- **Zero-config observe mode** — Track cost, PII, and tool usage with one line, block nothing

All governance is deterministic (no LLM in path), in-process (<5ms overhead), and uses AG2's native `register_reply` mechanism.

**Package:** [`ag2-tealtiger`](https://pypi.org/project/ag2-tealtiger/) — published on PyPI, `pip install ag2-tealtiger`

**Dependency:** `ag2>=0.6.0,<1.0`

## Related issue number

Closes #2942

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. *(N/A — docs-only PR)*
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
