### PR TITLE
fix(beta): aggregation should only count conversational/work events

### DIFF
--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -48,6 +48,7 @@ from .events import (
     Input,
     ModelRequest,
     ModelResponse,
+    ToolCallsEvent,
     ToolResultsEvent,
     UsageEvent,
 )
@@ -1843,7 +1844,7 @@ class _AggregationMiddleware(BaseMiddleware):
         event: BaseEvent,
         context: Context,
     ) -> Any:
-        count_before = len(list(await context.stream.history.get_events()))
+        events_before = list(await context.stream.history.get_events())
 
         try:
             result = await call_next(event, context)
@@ -1863,7 +1864,11 @@ class _AggregationMiddleware(BaseMiddleware):
 
             if self._trigger.every_n_events > 0:
                 threshold = self._trigger.every_n_events
-                if count_after // threshold > count_before // threshold:
+                # Count conversational/work events only, not telemetry (e.g. UsageEvent).
+                _countable = (ModelRequest, ModelResponse, ToolCallsEvent, ToolResultsEvent)
+                n_before = sum(1 for e in events_before if isinstance(e, _countable))
+                n_after = sum(1 for e in events_after if isinstance(e, _countable))
+                if n_after // threshold > n_before // threshold:
                     should_aggregate = True
 
             if should_aggregate:

--- a/test/beta/test_aggregate.py
+++ b/test/beta/test_aggregate.py
@@ -24,6 +24,7 @@ from autogen.beta.events import (
     ModelRequest,
     ModelResponse,
     TextInput,
+    Usage,
 )
 from autogen.beta.knowledge import MemoryKnowledgeStore
 from autogen.beta.stream import MemoryStream
@@ -325,6 +326,39 @@ class TestAggregationWiredOnAgent:
         await agent.ask("go")
 
         assert strategy.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_every_n_events_counts_work_events_not_telemetry(self) -> None:
+        """every_n_events must ignore telemetry (UsageEvent) on the stream.
+
+        A usage-carrying turn persists ModelRequest + UsageEvent + ModelResponse
+        (3 events) but only 2 are conversational. With every_n_events=3 the
+        crossings are at 3 and 6 -> asks 2 and 3 fire, not every ask.
+        """
+        store = MemoryKnowledgeStore()
+        strategy = _RecordingAggregate()
+        stream = MemoryStream()
+        completions: list[AggregationCompleted] = []
+        stream.where(AggregationCompleted).subscribe(lambda e: completions.append(e))
+
+        usage = Usage(prompt_tokens=5, completion_tokens=3, total_tokens=8)
+        agent = Agent(
+            "counter",
+            config=TestConfig(*(ModelResponse(ModelMessage("ok"), usage=usage) for _ in range(4))),
+            knowledge=KnowledgeConfig(
+                store=store,
+                aggregate=strategy,
+                aggregate_trigger=AggregateTrigger(every_n_events=3, on_end=False),
+            ),
+        )
+
+        r = await agent.ask("a", stream=stream)
+        r = await r.ask("b")
+        r = await r.ask("c")
+        await r.ask("d")
+
+        assert strategy.calls == 2
+        assert len(completions) == 2
 
     @pytest.mark.asyncio
     async def test_on_end_runs_even_when_turn_raises(self) -> None:


### PR DESCRIPTION
## Why are these changes needed?

`test/beta/providers/agent/test_harness.py::test_every_n_events_aggregation` was failing as the new UsageEvent was not being excluded from the counts. This change uses a defined list of countable events.

[Failed test](https://github.com/ag2ai/ag2/actions/runs/27389138130/job/80942653438)

@Lancetnik and @vvlrff can you please check if this aligns with the intention withe the introduced UsageEvent.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
