### PR TITLE
fix(beta/test): make concurrent-tool-execution test deterministic

### DIFF
--- a/test/beta/tools/test_agent_tools.py
+++ b/test/beta/tools/test_agent_tools.py
@@ -109,28 +109,39 @@ async def test_final_tool() -> None:
 
 @pytest.mark.asyncio()
 async def test_concurrent_tool_execution() -> None:
-    """Test that multiple tools are executed concurrently, not sequentially."""
-    execution_order: list[str] = []
+    """Test that multiple tools are executed concurrently, not sequentially.
+
+    Each tool blocks on a shared barrier that only releases once all three
+    have started. Concurrent execution releases it immediately; sequential
+    execution leaves the earlier tools waiting, so their bounded wait expires
+    and they never record completion — failing the ``finished`` assertion
+    fast instead of hanging.
+    """
+    started = 0
+    all_started = asyncio.Event()
+    finished: list[str] = []
+
+    async def _run(name: str) -> str:
+        nonlocal started
+        started += 1
+        if started == 3:
+            all_started.set()
+        try:
+            await asyncio.wait_for(all_started.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            return "not-concurrent"
+        finished.append(name)
+        return f"result_{name}"
 
     async def slow_tool_a() -> str:
-        execution_order.append("a_start")
-        await asyncio.sleep(0.005)  # Simulate slow operation
-        execution_order.append("a_end")
-        return "result_a"
+        return await _run("a")
 
     async def slow_tool_b() -> str:
-        execution_order.append("b_start")
-        await asyncio.sleep(0.005)  # Simulate slow operation
-        execution_order.append("b_end")
-        return "result_b"
+        return await _run("b")
 
     async def slow_tool_c() -> str:
-        execution_order.append("c_start")
-        await asyncio.sleep(0.005)  # Simulate slow operation
-        execution_order.append("c_end")
-        return "result_c"
+        return await _run("c")
 
-    # Create an agent with multiple slow tools
     agent = Agent(
         "test_agent",
         tools=[slow_tool_a, slow_tool_b, slow_tool_c],
@@ -148,30 +159,7 @@ async def test_concurrent_tool_execution() -> None:
         ),
     )
 
-    # Trigger tool calls - they should execute concurrently
     result = await agent.ask("Execute all tools")
     assert result.body == "result"
-
-    # Verify all tools were executed
-    assert "a_start" in execution_order
-    assert "b_start" in execution_order
-    assert "c_start" in execution_order
-    assert "a_end" in execution_order
-    assert "b_end" in execution_order
-    assert "c_end" in execution_order
-
-    # Verify tools started before any finished (concurrent execution)
-    # All starts should happen before all ends
-    start_indices = [
-        execution_order.index("a_start"),
-        execution_order.index("b_start"),
-        execution_order.index("c_start"),
-    ]
-    end_indices = [
-        execution_order.index("a_end"),
-        execution_order.index("b_end"),
-        execution_order.index("c_end"),
-    ]
-
-    # The last start should happen before the first end for true concurrency
-    assert max(start_indices) < min(end_indices), "Tools should start executing concurrently"
+    assert started == 3
+    assert sorted(finished) == ["a", "b", "c"]


### PR DESCRIPTION
## Why are these changes needed?

`test_concurrent_tool_execution` fails intermittently on loaded CI runners (most recently the Windows core-test lane) with `AssertionError: Tools should start executing concurrently`.

The test was never changed and the tool-execution path (`asyncio.gather` in `executor.py`) has been concurrent since the beta's first commit, the failure is purely a pre-existing timing race in the assertion, not a regression.

The fix removes the wall-clock dependence entirely: the three tools now rendezvous on a shared `asyncio.Event` that only releases once all three have arrived, which proves overlap causally rather than timing it. Each tool's wait is bounded (wait_for(..., timeout=2.0)) so a real sequential regression fails fast with a clean assertion instead of hanging.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
