### PR TITLE
feat(beta): Agent resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,8 @@ dmypy.json
 cython_debug/
 
 # UV artifacts
+# TODO: remove this once we remove most pyproject.toml dependencies.
+# TODO: update dependabot to use "uv" package-ecosystem then.
 uv.lock
 
 logs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-.agents
-.claude
-.codegraph
-.rtk
-skills-lock.json
-
 .docusaurus/
 node_modules/
 .vite/
@@ -13,6 +7,20 @@ node_modules/
 .vscode/
 .idea/
 .DS_Store
+
+# Agents
+.agents
+.cursor
+.claude
+.vercel
+
+.codegraph
+.rtk
+
+skills-lock.json
+.mcp.json
+
+/CLAUDE.md
 
 # Log files
 *.log
@@ -161,9 +169,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# UV artifacts
-uv.lock
-
 logs/
 
 output/
@@ -211,8 +216,3 @@ notebook/mcp/wikipedia_articles/
 notebook/mcp/arxiv_papers/
 
 remote-examples
-
-*CLAUDE.md:
-.cursor/
-.claude/
-.vercel/

--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# UV artifacts
+uv.lock
+
 logs/
 
 output/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,14 @@ Before opening a PR, read and follow `.github/AI_POLICY.md`.
 - Include validation and testing information in the PR body.
 - Be prepared to explain and revise the contribution in response to reviewer questions.
 
-## Common rules
+## Architecture Decision Records (ADR)
+
+Cross-cutting and hard-to-reverse design decisions are recorded in `docs/adr/`, sequentially numbered (`0001-*.md`, `0002-*.md`, …) with `status` / `date` frontmatter and a short Context / Decision / Consequences body.
+
+- **Consult them before changing established public API or architecture.** They explain *why* something is the way it is — e.g. `0003-eval-run-api-takes-agent-instances.md` records that the eval `run_*` API takes prebuilt `Agent` instances (not factories) and explicitly-built `Suite`s. If a change contradicts an ADR, supersede it rather than silently reverting the code.
+- **Add one when a decision qualifies**: it is hard to reverse, surprising without context (a reader would assume the opposite), and the result of a real trade-off. Scan `docs/adr/` for the highest number and increment. Keep it short — recording *that* a decision was made and *why* is the value.
+
+## Code Style Guidelines
 
 - Do not use `from __future__ import annotations`.
 - Do not use global variables or top-level side-effect function calls unless the user explicitly allows it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/autogen/beta/__init__.py
+++ b/autogen/beta/__init__.py
@@ -8,15 +8,11 @@ from .agent import Agent, AgentReply, KnowledgeConfig, TaskConfig
 from .annotations import Context, Inject, Variable
 from .events import (
     AudioInput,
-    BaseEvent,
     BinaryInput,
     DataInput,
     DocumentInput,
     ImageInput,
     TextInput,
-    ToolResultEvent,
-    ToolResultsEvent,
-    Usage,
     VideoInput,
 )
 from .files import FilesAPI
@@ -34,7 +30,6 @@ __all__ = (
     "AgentReply",
     "AgentSpec",
     "AudioInput",
-    "BaseEvent",
     "BinaryInput",
     "Context",
     "DataInput",
@@ -54,10 +49,7 @@ __all__ = (
     "TaskSpec",
     "TextInput",
     "ToolResult",
-    "ToolResultEvent",
-    "ToolResultsEvent",
     "Toolkit",
-    "Usage",
     "UsageRecord",
     "UsageReport",
     "Variable",

--- a/autogen/beta/__init__.py
+++ b/autogen/beta/__init__.py
@@ -23,7 +23,6 @@ from .spec import AgentSpec
 from .stream import MemoryStream
 from .task import Task, TaskInject, TaskSpec
 from .tools import ToolResult, Toolkit, tool
-from .usage import UsageRecord, UsageReport
 
 __all__ = (
     "Agent",
@@ -50,8 +49,6 @@ __all__ = (
     "TextInput",
     "ToolResult",
     "Toolkit",
-    "UsageRecord",
-    "UsageReport",
     "Variable",
     "VideoInput",
     "observer",

--- a/autogen/beta/__init__.py
+++ b/autogen/beta/__init__.py
@@ -8,11 +8,14 @@ from .agent import Agent, AgentReply, KnowledgeConfig, TaskConfig
 from .annotations import Context, Inject, Variable
 from .events import (
     AudioInput,
+    BaseEvent,
     BinaryInput,
     DataInput,
     DocumentInput,
     ImageInput,
     TextInput,
+    ToolResultEvent,
+    ToolResultsEvent,
     Usage,
     VideoInput,
 )
@@ -31,6 +34,7 @@ __all__ = (
     "AgentReply",
     "AgentSpec",
     "AudioInput",
+    "BaseEvent",
     "BinaryInput",
     "Context",
     "DataInput",
@@ -50,6 +54,8 @@ __all__ = (
     "TaskSpec",
     "TextInput",
     "ToolResult",
+    "ToolResultEvent",
+    "ToolResultsEvent",
     "Toolkit",
     "Usage",
     "UsageRecord",

--- a/autogen/beta/__init__.py
+++ b/autogen/beta/__init__.py
@@ -18,6 +18,7 @@ from .events import (
 from .files import FilesAPI
 from .middleware import Middleware
 from .observers import observer
+from .plugin import Plugin
 from .response import PromptedSchema, ResponseSchema, response_schema
 from .spec import AgentSpec
 from .stream import MemoryStream
@@ -40,6 +41,7 @@ __all__ = (
     "KnowledgeConfig",
     "MemoryStream",
     "Middleware",
+    "Plugin",
     "PromptedSchema",
     "ResponseSchema",
     "Task",

--- a/autogen/beta/_internal/__init__.py
+++ b/autogen/beta/_internal/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/autogen/beta/_internal/__init__.py
+++ b/autogen/beta/_internal/__init__.py
@@ -1,3 +1,0 @@
-# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
-#
-# SPDX-License-Identifier: Apache-2.0

--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -19,18 +19,15 @@ import asyncio
 import json
 import logging
 import types
-import warnings
-from collections.abc import Awaitable, Callable, Iterable
-from contextlib import AsyncExitStack, ExitStack, suppress
+from collections.abc import Callable, Iterable
+from contextlib import ExitStack, suppress
 from dataclasses import dataclass
 from functools import partial
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, overload
 from uuid import uuid4
 
 from fast_depends import Provider
-from fast_depends.library.serializer import SerializerProto
-from fast_depends.pydantic import PydanticSerializer
 from pydantic import ValidationError
 from typing_extensions import TypeVar as TypeVar313
 
@@ -52,7 +49,6 @@ from .events import (
     ToolResultsEvent,
     UsageEvent,
 )
-from .events.conditions import Condition
 from .events.lifecycle import (
     AggregationCompleted,
     AggregationFailed,
@@ -76,19 +72,17 @@ from .middleware.base import (
     ToolMiddleware,
 )
 from .observers import Observer
-from .observers import observer as observer_factory
+from .plugin import Plugin, PluginTarget, PromptType
 from .response import ResponseProto, ResponseSchema
 from .stream import MemoryStream, Stream
 from .task import CheckpointStore, Task, TaskSpec
-from .tools.executor import ToolExecutor
-from .tools.final import FunctionParameters, FunctionTool, FunctionToolSchema, tool
+from .tools.final import FunctionTool, FunctionToolSchema, tool
 from .tools.schemas import ToolSchema
 from .tools.subagents.run_task import run_task as _run_task
 from .tools.subagents.subagent_tool import StreamFactory, subagent_tool
 from .tools.tool import Tool
-from .types import ClassInfo, Omittable, SendableMessage, omit
+from .types import Omittable, SendableMessage, omit
 from .usage import UsageReport
-from .utils import CONTEXT_OPTION_NAME, build_model
 
 if TYPE_CHECKING:
     from .conversable import ConversableAdapter
@@ -100,10 +94,6 @@ logger = logging.getLogger(__name__)
 TResult = TypeVar313("TResult", default=str)
 TAgent = TypeVar313("TAgent", default=str)
 T2 = TypeVar("T2")
-
-
-PromptHook: TypeAlias = Callable[..., str] | Callable[..., Awaitable[str]]
-PromptType: TypeAlias = str | PromptHook
 
 
 @dataclass
@@ -378,7 +368,7 @@ def _get_stream_turn_lock(stream: Any) -> asyncio.Lock:
 _stream_id_locks: dict[int, asyncio.Lock] = {}
 
 
-class Agent(Generic[TResult]):
+class Agent(PluginTarget, Generic[TResult]):
     """The agentic unit of autogen.beta.
 
     An Agent runs a model loop, invokes tools, honours middleware, surfaces
@@ -496,45 +486,20 @@ class Agent(Generic[TResult]):
         knowledge: KnowledgeConfig | None = None,
         tasks: TaskConfig | Literal[False] = False,
         assembly: Iterable[AssemblyPolicy] = (),
-    ):
-        self.name = name
-        self.config = config
-
-        self._agent_dependencies = dependencies or {}
-        self._agent_variables = variables or {}
-
-        self._middleware = list(middleware)
-        self._observers = list(observers)
-
-        self._serializer: SerializerProto = PydanticSerializer(
-            pydantic_config={"arbitrary_types_allowed": True},
-            use_fastdepends_errors=False,
+    ) -> None:
+        self._init_target(
+            name,
+            prompt=prompt,
+            hitl_hook=hitl_hook,
+            tools=tools,
+            middleware=middleware,
+            observers=observers,
+            dependencies=dependencies,
+            variables=variables,
+            plugins=plugins,
         )
-
-        self.dependency_provider = Provider()
-        self.tools: list[FunctionTool] = []
-        for t in tools:
-            self.add_tool(t)
-
-        self._hitl_hook = wrap_hitl(hitl_hook) if hitl_hook else None
-        self.__tool_executor = ToolExecutor(self._serializer)
-
-        self._system_prompt: list[str] = []
-        self._dynamic_prompt: list[Callable[[ModelRequest, Context], Awaitable[str]]] = []
-
+        self.config = config
         self._response_schema = ResponseSchema.ensure_schema(response_schema)
-
-        if isinstance(prompt, str) or callable(prompt):
-            prompt = [prompt]
-
-        for p in prompt:
-            if isinstance(p, str):
-                self._system_prompt.append(p)
-            else:
-                self._dynamic_prompt.append(_wrap_prompt_hook(p))
-
-        for p in plugins:
-            p.register(self)
 
         # Task spawning. ``tasks=False`` (the default) means no auto-injected
         # ``run_subtask`` / ``run_subtasks`` tools. Pass ``tasks=TaskConfig(...)``
@@ -565,107 +530,10 @@ class Agent(Generic[TResult]):
         )
 
         # Assembly policies (empty by default; bare Agent has no harness).
-        self._policies: list[AssemblyPolicy] = list(assembly)
+        self._policies.extend(assembly)
         if self._policies:
             for w in AssemblerMiddleware.validate_order(self._policies):
                 logger.warning("Assembly policy ordering: %s", w)
-
-    def hitl_hook(self, func: HumanHook) -> HumanHook:
-        if self._hitl_hook is not None:
-            warnings.warn(
-                "You already set HITL hook, provided value overrides it",
-                category=RuntimeWarning,
-                stacklevel=2,
-            )
-
-        self._hitl_hook = wrap_hitl(func)
-        return func
-
-    @overload
-    def prompt(
-        self,
-        func: None = None,
-    ) -> Callable[[PromptHook], PromptHook]: ...
-
-    @overload
-    def prompt(
-        self,
-        func: PromptHook,
-    ) -> PromptHook: ...
-
-    def prompt(
-        self,
-        func: PromptHook | None = None,
-    ) -> PromptHook | Callable[[PromptHook], PromptHook]:
-        def wrapper(f: PromptHook) -> PromptHook:
-            self._dynamic_prompt.append(_wrap_prompt_hook(f))
-            return f
-
-        if func:
-            return wrapper(func)
-        return wrapper
-
-    @overload
-    def tool(
-        self,
-        function: Callable[..., Any],
-        *,
-        name: str | None = None,
-        description: str | None = None,
-        schema: FunctionParameters | None = None,
-        sync_to_thread: bool = True,
-        middleware: Iterable[ToolMiddleware] = (),
-    ) -> Tool: ...
-
-    @overload
-    def tool(
-        self,
-        function: None = None,
-        *,
-        name: str | None = None,
-        description: str | None = None,
-        schema: FunctionParameters | None = None,
-        sync_to_thread: bool = True,
-        middleware: Iterable[ToolMiddleware] = (),
-    ) -> Callable[[Callable[..., Any]], Tool]: ...
-
-    def add_middleware(self, m: MiddlewareFactory) -> "Agent[TResult]":
-        """Append middleware as the innermost wrapper in the chain.
-
-        The added middleware is called last on turn entry and first on turn exit,
-        executing closer to the LLM call than any middleware already registered.
-        """
-        self._middleware.append(m)
-        return self
-
-    def insert_middleware(self, m: MiddlewareFactory) -> "Agent[TResult]":
-        """Insert middleware as the outermost wrapper in the chain.
-
-        The inserted middleware is called first on turn entry and last on turn exit,
-        executing before all middleware already registered on the agent.
-        """
-        self._middleware.insert(0, m)
-        return self
-
-    def add_tool(self, t: Callable[..., Any] | Tool) -> "Agent[TResult]":
-        self.tools.append(FunctionTool.ensure_tool(t, provider=self.dependency_provider))
-        return self
-
-    def add_observer(self, observer: Observer) -> None:
-        """Register an observer (before calling ask())."""
-        self._observers.append(observer)
-
-    def add_policy(self, policy: AssemblyPolicy) -> "Agent[TResult]":
-        """Append an assembly policy to this agent's chain.
-
-        Policies run in order; a newly added policy runs after existing
-        ones. Construction-time ordering validation (warning on suspicious
-        sequences) only runs over policies passed via ``assembly=`` — late
-        additions skip the check, so callers should be confident in the
-        ordering they introduce.
-        """
-        self._policies.append(policy)
-        return self
 
     def task(
         self,
@@ -717,60 +585,6 @@ class Agent(Generic[TResult]):
             checkpoint_store=checkpoint_store,
             resume_from=resume_from,
         )
-
-    def tool(
-        self,
-        function: Callable[..., Any] | None = None,
-        *,
-        name: str | None = None,
-        description: str | None = None,
-        schema: FunctionParameters | None = None,
-        sync_to_thread: bool = True,
-        middleware: Iterable[ToolMiddleware] = (),
-    ) -> Tool | Callable[[Callable[..., Any]], Tool]:
-        def make_tool(f: Callable[..., Any]) -> Tool:
-            t = tool(
-                f,
-                name=name,
-                description=description,
-                schema=schema,
-                sync_to_thread=sync_to_thread,
-                middleware=middleware,
-            )
-            self.add_tool(t)
-            return t
-
-        if function:
-            return make_tool(function)
-
-        return make_tool
-
-    @overload
-    def observer(
-        self,
-        condition: ClassInfo | Condition | None,
-        callback: Callable[..., Any],
-    ) -> Callable[..., Any]: ...
-
-    @overload
-    def observer(
-        self,
-        condition: ClassInfo | Condition | None = None,
-    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]: ...
-
-    def observer(
-        self,
-        condition: ClassInfo | Condition | None = None,
-        callback: Callable[..., Any] | None = None,
-    ) -> Callable[..., Any] | Callable[[Callable[..., Any]], Callable[..., Any]]:
-        def wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
-            obs = observer_factory(condition, func)
-            self._observers.append(obs)
-            return func
-
-        if callback is not None:
-            return wrapper(callback)
-        return wrapper
 
     @overload
     async def ask(
@@ -1235,7 +1049,7 @@ class Agent(Generic[TResult]):
                         ),
                     )
 
-                self.__tool_executor.register(
+                self._tool_executor.register(
                     stack,
                     context,
                     tools=all_tools,
@@ -1384,25 +1198,6 @@ def _drain_pending(context: Context) -> ModelRequest | None:
     return ModelRequest(parts)
 
 
-def _wrap_prompt_hook(
-    func: PromptHook,
-) -> Callable[[ModelRequest, Context], Awaitable[str]]:
-    call_model = build_model(func)
-
-    async def wrapper(event: ModelRequest, context: Context) -> str:
-        async with AsyncExitStack() as stack:
-            r = await call_model.asolve(
-                event,
-                stack=stack,
-                cache_dependencies={},
-                dependency_provider=context.dependency_provider,
-                **{CONTEXT_OPTION_NAME: context},
-            )
-        return r
-
-    return wrapper
-
-
 _RUN_SUBTASK_DESCRIPTION = (
     "Spawn an isolated subtask agent for self-contained focused work. "
     "The subtask runs with a fresh conversation history and inherits this "
@@ -1526,172 +1321,6 @@ def _make_knowledge_tool(store: KnowledgeStore) -> Tool:
             return f"Unknown action: {action}. Available: read, write, list, delete."
 
     return knowledge
-
-
-class Plugin:
-    def __init__(
-        self,
-        *,
-        prompt: PromptType | Iterable[PromptType] = (),
-        hitl_hook: HumanHook | None = None,
-        tools: Iterable[Callable[..., Any] | Tool] = (),
-        middleware: Iterable[MiddlewareFactory] = (),
-        observers: Iterable[Observer] = (),
-        dependencies: dict[Any, Any] | None = None,
-        variables: dict[Any, Any] | None = None,
-    ) -> None:
-        self._tools = list(tools)
-        self._middleware = list(middleware)
-        self._observers = list(observers)
-        self._dependencies = dependencies or {}
-        self._variables = variables or {}
-        self._hitl_hook = hitl_hook
-
-        self._system_prompt: list[str] = []
-        self._dynamic_prompt: list[Callable[[ModelRequest, Context], Awaitable[str]]] = []
-
-        if isinstance(prompt, str) or callable(prompt):
-            prompt = [prompt]
-        for p in prompt:
-            if isinstance(p, str):
-                self._system_prompt.append(p)
-            else:
-                self._dynamic_prompt.append(_wrap_prompt_hook(p))
-
-    def register(self, agent: "Agent[Any]") -> None:
-        """Apply this plugin's contributions to an Agent instance."""
-        for t in self._tools:
-            agent.add_tool(t)
-
-        for m in self._middleware:
-            agent.add_middleware(m)
-
-        if self._hitl_hook is not None:
-            if agent._hitl_hook is not None:
-                warnings.warn(
-                    f"Agent '{agent.name}' already has a HITL hook; the plugin's hook will be ignored.",
-                    stacklevel=2,
-                )
-            else:
-                agent._hitl_hook = wrap_hitl(self._hitl_hook)
-
-        agent._agent_dependencies = self._dependencies | agent._agent_dependencies
-        agent._agent_variables.update(self._variables)
-
-        agent._observers.extend(self._observers)
-        agent._system_prompt.extend(self._system_prompt)
-        agent._dynamic_prompt.extend(self._dynamic_prompt)
-
-    def hitl_hook(self, func: HumanHook) -> HumanHook:
-        if self._hitl_hook is not None:
-            warnings.warn(
-                "You already set HITL hook, provided value overrides it",
-                category=RuntimeWarning,
-                stacklevel=2,
-            )
-        self._hitl_hook = func
-        return func
-
-    @overload
-    def prompt(
-        self,
-        func: PromptHook,
-    ) -> PromptHook: ...
-
-    @overload
-    def prompt(
-        self,
-        func: None = None,
-    ) -> Callable[[PromptHook], PromptHook]: ...
-
-    def prompt(
-        self,
-        func: PromptHook | None = None,
-    ) -> PromptHook | Callable[[PromptHook], PromptHook]:
-        def wrapper(f: PromptHook) -> PromptHook:
-            self._dynamic_prompt.append(_wrap_prompt_hook(f))
-            return f
-
-        if func:
-            return wrapper(func)
-        return wrapper
-
-    @overload
-    def tool(
-        self,
-        function: Callable[..., Any],
-        *,
-        name: str | None = None,
-        description: str | None = None,
-        schema: FunctionParameters | None = None,
-        sync_to_thread: bool = True,
-        middleware: Iterable[ToolMiddleware] = (),
-    ) -> FunctionTool: ...
-
-    @overload
-    def tool(
-        self,
-        function: None = None,
-        *,
-        name: str | None = None,
-        description: str | None = None,
-        schema: FunctionParameters | None = None,
-        sync_to_thread: bool = True,
-        middleware: Iterable[ToolMiddleware] = (),
-    ) -> Callable[[Callable[..., Any]], FunctionTool]: ...
-
-    def tool(
-        self,
-        function: Callable[..., Any] | None = None,
-        *,
-        name: str | None = None,
-        description: str | None = None,
-        schema: FunctionParameters | None = None,
-        sync_to_thread: bool = True,
-        middleware: Iterable[ToolMiddleware] = (),
-    ) -> FunctionTool | Callable[[Callable[..., Any]], FunctionTool]:
-        def make_tool(f: Callable[..., Any]) -> FunctionTool:
-            t = tool(
-                f,
-                name=name,
-                description=description,
-                schema=schema,
-                sync_to_thread=sync_to_thread,
-                middleware=middleware,
-            )
-            self._tools.append(t)
-            return t
-
-        if function:
-            return make_tool(function)
-        return make_tool
-
-    @overload
-    def observer(
-        self,
-        condition: ClassInfo | Condition | None,
-        callback: Callable[..., Any],
-    ) -> Callable[..., Any]: ...
-
-    @overload
-    def observer(
-        self,
-        condition: ClassInfo | Condition | None = None,
-    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]: ...
-
-    def observer(
-        self,
-        condition: ClassInfo | Condition | None = None,
-        callback: Callable[..., Any] | None = None,
-    ) -> Callable[..., Any] | Callable[[Callable[..., Any]], Callable[..., Any]]:
-        def wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
-            obs = observer_factory(condition, func)
-            self._observers.append(obs)
-            return func
-
-        if callback is not None:
-            return wrapper(callback)
-        return wrapper
 
 
 class _HaltCheckMiddleware(BaseMiddleware):

--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -86,7 +86,7 @@ from .tools.schemas import ToolSchema
 from .tools.subagents.run_task import run_task as _run_task
 from .tools.subagents.subagent_tool import StreamFactory, subagent_tool
 from .tools.tool import Tool
-from .types import ClassInfo, Omittable, omit
+from .types import ClassInfo, Omittable, SendableMessage, omit
 from .usage import UsageReport
 from .utils import CONTEXT_OPTION_NAME, build_model
 
@@ -248,7 +248,7 @@ class AgentReply(Generic[TResult, TAgent]):
     @overload
     async def ask(
         self,
-        *msg: str | Input,
+        *msg: SendableMessage | Input,
         dependencies: dict[Any, Any] | None = ...,
         variables: dict[Any, Any] | None = ...,
         prompt: Iterable[str] = ...,
@@ -263,7 +263,7 @@ class AgentReply(Generic[TResult, TAgent]):
     @overload
     async def ask(
         self,
-        *msg: str | Input,
+        *msg: SendableMessage | Input,
         dependencies: dict[Any, Any] | None = ...,
         variables: dict[Any, Any] | None = ...,
         prompt: Iterable[str] = ...,
@@ -278,7 +278,7 @@ class AgentReply(Generic[TResult, TAgent]):
     @overload
     async def ask(
         self,
-        *msg: str | Input,
+        *msg: SendableMessage | Input,
         dependencies: dict[Any, Any] | None = ...,
         variables: dict[Any, Any] | None = ...,
         prompt: Iterable[str] = ...,
@@ -293,7 +293,7 @@ class AgentReply(Generic[TResult, TAgent]):
     @overload
     async def ask(
         self,
-        *msg: str | Input,
+        *msg: SendableMessage | Input,
         dependencies: dict[Any, Any] | None = ...,
         variables: dict[Any, Any] | None = ...,
         prompt: Iterable[str] = ...,
@@ -306,7 +306,7 @@ class AgentReply(Generic[TResult, TAgent]):
 
     async def ask(
         self,
-        *msg: str | Input,
+        *msg: SendableMessage | Input,
         dependencies: dict[Any, Any] | None = None,
         variables: dict[Any, Any] | None = None,
         prompt: Iterable[str] = (),
@@ -775,7 +775,7 @@ class Agent(Generic[TResult]):
     @overload
     async def ask(
         self,
-        *msg: str | Input,
+        *msg: SendableMessage | Input,
         stream: Stream | None = ...,
         dependencies: dict[Any, Any] | None = ...,
         variables: dict[Any, Any] | None = ...,
@@ -791,7 +791,7 @@ class Agent(Generic[TResult]):
     @overload
     async def ask(
         self,
-        msg: str | Input,
+        msg: SendableMessage | Input,
         *,
         stream: Stream | None = ...,
         dependencies: dict[Any, Any] | None = ...,
@@ -808,7 +808,7 @@ class Agent(Generic[TResult]):
     @overload
     async def ask(
         self,
-        msg: str | Input,
+        msg: SendableMessage | Input,
         *,
         stream: Stream | None = ...,
         dependencies: dict[Any, Any] | None = ...,
@@ -825,7 +825,7 @@ class Agent(Generic[TResult]):
     @overload
     async def ask(
         self,
-        msg: str | Input,
+        msg: SendableMessage | Input,
         *,
         stream: Stream | None = ...,
         dependencies: dict[Any, Any] | None = ...,
@@ -840,7 +840,7 @@ class Agent(Generic[TResult]):
 
     async def ask(
         self,
-        *msg: str | Input,
+        *msg: SendableMessage | Input,
         stream: Stream | None = None,
         dependencies: dict[Any, Any] | None = None,
         variables: dict[Any, Any] | None = None,
@@ -859,29 +859,6 @@ class Agent(Generic[TResult]):
             dependencies=dependencies,
             variables=variables,
         )
-        return await self._drive(
-            ModelRequest.ensure_request(msg),
-            context=context,
-            config=config,
-            tools=tools,
-            middleware=middleware,
-            observers=observers,
-            response_schema=response_schema,
-            hitl_hook=hitl_hook,
-        )
-
-    async def _ask(
-        self,
-        *msg: str | Input,
-        context: Context,
-        config: ModelConfig | None = None,
-        tools: Iterable[Tool] = (),
-        middleware: Iterable[MiddlewareFactory] = (),
-        observers: Iterable[Observer] = (),
-        response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
-        hitl_hook: HumanHook | None = None,
-    ) -> "AgentReply[Any, Any]":
-        """`Agent.ask()` alternative method to call agent with prebuild `context`."""
         return await self._drive(
             ModelRequest.ensure_request(msg),
             context=context,
@@ -930,6 +907,29 @@ class Agent(Generic[TResult]):
 
         return await self._drive(
             trigger,
+            context=context,
+            config=config,
+            tools=tools,
+            middleware=middleware,
+            observers=observers,
+            response_schema=response_schema,
+            hitl_hook=hitl_hook,
+        )
+
+    async def _ask(
+        self,
+        *msg: SendableMessage | Input,
+        context: Context,
+        config: ModelConfig | None = None,
+        tools: Iterable[Tool] = (),
+        middleware: Iterable[MiddlewareFactory] = (),
+        observers: Iterable[Observer] = (),
+        response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
+        hitl_hook: HumanHook | None = None,
+    ) -> "AgentReply[Any, Any]":
+        """`Agent.ask()` alternative method to call agent with prebuild `context`."""
+        return await self._drive(
+            ModelRequest.ensure_request(msg),
             context=context,
             config=config,
             tools=tools,

--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -852,10 +852,13 @@ class Agent(Generic[TResult]):
         response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
         hitl_hook: HumanHook | None = None,
     ) -> "AgentReply[Any, Any]":
-        if not (config or self.config):
-            raise ConfigNotProvidedError()
         stream = stream or MemoryStream()
-        context = self._build_context(stream, prompt=prompt, dependencies=dependencies, variables=variables)
+        context = self.__build_context(
+            stream,
+            prompt=prompt,
+            dependencies=dependencies,
+            variables=variables,
+        )
         return await self._drive(
             ModelRequest.ensure_request(msg),
             context=context,
@@ -865,58 +868,6 @@ class Agent(Generic[TResult]):
             observers=observers,
             response_schema=response_schema,
             hitl_hook=hitl_hook,
-        )
-
-    def _build_context(
-        self,
-        stream: Stream,
-        *,
-        prompt: Iterable[str] = (),
-        dependencies: dict[Any, Any] | None = None,
-        variables: dict[Any, Any] | None = None,
-    ) -> Context:
-        return Context(
-            stream,
-            prompt=list(prompt),
-            dependencies=self._agent_dependencies | (dependencies or {}),
-            variables=self._agent_variables | (variables or {}),
-            dependency_provider=self.dependency_provider,
-        )
-
-    async def _drive(
-        self,
-        trigger: BaseEvent,
-        *,
-        context: Context,
-        config: ModelConfig | None = None,
-        tools: Iterable[Tool] = (),
-        middleware: Iterable[MiddlewareFactory] = (),
-        observers: Iterable[Observer] = (),
-        response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
-        hitl_hook: HumanHook | None = None,
-    ) -> "AgentReply[Any, Any]":
-        """Shared core for `ask`/`_ask`/`resume`: drive the loop from `trigger`."""
-        config = config or self.config
-        if not config:
-            raise ConfigNotProvidedError()
-        client = config.create()
-
-        if not context.prompt:
-            context.prompt.extend(self._system_prompt)
-
-            for dp in self._dynamic_prompt:
-                p = await dp(trigger, context)
-                context.prompt.append(p)
-
-        return await self._execute(
-            trigger,
-            context=context,
-            client=client,
-            hitl_hook=hitl_hook,
-            additional_tools=tools,
-            additional_middleware=middleware,
-            additional_observers=observers,
-            response_schema=response_schema,
         )
 
     async def _ask(
@@ -967,11 +918,16 @@ class Agent(Generic[TResult]):
         with ``history``. If ``stream`` is omitted a fresh ``MemoryStream`` is
         created; if one is supplied, its existing history is replaced.
         """
-        if not (config or self.config):
-            raise ConfigNotProvidedError()
         stream = stream or MemoryStream()
         await stream.history.replace(list(history))
-        context = self._build_context(stream, prompt=prompt, dependencies=dependencies, variables=variables)
+
+        context = self.__build_context(
+            stream,
+            prompt=prompt,
+            dependencies=dependencies,
+            variables=variables,
+        )
+
         return await self._drive(
             trigger,
             context=context,
@@ -981,6 +937,42 @@ class Agent(Generic[TResult]):
             observers=observers,
             response_schema=response_schema,
             hitl_hook=hitl_hook,
+        )
+
+    async def _drive(
+        self,
+        trigger: BaseEvent,
+        *,
+        context: Context,
+        config: ModelConfig | None = None,
+        tools: Iterable[Tool] = (),
+        middleware: Iterable[MiddlewareFactory] = (),
+        observers: Iterable[Observer] = (),
+        response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
+        hitl_hook: HumanHook | None = None,
+    ) -> "AgentReply[Any, Any]":
+        """Shared core for `ask`/`_ask`/`resume`: drive the loop from `trigger`."""
+        config = config or self.config
+        if not config:
+            raise ConfigNotProvidedError()
+        client = config.create()
+
+        if not context.prompt:
+            context.prompt.extend(self._system_prompt)
+
+            for dp in self._dynamic_prompt:
+                p = await dp(trigger, context)
+                context.prompt.append(p)
+
+        return await self._execute(
+            trigger,
+            context=context,
+            client=client,
+            hitl_hook=hitl_hook,
+            additional_tools=tools,
+            additional_middleware=middleware,
+            additional_observers=observers,
+            response_schema=response_schema,
         )
 
     def _build_knowledge_tool(self) -> list[Tool]:
@@ -1294,6 +1286,22 @@ class Agent(Generic[TResult]):
                                 error=str(exc),
                             )
                         )
+
+    def __build_context(
+        self,
+        stream: Stream,
+        *,
+        prompt: Iterable[str] = (),
+        dependencies: dict[Any, Any] | None = None,
+        variables: dict[Any, Any] | None = None,
+    ) -> Context:
+        return Context(
+            stream,
+            prompt=list(prompt),
+            dependencies=self._agent_dependencies | (dependencies or {}),
+            variables=self._agent_variables | (variables or {}),
+            dependency_provider=self.dependency_provider,
+        )
 
     def as_tool(
         self,

--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -461,11 +461,12 @@ class Agent(PluginTarget, Generic[TResult]):
         self.config = config
         self._response_schema = ResponseSchema.ensure_schema(response_schema)
 
-        # Auto-injected tools (subtask toolkit, knowledge tool) live in
-        # ``self.tools`` alongside user tools, but must NOT be inherited by
-        # spawned subtasks — that would re-enable recursion (run_subtask) or
-        # leak the parent's knowledge tool. Track the bound instances so
-        # ``_spawn_subtask`` can exclude them by identity.
+        # Auto-injected tools (subtask toolkit, knowledge tool) live here,
+        # NOT in the public ``self.tools`` (which holds only user-supplied
+        # tools). They are chained into the tool set at execution time but
+        # kept out of ``self.tools`` so they are never inherited by spawned
+        # subtasks — that would re-enable recursion (run_subtask) or leak the
+        # parent's knowledge tool.
         self._additional_tools: list[Tool] = []
 
         # Task spawning. ``tasks=False`` (the default) means no auto-injected
@@ -501,8 +502,8 @@ class Agent(PluginTarget, Generic[TResult]):
             for w in AssemblerMiddleware.validate_order(self._policies):
                 logger.warning("Assembly policy ordering: %s", w)
 
-            self.add_middleware.append(_AssemblerMiddlewareFactory(self._policies))
-            self.add_middleware.append(_HaltCheckMiddlewareFactory())
+            self.add_middleware(_AssemblerMiddlewareFactory(self._policies))
+            self.add_middleware(_HaltCheckMiddlewareFactory())
 
     def task(
         self,
@@ -669,12 +670,15 @@ class Agent(PluginTarget, Generic[TResult]):
     ) -> "AgentReply[Any, Any]":
         """Resume a turn from a recorded trajectory, driven by an arbitrary event.
 
-        ``resume`` accepts any ``BaseEvent`` as the ``trigger`` (such as a
-        ``ToolResultsEvent``) so a turn can be continued from any event.
+        ``events`` is the full trajectory to replay: all but the last event seed
+        the stream history, and the **last** event is used as the ``trigger``
+        (such as a ``ToolResultsEvent``) that re-enters the agent loop — so a
+        turn can be continued from any event.
 
-        The agent's conversation state is restored by replacing the stream's history
-        with ``history``. If ``stream`` is omitted a fresh ``MemoryStream`` is
-        created; if one is supplied, its existing history is replaced.
+        The agent's conversation state is restored by replacing the stream's
+        history with the seeded prefix. If ``stream`` is omitted a fresh
+        ``MemoryStream`` is created; if one is supplied, its existing history is
+        replaced.
         """
         stream = stream or MemoryStream()
         *history, trigger = events
@@ -914,7 +918,7 @@ class Agent(PluginTarget, Generic[TResult]):
                 )
 
                 async with _observer_lifecycle(
-                    chain(self._observers, additional_observers),
+                    tuple(chain(self._observers, additional_observers)),
                     stack,
                     context,
                 ):

--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -852,16 +852,30 @@ class Agent(Generic[TResult]):
         response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
         hitl_hook: HumanHook | None = None,
     ) -> "AgentReply[Any, Any]":
-        config = config or self.config
-        if not config:
+        if not (config or self.config):
             raise ConfigNotProvidedError()
-        client = config.create()
-
         stream = stream or MemoryStream()
+        context = self._build_context(stream, prompt=prompt, dependencies=dependencies, variables=variables)
+        return await self._drive(
+            ModelRequest.ensure_request(msg),
+            context=context,
+            config=config,
+            tools=tools,
+            middleware=middleware,
+            observers=observers,
+            response_schema=response_schema,
+            hitl_hook=hitl_hook,
+        )
 
-        initial_event = ModelRequest.ensure_request(msg)
-
-        context = Context(
+    def _build_context(
+        self,
+        stream: Stream,
+        *,
+        prompt: Iterable[str] = (),
+        dependencies: dict[Any, Any] | None = None,
+        variables: dict[Any, Any] | None = None,
+    ) -> Context:
+        return Context(
             stream,
             prompt=list(prompt),
             dependencies=self._agent_dependencies | (dependencies or {}),
@@ -869,15 +883,33 @@ class Agent(Generic[TResult]):
             dependency_provider=self.dependency_provider,
         )
 
+    async def _drive(
+        self,
+        trigger: BaseEvent,
+        *,
+        context: Context,
+        config: ModelConfig | None = None,
+        tools: Iterable[Tool] = (),
+        middleware: Iterable[MiddlewareFactory] = (),
+        observers: Iterable[Observer] = (),
+        response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
+        hitl_hook: HumanHook | None = None,
+    ) -> "AgentReply[Any, Any]":
+        """Shared core for `ask`/`_ask`/`resume`: drive the loop from `trigger`."""
+        config = config or self.config
+        if not config:
+            raise ConfigNotProvidedError()
+        client = config.create()
+
         if not context.prompt:
             context.prompt.extend(self._system_prompt)
 
             for dp in self._dynamic_prompt:
-                p = await dp(initial_event, context)
+                p = await dp(trigger, context)
                 context.prompt.append(p)
 
         return await self._execute(
-            initial_event,
+            trigger,
             context=context,
             client=client,
             hitl_hook=hitl_hook,
@@ -899,29 +931,56 @@ class Agent(Generic[TResult]):
         hitl_hook: HumanHook | None = None,
     ) -> "AgentReply[Any, Any]":
         """`Agent.ask()` alternative method to call agent with prebuild `context`."""
-        config = config or self.config
-        if not config:
-            raise ConfigNotProvidedError()
-        client = config.create()
-
-        initial_event = ModelRequest.ensure_request(msg)
-
-        if not context.prompt:
-            context.prompt.extend(self._system_prompt)
-
-            for dp in self._dynamic_prompt:
-                p = await dp(initial_event, context)
-                context.prompt.append(p)
-
-        return await self._execute(
-            initial_event,
+        return await self._drive(
+            ModelRequest.ensure_request(msg),
             context=context,
-            client=client,
-            hitl_hook=hitl_hook,
-            additional_tools=tools,
-            additional_middleware=middleware,
-            additional_observers=observers,
+            config=config,
+            tools=tools,
+            middleware=middleware,
+            observers=observers,
             response_schema=response_schema,
+            hitl_hook=hitl_hook,
+        )
+
+    async def resume(
+        self,
+        trigger: BaseEvent,
+        *,
+        history: Iterable[BaseEvent] = (),
+        stream: Stream | None = None,
+        dependencies: dict[Any, Any] | None = None,
+        variables: dict[Any, Any] | None = None,
+        prompt: Iterable[str] = (),
+        config: ModelConfig | None = None,
+        tools: Iterable[Tool] = (),
+        middleware: Iterable[MiddlewareFactory] = (),
+        observers: Iterable[Observer] = (),
+        response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
+        hitl_hook: HumanHook | None = None,
+    ) -> "AgentReply[Any, Any]":
+        """Resume a turn from a recorded trajectory, driven by an arbitrary event.
+
+        ``resume`` accepts any ``BaseEvent`` as the ``trigger`` (such as a
+        ``ToolResultsEvent``) so a turn can be continued from any event.
+
+        The agent's conversation state is restored by replacing the stream's history
+        with ``history``. If ``stream`` is omitted a fresh ``MemoryStream`` is
+        created; if one is supplied, its existing history is replaced.
+        """
+        if not (config or self.config):
+            raise ConfigNotProvidedError()
+        stream = stream or MemoryStream()
+        await stream.history.replace(list(history))
+        context = self._build_context(stream, prompt=prompt, dependencies=dependencies, variables=variables)
+        return await self._drive(
+            trigger,
+            context=context,
+            config=config,
+            tools=tools,
+            middleware=middleware,
+            observers=observers,
+            response_schema=response_schema,
+            hitl_hook=hitl_hook,
         )
 
     def _build_knowledge_tool(self) -> list[Tool]:

--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -19,8 +19,8 @@ import asyncio
 import json
 import logging
 import types
-from collections.abc import Callable, Iterable
-from contextlib import ExitStack, suppress
+from collections.abc import AsyncIterator, Callable, Iterable
+from contextlib import ExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass
 from functools import partial
 from itertools import chain
@@ -76,7 +76,7 @@ from .plugin import Plugin, PluginTarget, PromptType
 from .response import ResponseProto, ResponseSchema
 from .stream import MemoryStream, Stream
 from .task import CheckpointStore, Task, TaskSpec
-from .tools.final import FunctionTool, FunctionToolSchema, tool
+from .tools.final import FunctionTool, FunctionToolSchema, Toolkit, tool
 from .tools.schemas import ToolSchema
 from .tools.subagents.run_task import run_task as _run_task
 from .tools.subagents.subagent_tool import StreamFactory, subagent_tool
@@ -501,6 +501,13 @@ class Agent(PluginTarget, Generic[TResult]):
         self.config = config
         self._response_schema = ResponseSchema.ensure_schema(response_schema)
 
+        # Auto-injected tools (subtask toolkit, knowledge tool) live in
+        # ``self.tools`` alongside user tools, but must NOT be inherited by
+        # spawned subtasks — that would re-enable recursion (run_subtask) or
+        # leak the parent's knowledge tool. Track the bound instances so
+        # ``_spawn_subtask`` can exclude them by identity.
+        self._auto_tools: list[Tool] = []
+
         # Task spawning. ``tasks=False`` (the default) means no auto-injected
         # ``run_subtask`` / ``run_subtasks`` tools. Pass ``tasks=TaskConfig(...)``
         # to opt in.
@@ -508,8 +515,8 @@ class Agent(PluginTarget, Generic[TResult]):
             self._task_config: TaskConfig | None = None
         else:
             self._task_config = tasks
-
-        self._subtask_tools: list[Tool] = _build_subtask_tools(self) if self._task_config is not None else []
+            self.add_tool(_build_subtask_toolkit(self))
+            self._auto_tools.append(self.tools[-1])
 
         # Knowledge store + compaction/aggregation strategies
         kc = knowledge
@@ -523,11 +530,9 @@ class Agent(PluginTarget, Generic[TResult]):
         self._compact_trigger = kc.compact_trigger if kc and kc.compact_trigger else CompactTrigger()
         self._aggregate_strategy = kc.aggregate if kc else None
         self._aggregate_trigger = kc.aggregate_trigger if kc and kc.aggregate_trigger else AggregateTrigger()
-        self._knowledge_tools: list[Tool] = (
-            [_make_knowledge_tool(self._knowledge_store)]
-            if self._knowledge_store and self._knowledge_expose_tool
-            else []
-        )
+        if self._knowledge_store and self._knowledge_expose_tool:
+            self.add_tool(_make_knowledge_tool(self._knowledge_store))
+            self._auto_tools.append(self.tools[-1])
 
         # Assembly policies (empty by default; bare Agent has no harness).
         self._policies.extend(assembly)
@@ -789,19 +794,6 @@ class Agent(PluginTarget, Generic[TResult]):
             response_schema=response_schema,
         )
 
-    def _build_knowledge_tool(self) -> list[Tool]:
-        """Return the cached knowledge tool list (built at __init__ time)."""
-        return self._knowledge_tools
-
-    def _build_subtask_tools(self) -> list[Tool]:
-        """Return the cached subtask tool list (built at __init__ time).
-
-        Tools are built once per Agent instance to avoid reallocating closures
-        on every turn (and to satisfy AGENTS.md's "no nested functions in
-        runtime execution paths" rule).
-        """
-        return self._subtask_tools
-
     async def _spawn_subtask(self, task: str, ctx: Context) -> str:
         """Spawn a subtask Agent and delegate via ``run_task``.
 
@@ -818,7 +810,11 @@ class Agent(PluginTarget, Generic[TResult]):
         if tc is None:
             return "Error: subtask spawning is disabled on this Agent (pass tasks=TaskConfig(...) to enable)."
 
-        inherited = _filter_subtask_tools(self.tools, tc.include_tools, tc.exclude_tools)
+        # Inherit only the parent's user-supplied tools — never the
+        # auto-injected subtask toolkit or knowledge tool (excluded by
+        # identity), so the child can't recurse or see parent-only tooling.
+        user_tools = [t for t in self.tools if not any(t is a for a in self._auto_tools)]
+        inherited = _filter_subtask_tools(user_tools, tc.include_tools, tc.exclude_tools)
 
         bare = Agent(
             name=f"subtask-{uuid4().hex[:8]}",
@@ -887,7 +883,6 @@ class Agent(PluginTarget, Generic[TResult]):
         response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
     ) -> "AgentReply[Any, Any]":
         additional_observers = list(additional_observers)
-        subtask_tools = self._subtask_tools
 
         # Bootstrap the knowledge store on first use, guarded by an asyncio
         # lock so concurrent asks on the same Agent can't double-bootstrap.
@@ -896,6 +891,7 @@ class Agent(PluginTarget, Generic[TResult]):
         if self._knowledge_store and not self._bootstrap_done:
             if self._bootstrap_lock is None:
                 self._bootstrap_lock = asyncio.Lock()
+
             async with self._bootstrap_lock:
                 if not self._bootstrap_done:
                     if not await self._knowledge_store.exists("/.initialized"):
@@ -903,8 +899,6 @@ class Agent(PluginTarget, Generic[TResult]):
                         bootstrap = self._bootstrap or DefaultBootstrap(mention_tool=self._knowledge_expose_tool)
                         await bootstrap.bootstrap(self._knowledge_store, self.name)
                     self._bootstrap_done = True
-
-        knowledge_tools = self._knowledge_tools
 
         if self._knowledge_store:
             context.dependencies[KnowledgeStore] = self._knowledge_store
@@ -952,8 +946,6 @@ class Agent(PluginTarget, Generic[TResult]):
                 chain(
                     self.tools,
                     additional_tools,
-                    subtask_tools,
-                    knowledge_tools,
                 )
             )
 
@@ -1057,17 +1049,9 @@ class Agent(PluginTarget, Generic[TResult]):
                     middleware=middleware_instances,
                 )
 
-                for obs in all_observers:
-                    obs.register(stack, context)
-
-                # Observers are live — emit Started so they can see their own
-                # lifecycle event if they subscribe to it.
-                for obs in all_observers:
-                    await context.send(ObserverStarted(name=getattr(obs, "name", type(obs).__name__)))
-
-                try:
+                async with _observer_lifecycle(all_observers, stack, context):
                     message = await agent_turn(event, context)
-                    reply = AgentReply(
+                    return AgentReply(
                         message,
                         context=context,
                         agent=self,
@@ -1075,15 +1059,6 @@ class Agent(PluginTarget, Generic[TResult]):
                         provider=self.dependency_provider,
                         response_schema=final_schema,
                     )
-                finally:
-                    # Emit Completed while observers are still registered,
-                    # so observers subscribed to their own lifecycle event
-                    # see it before the ExitStack unregisters them.
-                    for obs in all_observers:
-                        with suppress(Exception):
-                            await context.send(ObserverCompleted(name=getattr(obs, "name", type(obs).__name__)))
-
-                return reply
 
         finally:
             if self._knowledge_store and self._knowledge_write_event_log:
@@ -1198,6 +1173,35 @@ def _drain_pending(context: Context) -> ModelRequest | None:
     return ModelRequest(parts)
 
 
+@asynccontextmanager
+async def _observer_lifecycle(
+    observers: list[Observer],
+    stack: ExitStack,
+    context: Context,
+) -> AsyncIterator[None]:
+    """Register ``observers`` on ``stack`` and bracket the turn with lifecycle events.
+
+    Observers subscribe to the stream under the caller's ``ExitStack``, then an
+    ``ObserverStarted`` is emitted for each so an observer can see its own start.
+    On exit ``ObserverCompleted`` is emitted for each *before* the ``ExitStack``
+    unwinds the subscriptions, so an observer subscribed to its own completion
+    event still receives it.
+    """
+    for obs in observers:
+        obs.register(stack, context)
+
+    for obs in observers:
+        await context.send(ObserverStarted(name=getattr(obs, "name", type(obs).__name__)))
+
+    try:
+        yield
+
+    finally:
+        for obs in observers:
+            with suppress(Exception):
+                await context.send(ObserverCompleted(name=getattr(obs, "name", type(obs).__name__)))
+
+
 _RUN_SUBTASK_DESCRIPTION = (
     "Spawn an isolated subtask agent for self-contained focused work. "
     "The subtask runs with a fresh conversation history and inherits this "
@@ -1216,7 +1220,7 @@ _RUN_SUBTASKS_DESCRIPTION = (
 )
 
 
-def _build_subtask_tools(agent: "Agent[Any]") -> list[Tool]:
+def _build_subtask_toolkit(agent: "Agent[Any]") -> Toolkit:
     """Construct the ``run_subtask`` / ``run_subtasks`` tools for ``agent``.
 
     Called once per Agent instance from ``__init__``. The closures capture
@@ -1224,12 +1228,13 @@ def _build_subtask_tools(agent: "Agent[Any]") -> list[Tool]:
     re-allocation (per AGENTS.md: no nested function creation in runtime
     execution paths).
     """
+    toolkit = Toolkit()
 
-    @tool(name="run_subtask", description=_RUN_SUBTASK_DESCRIPTION)
+    @toolkit.tool(name="run_subtask", description=_RUN_SUBTASK_DESCRIPTION)
     async def run_subtask(task: str, ctx: Context) -> str:
         return await agent._spawn_subtask(task, ctx)
 
-    @tool(name="run_subtasks", description=_RUN_SUBTASKS_DESCRIPTION)
+    @toolkit.tool(name="run_subtasks", description=_RUN_SUBTASKS_DESCRIPTION)
     async def run_subtasks(ctx: Context, tasks: list[str], parallel: bool = True) -> str:
         if parallel:
             raw = await asyncio.gather(
@@ -1248,7 +1253,7 @@ def _build_subtask_tools(agent: "Agent[Any]") -> list[Tool]:
         parts = [f"## {task_desc}\n\n{result}" for task_desc, result in zip(tasks, results)]
         return "\n\n---\n\n".join(parts)
 
-    return [run_subtask, run_subtasks]
+    return toolkit
 
 
 def _filter_subtask_tools(

--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -19,7 +19,7 @@ import asyncio
 import json
 import logging
 import types
-from collections.abc import AsyncIterator, Callable, Iterable
+from collections.abc import AsyncIterator, Callable, Iterable, Sequence
 from contextlib import ExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass
 from functools import partial
@@ -63,7 +63,8 @@ from .events.lifecycle import (
 from .exceptions import ConfigNotProvidedError
 from .history import History
 from .hitl import HumanHook, default_hitl_hook, wrap_hitl
-from .knowledge import DefaultBootstrap, EventLogWriter, KnowledgeStore, StoreBootstrap
+from .knowledge import DefaultBootstrap, EventLogWriter, KnowledgeStore
+from .knowledge.config import KnowledgeConfig
 from .middleware.base import (
     AgentTurn,
     BaseMiddleware,
@@ -94,47 +95,6 @@ logger = logging.getLogger(__name__)
 TResult = TypeVar313("TResult", default=str)
 TAgent = TypeVar313("TAgent", default=str)
 T2 = TypeVar("T2")
-
-
-@dataclass
-class KnowledgeConfig:
-    """Groups knowledge-related Agent parameters.
-
-    The ``store`` is registered into ``context.dependencies[KnowledgeStore]``
-    so policies (e.g. ``WorkingMemoryPolicy``, ``EpisodicMemoryPolicy``) can
-    read from it without an extra parameter. Everything else is a side
-    effect of attaching a store; each is opt-out via its flag below.
-
-    Attributes:
-        store: The backing knowledge store.
-        expose_tool: If True (default), the agent gets an auto-injected
-            ``knowledge`` action-group tool that lets the LLM call
-            ``read`` / ``write`` / ``list`` / ``delete`` on the store. Set
-            to False when policies are the only consumer of the store and
-            the LLM should not see it.
-        write_event_log: If True (default), the agent persists its stream
-            history to ``/log/{stream_id}.jsonl`` at the end of each
-            ``ask`` call. Set to False to keep the store free of stream
-            logs (useful when the store is purely user-facing memory).
-        compact, compact_trigger: Optional compaction strategy and its
-            firing rules.
-        aggregate, aggregate_trigger: Optional aggregation strategy and
-            its firing rules. Strategy failures emit ``AggregationFailed``
-            on the stream — subscribe to that event for observability.
-        bootstrap: Optional custom bootstrap. None falls back to
-            ``DefaultBootstrap(mention_tool=expose_tool)``, so the
-            generated SKILL.md text tells the LLM about the ``knowledge``
-            tool only when the tool is actually exposed.
-    """
-
-    store: KnowledgeStore
-    expose_tool: bool = True
-    write_event_log: bool = True
-    compact: CompactStrategy | None = None
-    compact_trigger: CompactTrigger | None = None
-    aggregate: AggregateStrategy | None = None
-    aggregate_trigger: AggregateTrigger | None = None
-    bootstrap: StoreBootstrap | None = None
 
 
 @dataclass
@@ -506,7 +466,7 @@ class Agent(PluginTarget, Generic[TResult]):
         # spawned subtasks — that would re-enable recursion (run_subtask) or
         # leak the parent's knowledge tool. Track the bound instances so
         # ``_spawn_subtask`` can exclude them by identity.
-        self._auto_tools: list[Tool] = []
+        self._additional_tools: list[Tool] = []
 
         # Task spawning. ``tasks=False`` (the default) means no auto-injected
         # ``run_subtask`` / ``run_subtasks`` tools. Pass ``tasks=TaskConfig(...)``
@@ -515,30 +475,34 @@ class Agent(PluginTarget, Generic[TResult]):
             self._task_config: TaskConfig | None = None
         else:
             self._task_config = tasks
-            self.add_tool(_build_subtask_toolkit(self))
-            self._auto_tools.append(self.tools[-1])
+            self._additional_tools.append(_build_subtask_toolkit(self))
 
         # Knowledge store + compaction/aggregation strategies
-        kc = knowledge
-        self._knowledge_store = kc.store if kc else None
-        self._knowledge_expose_tool = kc.expose_tool if kc else True
-        self._knowledge_write_event_log = kc.write_event_log if kc else True
-        self._bootstrap = kc.bootstrap if kc else None
-        self._bootstrap_done: bool = False
-        self._bootstrap_lock: asyncio.Lock | None = None
-        self._compact_strategy = kc.compact if kc else None
-        self._compact_trigger = kc.compact_trigger if kc and kc.compact_trigger else CompactTrigger()
-        self._aggregate_strategy = kc.aggregate if kc else None
-        self._aggregate_trigger = kc.aggregate_trigger if kc and kc.aggregate_trigger else AggregateTrigger()
-        if self._knowledge_store and self._knowledge_expose_tool:
-            self.add_tool(_make_knowledge_tool(self._knowledge_store))
-            self._auto_tools.append(self.tools[-1])
+        if knowledge:
+            self._agent_dependencies[KnowledgeStore] = knowledge.store
+            self._knowledge_context = _KnowledgeContext(knowledge, self.name)
+
+            if knowledge.expose_tool:
+                self._additional_tools.append(_make_knowledge_tool(knowledge.store))
+
+            if knowledge.compact:
+                self.add_middleware(_CompactionMiddlewareFactory(self.name, knowledge))
+
+            if (trigger := knowledge.aggregate_trigger) and (
+                trigger.every_n_turns > 0 or trigger.every_n_events > 0 or trigger.on_end
+            ):
+                self.add_middleware(_AggregationMiddlewareFactory(self.name, knowledge))
+        else:
+            self._knowledge_context = _FakeKnowledgeContext()
 
         # Assembly policies (empty by default; bare Agent has no harness).
         self._policies.extend(assembly)
         if self._policies:
             for w in AssemblerMiddleware.validate_order(self._policies):
                 logger.warning("Assembly policy ordering: %s", w)
+
+            self.add_middleware.append(_AssemblerMiddlewareFactory(self._policies))
+            self.add_middleware.append(_HaltCheckMiddlewareFactory())
 
     def task(
         self,
@@ -691,9 +655,7 @@ class Agent(PluginTarget, Generic[TResult]):
 
     async def resume(
         self,
-        trigger: BaseEvent,
-        *,
-        history: Iterable[BaseEvent] = (),
+        *events: BaseEvent,
         stream: Stream | None = None,
         dependencies: dict[Any, Any] | None = None,
         variables: dict[Any, Any] | None = None,
@@ -715,7 +677,8 @@ class Agent(PluginTarget, Generic[TResult]):
         created; if one is supplied, its existing history is replaced.
         """
         stream = stream or MemoryStream()
-        await stream.history.replace(list(history))
+        *history, trigger = events
+        await stream.history.replace(history)
 
         context = self.__build_context(
             stream,
@@ -794,41 +757,6 @@ class Agent(PluginTarget, Generic[TResult]):
             response_schema=response_schema,
         )
 
-    async def _spawn_subtask(self, task: str, ctx: Context) -> str:
-        """Spawn a subtask Agent and delegate via ``run_task``.
-
-        The subtask inherits the parent's user-supplied tools (filtered by
-        ``TaskConfig.include_tools`` / ``exclude_tools``) plus
-        ``TaskConfig.extra_tools``. It is constructed with ``tasks=False``
-        (the default) so the child has **no** ``run_subtask`` tools —
-        recursive delegation is impossible by construction. ``run_task``
-        emits the ``TaskStarted`` / ``TaskCompleted`` / ``TaskFailed``
-        lifecycle events and handles dependency/variable copy and HITL
-        bridging.
-        """
-        tc = self._task_config
-        if tc is None:
-            return "Error: subtask spawning is disabled on this Agent (pass tasks=TaskConfig(...) to enable)."
-
-        # Inherit only the parent's user-supplied tools — never the
-        # auto-injected subtask toolkit or knowledge tool (excluded by
-        # identity), so the child can't recurse or see parent-only tooling.
-        user_tools = [t for t in self.tools if not any(t is a for a in self._auto_tools)]
-        inherited = _filter_subtask_tools(user_tools, tc.include_tools, tc.exclude_tools)
-
-        bare = Agent(
-            name=f"subtask-{uuid4().hex[:8]}",
-            prompt=tc.prompt,
-            config=tc.config or self.config,
-            tools=[*inherited, *tc.extra_tools],
-            tasks=False,
-        )
-
-        result = await _run_task(bare, task, parent_context=ctx)
-        if not result.completed:
-            return f"Error: {result.error}"
-        return result.result or ""
-
     async def _execute(
         self,
         event: BaseEvent,
@@ -882,72 +810,14 @@ class Agent(PluginTarget, Generic[TResult]):
         additional_observers: Iterable[Observer] = (),
         response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
     ) -> "AgentReply[Any, Any]":
-        additional_observers = list(additional_observers)
-
-        # Bootstrap the knowledge store on first use, guarded by an asyncio
-        # lock so concurrent asks on the same Agent can't double-bootstrap.
-        # The lock is created lazily so Agent can be instantiated outside an
-        # event loop (asyncio.Lock binds to the running loop on first use).
-        if self._knowledge_store and not self._bootstrap_done:
-            if self._bootstrap_lock is None:
-                self._bootstrap_lock = asyncio.Lock()
-
-            async with self._bootstrap_lock:
-                if not self._bootstrap_done:
-                    if not await self._knowledge_store.exists("/.initialized"):
-                        await self._knowledge_store.write("/.initialized", self.name)
-                        bootstrap = self._bootstrap or DefaultBootstrap(mention_tool=self._knowledge_expose_tool)
-                        await bootstrap.bootstrap(self._knowledge_store, self.name)
-                    self._bootstrap_done = True
-
-        if self._knowledge_store:
-            context.dependencies[KnowledgeStore] = self._knowledge_store
-
-        all_observers = list(chain(self._observers, additional_observers))
-
-        # Build harness middleware chain. Assembler + halt-check only wire in
-        # when the user has provided assembly policies; compaction and
-        # aggregation middleware have independent gates.
-        harness_middleware: list[MiddlewareFactory] = []
-
-        if self._policies:
-            harness_middleware.append(_AssemblerMiddlewareFactory(self._policies))
-            harness_middleware.append(_HaltCheckMiddlewareFactory())
-
-        if self._compact_strategy:
-            harness_middleware.append(
-                _CompactionMiddlewareFactory(
-                    self.name,
-                    self._compact_strategy,
-                    self._knowledge_store,
-                    self._compact_trigger,
-                )
-            )
-
-        if self._aggregate_strategy and self._knowledge_store:
-            trigger = self._aggregate_trigger
-            if trigger.every_n_turns > 0 or trigger.every_n_events > 0 or trigger.on_end:
-                harness_middleware.append(
-                    _AggregationMiddlewareFactory(
-                        self.name,
-                        self._aggregate_strategy,
-                        self._knowledge_store,
-                        trigger,
-                    )
-                )
-
-        try:
+        async with self._knowledge_context.enter(context):
             if response_schema is omit:
                 final_schema = self._response_schema
             else:
                 final_schema = ResponseSchema.ensure_schema(response_schema)
 
-            all_tools: list[Tool] = list(
-                chain(
-                    self.tools,
-                    additional_tools,
-                )
-            )
+            # collect actual tools
+            all_tools: tuple[Tool, ...] = tuple(chain(self.tools, self._additional_tools, additional_tools))
 
             all_schemas: list[ToolSchema] = []
             known_tools: set[str] = set()
@@ -961,6 +831,7 @@ class Agent(PluginTarget, Generic[TResult]):
                     else:
                         known_tools.add(schema.type)
 
+            # instantiate middlewares
             middleware_instances: list[BaseMiddleware] = []
             agent_turn: AgentTurn = _execute_turn
             llm_call: LLMCall = partial(
@@ -970,21 +841,14 @@ class Agent(PluginTarget, Generic[TResult]):
                 serializer=self._serializer,
             )
 
-            for m in reversed(
-                list(
-                    chain(
-                        self._middleware,
-                        harness_middleware,
-                        additional_middleware,
-                    )
-                )
-            ):
+            for m in reversed(tuple(chain(self._middleware, additional_middleware))):
                 mw = m(event, context)
                 middleware_instances.append(mw)
 
                 agent_turn = partial(mw.on_turn, agent_turn)
                 llm_call = partial(mw.on_llm_call, llm_call)
 
+            # construct LLM callback
             async def _call_client(event: BaseEvent, context: Context) -> None:
                 # Skip the LLM trigger when re-entered with a request we
                 # injected ourselves a few lines below. Identity is carried by
@@ -1049,7 +913,11 @@ class Agent(PluginTarget, Generic[TResult]):
                     middleware=middleware_instances,
                 )
 
-                async with _observer_lifecycle(all_observers, stack, context):
+                async with _observer_lifecycle(
+                    chain(self._observers, additional_observers),
+                    stack,
+                    context,
+                ):
                     message = await agent_turn(event, context)
                     return AgentReply(
                         message,
@@ -1060,21 +928,39 @@ class Agent(PluginTarget, Generic[TResult]):
                         response_schema=final_schema,
                     )
 
-        finally:
-            if self._knowledge_store and self._knowledge_write_event_log:
-                try:
-                    events = list(await context.stream.history.get_events())
-                    await EventLogWriter(self._knowledge_store).persist(context.stream.id, events)
-                except Exception as exc:
-                    logger.exception("Event log persistence failed for %s", self.name)
-                    with suppress(Exception):
-                        await context.send(
-                            EventLogFailed(
-                                agent=self.name,
-                                error_type=type(exc).__name__,
-                                error=str(exc),
-                            )
-                        )
+    async def _spawn_subtask(self, task: str, ctx: Context) -> str:
+        """Spawn a subtask Agent and delegate via ``run_task``.
+
+        The subtask inherits the parent's user-supplied tools (filtered by
+        ``TaskConfig.include_tools`` / ``exclude_tools``) plus
+        ``TaskConfig.extra_tools``. It is constructed with ``tasks=False``
+        (the default) so the child has **no** ``run_subtask`` tools —
+        recursive delegation is impossible by construction. ``run_task``
+        emits the ``TaskStarted`` / ``TaskCompleted`` / ``TaskFailed``
+        lifecycle events and handles dependency/variable copy and HITL
+        bridging.
+        """
+        tc = self._task_config
+        if tc is None:
+            return "Error: subtask spawning is disabled on this Agent (pass tasks=TaskConfig(...) to enable)."
+
+        # Inherit only the parent's user-supplied tools — never the
+        # auto-injected subtask toolkit or knowledge tool (excluded by
+        # identity), so the child can't recurse or see parent-only tooling.
+        inherited = _filter_subtask_tools(self.tools, tc.include_tools, tc.exclude_tools)
+
+        bare = Agent(
+            name=f"subtask-{uuid4().hex[:8]}",
+            prompt=tc.prompt,
+            config=tc.config or self.config,
+            tools=[*inherited, *tc.extra_tools],
+            tasks=False,
+        )
+
+        result = await _run_task(bare, task, parent_context=ctx)
+        if not result.completed:
+            return f"Error: {result.error}"
+        return result.result or ""
 
     def __build_context(
         self,
@@ -1114,6 +1000,60 @@ class Agent(PluginTarget, Generic[TResult]):
         from .conversable import ConversableAdapter
 
         return ConversableAdapter(self)
+
+
+class _KnowledgeContext:
+    def __init__(
+        self,
+        config: "KnowledgeConfig",
+        agent_name: str,
+    ) -> None:
+        self.config = config
+        self._agent_name = agent_name
+
+        self.__lock: asyncio.Lock | None = None
+        self.__bootstrapped = None
+
+    @asynccontextmanager
+    async def enter(self, context: "Context") -> AsyncIterator[None]:
+        store = self.config.store
+
+        if not self.__bootstrapped:
+            if self.__lock is None:
+                self.__lock = asyncio.Lock()
+
+            async with self.__lock:
+                if not self.__bootstrapped:
+                    if not await store.exists("/.initialized"):
+                        await store.write("/.initialized", self._agent_name)
+                        bootstrap = self.config.bootstrap or DefaultBootstrap(mention_tool=self.config.expose_tool)
+                        await bootstrap.bootstrap(store, self._agent_name)
+
+                    self.__bootstrapped = True
+
+        yield None
+
+        if self.config.write_event_log:
+            try:
+                events = list(await context.stream.history.get_events())
+                await EventLogWriter(store).persist(context.stream.id, events)
+
+            except Exception as exc:
+                logger.exception("Event log persistence failed for %s", self._agent_name)
+                with suppress(Exception):
+                    await context.send(
+                        EventLogFailed(
+                            agent=self._agent_name,
+                            error_type=type(exc).__name__,
+                            error=str(exc),
+                        )
+                    )
+
+
+class _FakeKnowledgeContext:
+    @asynccontextmanager
+    async def enter(self, context: "Context") -> AsyncIterator[None]:
+        yield
 
 
 async def _execute_turn(event: BaseEvent, context: Context) -> ModelResponse:
@@ -1175,7 +1115,7 @@ def _drain_pending(context: Context) -> ModelRequest | None:
 
 @asynccontextmanager
 async def _observer_lifecycle(
-    observers: list[Observer],
+    observers: Sequence[Observer],
     stack: ExitStack,
     context: Context,
 ) -> AsyncIterator[None]:
@@ -1189,8 +1129,6 @@ async def _observer_lifecycle(
     """
     for obs in observers:
         obs.register(stack, context)
-
-    for obs in observers:
         await context.send(ObserverStarted(name=getattr(obs, "name", type(obs).__name__)))
 
     try:
@@ -1386,7 +1324,7 @@ class _HaltCheckMiddlewareFactory:
 class _AssemblerMiddlewareFactory:
     """Factory for AssemblerMiddleware."""
 
-    def __init__(self, policies: list[AssemblyPolicy]) -> None:
+    def __init__(self, policies: Iterable[AssemblyPolicy]) -> None:
         self._policies = policies
 
     def __call__(self, event: BaseEvent, context: Context) -> AssemblerMiddleware:
@@ -1484,26 +1422,18 @@ class _CompactionMiddleware(BaseMiddleware):
 class _CompactionMiddlewareFactory:
     """Factory for _CompactionMiddleware."""
 
-    def __init__(
-        self,
-        actor_name: str,
-        strategy: CompactStrategy,
-        store: KnowledgeStore | None,
-        trigger: CompactTrigger,
-    ) -> None:
+    def __init__(self, actor_name: str, config: KnowledgeConfig) -> None:
         self._actor_name = actor_name
-        self._strategy = strategy
-        self._store = store
-        self._trigger = trigger
+        self.config = config
 
     def __call__(self, event: BaseEvent, context: Context) -> _CompactionMiddleware:
         return _CompactionMiddleware(
             event,
             context,
             actor_name=self._actor_name,
-            strategy=self._strategy,
-            store=self._store,
-            trigger=self._trigger,
+            strategy=self.config.compact,
+            store=self.config.store,
+            trigger=self.config.compact_trigger,
         )
 
 
@@ -1612,17 +1542,11 @@ class _AggregationMiddleware(BaseMiddleware):
 class _AggregationMiddlewareFactory:
     """Factory for _AggregationMiddleware."""
 
-    def __init__(
-        self,
-        actor_name: str,
-        strategy: AggregateStrategy,
-        store: KnowledgeStore,
-        trigger: AggregateTrigger,
-    ) -> None:
+    def __init__(self, actor_name: str, config: "KnowledgeConfig") -> None:
         self._actor_name = actor_name
-        self._strategy = strategy
-        self._store = store
-        self._trigger = trigger
+        self._strategy = config.aggregate
+        self._store = config.store
+        self._trigger = config.aggregate_trigger
 
     def __call__(self, event: BaseEvent, context: Context) -> _AggregationMiddleware:
         return _AggregationMiddleware(

--- a/autogen/beta/aggregate.py
+++ b/autogen/beta/aggregate.py
@@ -17,13 +17,11 @@ from typing import Protocol, runtime_checkable
 
 from fast_depends.pydantic import PydanticSerializer
 
-from autogen.beta.annotations import Context
-from autogen.beta.config import ModelConfig
-from autogen.beta.context import ConversationContext
-from autogen.beta.events import BaseEvent, ModelRequest, UsageEvent
-from autogen.beta.stream import MemoryStream
-
+from .annotations import Context
+from .config import ModelConfig
+from .events import BaseEvent, ModelRequest, UsageEvent
 from .knowledge import CONVERSATIONS_PREFIX, WORKING_MEMORY_PATH, KnowledgeStore
+from .stream import MemoryStream
 
 
 @runtime_checkable
@@ -98,7 +96,7 @@ class ConversationSummaryAggregate:
         ])
         response = await client(
             [prompt_event],
-            ConversationContext(MemoryStream()),
+            Context(MemoryStream()),
             tools=[],
             response_schema=None,
             serializer=self._serializer,
@@ -194,7 +192,7 @@ class WorkingMemoryAggregate:
         )
         response = await client(
             [ModelRequest.ensure_request([prompt])],
-            ConversationContext(MemoryStream()),
+            Context(MemoryStream()),
             tools=[],
             response_schema=None,
             serializer=self._serializer,

--- a/autogen/beta/assembly.py
+++ b/autogen/beta/assembly.py
@@ -10,7 +10,7 @@ transforms (prompts, events) before each LLM call.
 Policies compose left-to-right: each sees the output of the previous.
 """
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import Protocol, runtime_checkable
 
 from autogen.beta.context import ConversationContext as Context
@@ -64,7 +64,7 @@ class AssemblerMiddleware(BaseMiddleware):
         event: BaseEvent,
         context: Context,
         *,
-        policies: list[AssemblyPolicy],
+        policies: Iterable[AssemblyPolicy],
     ) -> None:
         super().__init__(event, context)
         self._policies = policies

--- a/autogen/beta/config/bedrock/bedrock_client.py
+++ b/autogen/beta/config/bedrock/bedrock_client.py
@@ -176,9 +176,10 @@ class BedrockClient(LLMClient):
         text_parts: list[str] = []
         calls: list[ToolCallEvent] = []
         for block in content_blocks:
-            if reasoning := block.get("reasoningContent"):
-                if reasoning_text := (reasoning.get("reasoningText") or {}).get("text"):
-                    await context.send(ModelReasoning(reasoning_text))
+            if (reasoning := block.get("reasoningContent")) and (
+                reasoning_text := (reasoning.get("reasoningText") or {}).get("text")
+            ):
+                await context.send(ModelReasoning(reasoning_text))
 
             if text := block.get("text"):
                 text_parts.append(text)
@@ -235,12 +236,12 @@ class BedrockClient(LLMClient):
                 if text := delta.get("text"):
                     full_content += text
                     await context.send(ModelMessageChunk(text))
-                if reasoning := delta.get("reasoningContent"):
-                    if reasoning_text := reasoning.get("text"):
-                        await context.send(ModelReasoning(reasoning_text))
-                if tool_use := delta.get("toolUse"):
-                    if (acc := tool_accs.get(block_delta["contentBlockIndex"])) is not None:
-                        acc["arguments"] += tool_use.get("input") or ""
+                if (reasoning := delta.get("reasoningContent")) and (reasoning_text := reasoning.get("text")):
+                    await context.send(ModelReasoning(reasoning_text))
+                if (tool_use := delta.get("toolUse")) and (
+                    acc := tool_accs.get(block_delta["contentBlockIndex"])
+                ) is not None:
+                    acc["arguments"] += tool_use.get("input") or ""
 
             elif block_stop := event.get("contentBlockStop"):
                 if (acc := tool_accs.pop(block_stop["contentBlockIndex"], None)) is not None:

--- a/autogen/beta/config/bedrock/mappers.py
+++ b/autogen/beta/config/bedrock/mappers.py
@@ -229,9 +229,8 @@ def convert_messages(
             for r in message.results:
                 if r.parent_id:
                     resolved_tool_ids.add(r.parent_id)
-        elif isinstance(message, (ToolResultEvent, ToolErrorEvent)):
-            if message.parent_id:
-                resolved_tool_ids.add(message.parent_id)
+        elif isinstance(message, (ToolResultEvent, ToolErrorEvent)) and message.parent_id:
+            resolved_tool_ids.add(message.parent_id)
 
     # Pre-populate from wrappers so the loose-leaf fallback below doesn't
     # double-emit a toolResult that a later ToolResultsEvent also carries.

--- a/autogen/beta/eval/dataset/suite.py
+++ b/autogen/beta/eval/dataset/suite.py
@@ -34,15 +34,12 @@ class Suite:
 
     def __init__(
         self,
-        msg: str | None = None,
         tasks: Sequence[Task] = (),
         *,
         name: str = "inline",
         source: str = "inline",
     ) -> None:
         """Direct constructor — most callers should use :meth:`from_jsonl` or :meth:`from_list`."""
-        if msg:
-            tasks = [Task(inputs={"input": msg}), *tasks]
         self._tasks: tuple[Task, ...] = tuple(tasks)
         self._name = name
         self._source = source

--- a/autogen/beta/eval/dataset/suite.py
+++ b/autogen/beta/eval/dataset/suite.py
@@ -34,12 +34,15 @@ class Suite:
 
     def __init__(
         self,
-        tasks: Sequence[Task],
+        msg: str | None = None,
+        tasks: Sequence[Task] = (),
         *,
-        name: str,
-        source: str,
+        name: str = "inline",
+        source: str = "inline",
     ) -> None:
         """Direct constructor — most callers should use :meth:`from_jsonl` or :meth:`from_list`."""
+        if msg:
+            tasks = [Task(inputs={"input": msg}), *tasks]
         self._tasks: tuple[Task, ...] = tuple(tasks)
         self._name = name
         self._source = source
@@ -62,7 +65,7 @@ class Suite:
         p = Path(path)
         items = _read_jsonl(p)
         tasks = _items_to_tasks(items, source=str(p))
-        return cls(tasks, name=p.stem, source=str(p))
+        return cls(tasks=tasks, name=p.stem, source=str(p))
 
     @classmethod
     def from_list(
@@ -84,7 +87,7 @@ class Suite:
             A Suite whose ``source`` is ``"inline"``.
         """
         tasks = _items_to_tasks(items, source="inline")
-        return cls(tasks, name=name, source="inline")
+        return cls(tasks=tasks, name=name, source="inline")
 
     @property
     def name(self) -> str:
@@ -145,8 +148,8 @@ def _items_to_tasks(items: Sequence[dict[str, Any]], *, source: str) -> tuple[Ta
         metadata = dict(item.get("metadata", {}))
         tasks.append(
             Task(
-                task_id=task_id,
                 inputs=inputs,
+                task_id=task_id,
                 reference_outputs=reference_outputs,
                 tags=tags,
                 metadata=metadata,

--- a/autogen/beta/eval/dataset/task.py
+++ b/autogen/beta/eval/dataset/task.py
@@ -7,6 +7,7 @@
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Any
+from uuid import uuid4
 
 from pydantic import BaseModel
 
@@ -38,8 +39,9 @@ class Task:
             run JSON so scorers and reports can consume it.
     """
 
-    task_id: str
     inputs: dict[str, Any]
+
+    task_id: str = field(default_factory=lambda: str(uuid4()))
     reference_outputs: dict[str, Any] | None = None
     tags: tuple[str, ...] = ()
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/autogen/beta/eval/pairwise.py
+++ b/autogen/beta/eval/pairwise.py
@@ -280,7 +280,7 @@ async def evaluate_pairwise(
     source_b: TraceSource,
     *,
     comparators: Iterable[PairwiseComparator],
-    store_dir: str | os.PathLike[str],
+    store_dir: str | os.PathLike[str] | None,
     variant_a: str = "A",
     variant_b: str = "B",
     suite: Suite | None = None,
@@ -318,17 +318,17 @@ async def evaluate_pairwise(
     created_at = datetime.now(timezone.utc).isoformat()
     started = time.perf_counter()
 
-    eval_ctx = ConversationContext(stream=stream) if stream is not None else None
     if stream is not None:
-        await stream.send(
+        eval_ctx = ConversationContext(stream=stream)
+        await eval_ctx.send(
             PairwiseStarted(
                 run_id=actual_run_id, label=label, variant_a=variant_a, variant_b=variant_b, total=len(pairs)
             ),
-            eval_ctx,
         )
-    on_case = (
-        partial(_publish_pairwise_compared, stream, eval_ctx, actual_run_id, label) if stream is not None else None
-    )
+        on_case = partial(_publish_pairwise_compared, eval_ctx, actual_run_id, label)
+
+    else:
+        eval_ctx, on_case = None, None
 
     case_lists = await asyncio.gather(
         *(
@@ -351,9 +351,12 @@ async def evaluate_pairwise(
         label=label,
         store_dir=store_dir,
     )
-    result.save()
-    if stream is not None:
-        await stream.send(PairwiseCompleted(run_id=actual_run_id, label=label, result=result), eval_ctx)
+    if store_dir:
+        result.save()
+
+    if eval_ctx is not None:
+        await eval_ctx.send(PairwiseCompleted(run_id=actual_run_id, label=label, result=result))
+
     return result
 
 
@@ -398,16 +401,13 @@ async def _evaluate_pair(
 
 
 async def _publish_pairwise_compared(
-    stream: Stream,
     ctx: ConversationContext,
     run_id: str,
     label: str | None,
     case: PairwiseCase,
 ) -> None:
     """Publish a :class:`PairwiseCompared` event when one comparator finishes one pair."""
-    await stream.send(
-        PairwiseCompared(run_id=run_id, label=label, task_id=case.task_id, key=case.key, winner=case.winner), ctx
-    )
+    await ctx.send(PairwiseCompared(run_id=run_id, label=label, task_id=case.task_id, key=case.key, winner=case.winner))
 
 
 def _pos_to_ab(preferred: str, first: str, second: str) -> str:

--- a/autogen/beta/eval/results/result.py
+++ b/autogen/beta/eval/results/result.py
@@ -147,7 +147,7 @@ class RunResult:
 
     @property
     def target_path(self) -> str:
-        """``"<module>:<name>"`` provenance of the evaluated target (factory or instance type)."""
+        """``"<module>:<name>"`` provenance of the evaluated agent (its instance type)."""
         return self._target_path
 
     @property

--- a/autogen/beta/eval/results/store.py
+++ b/autogen/beta/eval/results/store.py
@@ -218,7 +218,7 @@ def load_run(path: str | os.PathLike[str]) -> "RunResult":
 
     suite_doc = doc.get("suite", {})
     suite = Suite(
-        tuple(tr.task for tr in task_results),
+        tasks=tuple(tr.task for tr in task_results),
         name=suite_doc.get("name", "loaded"),
         source=suite_doc.get("source", str(path)),
     )

--- a/autogen/beta/eval/runtime/evaluate.py
+++ b/autogen/beta/eval/runtime/evaluate.py
@@ -244,4 +244,4 @@ def _outputs_from_trace(trace: Trace) -> dict[str, Any]:
 def _suite_from_refs(refs: list[TraceRef]) -> Suite:
     """Synthesize a reference-free Suite (one task per trace) when none is supplied."""
     tasks = tuple(Task(task_id=ref.task_id or ref.trace_id, inputs={}, reference_outputs=None) for ref in refs)
-    return Suite(tasks, name="traces", source="trace-source")
+    return Suite(tasks=tasks, name="traces", source="trace-source")

--- a/autogen/beta/eval/runtime/evaluate.py
+++ b/autogen/beta/eval/runtime/evaluate.py
@@ -99,7 +99,7 @@ async def _grade(
     *,
     scorers: tuple[Scorer, ...],
     suite: Suite | None,
-    store_dir: str | os.PathLike[str],
+    store_dir: str | os.PathLike[str] | None,
     budgets: BudgetThresholds | None,
     concurrency: int,
     run_id: str | None,
@@ -127,19 +127,18 @@ async def _grade(
     actual_run_id = run_id if run_id is not None else uuid4().hex
     created_at = datetime.now(timezone.utc).isoformat()
 
-    eval_stream = stream
-    eval_ctx = ConversationContext(stream=eval_stream) if eval_stream is not None else None
-    if eval_stream is not None:
-        await eval_stream.send(
+    if stream is not None:
+        eval_ctx = ConversationContext(stream=stream) if stream is not None else None
+
+        await eval_ctx.send(
             EvalStarted(run_id=actual_run_id, label=label, suite=resolved_suite.name, total=len(refs)),
-            eval_ctx,
         )
 
-    on_result = (
-        partial(_publish_task_evaluated, eval_stream, eval_ctx, actual_run_id, label, variant)
-        if eval_stream is not None
-        else None
-    )
+        on_result = partial(_publish_task_evaluated, eval_ctx, actual_run_id, label, variant)
+
+    else:
+        eval_ctx, on_result = None, None
+
     coros = [
         _evaluate_ref(
             semaphore, source, ref, scorers=scorers, tasks_by_id=tasks_by_id, budgets=budgets, on_result=on_result
@@ -160,11 +159,13 @@ async def _grade(
         label=label,
         store_dir=store_dir,
     )
-    saved_path = result.save()
-    logger.info("Run %s saved to %s", actual_run_id, saved_path)
 
-    if eval_stream is not None:
-        await eval_stream.send(EvalCompleted(run_id=actual_run_id, label=label, result=result), eval_ctx)
+    if store_dir:
+        saved_path = result.save()
+        logger.info("Run %s saved to %s", actual_run_id, saved_path)
+
+    if eval_ctx is not None:
+        await eval_ctx.send(EvalCompleted(run_id=actual_run_id, label=label, result=result))
 
     return result
 
@@ -208,7 +209,6 @@ async def _evaluate_ref(
 
 
 async def _publish_task_evaluated(
-    stream: Stream,
     ctx: ConversationContext,
     run_id: str,
     label: str | None,
@@ -217,9 +217,8 @@ async def _publish_task_evaluated(
     result: TaskResult,
 ) -> None:
     """Publish a :class:`TaskEvaluated` event when one trace finishes scoring."""
-    await stream.send(
+    await ctx.send(
         TaskEvaluated(run_id=run_id, label=label, task_id=task.task_id, feedback=result.feedback, variant=variant),
-        ctx,
     )
 
 

--- a/autogen/beta/eval/runtime/runner.py
+++ b/autogen/beta/eval/runtime/runner.py
@@ -82,6 +82,11 @@ async def run_agent(
     :func:`~autogen.beta.eval.evaluate_traces` uses, and — when ``store_dir`` is set — the
     run is persisted as ``<store_dir>/<run_id>.json``.
 
+    The simplest run is one prompt against one agent — no suite, scorers, or
+    store needed::
+
+        result = await run_agent("Hi, agent!", agent=agent)
+
     Args:
         suite: A :class:`Suite`, or a bare ``str`` used as a single-prompt
             suite. Build multi-task suites explicitly with

--- a/autogen/beta/eval/runtime/runner.py
+++ b/autogen/beta/eval/runtime/runner.py
@@ -5,8 +5,8 @@
 """run_agent() — the eval runner.
 
 ``run_agent`` is *produce-then-grade*, and produces its trace **through OpenTelemetry** —
-the same substrate :func:`~autogen.beta.eval.evaluate_traces` grades. Per task it builds a
-fresh :class:`~autogen.beta.Agent`, runs it with a
+the same substrate :func:`~autogen.beta.eval.evaluate_traces` grades. Per task it runs the
+given :class:`~autogen.beta.Agent` with a
 :class:`~autogen.beta.middleware.builtin.telemetry.TelemetryMiddleware` exporting to an
 **in-memory** span exporter, then reconstructs the :class:`~autogen.beta.eval.Trace`
 from those spans via ``readable_spans_to_trace`` — exactly the span→Trace path the
@@ -16,10 +16,9 @@ the *same* reconstruction and the *same* grading core
 
 Because the trace is reconstructed from spans, ``run_agent`` inherits the OTEL path's
 fidelity (halt / tool-not-found are stream-only, so never spanned — see
-``sources/_spans.py``). Failures that emit no spans (a factory that raises, or an
-``ask`` that errors before the agent span starts) fall back to the caught exception so
-they still surface. Tasks run in parallel up to ``concurrency``, bounded by an
-:class:`asyncio.Semaphore`.
+``sources/_spans.py``). An ``ask`` that errors before the agent span starts emits no
+spans and falls back to the caught exception so it still surfaces. Tasks run in parallel
+up to ``concurrency``, bounded by an :class:`asyncio.Semaphore`.
 """
 
 import asyncio
@@ -75,38 +74,35 @@ async def run_agent(
 ) -> RunResult:
     """Run an evaluation suite end-to-end.
 
-    Each task gets a fresh :class:`~autogen.beta.Agent` built
-    from ``agent`` (an instance, reused, or a factory), run with a
+    The given :class:`~autogen.beta.Agent` is run once per task with a
     :class:`~autogen.beta.middleware.builtin.telemetry.TelemetryMiddleware` exporting to an
     in-memory span exporter; the :class:`~autogen.beta.eval.Trace` is then reconstructed
     from those spans (per-task duration timed around the ``ask``) — the same span→Trace
     path the trace-based sources use. Those traces are graded through the same core
-    :func:`~autogen.beta.eval.evaluate_traces` uses, and the run is persisted as
-    ``<store_dir>/<run_id>.json``.
+    :func:`~autogen.beta.eval.evaluate_traces` uses, and — when ``store_dir`` is set — the
+    run is persisted as ``<store_dir>/<run_id>.json``.
 
     Args:
-        suite: A :class:`Suite`, a JSONL path, or an inline list of dict
-            task records. Strings / paths are loaded via
-            :meth:`Suite.from_jsonl`; lists are loaded via
-            :meth:`Suite.from_list`.
-        agent: The agent to evaluate — either an :class:`~autogen.beta.Agent`
-            *instance*, reused for every task, or a *factory* callable that
-            builds a fresh :class:`~autogen.beta.Agent` per task. A factory may
-            take a keyword-only ``config`` parameter so the runner can inject
-            per-task or global model configs (use a factory, not an instance,
-            when you want per-task ``model_config``).
+        suite: A :class:`Suite`, or a bare ``str`` used as a single-prompt
+            suite. Build multi-task suites explicitly with
+            :meth:`Suite.from_list` (inline) or :meth:`Suite.from_jsonl`
+            (a file) and pass the result.
+        agent: The :class:`~autogen.beta.Agent` instance to evaluate, reused
+            for every task. Vary the model per task through ``model_config``,
+            which is forwarded to ``ask`` and overrides the agent's own config.
         scorers: Scorer instances (typically produced by ``@scorer``).
             Each is called once per task; the resulting feedback is
             recorded on the task's :class:`TaskResult`.
         store_dir: Directory under which the run JSON is persisted as
-            ``<store_dir>/<run_id>.json``. Required — evals are
-            comparison artifacts; a run that isn't persisted has no
-            shelf life. Use ``tmp_path`` in tests, a repo directory
-            for CI, or any path that fits your retention story.
-        model_config: ``None`` to let the factory pick (its default),
-            a single ``ModelConfig`` to use everywhere, or a
+            ``<store_dir>/<run_id>.json``. Optional — omit it to run without
+            persisting. Evals are comparison artifacts, so persist (``tmp_path``
+            in tests, a repo directory for CI, …) whenever a run should outlive
+            the call.
+        model_config: ``None`` to use the agent's own config, a single
+            ``ModelConfig`` to apply everywhere, or a
             ``dict[task_id, ModelConfig]`` for per-task configs (e.g.
-            one ``TestConfig`` cassette per task).
+            one ``TestConfig`` cassette per task). Passed to ``ask``, so it
+            overrides the agent's config for that task.
         repeats: Run each task this many times (default ``1``) — for
             measuring consistency. ``pass_rate`` / ``score_stats`` pool
             all runs; with ``repeats > 1`` each run gets a distinct
@@ -145,8 +141,8 @@ async def run_agent(
 
     Returns:
         A :class:`RunResult` containing per-task results and metadata.
-        The result has already been written to disk by the time this
-        function returns.
+        When ``store_dir`` is set, the result has already been written to
+        disk by the time this function returns.
     """
     resolved_suite = _resolve_suite(suite)
     tasks_to_run = _expand_repeats(resolved_suite, repeats)
@@ -243,7 +239,7 @@ async def _produce(
     span_attributes: dict[str, str] | None = None,
     span_processors: "Sequence[SpanProcessor] | None" = None,
 ) -> InMemoryTraceSource:
-    """Run ``factory``'s agent across ``tasks``, returning one Trace per task (in order)."""
+    """Run ``agent`` across ``tasks``, returning one Trace per task (in order)."""
     tasks = list(tasks)
     missing = [t.task_id for t in tasks if "input" not in t.inputs]
     if missing:
@@ -312,8 +308,8 @@ async def _produce_one(
             duration_ms = int((time.perf_counter() - started) * 1000)
 
         # run_agent()'s Trace is reconstructed from the emitted spans — the same span→Trace path
-        # evaluate_traces() uses, so the two grade identically. Pre-span failures (factory raise, or
-        # ask erroring before the agent span starts) emit no spans → fall back to the caught exception.
+        # evaluate_traces() uses, so the two grade identically. A pre-span failure (ask erroring
+        # before the agent span starts) emits no spans → fall back to the caught exception.
         spans = exporter.get_finished_spans()
         # Real root-span trace id, for deep-linking to an external backend; synthetic fallback if no spans.
         otel_trace_id = format(spans[0].context.trace_id, "032x") if spans else uuid4().hex
@@ -324,7 +320,13 @@ async def _produce_one(
 
 
 def _resolve_suite(suite: str | Suite) -> Suite:
-    """Normalize the ``suite`` argument into a :class:`Suite` instance."""
+    """Normalize the ``suite`` argument into a :class:`Suite` instance.
+
+    A :class:`Suite` passes through unchanged; a bare ``str`` becomes a
+    single-task suite whose one prompt is that string. Files and inline task
+    lists are constructed explicitly by the caller via :meth:`Suite.from_jsonl`
+    / :meth:`Suite.from_list`.
+    """
     if isinstance(suite, Suite):
         return suite
     return Suite([Task(inputs={"input": suite})])

--- a/autogen/beta/eval/runtime/runner.py
+++ b/autogen/beta/eval/runtime/runner.py
@@ -23,13 +23,10 @@ they still surface. Tasks run in parallel up to ``concurrency``, bounded by an
 """
 
 import asyncio
-import inspect
 import os
 import time
-import warnings
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import replace
-from functools import partial
 from typing import Any
 from uuid import uuid4
 
@@ -53,15 +50,18 @@ from ..sources._otel import readable_spans_to_trace
 from ..trace import Trace
 from .evaluate import _grade
 
-__all__ = ("run_agent", "run_pairwise")
+__all__ = (
+    "run_agent",
+    "run_pairwise",
+)
 
 
 async def run_agent(
-    suite: Suite | str | os.PathLike[str] | list[dict[str, Any]],
+    suite: str | Suite,
     *,
-    agent: Agent | Callable[..., Agent],
-    scorers: Iterable[Scorer],
-    store_dir: str | os.PathLike[str],
+    agent: Agent,
+    store_dir: str | os.PathLike[str] | None = None,
+    scorers: Iterable[Scorer] = (),
     model_config: ModelConfig | dict[str, ModelConfig] | None = None,
     repeats: int = 1,
     budgets: BudgetThresholds | None = None,
@@ -149,10 +149,7 @@ async def run_agent(
         function returns.
     """
     resolved_suite = _resolve_suite(suite)
-    scorer_list = tuple(scorers)
-    factory, accepts_config, target_path = _normalize_target(agent)
     tasks_to_run = _expand_repeats(resolved_suite, repeats)
-    suite_to_grade = Suite(tuple(tasks_to_run), name=resolved_suite.name, source=resolved_suite.source)
 
     # Resolve run_id up front so it can be stamped on the produced spans; caller keys win.
     resolved_run_id = run_id if run_id is not None else uuid4().hex
@@ -164,18 +161,20 @@ async def run_agent(
     }
 
     started = time.perf_counter()
+
     source = await _produce(
         tasks_to_run,
-        factory,
-        accepts_config=accepts_config,
+        agent,
         model_config=model_config,
         concurrency=concurrency,
         span_attributes=run_span_attributes,
         span_processors=span_processors,
     )
+
+    suite_to_grade = Suite(tuple(tasks_to_run), name=resolved_suite.name, source=resolved_suite.source)
     return await _grade(
         source,
-        scorers=scorer_list,
+        scorers=tuple(scorers),
         suite=suite_to_grade,
         store_dir=store_dir,
         budgets=budgets,
@@ -184,110 +183,18 @@ async def run_agent(
         label=label,
         stream=stream,
         variant=variant,
-        target_path=target_path,
+        target_path=f"{type(agent).__module__}:{type(agent).__qualname__}",
         started_at=started,
     )
 
 
-def _resolve_suite(
-    suite: Suite | str | os.PathLike[str] | list[dict[str, Any]],
-) -> Suite:
-    """Normalize the ``suite`` argument into a :class:`Suite` instance."""
-    if isinstance(suite, Suite):
-        return suite
-    if isinstance(suite, list):
-        return Suite.from_list(suite)
-    return Suite.from_jsonl(suite)
-
-
-def _factory_accepts_config(factory: Callable[..., Agent]) -> bool:
-    """Detect whether the factory takes a ``config`` parameter.
-
-    A bare factory like ``def build() -> Agent`` is supported — the
-    runner will call it with no args and skip injecting model_config.
-    """
-    try:
-        sig = inspect.signature(factory)
-    except (TypeError, ValueError):
-        return False
-    return "config" in sig.parameters
-
-
-def _factory_path(factory: Callable[..., Agent]) -> str:
-    """Return ``"<module>:<qualname>"`` for the factory, for the run JSON."""
-    module = getattr(factory, "__module__", "<unknown>")
-    qualname = getattr(factory, "__qualname__", getattr(factory, "__name__", "<unknown>"))
-    return f"{module}:{qualname}"
-
-
-def _return_instance(instance: Agent) -> Agent:
-    return instance
-
-
-def _normalize_target(
-    target: Agent | Callable[..., Agent],
-) -> tuple[Callable[..., Agent], bool, str]:
-    """Normalize ``target`` into ``(factory, accepts_config, provenance_path)``.
-
-    An :class:`Agent` instance is reused for every task. A callable is treated
-    as a factory built fresh per task and may accept a keyword-only ``config``
-    for per-task model injection.
-    """
-    if isinstance(target, Agent):
-        path = f"{type(target).__module__}:{type(target).__qualname__}"
-        return partial(_return_instance, target), False, path
-    if callable(target):
-        return target, _factory_accepts_config(target), _factory_path(target)
-    raise TypeError("target must be an Agent or a callable returning one")
-
-
-def _expand_repeats(suite: Suite, repeats: int) -> list[Task]:
-    """Expand each task into ``repeats`` runs with distinct ids (consistency sugar)."""
-    if repeats <= 1:
-        return list(suite)
-    return [replace(task, task_id=f"{task.task_id}#{i + 1}") for task in suite for i in range(repeats)]
-
-
-def _resolve_task_config(
-    task: Task,
-    model_config: ModelConfig | dict[str, ModelConfig] | None,
-) -> ModelConfig | None:
-    """Pick the right ``ModelConfig`` for a task from the ``model_config`` argument."""
-    if model_config is None:
-        return None
-    if isinstance(model_config, dict):
-        return model_config.get(task.task_id)
-    return model_config
-
-
-def _build_target(
-    factory: Callable[..., Agent],
-    *,
-    accepts_config: bool,
-    config: ModelConfig | None,
-) -> Agent:
-    """Call the user's factory, injecting ``config`` only when there is one to inject."""
-    if config is None:
-        # Nothing to inject — let the factory use its own default or a pre-bound
-        # config (e.g. a ``partial(build, config=...)`` produced by run_variants).
-        return factory()
-    if not accepts_config:
-        warnings.warn(
-            "target does not accept a 'config' parameter; model_config will be ignored for this run.",
-            category=RuntimeWarning,
-            stacklevel=3,
-        )
-        return factory()
-    return factory(config=config)
-
-
 async def run_pairwise(
-    suite: Suite | str | os.PathLike[str] | list[dict[str, Any]],
+    suite: str | Suite,
     *,
-    variant_a: Agent | Callable[..., Agent],
-    variant_b: Agent | Callable[..., Agent],
+    variant_a: Agent[Any],
+    variant_b: Agent[Any],
     comparators: Iterable[PairwiseComparator],
-    store_dir: str | os.PathLike[str],
+    store_dir: str | os.PathLike[str] | None = None,
     model_config: ModelConfig | dict[str, ModelConfig] | None = None,
     variant_a_name: str = "A",
     variant_b_name: str = "B",
@@ -310,14 +217,8 @@ async def run_pairwise(
     ``PairwiseCompleted`` lifecycle events as the comparison runs.
     """
     resolved_suite = _resolve_suite(suite)
-    factory_a, accepts_a, _ = _normalize_target(variant_a)
-    factory_b, accepts_b, _ = _normalize_target(variant_b)
-    source_a = await _produce(
-        resolved_suite, factory_a, accepts_config=accepts_a, model_config=model_config, concurrency=concurrency
-    )
-    source_b = await _produce(
-        resolved_suite, factory_b, accepts_config=accepts_b, model_config=model_config, concurrency=concurrency
-    )
+    source_a = await _produce(resolved_suite, variant_a, model_config=model_config, concurrency=concurrency)
+    source_b = await _produce(resolved_suite, variant_b, model_config=model_config, concurrency=concurrency)
     return await evaluate_pairwise(
         source_a,
         source_b,
@@ -335,9 +236,8 @@ async def run_pairwise(
 
 async def _produce(
     tasks: Iterable[Task],
-    factory: Callable[..., Agent],
+    agent: Agent[Any],
     *,
-    accepts_config: bool,
     model_config: ModelConfig | dict[str, ModelConfig] | None,
     concurrency: int,
     span_attributes: dict[str, str] | None = None,
@@ -357,8 +257,7 @@ async def _produce(
             _produce_one(
                 semaphore,
                 task,
-                factory,
-                accepts_config,
+                agent,
                 model_config,
                 span_attributes=span_attributes,
                 span_processors=span_processors,
@@ -373,8 +272,7 @@ async def _produce(
 async def _produce_one(
     semaphore: asyncio.Semaphore,
     task: Task,
-    factory: Callable[..., Agent],
-    accepts_config: bool,
+    agent: Agent,
     model_config: ModelConfig | dict[str, ModelConfig] | None,
     *,
     span_attributes: dict[str, str] | None = None,
@@ -392,24 +290,27 @@ async def _produce_one(
         stream = MemoryStream()
         exception: BaseException | None = None
         duration_ms = 0
+
+        telemetry = TelemetryMiddleware(
+            tracer_provider=provider,
+            agent_name=agent.name,
+            capture_content=True,
+            span_attributes=task_attributes,
+        )
+        started = time.perf_counter()
         try:
-            target = _build_target(factory, accepts_config=accepts_config, config=config)
+            await agent.ask(
+                task.inputs["input"],
+                stream=stream,
+                middleware=[telemetry],
+                # passed config overloads any original one
+                config=config,
+            )
         except Exception as exc:
             exception = exc
-        else:
-            telemetry = TelemetryMiddleware(
-                tracer_provider=provider,
-                agent_name=getattr(target, "name", "agent"),
-                capture_content=True,
-                span_attributes=task_attributes,
-            )
-            started = time.perf_counter()
-            try:
-                await target.ask(task.inputs["input"], stream=stream, middleware=[telemetry])
-            except Exception as exc:
-                exception = exc
-            finally:
-                duration_ms = int((time.perf_counter() - started) * 1000)
+        finally:
+            duration_ms = int((time.perf_counter() - started) * 1000)
+
         # run_agent()'s Trace is reconstructed from the emitted spans — the same span→Trace path
         # evaluate_traces() uses, so the two grade identically. Pre-span failures (factory raise, or
         # ask erroring before the agent span starts) emit no spans → fall back to the caught exception.
@@ -420,3 +321,29 @@ async def _produce_one(
         if trace.exception is None and exception is not None:
             trace = Trace(events=trace.events, exception=exception, duration_ms=duration_ms)
         return (TraceRef(trace_id=otel_trace_id, task_id=task.task_id), trace)
+
+
+def _resolve_suite(suite: str | Suite) -> Suite:
+    """Normalize the ``suite`` argument into a :class:`Suite` instance."""
+    if isinstance(suite, Suite):
+        return suite
+    return Suite(msg=suite)
+
+
+def _expand_repeats(suite: Suite, repeats: int) -> list[Task]:
+    """Expand each task into ``repeats`` runs with distinct ids (consistency sugar)."""
+    if repeats <= 1:
+        return list(suite)
+    return [replace(task, task_id=f"{task.task_id}#{i + 1}") for task in suite for i in range(repeats)]
+
+
+def _resolve_task_config(
+    task: Task,
+    model_config: ModelConfig | dict[str, ModelConfig] | None,
+) -> ModelConfig | None:
+    """Pick the right ``ModelConfig`` for a task from the ``model_config`` argument."""
+    if model_config is None:
+        return None
+    if isinstance(model_config, dict):
+        return model_config.get(task.task_id)
+    return model_config

--- a/autogen/beta/eval/runtime/runner.py
+++ b/autogen/beta/eval/runtime/runner.py
@@ -171,7 +171,7 @@ async def run_agent(
         span_processors=span_processors,
     )
 
-    suite_to_grade = Suite(tuple(tasks_to_run), name=resolved_suite.name, source=resolved_suite.source)
+    suite_to_grade = Suite(tasks=tuple(tasks_to_run), name=resolved_suite.name, source=resolved_suite.source)
     return await _grade(
         source,
         scorers=tuple(scorers),
@@ -327,7 +327,7 @@ def _resolve_suite(suite: str | Suite) -> Suite:
     """Normalize the ``suite`` argument into a :class:`Suite` instance."""
     if isinstance(suite, Suite):
         return suite
-    return Suite(msg=suite)
+    return Suite([Task(inputs={"input": suite})])
 
 
 def _expand_repeats(suite: Suite, repeats: int) -> list[Task]:

--- a/autogen/beta/eval/runtime/variants.py
+++ b/autogen/beta/eval/runtime/variants.py
@@ -2,36 +2,30 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""run_variants — compare named variants of a target and rank them.
+"""run_variants — compare named agent variants and rank them.
 
-A :class:`Variants` is a *single-axis* set of named builds — all configs, or
-all prompts, … — constructed via the typed ``Variants.from_*`` classmethods
-(mirroring ``Suite.from_*``). :func:`run_variants` runs each variant over the
-suite via :func:`~autogen.beta.eval.run_agent` and returns a :class:`VariantRunResult`
+A :class:`Variants` is a set of named :class:`~autogen.beta.Agent` instances —
+one per variant. :func:`run_variants` runs each variant over the suite via
+:func:`~autogen.beta.eval.run_agent` and returns a :class:`VariantRunResult`
 whose ``leaderboard(key)`` ranks the variants by a scorer.
 
-Each ``from_*`` fixes the axis and types its values, so one call can only vary
-one thing — comparisons stay controlled (vary one axis, hold the rest fixed).
-For an entirely different build per variant, use :meth:`Variants.from_targets`.
+Vary whatever you like across the agents (config, prompt, tools, middleware, …)
+by constructing them accordingly, and set ``axis`` to label what was varied —
+comparisons stay controlled when you hold everything but one axis fixed.
 """
 
 import os
 import re
 import time
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from functools import partial
 from operator import itemgetter
-from typing import Any
 from uuid import uuid4
 
 from autogen.beta.agent import Agent
-from autogen.beta.config import ModelConfig
 from autogen.beta.context import ConversationContext
-from autogen.beta.middleware.base import MiddlewareFactory
 from autogen.beta.stream import Stream
-from autogen.beta.tools.tool import Tool
 
 from ..dataset import Suite
 from ..events import VariantCompleted, VariantStarted
@@ -46,44 +40,29 @@ __all__ = (
     "run_variants",
 )
 
-_Build = Callable[..., Agent] | Agent
-
 
 @dataclass(frozen=True, slots=True)
 class Variants:
-    """A single-axis set of named target builds. Construct via the ``from_*`` classmethods."""
+    """A set of named :class:`~autogen.beta.Agent` variants to compare and rank.
 
-    axis: str
-    builds: Mapping[str, _Build]
+    Each value is a prebuilt agent instance; the keys name the variants. Vary
+    whatever you like across them (config, prompt, tools, middleware, …) by
+    constructing the agents accordingly, and set ``axis`` to label what you
+    varied (used in :meth:`VariantRunResult.summary`).
 
-    @classmethod
-    def from_configs(cls, factory: Callable[..., Agent], variants: Mapping[str, ModelConfig]) -> "Variants":
-        """One variant per model config — varies ``config`` on a shared factory."""
-        return cls("config", {name: partial(factory, config=cfg) for name, cfg in variants.items()})
+    ::
 
-    @classmethod
-    def from_prompts(cls, factory: Callable[..., Agent], variants: Mapping[str, str]) -> "Variants":
-        """One variant per system prompt — varies ``prompt`` on a shared factory."""
-        return cls("prompt", {name: partial(factory, prompt=prompt) for name, prompt in variants.items()})
+        Variants(
+            {
+                "gpt-4o": Agent("a", config=openai_cfg),
+                "sonnet": Agent("a", config=anthropic_cfg),
+            },
+            axis="config",
+        )
+    """
 
-    @classmethod
-    def from_tools(
-        cls, factory: Callable[..., Agent], variants: Mapping[str, Sequence[Callable[..., Any] | Tool]]
-    ) -> "Variants":
-        """One variant per tool set — varies ``tools`` on a shared factory."""
-        return cls("tools", {name: partial(factory, tools=list(tools)) for name, tools in variants.items()})
-
-    @classmethod
-    def from_middleware(
-        cls, factory: Callable[..., Agent], variants: Mapping[str, Sequence[MiddlewareFactory]]
-    ) -> "Variants":
-        """One variant per middleware stack — varies ``middleware`` on a shared factory."""
-        return cls("middleware", {name: partial(factory, middleware=list(mw)) for name, mw in variants.items()})
-
-    @classmethod
-    def from_targets(cls, variants: Mapping[str, _Build]) -> "Variants":
-        """One variant per whole build — each value is a factory or an instance (the escape hatch)."""
-        return cls("target", dict(variants))
+    agents: Mapping[str, Agent]
+    axis: str = "variant"
 
 
 @dataclass(frozen=True, slots=True)
@@ -146,11 +125,11 @@ class VariantRunResult:
 
 
 async def run_variants(
-    suite: Suite | str | os.PathLike[str] | list[dict[str, Any]],
+    suite: str | Suite,
     *,
     variants: Variants,
-    scorers: Iterable[Scorer],
-    store_dir: str | os.PathLike[str],
+    scorers: Iterable[Scorer] = (),
+    store_dir: str | os.PathLike[str] | None = None,
     repeats: int = 1,
     concurrency: int = 4,
     run_id: str | None = None,
@@ -160,8 +139,9 @@ async def run_variants(
     """Run each variant over ``suite`` and return a ranked :class:`VariantRunResult`.
 
     Variants run sequentially; within each, tasks run up to ``concurrency`` in
-    parallel (and ``repeats`` times each). Every variant's run is persisted as
-    its own schema-0.1 JSON under ``store_dir`` (``<run_id>-<variant>.json``).
+    parallel (and ``repeats`` times each). When ``store_dir`` is set, every
+    variant's run is persisted as its own schema-0.1 JSON under it
+    (``<run_id>-<variant>.json``); omit it to run without persisting.
 
     Pass ``stream`` to observe the sweep: ``VariantStarted`` / ``VariantCompleted``
     wrap each variant, and that variant's own ``EvalStarted`` / ``TaskEvaluated``
@@ -173,33 +153,32 @@ async def run_variants(
     created_at = datetime.now(timezone.utc).isoformat()
     started = time.perf_counter()
 
-    eval_stream = stream
-    eval_ctx = ConversationContext(stream=eval_stream) if eval_stream is not None else None
+    eval_ctx = ConversationContext(stream=stream) if stream is not None else None
 
     results: dict[str, RunResult] = {}
-    total = len(variants.builds)
-    for index, (name, build) in enumerate(variants.builds.items(), start=1):
-        if eval_stream is not None:
-            await eval_stream.send(
+    total = len(variants.agents)
+    for index, (name, agent) in enumerate(variants.agents.items(), start=1):
+        if eval_ctx is not None:
+            await eval_ctx.send(
                 VariantStarted(run_id=base_run_id, label=label, variant=name, index=index, total=total),
-                eval_ctx,
             )
+
         results[name] = await run_agent(
             suite,
-            agent=build,
+            agent=agent,
             scorers=scorer_list,
             store_dir=store_dir,
             repeats=repeats,
             concurrency=concurrency,
             run_id=f"{base_run_id}-{_slug(name)}",
             label=label,
-            stream=eval_stream,
+            stream=stream,
             variant=name,
         )
-        if eval_stream is not None:
-            await eval_stream.send(
+
+        if eval_ctx is not None:
+            await eval_ctx.send(
                 VariantCompleted(run_id=base_run_id, label=label, variant=name, result=results[name]),
-                eval_ctx,
             )
 
     duration_ms = int((time.perf_counter() - started) * 1000)

--- a/autogen/beta/events/input_events.py
+++ b/autogen/beta/events/input_events.py
@@ -40,7 +40,7 @@ class ModelRequest(BaseEvent):
     parts: "list[Input]" = Field(kw_only=False)
 
     @classmethod
-    def ensure_request(cls, msgs: "Iterable[str | Input]") -> "ModelRequest":
+    def ensure_request(cls, msgs: "Iterable[SendableMessage | Input]") -> "ModelRequest":
         return cls([Input.ensure_input(m) for m in msgs])
 
 

--- a/autogen/beta/knowledge/config.py
+++ b/autogen/beta/knowledge/config.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+from ..aggregate import AggregateStrategy, AggregateTrigger
+from ..compact import CompactStrategy, CompactTrigger
+from .base import KnowledgeStore
+from .bootstrap import StoreBootstrap
+
+
+@dataclass(slots=True)
+class KnowledgeConfig:
+    """Groups knowledge-related Agent parameters.
+
+    The ``store`` is registered into ``context.dependencies[KnowledgeStore]``
+    so policies (e.g. ``WorkingMemoryPolicy``, ``EpisodicMemoryPolicy``) can
+    read from it without an extra parameter. Everything else is a side
+    effect of attaching a store; each is opt-out via its flag below.
+
+    Attributes:
+        store: The backing knowledge store.
+        expose_tool: If True (default), the agent gets an auto-injected
+            ``knowledge`` action-group tool that lets the LLM call
+            ``read`` / ``write`` / ``list`` / ``delete`` on the store. Set
+            to False when policies are the only consumer of the store and
+            the LLM should not see it.
+        write_event_log: If True (default), the agent persists its stream
+            history to ``/log/{stream_id}.jsonl`` at the end of each
+            ``ask`` call. Set to False to keep the store free of stream
+            logs (useful when the store is purely user-facing memory).
+        compact, compact_trigger: Optional compaction strategy and its
+            firing rules.
+        aggregate, aggregate_trigger: Optional aggregation strategy and
+            its firing rules. Strategy failures emit ``AggregationFailed``
+            on the stream — subscribe to that event for observability.
+        bootstrap: Optional custom bootstrap. None falls back to
+            ``DefaultBootstrap(mention_tool=expose_tool)``, so the
+            generated SKILL.md text tells the LLM about the ``knowledge``
+            tool only when the tool is actually exposed.
+    """
+
+    store: KnowledgeStore
+    expose_tool: bool = True
+    write_event_log: bool = True
+    compact: CompactStrategy | None = None
+    compact_trigger: CompactTrigger | None = None
+    aggregate: AggregateStrategy | None = None
+    aggregate_trigger: AggregateTrigger | None = None
+    bootstrap: StoreBootstrap | None = None

--- a/autogen/beta/live/realtime.py
+++ b/autogen/beta/live/realtime.py
@@ -2,25 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import warnings
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
+from collections.abc import AsyncIterator, Callable, Iterable
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager, suppress
-from typing import Any, Protocol, overload
+from typing import Any, Protocol
 
-from fast_depends import Provider
 from fast_depends.library.serializer import SerializerProto
-from fast_depends.pydantic import PydanticSerializer
 
-from autogen.beta.agent import HumanHook, Plugin, PromptHook, PromptType, _wrap_prompt_hook, wrap_hitl
+from autogen.beta.agent import HumanHook, Plugin, PluginTarget, PromptType, wrap_hitl
 from autogen.beta.context import ConversationContext, Stream
 from autogen.beta.events import HumanInputRequest, ModelRequest, ObserverCompleted, ObserverStarted
-from autogen.beta.middleware import ToolMiddleware
 from autogen.beta.middleware.base import BaseMiddleware, MiddlewareFactory
 from autogen.beta.observers import Observer
 from autogen.beta.stream import MemoryStream
-from autogen.beta.tools.executor import ToolExecutor
-from autogen.beta.tools.final import FunctionParameters, FunctionTool, FunctionToolSchema
-from autogen.beta.tools.final import tool as _tool
+from autogen.beta.tools.final import FunctionTool, FunctionToolSchema
 from autogen.beta.tools.schemas import ToolSchema
 from autogen.beta.tools.tool import Tool
 from autogen.beta.usage import UsageReport
@@ -50,7 +44,7 @@ class RealtimeConfig(Protocol):
     ) -> AbstractAsyncContextManager[None]: ...
 
 
-class LiveAgent:
+class LiveAgent(PluginTarget):
     """Realtime STT agent. Open a session via `agent.run()`.
 
     If `stream` is omitted, owns a fresh `MemoryStream`; otherwise binds to
@@ -84,149 +78,19 @@ class LiveAgent:
         # assembly
         stream: Stream | None = None,
     ) -> None:
-        self.name = name
-
+        self._init_target(
+            name,
+            prompt=prompt,
+            hitl_hook=hitl_hook,
+            tools=tools,
+            middleware=middleware,
+            observers=observers,
+            dependencies=dependencies,
+            variables=variables,
+            plugins=plugins,
+        )
         self._config = config
         self._stream = stream
-
-        self._agent_dependencies: dict[Any, Any] = dependencies or {}
-        self._agent_variables: dict[Any, Any] = variables or {}
-        self._hitl_hook = wrap_hitl(hitl_hook) if hitl_hook else None
-
-        self._dependency_provider = Provider()
-        self._tools: list[Tool] = []
-        for t in tools:
-            self.add_tool(t)
-
-        self._middleware: list[MiddlewareFactory] = list(middleware)
-
-        self._observers: list[Observer] = []
-        for obs in observers:
-            self.add_observer(obs)
-
-        self._serializer: SerializerProto = PydanticSerializer(
-            pydantic_config={"arbitrary_types_allowed": True},
-            use_fastdepends_errors=False,
-        )
-        self._tool_executor = ToolExecutor(self._serializer)
-
-        self._system_prompt: list[str] = []
-        self._dynamic_prompt: list[Callable[[ModelRequest, ConversationContext], Awaitable[str]]] = []
-
-        if isinstance(prompt, str) or callable(prompt):
-            prompt = [prompt]
-        for p in prompt:
-            if isinstance(p, str):
-                self._system_prompt.append(p)
-            else:
-                self._dynamic_prompt.append(_wrap_prompt_hook(p))
-
-        for plg in plugins:
-            plg.register(self)  # type: ignore[arg-type]
-
-    def hitl_hook(self, func: HumanHook) -> HumanHook:
-        if self._hitl_hook is not None:
-            warnings.warn(
-                "You already set HITL hook, provided value overrides it",
-                category=RuntimeWarning,
-                stacklevel=2,
-            )
-
-        self._hitl_hook = wrap_hitl(func)
-        return func
-
-    @overload
-    def prompt(
-        self,
-        func: None = None,
-    ) -> Callable[[PromptHook], PromptHook]: ...
-
-    @overload
-    def prompt(
-        self,
-        func: PromptHook,
-    ) -> PromptHook: ...
-
-    def prompt(
-        self,
-        func: PromptHook | None = None,
-    ) -> PromptHook | Callable[[PromptHook], PromptHook]:
-        def wrapper(f: PromptHook) -> PromptHook:
-            self._dynamic_prompt.append(_wrap_prompt_hook(f))
-            return f
-
-        if func:
-            return wrapper(func)
-        return wrapper
-
-    @overload
-    def tool(
-        self,
-        function: Callable[..., Any],
-        *,
-        name: str | None = None,
-        description: str | None = None,
-        schema: FunctionParameters | None = None,
-        sync_to_thread: bool = True,
-        middleware: Iterable[ToolMiddleware] = (),
-    ) -> Tool: ...
-
-    @overload
-    def tool(
-        self,
-        function: None = None,
-        *,
-        name: str | None = None,
-        description: str | None = None,
-        schema: FunctionParameters | None = None,
-        sync_to_thread: bool = True,
-        middleware: Iterable[ToolMiddleware] = (),
-    ) -> Callable[[Callable[..., Any]], Tool]: ...
-
-    def tool(
-        self,
-        function: Callable[..., Any] | None = None,
-        *,
-        name: str | None = None,
-        description: str | None = None,
-        schema: FunctionParameters | None = None,
-        sync_to_thread: bool = True,
-        middleware: Iterable[ToolMiddleware] = (),
-    ) -> Tool | Callable[[Callable[..., Any]], Tool]:
-        def make_tool(f: Callable[..., Any]) -> Tool:
-            t = _tool(
-                f,
-                name=name,
-                description=description,
-                schema=schema,
-                sync_to_thread=sync_to_thread,
-                middleware=middleware,
-            )
-            self.add_tool(t)
-            return t
-
-        if function:
-            return make_tool(function)
-
-        return make_tool
-
-    def add_tool(self, t: Callable[..., Any] | Tool) -> "LiveAgent":
-        self._tools.append(FunctionTool.ensure_tool(t, provider=self._dependency_provider))
-        return self
-
-    def add_middleware(self, m: MiddlewareFactory) -> "LiveAgent":
-        """Append middleware as the innermost wrapper in the chain."""
-        self._middleware.append(m)
-        return self
-
-    def insert_middleware(self, m: MiddlewareFactory) -> "LiveAgent":
-        """Insert middleware as the outermost wrapper in the chain."""
-        self._middleware.insert(0, m)
-        return self
-
-    def add_observer(self, observer: Observer) -> None:
-        """Register an observer (before calling run())."""
-        self._observers.append(observer)
 
     @staticmethod
     async def usage_report(context: ConversationContext) -> UsageReport:
@@ -251,7 +115,7 @@ class LiveAgent:
 
         context = ConversationContext(
             stream=stream,
-            dependency_provider=self._dependency_provider,
+            dependency_provider=self.dependency_provider,
             dependencies=self._agent_dependencies | (dependencies or {}),
             variables=self._agent_variables | (variables or {}),
         )
@@ -259,8 +123,8 @@ class LiveAgent:
         active_config = config if config is not None else self._config
         active_hitl = wrap_hitl(hitl_hook) if hitl_hook else self._hitl_hook
 
-        all_tools: list[Tool] = self._tools + [
-            FunctionTool.ensure_tool(t, provider=self._dependency_provider) for t in tools
+        all_tools: list[Tool] = self.tools + [
+            FunctionTool.ensure_tool(t, provider=self.dependency_provider) for t in tools
         ]
         all_observers: list[Observer] = self._observers + list(observers)
 

--- a/autogen/beta/network/client/hub_client.py
+++ b/autogen/beta/network/client/hub_client.py
@@ -443,7 +443,7 @@ class HubClient:
         self._clients[passport.agent_id] = client
 
         if attach_plugin:
-            NetworkPlugin(client).register(agent)
+            agent._apply_plugin(NetworkPlugin(client))
 
         return client
 
@@ -538,7 +538,7 @@ class HubClient:
         )
         self._clients[existing_agent_id] = client
         if attach_plugin:
-            NetworkPlugin(client).register(agent)
+            agent._apply_plugin(NetworkPlugin(client))
         return client
 
     async def _attach_remote(
@@ -582,7 +582,7 @@ class HubClient:
         )
         self._clients[existing_agent_id] = client
         if attach_plugin:
-            NetworkPlugin(client).register(agent)
+            agent._apply_plugin(NetworkPlugin(client))
 
         # Reconnect handshake — binds this endpoint to the identity and
         # replays unacked notifies past the high-water mark.

--- a/autogen/beta/network/client/plugin.py
+++ b/autogen/beta/network/client/plugin.py
@@ -25,7 +25,6 @@ chain so every LLM call sees a "you are <name>" prefix.
 from typing import TYPE_CHECKING
 
 from autogen.beta.agent import Plugin
-from autogen.beta.assembly import AssemblyPolicy
 from autogen.beta.events import BaseEvent
 
 from .tools import (
@@ -37,7 +36,6 @@ from .tools import (
 )
 
 if TYPE_CHECKING:
-    from autogen.beta.agent import Agent
     from autogen.beta.context import ConversationContext as Context
 
     from .agent_client import AgentClient
@@ -96,19 +94,4 @@ class NetworkPlugin(Plugin):
             ],
         )
         self._client = client
-
-    def register(self, agent: "Agent") -> None:
-        """Wire tools + assembly policy onto the agent. Idempotent-ish.
-
-        Calling ``register`` more than once on the same agent will add
-        the tools / policies again. ``HubClient.register`` only attaches
-        once per ``(Agent, identity)``, so this is rare in practice.
-        """
-        super().register(agent)
-        agent.add_policy(NetworkContextPolicy(self._client))
-
-
-# Make ``NetworkPlugin`` satisfy ``AssemblyPolicy`` indirectly via its
-# context-policy member. The Protocol is structural; ``NetworkContextPolicy``
-# implements ``apply`` correctly so the implicit assertion holds.
-_: AssemblyPolicy
+        self.add_policy(NetworkContextPolicy(client))

--- a/autogen/beta/plugin.py
+++ b/autogen/beta/plugin.py
@@ -5,11 +5,12 @@
 import warnings
 from collections.abc import Awaitable, Callable, Iterable
 from contextlib import AsyncExitStack
-from typing import Any, Self, TypeAlias, overload
+from typing import Any, TypeAlias, overload
 
 from fast_depends import Provider
 from fast_depends.library.serializer import SerializerProto
 from fast_depends.pydantic import PydanticSerializer
+from typing_extensions import Self
 
 from .annotations import Context
 from .assembly import AssemblyPolicy

--- a/autogen/beta/plugin.py
+++ b/autogen/beta/plugin.py
@@ -2,6 +2,368 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .agent import Plugin
+import warnings
+from collections.abc import Awaitable, Callable, Iterable
+from contextlib import AsyncExitStack
+from typing import Any, Self, TypeAlias, overload
 
-__all__ = ("Plugin",)
+from fast_depends import Provider
+from fast_depends.library.serializer import SerializerProto
+from fast_depends.pydantic import PydanticSerializer
+
+from .annotations import Context
+from .assembly import AssemblyPolicy
+from .events import (
+    ModelRequest,
+)
+from .events.conditions import Condition
+from .hitl import HumanHook, wrap_hitl
+from .middleware.base import (
+    MiddlewareFactory,
+    ToolMiddleware,
+)
+from .observers import Observer
+from .observers import observer as observer_factory
+from .tools.executor import ToolExecutor
+from .tools.final import FunctionParameters, FunctionTool, tool
+from .tools.tool import Tool
+from .types import ClassInfo
+from .utils import CONTEXT_OPTION_NAME, build_model
+
+PromptHook: TypeAlias = Callable[..., str] | Callable[..., Awaitable[str]]
+PromptType: TypeAlias = str | PromptHook
+
+
+class PromptObserverMixin:
+    """Shared prompt/observer/tool/middleware collection for :class:`Agent`,
+    :class:`LiveAgent`, and :class:`Plugin`.
+
+    Builds ``_system_prompt`` / ``_dynamic_prompt`` from a ``prompt`` argument
+    and exposes the ``prompt()`` / ``observer()`` / ``tool()`` decorators plus
+    the imperative ``add_middleware()`` / ``insert_middleware()`` /
+    ``add_policy()`` / ``add_observer()`` collectors. Subclasses initialise
+    ``_observers`` / ``_middleware`` / ``_policies`` themselves (each takes
+    matching constructor arguments) and define ``add_tool()`` to choose how a
+    freshly built tool is stored — eagerly (Agent/LiveAgent) or deferred
+    (Plugin).
+    """
+
+    _system_prompt: list[str]
+    _dynamic_prompt: list[Callable[[ModelRequest, Context], Awaitable[str]]]
+    _observers: list[Observer]
+    _middleware: list[MiddlewareFactory]
+    _policies: list[AssemblyPolicy]
+
+    def _init_prompts(self, prompt: PromptType | Iterable[PromptType]) -> None:
+        self._system_prompt = []
+        self._dynamic_prompt = []
+
+        if isinstance(prompt, str) or callable(prompt):
+            prompt = [prompt]
+        for p in prompt:
+            if isinstance(p, str):
+                self._system_prompt.append(p)
+            else:
+                self._dynamic_prompt.append(_wrap_prompt_hook(p))
+
+    @overload
+    def prompt(
+        self,
+        func: PromptHook,
+    ) -> PromptHook: ...
+
+    @overload
+    def prompt(
+        self,
+        func: None = None,
+    ) -> Callable[[PromptHook], PromptHook]: ...
+
+    def prompt(
+        self,
+        func: PromptHook | None = None,
+    ) -> PromptHook | Callable[[PromptHook], PromptHook]:
+        def wrapper(f: PromptHook) -> PromptHook:
+            self._dynamic_prompt.append(_wrap_prompt_hook(f))
+            return f
+
+        if func:
+            return wrapper(func)
+        return wrapper
+
+    @overload
+    def observer(
+        self,
+        condition: ClassInfo | Condition | None,
+        callback: Callable[..., Any],
+    ) -> Callable[..., Any]: ...
+
+    @overload
+    def observer(
+        self,
+        condition: ClassInfo | Condition | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]: ...
+
+    def observer(
+        self,
+        condition: ClassInfo | Condition | None = None,
+        callback: Callable[..., Any] | None = None,
+    ) -> Callable[..., Any] | Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
+            obs = observer_factory(condition, func)
+            self._observers.append(obs)
+            return func
+
+        if callback is not None:
+            return wrapper(callback)
+        return wrapper
+
+    def add_tool(self, t: FunctionTool) -> None:
+        """Store a freshly built tool. Subclasses choose eager vs deferred."""
+        raise NotImplementedError
+
+    @overload
+    def tool(
+        self,
+        function: Callable[..., Any],
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        schema: FunctionParameters | None = None,
+        sync_to_thread: bool = True,
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> FunctionTool: ...
+
+    @overload
+    def tool(
+        self,
+        function: None = None,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        schema: FunctionParameters | None = None,
+        sync_to_thread: bool = True,
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> Callable[[Callable[..., Any]], FunctionTool]: ...
+
+    def tool(
+        self,
+        function: Callable[..., Any] | None = None,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        schema: FunctionParameters | None = None,
+        sync_to_thread: bool = True,
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> FunctionTool | Callable[[Callable[..., Any]], FunctionTool]:
+        def make_tool(f: Callable[..., Any]) -> FunctionTool:
+            t = tool(
+                f,
+                name=name,
+                description=description,
+                schema=schema,
+                sync_to_thread=sync_to_thread,
+                middleware=middleware,
+            )
+            self.add_tool(t)
+            return t
+
+        if function:
+            return make_tool(function)
+        return make_tool
+
+    def add_middleware(self, m: MiddlewareFactory) -> Self:
+        """Append middleware as the innermost wrapper in the chain.
+
+        The added middleware is called last on turn entry and first on turn exit,
+        executing closer to the LLM call than any middleware already registered.
+        """
+        self._middleware.append(m)
+        return self
+
+    def insert_middleware(self, m: MiddlewareFactory) -> Self:
+        """Insert middleware as the outermost wrapper in the chain.
+
+        The inserted middleware is called first on turn entry and last on turn exit,
+        executing before all middleware already registered.
+        """
+        self._middleware.insert(0, m)
+        return self
+
+    def add_policy(self, policy: AssemblyPolicy) -> Self:
+        """Append an assembly policy to the chain.
+
+        Policies run in order; a newly added policy runs after existing ones.
+        Construction-time ordering validation (warning on suspicious sequences)
+        only runs over policies passed via ``assembly=`` — late additions skip
+        the check, so callers should be confident in the ordering they introduce.
+        """
+        self._policies.append(policy)
+        return self
+
+    def add_observer(self, observer: Observer) -> None:
+        """Register an observer (before running the agent)."""
+        self._observers.append(observer)
+
+
+class Plugin(PromptObserverMixin):
+    def __init__(
+        self,
+        *,
+        prompt: PromptType | Iterable[PromptType] = (),
+        hitl_hook: HumanHook | None = None,
+        tools: Iterable[Callable[..., Any] | Tool] = (),
+        middleware: Iterable[MiddlewareFactory] = (),
+        observers: Iterable[Observer] = (),
+        dependencies: dict[Any, Any] | None = None,
+        variables: dict[Any, Any] | None = None,
+    ) -> None:
+        self._tools = list(tools)
+        self._middleware = list(middleware)
+        self._observers = list(observers)
+        self._policies = []
+        self._dependencies = dependencies or {}
+        self._variables = variables or {}
+        self._hitl_hook = hitl_hook
+
+        self._init_prompts(prompt)
+
+    def hitl_hook(self, func: HumanHook) -> HumanHook:
+        if self._hitl_hook is not None:
+            warnings.warn(
+                "You already set HITL hook, provided value overrides it",
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
+        self._hitl_hook = func
+        return func
+
+    def add_tool(self, t: FunctionTool) -> None:
+        """Defer the tool; it is applied to an agent later via ``_apply_plugin``."""
+        self._tools.append(t)
+
+
+class PluginTarget(PromptObserverMixin):
+    """A :class:`PromptObserverMixin` that a :class:`Plugin` can be applied to.
+
+    Shared by the runnable agent types (``Agent``, ``LiveAgent``). Both expose
+    the agent-side surface a plugin needs — ``name``, ``_agent_dependencies``,
+    ``_agent_variables``, ``_hitl_hook`` — so a plugin's collected contributions
+    copy onto them identically.
+
+    ``Plugin`` itself stays on the bare mixin: it is the *source* of
+    contributions, never a target.
+    """
+
+    name: str
+    tools: list[FunctionTool]
+    dependency_provider: Provider
+    _serializer: SerializerProto
+    _tool_executor: ToolExecutor
+    _hitl_hook: HumanHook | None
+    _agent_dependencies: dict[Any, Any]
+    _agent_variables: dict[Any, Any]
+
+    def hitl_hook(self, func: HumanHook) -> HumanHook:
+        if self._hitl_hook is not None:
+            warnings.warn(
+                "You already set HITL hook, provided value overrides it",
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
+
+        self._hitl_hook = wrap_hitl(func)
+        return func
+
+    def add_tool(self, t: Callable[..., Any] | Tool) -> Self:
+        """Bind a tool to this target's provider immediately (eager)."""
+        self.tools.append(FunctionTool.ensure_tool(t, provider=self.dependency_provider))
+        return self
+
+    def _init_target(
+        self,
+        name: str,
+        *,
+        prompt: PromptType | Iterable[PromptType],
+        hitl_hook: HumanHook | None,
+        tools: Iterable[Callable[..., Any] | Tool],
+        middleware: Iterable[MiddlewareFactory],
+        observers: Iterable[Observer],
+        dependencies: dict[Any, Any],
+        variables: dict[Any, Any],
+        plugins: Iterable["Plugin"],
+    ) -> None:
+        """Set up the contribution surface shared by every plugin target.
+
+        Callers set their own type-specific state (config, stream, …) around
+        this call; plugins are applied at the end, once tools, middleware, and
+        the HITL hook are in place.
+        """
+        self.name = name
+
+        self._agent_dependencies = dependencies or {}
+        self._agent_variables = variables or {}
+        self._hitl_hook = wrap_hitl(hitl_hook) if hitl_hook else None
+
+        self._middleware = list(middleware)
+        self._observers = list(observers)
+        self._policies = []
+
+        self._serializer = PydanticSerializer(
+            pydantic_config={"arbitrary_types_allowed": True},
+            use_fastdepends_errors=False,
+        )
+        self._tool_executor = ToolExecutor(self._serializer)
+
+        self.dependency_provider = Provider()
+        self.tools = []
+        for t in tools:
+            self.add_tool(t)
+
+        self._init_prompts(prompt)
+
+        for p in plugins:
+            self._apply_plugin(p)
+
+    def _apply_plugin(self, plugin: Plugin) -> None:
+        """Apply a plugin's collected contributions to this target."""
+        for t in plugin._tools:
+            self.add_tool(t)
+
+        for m in plugin._middleware:
+            self.add_middleware(m)
+
+        if plugin._hitl_hook is not None:
+            if self._hitl_hook is not None:
+                warnings.warn(
+                    f"{type(self).__name__} '{self.name}' already has a HITL hook; the plugin's hook will be ignored.",
+                    stacklevel=2,
+                )
+            else:
+                self._hitl_hook = wrap_hitl(plugin._hitl_hook)
+
+        self._agent_dependencies = plugin._dependencies | self._agent_dependencies
+        self._agent_variables.update(plugin._variables)
+
+        self._observers.extend(plugin._observers)
+        self._policies.extend(plugin._policies)
+        self._system_prompt.extend(plugin._system_prompt)
+        self._dynamic_prompt.extend(plugin._dynamic_prompt)
+
+
+def _wrap_prompt_hook(
+    func: PromptHook,
+) -> Callable[[ModelRequest, Context], Awaitable[str]]:
+    call_model = build_model(func)
+
+    async def wrapper(event: ModelRequest, context: Context) -> str:
+        async with AsyncExitStack() as stack:
+            r = await call_model.asolve(
+                event,
+                stack=stack,
+                cache_dependencies={},
+                dependency_provider=context.dependency_provider,
+                **{CONTEXT_OPTION_NAME: context},
+            )
+        return r
+
+    return wrapper

--- a/docs/adr/0001-plugin-target-hierarchy.md
+++ b/docs/adr/0001-plugin-target-hierarchy.md
@@ -1,0 +1,64 @@
+---
+status: accepted
+date: 2026-06-16
+---
+
+# Agent, LiveAgent, and Plugin share a three-layer mixin hierarchy
+
+## Context
+
+`Agent`, `LiveAgent`, and `Plugin` independently grew near-identical authoring
+surfaces — `prompt()` / `observer()` / `tool()` decorators, middleware and
+policy registration, the prompt-init loop, and the constructor that wires up
+tools, observers, dependencies, a serializer, and a tool executor. The copies
+drifted (e.g. an attribute named `tools` on one and `_tools` on another), and a
+silent bug — `Agent.add_tool` delegating to an abstract hook — slipped in under
+the duplication.
+
+## Decision
+
+Collapse the shared surface into two base classes in `autogen/beta/plugin.py`:
+
+- **`PromptObserverMixin`** — the authoring/collection surface common to *all
+  three*: `prompt`/`observer`/`tool` decorators, `add_middleware` /
+  `insert_middleware` / `add_policy` / `add_observer`, `_init_prompts`, and an
+  **abstract `add_tool`** that subclasses implement to choose storage.
+- **`PluginTarget(PromptObserverMixin)`** — for the *runnable* targets (`Agent`,
+  `LiveAgent`): the shared constructor body (`_init_target`), eager `add_tool`,
+  the wrap-now `hitl_hook`, the `_tool_executor`, and `_apply_plugin`.
+
+`Plugin` stays on the **bare mixin** — it is the *source* of contributions,
+never a target. `Agent` and `LiveAgent` inherit `PluginTarget`; each constructor
+is now a single `_init_target(...)` call plus its own type-specific state
+(`Agent`: config / response_schema / tasks / knowledge / assembly / execution
+loop; `LiveAgent`: `_config` / `_stream` / realtime `run()`).
+
+## Consequences / things that look wrong but are deliberate
+
+- **`_apply_plugin` lives on `PluginTarget`, not the mixin.** Applying a plugin
+  mutates the agent-side surface (`add_middleware`, `_agent_dependencies`, …)
+  that `Plugin` does not have. Putting it on the mixin would give `Plugin` a
+  method it cannot satisfy.
+- **`add_tool` is intentionally split.** `Plugin.add_tool` is *deferred* (raw
+  append to `_tools`); `PluginTarget.add_tool` is *eager* (binds to
+  `dependency_provider` immediately). This is the one genuine behavioural
+  difference; the mixin's abstract `add_tool` is the seam. Likewise
+  `Plugin.hitl_hook` stores the hook raw while `PluginTarget.hitl_hook` wraps it
+  now — deferred wrapping happens in `_apply_plugin`.
+- **There is no `Plugin.register` / `NetworkPlugin.register`.** Plugins are pure
+  *collectors* — tools, middleware, observers, prompts, hooks, **and assembly
+  policies** all accumulate on the `Plugin`, and the single `_apply_plugin`
+  copies every category onto the target. Earlier a `register(agent)` hook
+  existed so subclasses could add extra wiring; once policies became a collected
+  contribution, the only remaining override (`NetworkPlugin` adding its context
+  policy) reduced to `self.add_policy(...)` in `__init__`. Apply a plugin with
+  `agent._apply_plugin(plugin)`, not `plugin.register(agent)`.
+- **`LiveAgent` mirrors `Agent`'s public attribute names** (`tools`,
+  `dependency_provider`) so the eager `add_tool` and `_init_target` are truly
+  shared rather than near-copies.
+
+To add a new collectible contribution: declare it on `PromptObserverMixin`,
+initialise it in both `Plugin.__init__` and `PluginTarget._init_target`, and
+copy it in `_apply_plugin`. To add a new runnable agent type: subclass
+`PluginTarget`, call `_init_target` from its constructor, and add only the
+type-specific state.

--- a/docs/adr/0002-tool-composite-hierarchy.md
+++ b/docs/adr/0002-tool-composite-hierarchy.md
@@ -1,0 +1,93 @@
+---
+status: accepted
+date: 2026-06-16
+---
+
+# Tools are one `Tool` abstraction with three seams; `Toolkit` is itself a `Tool`
+
+## Context
+
+The beta agent loop has to expose several very different kinds of "tool" to the
+same execution machinery:
+
+- **`FunctionTool`** — wraps a Python callable; the agent executes it locally.
+- **`ClientTool`** — schema only; execution is handed back to the *client*
+  (e.g. a browser, an A2A peer, the AG-UI front-end).
+- **builtin / provider-native tools** (`ShellTool`, `CodeExecutionTool`,
+  `ImageGenerationTool`, `MCPServerTool`, `WebSearchTool`, `MemoryTool`, …) —
+  the *provider* executes them server-side; the agent only declares the
+  capability.
+- **`_MCPProxyTool`** — function-tool-shaped, but forwards each call to a remote
+  MCP server.
+- **`Toolkit`** — a *collection* of tools (skills, Google Drive, an MCP server's
+  whole tool list).
+
+A naïve design would give each kind its own container type and its own
+registration path, and would make `Toolkit` a separate "bag of tools" that the
+agent has to special-case. The legacy `autogen/tools/Toolkit` does exactly that
+— it is a plain container that is **not** a `Tool`.
+
+## Decision
+
+There is **one** abstraction: `Tool` (ABC, `autogen/beta/tools/tool.py`), with
+exactly three seams that every kind implements:
+
+- **`schemas(context) -> Iterable[ToolSchema]`** — what capability(ies) this
+  contributes to the model request. Function-shaped tools emit
+  `FunctionToolSchema`; provider-native tools emit their own `*ToolSchema`
+  (a provider-neutral capability flag the mappers translate).
+- **`set_provider(provider)`** — bind the `fast_depends` DI provider. Only the
+  function family needs it; the base and the builtins no-op.
+- **`register(stack, context, *, middleware)`** — subscribe this tool's
+  execution behaviour onto the event stream for the duration of a run.
+
+`Toolkit(Tool)` is the **composite**: it holds `dict[str, Tool]` and implements
+all three seams by fanning out to its children. Because a toolkit *is a* `Tool`,
+the agent treats a single tool and a toolkit identically, and toolkits nest
+(`MCPToolkit(Toolkit)`, `SkillsToolkit(Toolkit)`, …). `ToolExecutor.register`
+just calls `tool.register(...)` over a flat `Iterable[Tool]`, plus a fallback
+`ToolNotFound` subscriber — it never inspects tool kind.
+
+## Consequences / things that look wrong but are deliberate
+
+- **`register()` carries *different* execution semantics per subclass — by
+  design; do not hoist execution into the base.** `FunctionTool.register`
+  wraps middleware, runs the callable, and sends a `ToolResultEvent`.
+  `ClientTool.register` emits a `ClientToolCallEvent` and **never executes** —
+  the result comes back from the client. `_MCPProxyTool.register` forwards to
+  the remote server. The seam is `register`, not an `execute()` method,
+  precisely *because* these paths have nothing in common except "subscribe
+  something to the stream."
+
+- **Builtin tools implement `register()` with a no-op subscriber, and that is
+  not dead code.** `ShellTool` / `MCPServerTool` / `ImageGenerationTool` /
+  etc. subscribe an empty `execute` on `BuiltinToolCallEvent`. The *provider*
+  runs these server-side, so there is nothing for the agent to execute; the
+  no-op subscription exists so the call event has a consumer. Their real
+  contribution is `schemas()` — the `*ToolSchema` capability flag. Removing the
+  `register` override would be wrong even though the body is `pass`.
+
+- **`Toolkit` *is a* `Tool` (composite), unlike the legacy
+  `autogen/tools/Toolkit`.** Do not "align" the two. The beta toolkit being a
+  `Tool` is what lets an agent accept a toolkit anywhere it accepts a tool, lets
+  toolkits nest, and lets `MCPToolkit` lazily turn a server into a toolkit of
+  proxies without the agent knowing.
+
+- **`MCPToolkit.schemas()` mutates `self._tools` on first call (lazy
+  discovery).** This looks like a side effect in a getter, but it is the
+  *correct* place per the project rule "no side effects in init": the MCP
+  handshake (network I/O) must happen at runtime, not construction. The double-
+  checked `_discover_lock` guards concurrent first calls.
+
+- **`set_provider` is a no-op on most tools.** Only `FunctionTool` (and via the
+  composite, `Toolkit`) needs the DI provider, because only locally-executed
+  Python callables resolve `Context` / `Inject` / `Variable` dependencies.
+  Client, builtin, and MCP-proxy tools ignore it. The base `Tool.set_provider`
+  being a no-op rather than abstract is what keeps those subclasses free of
+  boilerplate.
+
+To add a new kind of tool: subclass `Tool`, implement `schemas()` (always), and
+implement `register()` to express how it runs (locally, client-side, provider-
+side no-op, or remote-forward). Implement `set_provider()` only if it executes
+local Python. To group tools, build on `Toolkit` and override `schemas()` if
+discovery is lazy — never special-case it in the agent or `ToolExecutor`.

--- a/docs/adr/0003-eval-run-api-takes-agent-instances.md
+++ b/docs/adr/0003-eval-run-api-takes-agent-instances.md
@@ -45,7 +45,8 @@ heavier (files, task lists) is constructed explicitly.
 
 > **Eval application:** `suite: Suite | str | Path | list[dict]` → `suite: str | Suite`.
 > Callers pass `Suite.from_list([...])` / `Suite.from_jsonl(path)`; a bare `str`
-> is one-prompt sugar.
+> is one-prompt sugar, which keeps the simplest run a one-liner:
+> `await run_agent("Hi, agent!", agent=agent)`.
 
 ### 2. Don't add a mechanism for behavior an existing seam already covers
 

--- a/docs/adr/0003-eval-run-api-takes-agent-instances.md
+++ b/docs/adr/0003-eval-run-api-takes-agent-instances.md
@@ -1,0 +1,80 @@
+---
+status: accepted
+date: 2026-06-16
+---
+
+# Public APIs take ready-to-use objects and reuse existing seams
+
+Two general design rules, surfaced while cleaning up the eval entry points
+(`run_agent` / `run_pairwise` / `run_variants` in `autogen/beta/eval/runtime/`)
+but meant to apply framework-wide. The eval change is the worked example.
+
+## Context
+
+The eval runners each take a *target* to run over a *dataset*. Two earlier
+conveniences made both inputs polymorphic:
+
+- **Suite as anything** — `suite=` accepted a `Suite`, a `Path`/path-string, or
+  an inline `list[dict]`, and the runner dispatched to `Suite.from_jsonl` /
+  `Suite.from_list` internally.
+- **Target as a factory** — `agent=` accepted an `Agent` instance *or* a callable
+  that built a fresh `Agent` per task (optionally taking a keyword-only `config`
+  the runner injected). `Variants` was built entirely on this:
+  `Variants.from_configs(factory, {...})` produced one `partial` per variant.
+
+Both turned out to be the wrong kind of convenience, each for a reason that
+generalizes past eval.
+
+## Decision
+
+### 1. A parameter's type should be a ready-to-use object, not a side-effecting recipe
+
+Accept what the caller already holds, fully constructed. Reject union members
+whose meaning is "go do I/O or construction *inside* the function": a `Path`
+silently implies *reading happens in here*, a `list[dict]` implies *parsing and
+validation happen in here*. Push that work to the call site so the side effect
+is explicit and lives outside the callee — the function just consumes the
+result. (This is the runtime-side-effect rule from `AGENTS.md` applied to
+signatures: the I/O belongs in the constructor seam — `Suite.from_jsonl(path)`,
+`Suite.from_list([...])` — not in every consumer of a `Suite`.)
+
+Allow exactly one deliberate exception: the single most common, lowest-friction
+shorthand may stay as sugar. Here that is `str` — a bare string is the easiest,
+most-reached-for input, so `run_*` keeps it as "a one-prompt suite". Everything
+heavier (files, task lists) is constructed explicitly.
+
+> **Eval application:** `suite: Suite | str | Path | list[dict]` → `suite: str | Suite`.
+> Callers pass `Suite.from_list([...])` / `Suite.from_jsonl(path)`; a bare `str`
+> is one-prompt sugar.
+
+### 2. Don't add a mechanism for behavior an existing seam already covers
+
+Before introducing indirection, check whether existing composition already does
+the job. The factory target existed only to vary an agent's config per task —
+but `Agent.ask(config=…)` *already* overrides the agent's own config per call.
+So on-the-fly agent construction is redundant: pass the agent you have (with or
+without a baked-in config) and let the per-call override carry the rest. The
+parallel machinery the factory required — signature introspection ("does it take
+`config`?"), a `RuntimeWarning` when it doesn't, build-vs-reuse branching — is
+deleted rather than maintained.
+
+> **Eval application:** `run_*` consume a prebuilt `Agent` instance; per-task
+> config flows via `model_config` → `ask(config=…)`. `Variants` is a mapping of
+> name → `Agent` instance (`agents=`, with an `axis` label defaulting to
+> `"variant"`); the `from_*` factory constructors are removed. `store_dir` is
+> optional across all three runners.
+
+## Consequences
+
+- The runner no longer introspects callables or branches on build-vs-reuse — a
+  target is just an object with `.name` and `.ask`. A construction that can fail
+  now fails at the call site, where the caller sees it; a failing `ask` is still
+  captured on the per-task `Trace` (never raised out of `run_*`), so a bad
+  variant is recorded rather than aborting a sweep.
+- One shared `Agent` instance is reused across a suite's tasks (and repeats).
+  Agents are effectively stateless across `ask` calls — history lives on the
+  per-call stream — so reuse is safe; do not rely on per-task instance identity.
+- Applying rule 1 elsewhere: a new public function that needs a built thing
+  should take the built thing, and offer a separate explicit constructor for the
+  path/dict/recipe form — not fold the I/O into itself. Reserve the `str`-style
+  sugar for the one input that earns it.

--- a/test/beta/agent/test_knowledge_tool.py
+++ b/test/beta/agent/test_knowledge_tool.py
@@ -21,7 +21,7 @@ from autogen.beta.testing import TestConfig
 
 def _knowledge_tool_call(agent: Agent):
     """Extract the underlying async function from the auto-injected tool."""
-    return agent._build_knowledge_tool()[0].model.call
+    return agent.tools[0].model.call
 
 
 @pytest.mark.asyncio
@@ -102,12 +102,12 @@ class TestExposeToolFlag:
             "policy-only",
             knowledge=KnowledgeConfig(store=store, expose_tool=False),
         )
-        assert agent._build_knowledge_tool() == []
+        assert not agent.tools
 
     async def test_expose_tool_true_is_default(self) -> None:
         store = MemoryKnowledgeStore()
         agent = Agent("with-tool", knowledge=KnowledgeConfig(store=store))
-        assert len(agent._build_knowledge_tool()) == 1
+        assert len(agent.tools) == 1
 
     async def test_default_bootstrap_omits_tool_instruction_when_unexposed(self) -> None:
         """The root SKILL.md should not tell the model about a tool that does not exist."""

--- a/test/beta/agent/test_knowledge_tool.py
+++ b/test/beta/agent/test_knowledge_tool.py
@@ -20,8 +20,12 @@ from autogen.beta.testing import TestConfig
 
 
 def _knowledge_tool_call(agent: Agent):
-    """Extract the underlying async function from the auto-injected tool."""
-    return agent.tools[0].model.call
+    """Extract the underlying async function from the auto-injected tool.
+
+    Auto-injected tools (the knowledge tool) live in ``_additional_tools``,
+    not the public ``agent.tools`` (which holds only user-supplied tools).
+    """
+    return agent._additional_tools[0].model.call
 
 
 @pytest.mark.asyncio
@@ -102,12 +106,12 @@ class TestExposeToolFlag:
             "policy-only",
             knowledge=KnowledgeConfig(store=store, expose_tool=False),
         )
-        assert not agent.tools
+        assert not agent._additional_tools
 
     async def test_expose_tool_true_is_default(self) -> None:
         store = MemoryKnowledgeStore()
         agent = Agent("with-tool", knowledge=KnowledgeConfig(store=store))
-        assert len(agent.tools) == 1
+        assert len(agent._additional_tools) == 1
 
     async def test_default_bootstrap_omits_tool_instruction_when_unexposed(self) -> None:
         """The root SKILL.md should not tell the model about a tool that does not exist."""

--- a/test/beta/agent/test_usage.py
+++ b/test/beta/agent/test_usage.py
@@ -4,8 +4,8 @@
 
 import pytest
 
-from autogen.beta import Agent, Usage
-from autogen.beta.events import ModelMessage, ModelResponse
+from autogen.beta import Agent
+from autogen.beta.events import ModelMessage, ModelResponse, Usage
 from autogen.beta.testing import TestConfig
 
 

--- a/test/beta/eval/runtime/test_eval_stream.py
+++ b/test/beta/eval/runtime/test_eval_stream.py
@@ -9,7 +9,7 @@ import pytest
 pytest.importorskip("opentelemetry.sdk")
 
 from autogen.beta import Agent
-from autogen.beta.eval import Variants, console_reporter, run_agent, run_pairwise, run_variants, scorer
+from autogen.beta.eval import Suite, Variants, console_reporter, run_agent, run_pairwise, run_variants, scorer
 from autogen.beta.eval.pairwise import PairwiseOutcome
 from autogen.beta.stream import MemoryStream
 from autogen.beta.testing import TestConfig
@@ -45,7 +45,7 @@ async def test_run_publishes_lifecycle_events(tmp_path) -> None:
     stream, seen = _collector()
 
     await run_agent(
-        [{"task_id": "t1", "inputs": {"input": "hi"}}],
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "hi"}}]),
         agent=Agent("a", config=TestConfig("ok")),
         scorers=[_ok],
         store_dir=tmp_path,
@@ -61,13 +61,13 @@ async def test_run_publishes_lifecycle_events(tmp_path) -> None:
 @pytest.mark.asyncio()
 async def test_run_variants_publishes_variant_events(tmp_path) -> None:
     stream, seen = _collector()
-    variants = Variants.from_targets({
-        "a": lambda: Agent("a", config=TestConfig("hi a")),
-        "b": lambda: Agent("b", config=TestConfig("hi b")),
+    variants = Variants({
+        "a": Agent("a", config=TestConfig("hi a")),
+        "b": Agent("b", config=TestConfig("hi b")),
     })
 
     await run_variants(
-        [{"task_id": "t1", "inputs": {"input": "hi"}}],
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "hi"}}]),
         variants=variants,
         scorers=[_ok],
         store_dir=tmp_path,
@@ -89,13 +89,13 @@ async def test_run_variants_tags_task_evaluated_with_variant(tmp_path) -> None:
             tagged.append((event.task_id, event.variant))
 
     stream.subscribe(collect, sync_to_thread=False)
-    variants = Variants.from_targets({
-        "a": lambda: Agent("a", config=TestConfig("hi a")),
-        "b": lambda: Agent("b", config=TestConfig("hi b")),
+    variants = Variants({
+        "a": Agent("a", config=TestConfig("hi a")),
+        "b": Agent("b", config=TestConfig("hi b")),
     })
 
     await run_variants(
-        [{"task_id": "t1", "inputs": {"input": "hi"}}],
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "hi"}}]),
         variants=variants,
         scorers=[_ok],
         store_dir=tmp_path,
@@ -111,9 +111,9 @@ async def test_run_pairwise_publishes_lifecycle_events(tmp_path) -> None:
     stream, seen = _collector()
 
     await run_pairwise(
-        [{"task_id": "t1", "inputs": {"input": "hi"}}],
-        variant_a=lambda: Agent("a", config=TestConfig("from a")),
-        variant_b=lambda: Agent("b", config=TestConfig("from b")),
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "hi"}}]),
+        variant_a=Agent("a", config=TestConfig("from a")),
+        variant_b=Agent("b", config=TestConfig("from b")),
         comparators=[_PickB()],
         store_dir=tmp_path,
         stream=stream,
@@ -132,7 +132,7 @@ async def test_console_reporter_prints_progress(tmp_path, capsys) -> None:
     stream.subscribe(console_reporter, sync_to_thread=False)
 
     await run_agent(
-        [{"task_id": "t1", "inputs": {"input": "hi"}}],
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "hi"}}]),
         agent=Agent("a", config=TestConfig("ok")),
         scorers=[_ok],
         store_dir=tmp_path,
@@ -151,9 +151,9 @@ async def test_console_reporter_prints_pairwise_progress(tmp_path, capsys) -> No
     stream.subscribe(console_reporter, sync_to_thread=False)
 
     await run_pairwise(
-        [{"task_id": "t1", "inputs": {"input": "hi"}}],
-        variant_a=lambda: Agent("a", config=TestConfig("from a")),
-        variant_b=lambda: Agent("b", config=TestConfig("from b")),
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "hi"}}]),
+        variant_a=Agent("a", config=TestConfig("from a")),
+        variant_b=Agent("b", config=TestConfig("from b")),
         comparators=[_PickB()],
         store_dir=tmp_path,
         stream=stream,

--- a/test/beta/eval/runtime/test_run_pairwise.py
+++ b/test/beta/eval/runtime/test_run_pairwise.py
@@ -45,8 +45,8 @@ async def test_run_pairwise_produces_then_compares(tmp_path) -> None:
 
     result = await run_pairwise(
         suite,
-        variant_a=_build_a,
-        variant_b=_build_b,
+        variant_a=_build_a(),
+        variant_b=_build_b(),
         comparators=[judge],
         variant_a_name="v1",
         variant_b_name="v2",
@@ -84,8 +84,8 @@ async def test_run_pairwise_label_is_recorded_and_serialized(tmp_path) -> None:
 
     result = await run_pairwise(
         suite,
-        variant_a=_build_a,
-        variant_b=_build_b,
+        variant_a=_build_a(),
+        variant_b=_build_b(),
         comparators=[judge],
         store_dir=tmp_path,
         label="bake-off",

--- a/test/beta/eval/runtime/test_runner.py
+++ b/test/beta/eval/runtime/test_runner.py
@@ -79,7 +79,7 @@ async def test_runs_one_task_and_captures_events(tmp_path: Path) -> None:
 
     result = await run_agent(
         suite,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[called_get_weather, city_argument_correct],
         store_dir=tmp_path,
         model_config={"t-tokyo": _cassette("Tokyo")},
@@ -109,7 +109,7 @@ async def test_runs_multiple_tasks_concurrently(tmp_path: Path) -> None:
 
     result = await run_agent(
         suite,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[called_get_weather, city_argument_correct],
         store_dir=tmp_path,
         model_config={
@@ -134,7 +134,7 @@ async def test_global_model_config_applied_to_every_task(tmp_path: Path) -> None
 
     result = await run_agent(
         suite,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config=_cassette("London"),
@@ -146,17 +146,20 @@ async def test_global_model_config_applied_to_every_task(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
-async def test_target_factory_exception_is_captured_not_raised(tmp_path: Path) -> None:
-    """A factory that explodes during construction does not abort the run."""
+async def test_agent_ask_exception_is_captured_not_raised(tmp_path: Path) -> None:
+    """An agent whose ``ask`` explodes does not abort the run — the error is captured on the trace."""
 
-    def broken_factory(*, config: object = None) -> Agent:
-        raise RuntimeError("factory exploded")
+    class ExplodingAgent:
+        name = "exploding"
+
+        async def ask(self, *args: object, **kwargs: object) -> object:
+            raise RuntimeError("ask exploded")
 
     suite = Suite.from_list([{"task_id": "t1", "inputs": {"input": "hi"}}])
 
     result = await run_agent(
         suite,
-        agent=broken_factory,
+        agent=ExplodingAgent(),  # type: ignore[arg-type]
         scorers=[called_get_weather],
         store_dir=tmp_path,
         concurrency=1,
@@ -170,37 +173,6 @@ async def test_target_factory_exception_is_captured_not_raised(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_factory_without_config_parameter_works_with_warning(tmp_path: Path) -> None:
-    """A factory without a ``config`` parameter is supported (with a warning)."""
-
-    @scorer
-    def constant() -> bool:
-        return True
-
-    def bare_factory() -> Agent:
-        return Agent(
-            "bare",
-            config=_cassette("Anywhere"),
-            tools=[get_weather],
-        )
-
-    suite = Suite.from_list([{"task_id": "t1", "inputs": {"input": "Anywhere?"}}])
-
-    with pytest.warns(RuntimeWarning, match="does not accept a 'config' parameter"):
-        result = await run_agent(
-            suite,
-            agent=bare_factory,
-            scorers=[constant],
-            store_dir=tmp_path,
-            model_config=_cassette("Anywhere"),  # would normally be injected; ignored here
-            concurrency=1,
-        )
-
-    [task_result] = result.tasks
-    assert task_result.feedback == (Feedback(key="constant", score=True),)
-
-
-@pytest.mark.asyncio
 async def test_missing_input_key_raises(tmp_path: Path) -> None:
     """A task whose inputs lack 'input' fails fast — run_agent grades inputs['input']."""
     suite = Suite.from_list([{"task_id": "t1", "inputs": {"question": "Tokyo?"}}])
@@ -208,7 +180,7 @@ async def test_missing_input_key_raises(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match=r"no 'input' key"):
         await run_agent(
             suite,
-            agent=_build_weather_agent,
+            agent=_build_weather_agent(),
             scorers=[called_get_weather],
             store_dir=tmp_path,
             model_config=_cassette("Tokyo"),
@@ -223,7 +195,7 @@ async def test_explicit_empty_input_is_allowed(tmp_path: Path) -> None:
 
     result = await run_agent(
         suite,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config=_cassette("Tokyo"),
@@ -238,7 +210,7 @@ async def test_run_id_is_generated_unless_provided(tmp_path: Path) -> None:
 
     auto = await run_agent(
         suite,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config={"t1": _cassette("Tokyo")},
@@ -246,7 +218,7 @@ async def test_run_id_is_generated_unless_provided(tmp_path: Path) -> None:
     )
     explicit = await run_agent(
         suite,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config={"t1": _cassette("Tokyo")},
@@ -266,7 +238,7 @@ async def test_run_persists_to_store_dir(tmp_path: Path) -> None:
 
     result = await run_agent(
         suite,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config={"t1": _cassette("Tokyo")},
@@ -286,7 +258,7 @@ async def test_budget_violation_recorded_not_aborted(tmp_path: Path) -> None:
 
     result = await run_agent(
         suite,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config={"t1": _cassette("Tokyo")},
@@ -309,7 +281,7 @@ async def test_inline_list_dataset_is_loaded(tmp_path: Path) -> None:
 
     result = await run_agent(
         items,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config={"t1": _cassette("Tokyo")},
@@ -333,14 +305,12 @@ async def test_user_middleware_and_observers_still_fire(tmp_path: Path) -> None:
 
     user_observer = observer_factory(callback=record, sync_to_thread=False)
 
-    def factory(*, config: object = None) -> Agent:
-        return Agent(
-            "weather",
-            prompt="Use get_weather.",
-            config=config,
-            tools=[get_weather],
-            observers=[user_observer],
-        )
+    agent = Agent(
+        "weather",
+        prompt="Use get_weather.",
+        tools=[get_weather],
+        observers=[user_observer],
+    )
 
     suite = Suite.from_list([
         {"task_id": "t1", "inputs": {"input": "Tokyo?"}, "reference_outputs": {"city": "Tokyo"}},
@@ -348,7 +318,7 @@ async def test_user_middleware_and_observers_still_fire(tmp_path: Path) -> None:
 
     result = await run_agent(
         suite,
-        agent=factory,
+        agent=agent,
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config={"t1": _cassette("Tokyo")},
@@ -368,7 +338,7 @@ async def test_run_duration_is_recorded(tmp_path: Path) -> None:
 
     result = await run_agent(
         suite,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config={"t1": _cassette("Tokyo")},
@@ -382,7 +352,7 @@ async def test_run_duration_is_recorded(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_reply_ask_continuations_are_captured(tmp_path: Path) -> None:
-    """A factory that drives ``reply.ask`` internally still has all events captured.
+    """An agent that drives ``reply.ask`` internally still has all events captured.
 
     EventCapture subscribes directly to the stream (not via ``sub_scope``),
     so its subscription survives the ``agent.ask`` → ``reply.ask`` transition
@@ -409,17 +379,15 @@ async def test_reply_ask_continuations_are_captured(tmp_path: Path) -> None:
             reply = await self._agent.ask(prompt, **kwargs)
             return await reply.ask("And how warm is it?")
 
-    def factory(*, config: object = None) -> Agent:
-        inner = Agent("weather", config=config, tools=[get_weather])
-        return TwoTurnWeather(inner)  # type: ignore[return-value]
+    agent = TwoTurnWeather(Agent("weather", tools=[get_weather]))
 
     @scorer
     def saw_at_least_two_model_responses(trace: Trace) -> bool:
         return len(trace.events_of(ModelResponse)) >= 2
 
     result = await run_agent(
-        [{"task_id": "t1", "inputs": {"input": "Tokyo weather?"}}],
-        agent=factory,
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "Tokyo weather?"}}]),
+        agent=agent,  # type: ignore[arg-type]
         scorers=[saw_at_least_two_model_responses],
         model_config={"t1": cassette},
         store_dir=tmp_path,
@@ -433,26 +401,29 @@ async def test_reply_ask_continuations_are_captured(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_store_dir_is_required(tmp_path: Path) -> None:
-    """Calling run_agent() without store_dir is a TypeError — the kwarg is mandatory."""
+async def test_store_dir_is_optional(tmp_path: Path) -> None:
+    """Omitting store_dir runs the eval without persisting a run JSON."""
     suite = Suite.from_list([{"task_id": "t1", "inputs": {"input": "?"}}])
 
-    with pytest.raises(TypeError, match="store_dir"):
-        await run_agent(  # type: ignore[call-arg]
-            suite,
-            agent=_build_weather_agent,
-            scorers=[called_get_weather],
-            model_config={"t1": _cassette("Tokyo")},
-        )
+    result = await run_agent(
+        suite,
+        agent=_build_weather_agent(),
+        scorers=[called_get_weather],
+        model_config={"t1": _cassette("Tokyo")},
+    )
+
+    assert len(result.tasks) == 1
+    # Nothing was written — no run JSON exists under tmp_path.
+    assert list(tmp_path.glob("*.json")) == []
 
 
 @pytest.mark.asyncio
 async def test_run_accepts_an_agent_instance(tmp_path: Path) -> None:
-    """``agent=`` accepts a prebuilt Agent instance, not just a factory."""
+    """``agent=`` accepts a prebuilt Agent instance."""
     agent = Agent("weather", config=_cassette("Tokyo"), tools=[get_weather])
 
     result = await run_agent(
-        [{"task_id": "t1", "inputs": {"input": "Tokyo?"}, "reference_outputs": {"city": "Tokyo"}}],
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "Tokyo?"}, "reference_outputs": {"city": "Tokyo"}}]),
         agent=agent,
         scorers=[called_get_weather, city_argument_correct],
         store_dir=tmp_path,
@@ -470,8 +441,8 @@ async def test_run_accepts_an_agent_instance(tmp_path: Path) -> None:
 async def test_repeats_runs_each_task_n_times(tmp_path: Path) -> None:
     """``repeats=N`` runs each task N times (distinct ids) and pools the pass-rate."""
     result = await run_agent(
-        [{"task_id": "tokyo", "inputs": {"input": "Tokyo?"}, "reference_outputs": {"city": "Tokyo"}}],
-        agent=_build_weather_agent,
+        Suite.from_list([{"task_id": "tokyo", "inputs": {"input": "Tokyo?"}, "reference_outputs": {"city": "Tokyo"}}]),
+        agent=_build_weather_agent(),
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config=_cassette("Tokyo"),  # one config, applied to every repeat
@@ -488,8 +459,8 @@ async def test_repeats_runs_each_task_n_times(tmp_path: Path) -> None:
 async def test_label_is_recorded_and_serialized(tmp_path: Path) -> None:
     """A user-defined ``label`` is carried on the result and persisted to the run JSON."""
     result = await run_agent(
-        [{"task_id": "t1", "inputs": {"input": "Tokyo?"}}],
-        agent=_build_weather_agent,
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "Tokyo?"}}]),
+        agent=_build_weather_agent(),
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config={"t1": _cassette("Tokyo")},
@@ -504,8 +475,8 @@ async def test_label_is_recorded_and_serialized(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_label_defaults_to_none(tmp_path: Path) -> None:
     result = await run_agent(
-        [{"task_id": "t1", "inputs": {"input": "Tokyo?"}}],
-        agent=_build_weather_agent,
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "Tokyo?"}}]),
+        agent=_build_weather_agent(),
         scorers=[called_get_weather],
         store_dir=tmp_path,
         model_config={"t1": _cassette("Tokyo")},
@@ -547,8 +518,8 @@ class TestTelemetryInjection:
         """every emitted span carries caller attrs + auto-seeded eval ids (task_id per task)."""
         captured = InMemorySpanExporter()
         await run_agent(
-            [{"task_id": "t-tokyo", "inputs": {"input": "Tokyo?"}}],
-            agent=_build_weather_agent,
+            Suite.from_list([{"task_id": "t-tokyo", "inputs": {"input": "Tokyo?"}}]),
+            agent=_build_weather_agent(),
             scorers=[called_get_weather],
             store_dir=tmp_path,
             model_config={"t-tokyo": _cassette("Tokyo")},
@@ -574,8 +545,8 @@ class TestTelemetryInjection:
         """A caller-supplied ag2.eval.run_id overrides the auto-seeded one."""
         captured = InMemorySpanExporter()
         await run_agent(
-            [{"task_id": "t1", "inputs": {"input": "Tokyo?"}}],
-            agent=_build_weather_agent,
+            Suite.from_list([{"task_id": "t1", "inputs": {"input": "Tokyo?"}}]),
+            agent=_build_weather_agent(),
             scorers=[called_get_weather],
             store_dir=tmp_path,
             model_config={"t1": _cassette("Tokyo")},
@@ -588,12 +559,14 @@ class TestTelemetryInjection:
 
     async def test_injected_processor_is_additive_grading_unchanged(self, tmp_path: Path) -> None:
         """the capturing processor sees the spans, and grading is identical with/without it."""
-        suite = [{"task_id": "t1", "inputs": {"input": "Tokyo?"}, "reference_outputs": {"city": "Tokyo"}}]
+        suite = Suite.from_list([
+            {"task_id": "t1", "inputs": {"input": "Tokyo?"}, "reference_outputs": {"city": "Tokyo"}}
+        ])
         scorers = [called_get_weather, city_argument_correct]
 
         baseline = await run_agent(
             suite,
-            agent=_build_weather_agent,
+            agent=_build_weather_agent(),
             scorers=scorers,
             store_dir=tmp_path,
             model_config={"t1": _cassette("Tokyo")},
@@ -603,7 +576,7 @@ class TestTelemetryInjection:
         captured = InMemorySpanExporter()
         injected = await run_agent(
             suite,
-            agent=_build_weather_agent,
+            agent=_build_weather_agent(),
             scorers=scorers,
             store_dir=tmp_path,
             model_config={"t1": _cassette("Tokyo")},
@@ -619,8 +592,8 @@ class TestTelemetryInjection:
         """TaskResult.trace_ref.trace_id equals the real OTEL trace id of the emitted spans."""
         captured = InMemorySpanExporter()
         result = await run_agent(
-            [{"task_id": "t1", "inputs": {"input": "Tokyo?"}}],
-            agent=_build_weather_agent,
+            Suite.from_list([{"task_id": "t1", "inputs": {"input": "Tokyo?"}}]),
+            agent=_build_weather_agent(),
             scorers=[called_get_weather],
             store_dir=tmp_path,
             model_config={"t1": _cassette("Tokyo")},
@@ -650,8 +623,8 @@ class TestTelemetryInjection:
     async def test_no_extra_args_is_unchanged(self, tmp_path: Path) -> None:
         """a no-arg run still grades identically (trace_ref present, eval ids self-seeded)."""
         result = await run_agent(
-            [{"task_id": "t1", "inputs": {"input": "Tokyo?"}, "reference_outputs": {"city": "Tokyo"}}],
-            agent=_build_weather_agent,
+            Suite.from_list([{"task_id": "t1", "inputs": {"input": "Tokyo?"}, "reference_outputs": {"city": "Tokyo"}}]),
+            agent=_build_weather_agent(),
             scorers=[called_get_weather, city_argument_correct],
             store_dir=tmp_path,
             model_config={"t1": _cassette("Tokyo")},

--- a/test/beta/eval/runtime/test_smoke_weather.py
+++ b/test/beta/eval/runtime/test_smoke_weather.py
@@ -122,7 +122,7 @@ async def test_smoke_weather_end_to_end(tmp_path: Path) -> None:
 
     result = await run_agent(
         suite,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[*_PREBUILT_SCORERS, *_CUSTOM_SCORERS],
         model_config=_CASSETTES,
         budgets=BudgetThresholds(max_tokens_per_task=2_000, max_seconds_per_task=10.0),
@@ -214,7 +214,7 @@ async def test_smoke_weather_summary_is_printable(tmp_path: Path) -> None:
 
     result = await run_agent(
         suite,
-        agent=_build_weather_agent,
+        agent=_build_weather_agent(),
         scorers=[*_PREBUILT_SCORERS, *_CUSTOM_SCORERS],
         store_dir=tmp_path,
         model_config=_CASSETTES,

--- a/test/beta/eval/runtime/test_variants.py
+++ b/test/beta/eval/runtime/test_variants.py
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for run_variants — typed single-axis variant comparison + leaderboard."""
+"""Tests for run_variants — instance-based variant comparison + leaderboard."""
 
 import pytest
 
 pytest.importorskip("opentelemetry.sdk")
 
 from autogen.beta import Agent
-from autogen.beta.eval import Variants, run_variants, scorer
+from autogen.beta.eval import Suite, Variants, run_variants, scorer
 from autogen.beta.eval.scorers import final_answer_matches
 from autogen.beta.testing import TestConfig
 
@@ -24,17 +24,19 @@ def got_reply(outputs) -> bool:
 
 
 @pytest.mark.asyncio()
-async def test_from_configs_runs_each_variant_and_ranks(tmp_path) -> None:
-    variants = Variants.from_configs(
-        _build,
+async def test_runs_each_variant_and_ranks(tmp_path) -> None:
+    variants = Variants(
         {
-            "right": TestConfig("The capital is Tokyo."),
-            "wrong": TestConfig("The capital is Paris."),
+            "right": _build(config=TestConfig("The capital is Tokyo.")),
+            "wrong": _build(config=TestConfig("The capital is Paris.")),
         },
+        axis="config",
     )
 
     board = await run_variants(
-        [{"task_id": "t1", "inputs": {"input": "Capital of Japan?"}, "reference_outputs": {"answer": "Tokyo"}}],
+        Suite.from_list([
+            {"task_id": "t1", "inputs": {"input": "Capital of Japan?"}, "reference_outputs": {"answer": "Tokyo"}}
+        ]),
         variants=variants,
         scorers=[final_answer_matches(field="answer", matcher="contains")],
         store_dir=tmp_path,
@@ -55,36 +57,33 @@ async def test_from_configs_runs_each_variant_and_ranks(tmp_path) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_from_targets_accepts_factories_and_instances(tmp_path) -> None:
-    variants = Variants.from_targets({
-        "factory": lambda: Agent("a", config=TestConfig("hi from factory")),
-        "instance": Agent("b", config=TestConfig("hi from instance")),  # reused as-is
+async def test_variants_are_agent_instances(tmp_path) -> None:
+    variants = Variants({
+        "a": Agent("a", config=TestConfig("hi from a")),
+        "b": Agent("b", config=TestConfig("hi from b")),
     })
 
     board = await run_variants(
-        [{"task_id": "t1", "inputs": {"input": "say hi"}}],
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "say hi"}}]),
         variants=variants,
         scorers=[got_reply],
         store_dir=tmp_path,
     )
 
-    assert board.axis == "target"
-    assert set(board.results) == {"factory", "instance"}
-    assert board.results["factory"].pass_rate("got_reply") == 1.0
-    assert board.results["instance"].pass_rate("got_reply") == 1.0
+    assert board.axis == "variant"  # default axis label
+    assert set(board.results) == {"a", "b"}
+    assert board.results["a"].pass_rate("got_reply") == 1.0
+    assert board.results["b"].pass_rate("got_reply") == 1.0
 
 
 @pytest.mark.asyncio()
 async def test_errored_variant_does_not_abort_the_sweep(tmp_path) -> None:
-    """A variant whose build raises is recorded (ranked last), not fatal to the others."""
-
-    def boom(*, config=None) -> Agent:
-        raise RuntimeError("bad build")
-
-    variants = Variants.from_targets({"ok": lambda: Agent("ok", config=TestConfig("hi")), "broken": boom})
+    """A variant whose agent errors is recorded (ranked last), not fatal to the others."""
+    # The "broken" agent has no config, so its ``ask`` raises — captured on the trace.
+    variants = Variants({"ok": Agent("ok", config=TestConfig("hi")), "broken": Agent("broken")})
 
     board = await run_variants(
-        [{"task_id": "t1", "inputs": {"input": "hi"}}],
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "hi"}}]),
         variants=variants,
         scorers=[got_reply],
         store_dir=tmp_path,
@@ -98,10 +97,16 @@ async def test_errored_variant_does_not_abort_the_sweep(tmp_path) -> None:
 @pytest.mark.asyncio()
 async def test_tie_shares_a_rank_and_has_no_unique_best(tmp_path) -> None:
     """Variants tied on the top score share rank 1, and ``best()`` returns None."""
-    variants = Variants.from_configs(_build, {"a": TestConfig("Tokyo"), "b": TestConfig("Tokyo")})
+    variants = Variants(
+        {
+            "a": _build(config=TestConfig("Tokyo")),
+            "b": _build(config=TestConfig("Tokyo")),
+        },
+        axis="config",
+    )
 
     board = await run_variants(
-        [{"task_id": "t1", "inputs": {"input": "capital?"}, "reference_outputs": {"answer": "Tokyo"}}],
+        Suite.from_list([{"task_id": "t1", "inputs": {"input": "capital?"}, "reference_outputs": {"answer": "Tokyo"}}]),
         variants=variants,
         scorers=[final_answer_matches(field="answer", matcher="contains")],
         store_dir=tmp_path,

--- a/test/beta/live/test_gemini_realtime_usage.py
+++ b/test/beta/live/test_gemini_realtime_usage.py
@@ -8,7 +8,7 @@ pytest.importorskip("google.genai")
 
 from google.genai import types as gtypes
 
-from autogen.beta import Usage
+from autogen.beta.events import Usage
 from autogen.beta.live.gemini import normalize_realtime_usage
 
 

--- a/test/beta/live/test_openai_realtime_usage.py
+++ b/test/beta/live/test_openai_realtime_usage.py
@@ -11,7 +11,7 @@ from openai.types.realtime.realtime_response_usage_input_token_details import (
     RealtimeResponseUsageInputTokenDetails,
 )
 
-from autogen.beta import Usage
+from autogen.beta.events import Usage
 from autogen.beta.live.openai import normalize_realtime_usage
 
 

--- a/test/beta/live/test_realtime_usage.py
+++ b/test/beta/live/test_realtime_usage.py
@@ -4,11 +4,11 @@
 
 import pytest
 
-from autogen.beta import Usage, UsageReport
 from autogen.beta.context import ConversationContext
-from autogen.beta.events import UsageEvent
+from autogen.beta.events import Usage, UsageEvent
 from autogen.beta.live import LiveAgent
 from autogen.beta.stream import MemoryStream
+from autogen.beta.usage import UsageReport
 
 
 @pytest.mark.asyncio

--- a/test/beta/observer/test_lifecycle.py
+++ b/test/beta/observer/test_lifecycle.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic observer lifecycle tests.
+
+Locks in the ``ObserverStarted`` / ``ObserverCompleted`` contract around an
+agent turn without hitting a real provider:
+
+* one ``Started`` and one ``Completed`` per registered observer;
+* ``Started`` fires before the turn body, ``Completed`` after;
+* ``Completed`` is emitted while observers are still registered, so an
+  observer subscribed to ``ObserverCompleted`` receives its own event.
+"""
+
+import pytest
+
+from autogen.beta import Agent, observer
+from autogen.beta.events import ModelResponse, ObserverCompleted, ObserverStarted
+from autogen.beta.stream import MemoryStream
+from autogen.beta.testing import TestConfig
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_lifecycle_events_emitted_per_observer() -> None:
+    started: list[ObserverStarted] = []
+    completed: list[ObserverCompleted] = []
+
+    stream = MemoryStream()
+    stream.where(ObserverStarted).subscribe(lambda e: started.append(e))
+    stream.where(ObserverCompleted).subscribe(lambda e: completed.append(e))
+
+    obs_a = observer(ModelResponse, lambda e: None)
+    obs_b = observer(ModelResponse, lambda e: None)
+
+    agent = Agent("lifecycle", config=TestConfig("ok"), observers=[obs_a, obs_b])
+    await agent.ask("hi", stream=stream)
+
+    assert len(started) == 2
+    assert len(completed) == 2
+
+
+async def test_started_before_turn_and_completed_after() -> None:
+    order: list[str] = []
+
+    stream = MemoryStream()
+    stream.where(ObserverStarted).subscribe(lambda e: order.append("started"))
+    stream.where(ModelResponse).subscribe(lambda e: order.append("response"))
+    stream.where(ObserverCompleted).subscribe(lambda e: order.append("completed"))
+
+    obs = observer(ModelResponse, lambda e: None)
+
+    agent = Agent("lifecycle", config=TestConfig("ok"), observers=[obs])
+    await agent.ask("hi", stream=stream)
+
+    assert order == ["started", "response", "completed"]
+
+
+async def test_observer_receives_its_own_completed() -> None:
+    """``Completed`` is emitted before observers unregister, so an observer
+    subscribed to ``ObserverCompleted`` still sees it."""
+    seen: list[ObserverCompleted] = []
+
+    obs = observer(ObserverCompleted, lambda e: seen.append(e))
+
+    agent = Agent("lifecycle", config=TestConfig("ok"), observers=[obs])
+    await agent.ask("hi")
+
+    assert len(seen) == 1
+
+
+async def test_no_lifecycle_events_without_observers() -> None:
+    started: list[ObserverStarted] = []
+    completed: list[ObserverCompleted] = []
+
+    stream = MemoryStream()
+    stream.where(ObserverStarted).subscribe(lambda e: started.append(e))
+    stream.where(ObserverCompleted).subscribe(lambda e: completed.append(e))
+
+    agent = Agent("lifecycle", config=TestConfig("ok"))
+    await agent.ask("hi", stream=stream)
+
+    assert started == []
+    assert completed == []

--- a/test/beta/providers/agent/test_subtasks.py
+++ b/test/beta/providers/agent/test_subtasks.py
@@ -175,7 +175,7 @@ async def test_subtask_cannot_recurse(provider_config) -> None:
     assert captured_subtasks, "subtask must have been spawned"
     child = captured_subtasks[0]
     assert child._task_config is None
-    assert child._build_subtask_tools() == []
+    assert not child.tools
 
 
 async def test_persistent_stream_shares_history(provider_config) -> None:

--- a/test/beta/test_agent_resume.py
+++ b/test/beta/test_agent_resume.py
@@ -45,7 +45,7 @@ class TestAgentResume:
         agent = Agent("retriever", config=TestConfig("Final answer grounded on the result."))
 
         trigger = ToolResultsEvent([ToolResultEvent.from_call(tc, "X is at file.cc:42")])
-        reply = await agent.resume(trigger, history=history)
+        reply = await agent.resume(*history, trigger)
 
         assert reply.body == "Final answer grounded on the result."
 
@@ -64,7 +64,7 @@ class TestAgentResume:
         agent = Agent("retriever", config=tracking)
 
         trigger = ToolResultsEvent([ToolResultEvent.from_call(tc, "evidence")])
-        await agent.resume(trigger, history=history)
+        await agent.resume(*history, trigger)
 
         # Exactly one LLM call; its last message is the tool-results trigger.
         tracking.mock.assert_called_once()
@@ -84,7 +84,7 @@ class TestAgentResume:
         agent = Agent("retriever", tools=[echo], config=TestConfig(next_call, "All done."))
 
         trigger = ToolResultsEvent([ToolResultEvent.from_call(tc, "first result")])
-        reply = await agent.resume(trigger, history=history)
+        reply = await agent.resume(*history, trigger)
 
         assert reply.body == "All done."
         events = list(await reply.context.stream.history.get_events())
@@ -103,7 +103,7 @@ class TestAgentResume:
         agent = Agent("retriever", config=TestConfig("answer"))
 
         trigger = ToolResultsEvent([ToolResultEvent.from_call(tc, "r")])
-        reply = await agent.resume(trigger, history=history, stream=stream)
+        reply = await agent.resume(*history, trigger, stream=stream)
 
         events = list(await reply.context.stream.history.get_events())
         texts = [p.content for e in events if isinstance(e, ModelRequest) for p in e.parts if isinstance(p, TextInput)]

--- a/test/beta/test_agent_resume.py
+++ b/test/beta/test_agent_resume.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``Agent.resume`` — resuming a turn from a recorded trajectory.
+
+``resume`` blesses, as public API, the ``_execute(trigger)`` path: it seeds the
+stream history with a recorded trajectory and re-enters the agent loop with an
+arbitrary ``BaseEvent`` trigger (typically a ``ToolResultsEvent``), so the model
+reacts to a tool result mid-loop without the tool being re-executed.
+"""
+
+import pytest
+
+from autogen.beta import Agent
+from autogen.beta.events import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    ToolCallEvent,
+    ToolCallsEvent,
+    ToolResultEvent,
+    ToolResultsEvent,
+)
+from autogen.beta.stream import MemoryStream
+from autogen.beta.testing import TestConfig, TrackingConfig
+
+
+def _seed_through_tool_call(question: str, tool_name: str, args: str, tc_id: str):
+    """Build the trajectory [user question, assistant tool-call] to seed."""
+    tc = ToolCallEvent(name=tool_name, arguments=args, id=tc_id)
+    history = [
+        ModelRequest([TextInput(question)]),
+        ModelResponse(message=ModelMessage(""), tool_calls=ToolCallsEvent([tc])),
+    ]
+    return history, tc
+
+
+class TestAgentResume:
+    @pytest.mark.asyncio
+    async def test_resume_from_tool_results_continues_turn(self) -> None:
+        """A ToolResultsEvent trigger drives one LLM call → final answer."""
+        history, tc = _seed_through_tool_call("Where is X?", "get_node_details", '{"id": "X"}', "call-1")
+        agent = Agent("retriever", config=TestConfig("Final answer grounded on the result."))
+
+        trigger = ToolResultsEvent([ToolResultEvent.from_call(tc, "X is at file.cc:42")])
+        reply = await agent.resume(trigger, history=history)
+
+        assert reply.body == "Final answer grounded on the result."
+
+        events = list(await reply.context.stream.history.get_events())
+        # Seeded prefix is preserved, the trigger is appended, and the final
+        # model response lands after it — contiguous, no re-execution.
+        assert any(isinstance(e, ModelRequest) for e in events)
+        assert any(isinstance(e, ToolResultsEvent) for e in events)
+        assert isinstance(events[-1], ModelResponse)
+
+    @pytest.mark.asyncio
+    async def test_resume_feeds_seeded_history_and_trigger_to_model(self) -> None:
+        """The LLM call sees the seeded history, with the trigger as the last message."""
+        history, tc = _seed_through_tool_call("Q?", "search_docs", "{}", "call-1")
+        tracking = TrackingConfig(TestConfig("done"))
+        agent = Agent("retriever", config=tracking)
+
+        trigger = ToolResultsEvent([ToolResultEvent.from_call(tc, "evidence")])
+        await agent.resume(trigger, history=history)
+
+        # Exactly one LLM call; its last message is the tool-results trigger.
+        tracking.mock.assert_called_once()
+        last_message = tracking.mock.call_args.args[0]
+        assert isinstance(last_message, ToolResultsEvent)
+
+    @pytest.mark.asyncio
+    async def test_resume_continues_into_more_tool_calls(self) -> None:
+        """After reacting to the result, the model may issue further tool calls."""
+        history, tc = _seed_through_tool_call("Q?", "search_docs", "{}", "call-1")
+
+        def echo(value: str) -> str:
+            return f"echoed:{value}"
+
+        # React to the seeded result by calling another tool, then finish.
+        next_call = ToolCallEvent(name="echo", arguments='{"value": "again"}', id="call-2")
+        agent = Agent("retriever", tools=[echo], config=TestConfig(next_call, "All done."))
+
+        trigger = ToolResultsEvent([ToolResultEvent.from_call(tc, "first result")])
+        reply = await agent.resume(trigger, history=history)
+
+        assert reply.body == "All done."
+        events = list(await reply.context.stream.history.get_events())
+        # The live continuation actually executed the echo tool.
+        assert any(
+            isinstance(e, ToolResultsEvent) and any("echoed:again" in str(r.result) for r in e.results) for e in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_replaces_existing_stream_history(self) -> None:
+        """A supplied stream's pre-existing history is replaced by ``history``."""
+        stream = MemoryStream()
+        await stream.history.replace([ModelRequest([TextInput("stale prior turn")])])
+
+        history, tc = _seed_through_tool_call("fresh question", "search_docs", "{}", "call-1")
+        agent = Agent("retriever", config=TestConfig("answer"))
+
+        trigger = ToolResultsEvent([ToolResultEvent.from_call(tc, "r")])
+        reply = await agent.resume(trigger, history=history, stream=stream)
+
+        events = list(await reply.context.stream.history.get_events())
+        texts = [p.content for e in events if isinstance(e, ModelRequest) for p in e.parts if isinstance(p, TextInput)]
+        assert "fresh question" in texts
+        assert "stale prior turn" not in texts

--- a/test/beta/test_usage.py
+++ b/test/beta/test_usage.py
@@ -4,8 +4,8 @@
 
 import pytest
 
-from autogen.beta import UsageRecord, UsageReport
 from autogen.beta.events import ModelMessage, ModelResponse, Usage, UsageEvent
+from autogen.beta.usage import UsageRecord, UsageReport
 
 
 def _usage_event(prompt: int, completion: int, *, model: str, provider: str) -> UsageEvent:

--- a/test/beta/test_usage.py
+++ b/test/beta/test_usage.py
@@ -4,8 +4,8 @@
 
 import pytest
 
-from autogen.beta import Usage, UsageRecord, UsageReport
-from autogen.beta.events import ModelMessage, ModelResponse, UsageEvent
+from autogen.beta import UsageRecord, UsageReport
+from autogen.beta.events import ModelMessage, ModelResponse, Usage, UsageEvent
 
 
 def _usage_event(prompt: int, completion: int, *, model: str, provider: str) -> UsageEvent:

--- a/test/beta/tools/test_task.py
+++ b/test/beta/tools/test_task.py
@@ -561,19 +561,20 @@ class TestSubtaskOptOut:
         """A bare Agent has no subtask tools by default (``tasks=False``)."""
         agent = Agent("default")
 
-        assert _tool_names(agent.tools) == set()
+        # Auto-injected tools live in ``_additional_tools``, not ``agent.tools``.
+        assert _tool_names(agent._additional_tools) == set()
 
     async def test_explicit_disabled_actor_has_no_subtask_tools(self) -> None:
         """Explicit ``tasks=False`` also suppresses subtask tools."""
         agent = Agent("disabled", tasks=False)
 
-        assert _tool_names(agent.tools) == set()
+        assert _tool_names(agent._additional_tools) == set()
 
     async def test_taskconfig_actor_has_subtask_tools(self) -> None:
         """Passing ``tasks=TaskConfig(...)`` opts in to the auto-injected subtask tools."""
         agent = Agent("enabled", tasks=TaskConfig())
 
-        assert _tool_names(agent.tools) == {"run_subtask", "run_subtasks"}
+        assert _tool_names(agent._additional_tools) == {"run_subtask", "run_subtasks"}
 
 
 @pytest.mark.asyncio
@@ -851,7 +852,7 @@ def test_run_subtask_description_advertises_parallel_invocation() -> None:
     blocks in one assistant message rather than serializing them.
     """
     agent = Agent("any", tasks=TaskConfig())
-    [toolkit] = agent.tools
+    [toolkit] = agent._additional_tools
     [run_subtask, run_subtasks] = toolkit.tools
 
     desc = run_subtask.schema.function.description

--- a/test/beta/tools/test_task.py
+++ b/test/beta/tools/test_task.py
@@ -25,10 +25,22 @@ from autogen.beta.events import (
     UsageEvent,
 )
 from autogen.beta.testing import TestConfig
+from autogen.beta.tools import Toolkit
 from autogen.beta.tools.subagents import run_task as run_task_mod
 from autogen.beta.tools.subagents import subagent_tool
 from autogen.beta.tools.subagents.run_task import run_task
 from autogen.beta.usage import UsageReport
+
+
+def _tool_names(tools: list) -> set[str]:
+    """Collect tool names, expanding any ``Toolkit`` into its member tools."""
+    names: set[str] = set()
+    for t in tools:
+        if isinstance(t, Toolkit):
+            names |= {inner.schema.function.name for inner in t.tools}
+        else:
+            names.add(t.schema.function.name)
+    return names
 
 
 def _make_parent_context(
@@ -549,22 +561,19 @@ class TestSubtaskOptOut:
         """A bare Agent has no subtask tools by default (``tasks=False``)."""
         agent = Agent("default")
 
-        names = {t.schema.function.name for t in agent._build_subtask_tools()}
-        assert names == set()
+        assert _tool_names(agent.tools) == set()
 
     async def test_explicit_disabled_actor_has_no_subtask_tools(self) -> None:
         """Explicit ``tasks=False`` also suppresses subtask tools."""
         agent = Agent("disabled", tasks=False)
 
-        names = {t.schema.function.name for t in agent._build_subtask_tools()}
-        assert names == set()
+        assert _tool_names(agent.tools) == set()
 
     async def test_taskconfig_actor_has_subtask_tools(self) -> None:
         """Passing ``tasks=TaskConfig(...)`` opts in to the auto-injected subtask tools."""
         agent = Agent("enabled", tasks=TaskConfig())
 
-        names = {t.schema.function.name for t in agent._build_subtask_tools()}
-        assert names == {"run_subtask", "run_subtasks"}
+        assert _tool_names(agent.tools) == {"run_subtask", "run_subtasks"}
 
 
 @pytest.mark.asyncio
@@ -632,33 +641,26 @@ class TestSubtaskInheritance:
             tasks=TaskConfig(config=sub_config, exclude_tools=["secret_tool"]),
         )
 
-        # Reach the spawn path directly so we can inspect what the subtask sees.
-        parent_ctx = _make_parent_context()
-        # Trigger _spawn_subtask via the wrapped tool; capture spawned agent.
-        spawned_actors: list[Agent] = []
-        original_spawn = parent._spawn_subtask
+        # Capture the bare child Agent the real ``_spawn_subtask`` hands to
+        # ``run_task`` (rather than reconstructing the spawn logic), then assert
+        # on the tools it actually inherited.
+        captured: list[Agent] = []
+        original = run_task_mod.run_task
 
-        async def capture_spawn(task: str, ctx: Context) -> str:
-            # Reconstruct the spawn manually so we can intercept the bare agent.
-            tc = parent._task_config
-            assert tc is not None
-            inherited = [t for t in parent.tools if t.schema.function.name not in set(tc.exclude_tools)]
-            bare = Agent(
-                name="captured",
-                prompt=tc.prompt,
-                config=tc.config,
-                tools=inherited,
-                tasks=False,
-            )
-            spawned_actors.append(bare)
-            return await original_spawn(task, ctx)
+        async def capturing_run_task(agent, *args, **kwargs):
+            captured.append(agent)
+            return await original(agent, *args, **kwargs)
 
-        parent._spawn_subtask = capture_spawn  # type: ignore[assignment]
-        await parent.ask("go", stream=parent_ctx.stream)
+        run_task_mod.run_task = capturing_run_task
+        actor_mod._run_task = capturing_run_task
+        try:
+            await parent.ask("go", stream=MemoryStream())
+        finally:
+            run_task_mod.run_task = original
+            actor_mod._run_task = original
 
-        # The captured subtask agent must not have secret_tool.
-        assert spawned_actors, "subtask must have been spawned"
-        names = {t.schema.function.name for t in spawned_actors[0].tools}
+        assert captured, "subtask must have been spawned"
+        names = _tool_names(captured[0].tools)
         assert "secret_tool" not in names
         assert "public_tool" in names
 
@@ -732,8 +734,8 @@ class TestSubtaskNoRecursion:
     async def test_child_has_no_subtask_tools(self) -> None:
         """A subtask Agent never gets ``run_subtask`` — recursion impossible.
 
-        Spawn a subtask, capture the bare child Agent, and assert its
-        ``_subtask_tools`` is empty regardless of what the parent has.
+        Spawn a subtask, capture the bare child Agent, and assert it has
+        no tools regardless of what the parent has.
         """
         sub_config = TestConfig(ModelResponse(ModelMessage("Done.")))
         parent = Agent(
@@ -765,7 +767,7 @@ class TestSubtaskNoRecursion:
         child = captured[0]
         # The child Agent has zero subtask tools and zero ``_task_config``.
         assert child._task_config is None
-        assert child._build_subtask_tools() == []
+        assert not child.tools
 
 
 @pytest.mark.asyncio
@@ -849,7 +851,8 @@ def test_run_subtask_description_advertises_parallel_invocation() -> None:
     blocks in one assistant message rather than serializing them.
     """
     agent = Agent("any", tasks=TaskConfig())
-    [run_subtask, run_subtasks] = agent._build_subtask_tools()
+    [toolkit] = agent.tools
+    [run_subtask, run_subtasks] = toolkit.tools
 
     desc = run_subtask.schema.function.description
     assert "parallel" in desc.lower()

--- a/test/beta/tools/test_task.py
+++ b/test/beta/tools/test_task.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from autogen.beta import Agent, Context, MemoryStream, Usage, UsageReport, Variable, tool
+from autogen.beta import Agent, Context, MemoryStream, Variable, tool
 from autogen.beta import agent as actor_mod
 from autogen.beta.agent import TaskConfig
 from autogen.beta.events import (
@@ -21,12 +21,14 @@ from autogen.beta.events import (
     TaskStarted,
     ToolCallEvent,
     ToolCallsEvent,
+    Usage,
     UsageEvent,
 )
 from autogen.beta.testing import TestConfig
 from autogen.beta.tools.subagents import run_task as run_task_mod
 from autogen.beta.tools.subagents import subagent_tool
 from autogen.beta.tools.subagents.run_task import run_task
+from autogen.beta.usage import UsageReport
 
 
 def _make_parent_context(

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -82,6 +82,13 @@ def greet(name: str) -> str:  # highlighted
 ```
 ````
 
+**Maintaining `hl_lines`** — these line numbers are easy to break:
+
+- **Line numbers are 1-indexed from the first code line** — the line immediately after the opening ```` ``` ```` fence is line `1`. The fence itself is not counted, and the count is independent of what `linenums="1"` starts the *displayed* numbering at.
+- **Recompute `hl_lines` whenever you edit a block.** Inserting or removing a line shifts every range below it, so an unrelated edit silently mis-highlights. After editing, re-count from the first code line and update the ranges.
+- **Highlight the lines that carry the point** — the construction, the call, the changed lines. Do not highlight blank lines, lone closing brackets, or unrelated imports; a range that includes them is a sign the numbers have drifted.
+- **Verify before committing.** Open the block, count to each highlighted line, and confirm it lands on what the surrounding prose says it does.
+
 ### Code Examples
 
 - Examples should be self-contained: a reader should be able to copy-paste and run them.

--- a/website/docs/beta/evaluation/evaluation.mdx
+++ b/website/docs/beta/evaluation/evaluation.mdx
@@ -20,8 +20,8 @@ The framework supports both. You can wrap eval metrics in pytest assertions ("pa
 
 Every eval suite has four pieces. That's it.
 
-1. A **dataset** — a suite of tasks with inputs and (optional) expected outputs.
-2. An **agent** — an `Agent` instance, or a factory that builds a fresh one per task.
+1. A **dataset** — a `Suite` of tasks with inputs and (optional) expected outputs.
+2. An **agent** — an `Agent` instance.
 3. One or more **scorers** — functions that grade a run.
 4. A call to **run_agent** — the framework's entry point.
 
@@ -34,36 +34,35 @@ The rest of these docs cover each piece in depth. Read the quick-start below fir
 
 The simplest plausible eval. Two tasks, one custom scorer, one prebuilt.
 
-```python linenums="1" hl_lines="13-15 17-19 22-24 26-32"
+```python linenums="1" hl_lines="12-17 24-28 31-33 37-45"
 import asyncio
 from pathlib import Path
 
 from autogen.beta import Agent, tool
 from autogen.beta.config import GeminiConfig
 from autogen.beta.events import ToolCallEvent
-from autogen.beta.eval import run_agent, scorer
+from autogen.beta.eval import Suite, run_agent, scorer
 from autogen.beta.eval.scorers import tool_called
 
 
-# 1. Dataset — inline list (or load from JSONL)
-dataset = [
+# 1. Dataset — inline tasks (or Suite.from_jsonl("tasks.jsonl"))
+dataset = Suite.from_list([
     {"task_id": "t1", "inputs": {"input": "What's the weather in Tokyo?"},
      "reference_outputs": {"city": "Tokyo"}},
     {"task_id": "t2", "inputs": {"input": "Weather in Paris?"},
      "reference_outputs": {"city": "Paris"}},
-]
+])
 
-# 2. Agent factory — a fresh agent per task
+# 2. Agent — one instance, reused across tasks
 @tool
 async def get_weather(city: str) -> str:
     return f"Sunny, 72F in {city}"
 
-def build_agent(*, config=None):
-    return Agent(
-        "weather",
-        config=config or GeminiConfig(model="gemini-3-flash-preview"),
-        tools=[get_weather],
-    )
+agent = Agent(
+    "weather",
+    config=GeminiConfig(model="gemini-3-flash-preview"),
+    tools=[get_weather],
+)
 
 # 3. Scorer — a plain function with @scorer
 @scorer
@@ -74,7 +73,7 @@ def called_get_weather(trace) -> bool:
 async def main():
     result = await run_agent(
         dataset,
-        agent=build_agent,
+        agent=agent,
         scorers=[
             called_get_weather,
             tool_called("get_weather"),  # prebuilt
@@ -119,7 +118,7 @@ cassettes = {
 
 result = await run_agent(
     dataset,
-    agent=build_agent,
+    agent=agent,
     scorers=[called_get_weather],
     model_config=cassettes,  # dict keyed by task_id
     store_dir=Path("./runs"),

--- a/website/docs/beta/evaluation/getting-started.mdx
+++ b/website/docs/beta/evaluation/getting-started.mdx
@@ -117,17 +117,13 @@ You don't want pre-merge CI calling a live model — slow, costly, flaky. Swap t
 ```python linenums="1"
 from autogen.beta.testing import TestConfig
 
-
-def build(*, config=None):
-    return Agent("geographer", prompt="Answer with the capital city.", config=config)
-
-
+# Same agent as Step 1 — a canned reply per task_id
 canned = {"france": TestConfig("Paris"), "japan": TestConfig("Tokyo")}
 
-result = await run_agent(suite, agent=build, scorers=scorers, model_config=canned, store_dir="./runs")
+result = await run_agent(suite, agent=agent, scorers=scorers, model_config=canned, store_dir="./runs")
 ```
 
-Two things changed. The agent is now a **factory** (`build`) so the runner can hand each task its own config, and `model_config` supplies the canned replies keyed by `task_id`. (A single fixed config can stay a plain instance, as in Step 1; per-task configs need the factory.) Same suite, same scorers, identical output on every machine — wrap `result.pass_rate(...)` in a `pytest` assertion and you have a CI gate.
+One thing changed: `model_config` supplies the canned replies keyed by `task_id`. It's passed through to `ask`, which **overrides** the agent's own config for that task — so the same `agent` from Step 1 runs deterministically with no API key, no separate build needed. Same suite, same scorers, identical output on every machine — wrap `result.pass_rate(...)` in a `pytest` assertion and you have a CI gate.
 
 ## Where to next
 

--- a/website/docs/beta/evaluation/pairwise.mdx
+++ b/website/docs/beta/evaluation/pairwise.mdx
@@ -13,8 +13,8 @@ from autogen.beta.eval.scorers import pairwise_judge
 
 result = await run_pairwise(
     suite,
-    variant_a=build_v1,
-    variant_b=build_v2,
+    variant_a=agent_v1,
+    variant_b=agent_v2,
     comparators=[pairwise_judge(config, criterion="more helpful answer", key="quality")],
     store_dir="runs",
 )
@@ -45,8 +45,8 @@ from autogen.beta.eval.scorers import human_pairwise
 
 result = await run_pairwise(
     suite,
-    variant_a=build_v1,
-    variant_b=build_v2,
+    variant_a=agent_v1,
+    variant_b=agent_v2,
     comparators=[human_pairwise(key="quality")],   # prompts in the terminal, per task
     store_dir="runs",
 )

--- a/website/docs/beta/evaluation/persistence.mdx
+++ b/website/docs/beta/evaluation/persistence.mdx
@@ -17,7 +17,7 @@ Every `run_agent()` writes a JSON file to `store_dir/<run_id>.json` before retur
   "created_at": "2026-05-11T14:23:00+00:00",
   "duration_ms": 5292,
   "suite": { "name": "dataset", "size": 5, "source": "eval/dataset.jsonl" },
-  "target": "weather_agent.agent:build_weather_agent",
+  "target": "autogen.beta.agent:Agent",
   "concurrency": 4,
   "tasks": [
     {
@@ -95,7 +95,7 @@ Then every iteration follows the same loop: **run → compare to the last → ac
 
 ```python linenums="1"
 result = await run_agent(
-    suite, agent=build_v1, scorers=SCORERS,
+    suite, agent=agent_v1, scorers=SCORERS,
     store_dir="runs/blog-writer", run_id="v1", label="first cut",
 )
 print(result.summary())
@@ -111,7 +111,7 @@ You tweak the prompt to always end with a call to action, and re-run against the
 from autogen.beta.eval import load_run
 
 current = await run_agent(
-    suite, agent=build_v2, scorers=SCORERS,
+    suite, agent=agent_v2, scorers=SCORERS,
     store_dir="runs/blog-writer", run_id="v2", label="add CTA",
 )
 print(current.diff(load_run("runs/blog-writer/v1.json")).summary())
@@ -127,7 +127,7 @@ Later you swap to a cheaper model and re-run:
 
 ```python linenums="1"
 current = await run_agent(
-    suite, agent=build_v3, scorers=SCORERS,
+    suite, agent=agent_v3, scorers=SCORERS,
     store_dir="runs/blog-writer", run_id="v3", label="cheaper model",
 )
 diff = current.diff(load_run("runs/blog-writer/v2.json"))

--- a/website/docs/beta/evaluation/runs.mdx
+++ b/website/docs/beta/evaluation/runs.mdx
@@ -64,31 +64,26 @@ suite = Suite.from_list([
 
 Same shape as JSONL lines. Use this in notebooks or for ad-hoc suites that don't deserve a file yet.
 
-## The agent — an instance or a factory
+## The agent — an `Agent` instance
 
-`run_agent(agent=...)` accepts either a built **agent instance** or a **factory** that builds one:
+`run_agent(agent=...)` takes a built **`Agent` instance**, reused across every task. Each task runs on a fresh stream, so conversation history never leaks between tasks — agents are effectively stateless across `ask` calls (history lives on the per-call stream), so reusing one instance is safe for any normal agent.
 
-- **An instance** is the simplest path — `agent=my_agent`. The runner reuses it across tasks, but each task gets a fresh stream, so conversation history never leaks. Fine for any stateless agent (i.e. most agents).
-- **A factory** (a callable returning a fresh agent) is what you want when you need a clean instance per task — for per-task `model_config` injection (cassette-based CI), or for an agent that carries mutable instance state (e.g. a knowledge bootstrap). The runner calls it once per task.
+```python linenums="1"
+from autogen.beta import Agent
+from autogen.beta.config import GeminiConfig
 
-```python linenums="1" hl_lines="6 11"
-from autogen.beta import Agent, tool
-from autogen.beta.config import GeminiConfig, ModelConfig
-
-
-def build_weather_agent(*, config: ModelConfig | None = None) -> Agent:
-    return Agent(
-        "weather",
-        prompt="You are a weather assistant. Use get_weather.",
-        config=config or GeminiConfig(model="gemini-3-flash-preview"),
-        tools=[get_weather],
-    )
+weather_agent = Agent(
+    "weather",
+    prompt="You are a weather assistant. Use get_weather.",
+    config=GeminiConfig(model="gemini-3-flash-preview"),
+    tools=[get_weather],
+)
 ```
 
-The `config=` keyword is what the runner uses to inject either a live `ModelConfig` (when you pass `model_config=` to `run_agent()`) or a `TestConfig` cassette for deterministic CI. A factory without a `config=` parameter still works — the runner warns and falls through to the factory's default.
+Need a different model per task — a live `ModelConfig`, or a `TestConfig` cassette for deterministic CI? Pass `model_config=` to `run_agent()`; it is forwarded to `ask` and **overrides** the agent's own config for that task. One instance covers the whole suite — no per-task rebuild, no factory.
 
 !!! note "Multi-agent flows go through `evaluate_traces`"
-    `run_agent` is for an ask-shaped target — an `Agent` (or a factory of one). Multi-agent / network / workflow flows aren't driven by a single `ask(prompt)`, so they don't go through `run_agent`. Run them however they run — they emit OpenTelemetry spans — and grade the reconstructed trace with `evaluate_traces`. Grading is decoupled from production via the `Trace`, so the same scorers work either way.
+    `run_agent` is for an ask-shaped target — an `Agent`. Multi-agent / network / workflow flows aren't driven by a single `ask(prompt)`, so they don't go through `run_agent`. Run them however they run — they emit OpenTelemetry spans — and grade the reconstructed trace with `evaluate_traces`. Grading is decoupled from production via the `Trace`, so the same scorers work either way.
 
 ## Running
 
@@ -98,10 +93,10 @@ The `config=` keyword is what the runner uses to inject either a live `ModelConf
 from autogen.beta.eval import BudgetThresholds, run_agent
 
 result = await run_agent(
-    suite,                                 # Suite, str/Path (JSONL), or list[dict]
-    agent=build_weather_agent,
+    suite,                                 # a Suite, or a bare str (single-prompt suite)
+    agent=weather_agent,
     scorers=[...],                         # list of Scorer instances
-    store_dir=Path("./runs"),              # required — where the JSON lands
+    store_dir=Path("./runs"),              # optional — where the JSON lands (omit to skip persisting)
     model_config=cassettes,                # optional — None / ModelConfig / dict[task_id, ModelConfig]
     budgets=BudgetThresholds(              # optional — observational, doesn't abort
         max_tokens_per_task=2_000,
@@ -123,8 +118,8 @@ The same parameter is overloaded three ways:
 
 | Value | Behavior |
 |---|---|
-| `#!python None` (default) | Factory's default config wins. |
-| A single `ModelConfig` | Same config for every task. |
+| `#!python None` (default) | The agent's own config is used. |
+| A single `ModelConfig` | Same config for every task (overrides the agent's). |
 | A `#!python dict[task_id, ModelConfig]` | Per-task config. Standard pattern for cassette-based CI. |
 
 ### Repeats — consistency
@@ -132,7 +127,7 @@ The same parameter is overloaded three ways:
 `repeats=N` runs **each task N times** — the simplest way to ask "does my agent do this *consistently*?". The per-key `pass_rate` / `score_stats` pool across every run (so 8 of 10 passing shows as `80%`), and each run gets a distinct `task_id` suffix (`"weather-001#1"`, `"weather-001#2"`, …).
 
 ```python
-result = await run_agent(suite, agent=build_weather_agent, scorers=[...], store_dir="runs", repeats=10)
+result = await run_agent(suite, agent=weather_agent, scorers=[...], store_dir="runs", repeats=10)
 ```
 
 (At `temperature=0` consistency is near-trivial; `repeats` earns its keep when there's real nondeterminism.)
@@ -164,7 +159,7 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 result = await run_agent(
-    suite, agent=build_weather_agent, scorers=[...], store_dir="runs",
+    suite, agent=weather_agent, scorers=[...], store_dir="runs",
     run_id="evalrun_abc", variant="v3", label="checkout-suite",
     span_attributes={"ag2.org.id": org_id},                   # stamped on every span
     span_processors=[BatchSpanProcessor(OTLPSpanExporter())],  # also export to your backend
@@ -315,8 +310,7 @@ The framework catches exceptions at three levels and records them on the task in
 
 | Level | What happens |
 |---|---|
-| Target factory raises | Task gets `trace.exception = <the error>`, no events. Other tasks continue. |
-| `agent.ask()` raises | Same — exception lands on `trace.exception`, other tasks continue. |
+| `agent.ask()` raises | The exception lands on `trace.exception` (no events), and other tasks continue. |
 | A scorer raises | The scorer's feedback becomes `Feedback(score=None, comment="scorer raised: ...")`. Other scorers run normally. |
 
 The aggregate count of agent-level errors surfaces in `result.aggregates.errors`. Treat it as a CI signal — a healthy suite has zero.

--- a/website/docs/beta/evaluation/scorers.mdx
+++ b/website/docs/beta/evaluation/scorers.mdx
@@ -129,7 +129,7 @@ Six ship under `autogen.beta.eval.scorers`. Four are simple, deterministic check
 
 Each is a *factory* — calling it returns a `Scorer`. Drop them straight into the `scorers=` list:
 
-```python linenums="1" hl_lines="3-6"
+```python linenums="1" hl_lines="8-13"
 from autogen.beta.eval.scorers import (
     final_answer_matches,
     no_tool_errors,

--- a/website/docs/beta/evaluation/variants.mdx
+++ b/website/docs/beta/evaluation/variants.mdx
@@ -7,18 +7,19 @@ To answer "which is best?" — across models, prompts, tools, middleware, or who
 
 ## `run_variants`
 
-A `Variants` is a *single-axis* set, built with a typed `from_*` constructor:
+A `Variants` is a mapping of name → `Agent` instance, plus an `axis` label that records what you varied:
 
 ```python linenums="1"
+from autogen.beta import Agent
 from autogen.beta.config import GeminiConfig, OpenAIConfig
 from autogen.beta.eval import Variants, run_variants
 
 board = await run_variants(
     suite,
-    variants=Variants.from_configs(build_weather_agent, {
-        "gpt-4o": OpenAIConfig("gpt-4o"),
-        "flash":  GeminiConfig("gemini-3-flash-preview"),
-    }),
+    variants=Variants({
+        "gpt-4o": Agent("weather", config=OpenAIConfig("gpt-4o"), tools=[get_weather]),
+        "flash":  Agent("weather", config=GeminiConfig("gemini-3-flash-preview"), tools=[get_weather]),
+    }, axis="config"),
     scorers=[...],
     store_dir="runs",
     repeats=5,                                # optional — N runs per variant for stability
@@ -31,15 +32,24 @@ board.results["gpt-4o"]                        # each variant's full RunResult
 
 ## One axis at a time
 
-Each `from_*` constructor fixes one axis and types its values, so a single call only varies one thing — a controlled comparison (vary one axis, hold the rest fixed):
+`Variants` holds prebuilt agents, so you vary whatever you like by constructing them accordingly. For a controlled comparison, vary **one** axis across the agents and hold the rest fixed — then set `axis=` to label what changed (it shows up in `summary()`; it defaults to `"variant"`):
 
-| Constructor | Varies | Value type |
+| Axis | Vary across the agents | `axis=` |
 |---|---|---|
-| `Variants.from_configs(factory, {...})` | model / provider / params | `ModelConfig` |
-| `Variants.from_prompts(factory, {...})` | system prompt | `str` |
-| `Variants.from_tools(factory, {...})` | tool set | `Sequence[Tool]` |
-| `Variants.from_middleware(factory, {...})` | middleware stack | `Sequence[MiddlewareFactory]` |
-| `Variants.from_targets({...})` | the whole build | a factory or instance each |
+| model / provider / params | `config=` | `"config"` |
+| system prompt | `prompt=` | `"prompt"` |
+| tool set | `tools=` | `"tools"` |
+| middleware stack | `middleware=` | `"middleware"` |
+
+```python linenums="1"
+# Vary the system prompt, hold everything else fixed.
+variants = Variants({
+    "terse":   Agent("a", prompt="Answer in one word.", config=cfg, tools=tools),
+    "verbose": Agent("a", prompt="Explain, then answer.", config=cfg, tools=tools),
+}, axis="prompt")
+```
+
+Need a per-task model override *within* a variant? Pass `model_config=` to `run_variants` exactly as with `run_agent` — it reaches each variant's `run_agent` call.
 
 Each variant runs via `run_agent()` (so `repeats`, persistence, everything applies) and is saved as its own `<run_id>-<variant>.json`. `VariantRunResult.leaderboard(key)` ranks variants by a scorer — pass-rate for boolean scorers, mean for numeric — best first; **tied scores share a rank**, and `best(key)` returns `None` when there's no unique winner. (A 3-way 100% tie usually means the eval isn't *discriminating* — make the task harder, or score quality with a judge — not that there's a true winner.)
 

--- a/website/docs/beta/resume.mdx
+++ b/website/docs/beta/resume.mdx
@@ -1,0 +1,167 @@
+---
+title: Resuming a Turn
+sidebarTitle: Resuming
+---
+
+`agent.ask(...)` starts a turn from a new message on the agent's current stream. `agent.resume(...)` does the same job from a **recorded trajectory**: you hand it a list of past events, and it re-enters the agent loop driven by the **last** event in that list. The trigger can be *any* event (a fresh user message, a tool result, a human reply) so `resume` is the general way to rebuild a conversation from stored state and carry it forward.
+
+!!! tip "Most multi-turn chats do **not** need `resume`"
+    To continue a conversation within a running process, just keep using the reply: call `agent.ask(...)` once, then `reply.ask(...)` for each follow-up. That is the normal continuation path — `resume` is **not** a step you run after `ask`.
+
+    ```python linenums="1"
+    reply = await agent.ask("Plan a trip to Kyoto.")
+    reply = await reply.ask("Make it five days.")   # continue — no resume needed
+    ```
+
+    Reach for `resume` only when you **can't** hold onto that reply: the process ended, another worker picks the turn up, or you need to drive the loop from a non-message event such as a tool result. See [How it relates to `ask` / `reply.ask`](#how-resume-works) below.
+
+## How `resume` works
+
+`resume` takes the full trajectory as positional `events`:
+
+```python
+await agent.resume(*events, ...)
+```
+
+The list is split in two:
+
+- **All events except the last** seed the stream's history — the conversation state the model will see.
+- **The last event** is the **trigger**: the event that drives the next LLM call. It can be any [event](/docs/beta/advanced/stream) — typically a `ModelRequest` (a new user message) or a `ToolResultsEvent` (a tool result the model should react to).
+
+```python linenums="1"
+*history, trigger = events
+# history  -> replaces the stream's history (the prefix the model sees)
+# trigger  -> drives the next LLM call (any BaseEvent)
+```
+
+Everything after that is identical to `ask`: the agent calls the model, may issue tool calls, and returns an `AgentReply`. The `resume` signature mirrors `ask` exactly — `stream`, `dependencies`, `variables`, `prompt`, `config`, `tools`, `middleware`, `observers`, `response_schema`, and `hitl_hook` all behave the same way.
+
+!!! note "How it relates to `ask` / `reply.ask`"
+    [`reply.ask(...)`](/docs/beta/agents) continues the **same live stream** the turn ran on — you keep the conversation going as long as you still hold the `AgentReply` object in the running process. That stream may itself be durable (a `RedisStream`, say); what `reply.ask` needs is the in-process handle, not where the history happens to be stored. `resume` is for when you no longer have that handle — a process restart, a worker on another machine, a turn rebuilt from a store — so you supply the events yourself and drive the next one.
+
+## Continue a stored conversation
+
+The most common use is multi-turn that outlives the process: persist a conversation, load it back later, and continue with a new user message as the trigger.
+
+```python linenums="1" hl_lines="12 15-16"
+from autogen.beta import Agent
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.events import ModelRequest, TextInput
+
+agent = Agent(
+    "assistant",
+    prompt="You are a helpful travel assistant.",
+    config=OpenAIConfig("gpt-4o-mini"),
+)
+
+# A conversation you stored earlier and just loaded back from your database.
+past_events = load_conversation("thread-42")
+
+# Drive the next turn with a fresh user message as the trigger.
+trigger = ModelRequest([TextInput("And what about getting there by train?")])
+reply = await agent.resume(*past_events, trigger)
+print(reply.body)
+```
+
+This is `reply.ask("...")`, except you drive it from events you reload yourself rather than from a live `AgentReply` handle held in the running process.
+
+## Resume from a tool result
+
+A turn can also stop **mid-loop** — the model asked to run a tool whose result is produced elsewhere: a webhook, a queue worker, a long-running job, or a human approving a request. You record the tool call, run the work separately, then hand the result back as the trigger. The model reacts to the result without the tool being re-executed.
+
+```python linenums="1" hl_lines="18 25 28"
+from autogen.beta import Agent
+from autogen.beta.config import OpenAIConfig
+from autogen.beta.events import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    ToolCallEvent,
+    ToolCallsEvent,
+    ToolResultEvent,
+    ToolResultsEvent,
+)
+
+agent = Agent("support", prompt="Answer using the tool result.", config=OpenAIConfig("gpt-4o-mini"))
+
+# The trajectory recorded earlier: the user asked, and the model responded
+# by requesting a tool call (whose result is not yet known).
+call = ToolCallEvent(name="lookup_order", arguments='{"id": "A-1001"}', id="call-1")
+history = [
+    ModelRequest([TextInput("Where is order A-1001?")]),
+    ModelResponse(message=ModelMessage(""), tool_calls=ToolCallsEvent([call])),
+]
+
+# The tool result, produced out of band, becomes the trigger.
+trigger = ToolResultsEvent([ToolResultEvent.from_call(call, "Shipped, arriving Tuesday.")])
+
+# Re-enter the loop: the model sees the history + result and writes the answer.
+reply = await agent.resume(*history, trigger)
+print(reply.body)  # -> grounded answer using "Shipped, arriving Tuesday."
+```
+
+`ToolResultEvent.from_call(call, result)` pairs the result with the original call so the model can match it to its request. Because `resume` re-enters the **live** loop, the model is free to react by calling more tools — those continuation calls execute normally; only the trigger event is replayed.
+
+## Capture, persist, resume
+
+A trajectory is just a list of events, so you can store it anywhere and pass it back to `resume` later — even from another process. Pull the events from a live stream with `await stream.history.get_events()`, or build them yourself, as long as the prefix ends at the point you want to continue from.
+
+```python linenums="1" hl_lines="2 7"
+# --- First process: capture the trajectory and persist it ---
+events = list(await reply.context.stream.history.get_events())
+save_to_store(stream_id="thread-42", events=events)
+
+# --- Later / another process: load it back and drive the next event ---
+events = load_from_store(stream_id="thread-42")
+reply = await agent.resume(*events, ModelRequest([TextInput("Carry on.")]))
+print(reply.body)
+```
+
+!!! note "Reading back the event log"
+    `resume` reads only the events you pass in — it does not load history from a store on its own. The [event log](/docs/beta/advanced/knowledge_store) written by `KnowledgeConfig(write_event_log=True)` is one place these trajectories can come from: it persists each turn to `/log/{stream_id}.jsonl`, and `EventLogWriter(store).load(stream_id)` reads it back as typed events ready to pass straight to `resume`.
+
+    ```python linenums="1"
+    from autogen.beta.knowledge import EventLogWriter
+
+    events = await EventLogWriter(store).load(stream_id)
+    reply = await agent.resume(*events, ModelRequest([TextInput("Carry on.")]))
+    ```
+
+## The stream is replaced, not appended
+
+`resume` **replaces** the target stream's history with the seeded prefix. If you omit `stream`, a fresh `MemoryStream` is created. If you pass an existing stream, any history it already held is discarded in favour of the trajectory you provide.
+
+```python linenums="1" hl_lines="7"
+from autogen.beta.stream import MemoryStream
+
+stream = MemoryStream()
+await stream.history.replace([ModelRequest([TextInput("stale prior turn")])])
+
+# The stale turn is dropped; only the events you pass remain.
+reply = await agent.resume(*history, trigger, stream=stream)
+```
+
+This makes the recorded trajectory the single source of truth for the resumed turn — the events you pass are exactly what the model sees.
+
+!!! warning "Durable-backed streams are overwritten in place"
+    The replacement is applied to the stream's **storage**, not just an in-memory copy. For a persistent stream such as `RedisStream`, seeding the prefix overwrites the durable history stored under that stream id — the backing store clears the key and rewrites it. Resume into a fresh stream, or use a new stream id, when you need to keep the original conversation's stored history intact.
+
+## Caveats — resuming isn't always possible
+
+`resume` replays provider-native events back to the model, and some providers attach opaque, **required** metadata to those events. Gemini 3.x, for example, binds a *thought signature* to each function call and rejects a replayed call that arrives without it:
+
+```
+400 INVALID_ARGUMENT — Function call is missing a thought_signature in functionCall parts
+```
+
+OpenAI reasoning items and Anthropic thinking signatures carry similar provider-specific state. As long as you resume from the **original** events — the ones the agent emitted, written verbatim by the [event log](#capture-persist-resume) — this metadata travels with them and `resume` round-trips cleanly. The risk appears when a trajectory is rebuilt from a lossy form: a hand-rolled `{name, args, result}` record, or a trace store that keeps only the fields it understands. The required metadata is silently dropped, and the provider rejects the resumed turn.
+
+!!! warning
+    Resuming is not guaranteed for every provider and every trajectory. Preserve the events exactly as the agent emitted them; do not assume a trajectory reconstructed from a reduced or normalized form can be resumed.
+
+## Related
+
+- [Agent Communication](/docs/beta/agents) — `ask` / `reply.ask`, the in-memory entry points.
+- [Human in the Loop](/docs/beta/context/human_in_the_loop) — pausing for human input, a common reason a turn is continued out of band.
+- [Stream & Events](/docs/beta/advanced/stream) — the event types that make up a trajectory and how to subscribe to them.

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -368,6 +368,7 @@
         "docs/beta/motivation",
         "docs/beta/agents",
         "docs/beta/agent_harness",
+        "docs/beta/resume",
         "docs/beta/structured_output",
         {
           "group": "Models & Providers",


### PR DESCRIPTION
## Why are these changes needed?

Adds a `resume` method on Agent (and a new `_drive` method internally to handle both the common `ask` and `resume` paths). This `resume` method allows resumption from a specific event, such as a tool result.

@Lancetnik can you please review. I believe the current `ask` was intended to support resumption and it may be better not to have a separate method like `resume`.

If we proceed with this, then I'll add documentation. 

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
