### PR TITLE
style(beta/bedrock): collapse nested if statements (ruff SIM102)

### DIFF
--- a/autogen/beta/config/bedrock/bedrock_client.py
+++ b/autogen/beta/config/bedrock/bedrock_client.py
@@ -176,9 +176,10 @@ class BedrockClient(LLMClient):
         text_parts: list[str] = []
         calls: list[ToolCallEvent] = []
         for block in content_blocks:
-            if reasoning := block.get("reasoningContent"):
-                if reasoning_text := (reasoning.get("reasoningText") or {}).get("text"):
-                    await context.send(ModelReasoning(reasoning_text))
+            if (reasoning := block.get("reasoningContent")) and (
+                reasoning_text := (reasoning.get("reasoningText") or {}).get("text")
+            ):
+                await context.send(ModelReasoning(reasoning_text))
 
             if text := block.get("text"):
                 text_parts.append(text)
@@ -235,12 +236,12 @@ class BedrockClient(LLMClient):
                 if text := delta.get("text"):
                     full_content += text
                     await context.send(ModelMessageChunk(text))
-                if reasoning := delta.get("reasoningContent"):
-                    if reasoning_text := reasoning.get("text"):
-                        await context.send(ModelReasoning(reasoning_text))
-                if tool_use := delta.get("toolUse"):
-                    if (acc := tool_accs.get(block_delta["contentBlockIndex"])) is not None:
-                        acc["arguments"] += tool_use.get("input") or ""
+                if (reasoning := delta.get("reasoningContent")) and (reasoning_text := reasoning.get("text")):
+                    await context.send(ModelReasoning(reasoning_text))
+                if (tool_use := delta.get("toolUse")) and (
+                    acc := tool_accs.get(block_delta["contentBlockIndex"])
+                ) is not None:
+                    acc["arguments"] += tool_use.get("input") or ""
 
             elif block_stop := event.get("contentBlockStop"):
                 if (acc := tool_accs.pop(block_stop["contentBlockIndex"], None)) is not None:

--- a/autogen/beta/config/bedrock/mappers.py
+++ b/autogen/beta/config/bedrock/mappers.py
@@ -229,9 +229,8 @@ def convert_messages(
             for r in message.results:
                 if r.parent_id:
                     resolved_tool_ids.add(r.parent_id)
-        elif isinstance(message, (ToolResultEvent, ToolErrorEvent)):
-            if message.parent_id:
-                resolved_tool_ids.add(message.parent_id)
+        elif isinstance(message, (ToolResultEvent, ToolErrorEvent)) and message.parent_id:
+            resolved_tool_ids.add(message.parent_id)
 
     # Pre-populate from wrappers so the loose-leaf fallback below doesn't
     # double-emit a toolResult that a later ToolResultsEvent also carries.


### PR DESCRIPTION
## Why are these changes needed?

`pre-commit` (ruff **SIM102**) failed on the Bedrock provider client: two spots used nested `if` statements where a single combined condition is clearer and equivalent. This PR collapses them, so `pre-commit run --all-files` passes cleanly.

Changes (no behavior change — pure readability/lint fix):

- `autogen/beta/config/bedrock/bedrock_client.py` — `_process_completion` and `_process_stream`: merged nested `reasoningContent` / `toolUse` guards into single `and`-combined conditions.
- `autogen/beta/config/bedrock/mappers.py` — folded the `ToolResultEvent`/`ToolErrorEvent` `parent_id` check into the `elif`.
