### PR TITLE
fix(beta/events): preserve falsy non-Field defaults on events

### DIFF
--- a/autogen/beta/events/base.py
+++ b/autogen/beta/events/base.py
@@ -117,6 +117,9 @@ class _ConditionMeta(type):
         return TypeCondition(cls).not_()
 
 
+_MISSING = object()
+
+
 def _process_fields(cls: type) -> None:
     """Process annotations and set up Field descriptors for a class."""
     fields: dict[str, Field] = {}
@@ -130,8 +133,8 @@ def _process_fields(cls: type) -> None:
 
     own_namespace = vars(cls)
     for field_name in annotations:
-        raw = own_namespace.get(field_name)
-        if not raw:
+        raw = own_namespace.get(field_name, _MISSING)
+        if raw is _MISSING:
             field = Field()
         elif isinstance(raw, Field):
             field = raw

--- a/test/beta/events/test_field.py
+++ b/test/beta/events/test_field.py
@@ -27,6 +27,27 @@ class TestFieldBasics:
         obj = Event()
         assert obj.a == "1"
 
+    def test_event_with_falsy_value_field(self):
+        # A plain (non-Field) default that is falsy must still be applied;
+        # 0 / False / "" / () are real defaults, not "no default".
+        class Event(BaseEvent):
+            count: int = 0
+            flag: bool = False
+            label: str = ""
+            items: tuple = ()
+
+        obj = Event()
+        assert obj.count == 0
+        assert obj.flag is False
+        assert obj.label == ""
+        assert obj.items == ()
+
+    def test_falsy_value_field_is_serialized(self):
+        class Event(BaseEvent):
+            count: int = 0
+
+        assert Event().to_dict()["count"] == 0
+
     def test_event_with_default_field(self):
         class Event(BaseEvent):
             a: str = Field("1")


### PR DESCRIPTION
When a `BaseEvent` subclass declares a field with a plain (non-`Field`) default, `_process_fields` decides whether it is a real default with `if not raw:`. That test cannot distinguish "no default given" from "the default is a falsy value", so any falsy default (`0`, `False`, `""`, `()`) is silently discarded and the field ends up with no default at all.

Real events hit this today:

- `ModelResponse.response_force: bool = False`
- `CompactionCompleted.llm_calls: int = 0`
- `AggregationCompleted.llm_calls: int = 0`

Reading these on an instance constructed without the field returns `None` instead of the declared default, which:

- drops the field from `to_dict()` (it is never set on the instance), and
- raises `TypeError` on arithmetic, e.g. `event.llm_calls + 1` -> `unsupported operand type(s) for +: 'NoneType' and 'int'`.

Reproduction on `main`:

```python
from autogen.beta.events.types import ModelResponse
from autogen.beta.events.lifecycle import CompactionCompleted

ModelResponse().response_force                       # None  (declared False)
c = CompactionCompleted(agent="a", strategy="s", events_before=2, events_after=1)
c.llm_calls                                          # None  (declared 0)
c.llm_calls + 1                                      # TypeError
"llm_calls" in c.to_dict()                           # False
```

## Fix

Look the value up with a sentinel and only fall back to a bare `Field()` when the attribute is genuinely absent. A present-but-falsy value is wrapped in `Field(value)` like any other value default, so its default is preserved. Annotation-only fields (no class-body value) still become required `Field()` as before, and `Field(...)`/`default_factory` declarations are untouched.

## Testing

- Added regression tests in `test/beta/events/test_field.py` covering falsy value defaults (`0`, `False`, `""`, `()`) and their serialization.
- `pytest test/beta/events/` — 145 passed.
- Full `pytest test/beta/` — 2789 passed, 242 skipped, 1 xfailed (2 unrelated failures are local-env only: the sandbox/skills tests need a `python` binary on PATH; this box only has `python3`).