### PR TITLE
fix(beta/config/openai): drop unreachable FileIdInput branch in completions mapper

### DIFF
--- a/autogen/beta/config/openai/mappers.py
+++ b/autogen/beta/config/openai/mappers.py
@@ -349,13 +349,6 @@ def convert_messages(
                     else:
                         raise UnsupportedInputError(f"BinaryInput({inp.kind.value})", "openai-completions")
 
-                elif isinstance(inp, FileIdInput):
-                    raise UnsupportedInputError(
-                        "FileIdInput is not supported by OpenAI Chat Completions API. "
-                        "Use OpenAIResponsesConfig instead of OpenAIConfig to work with file uploads.",
-                        "openai-completions",
-                    )
-
                 else:
                     raise UnsupportedInputError(type(inp).__name__, "openai-completions")
 


### PR DESCRIPTION
In `convert_messages` (the OpenAI Chat Completions path), `FileIdInput` is already mapped to a `{"type": "file", "file": {"file_id": ...}}` content part:

```python
elif isinstance(inp, FileIdInput):
    parts.append({"type": "file", "file": {"file_id": inp.file_id}})
```

A second `elif isinstance(inp, FileIdInput)` appears later in the same `if/elif` chain and raises `UnsupportedInputError`. Because the first branch always matches first, the second one is unreachable. Worse, its message claims the opposite of what the code does:

```python
elif isinstance(inp, FileIdInput):
    raise UnsupportedInputError(
        "FileIdInput is not supported by OpenAI Chat Completions API. "
        "Use OpenAIResponsesConfig instead of OpenAIConfig to work with file uploads.",
        "openai-completions",
    )
```

This dead-but-contradictory branch is a hazard: a future edit that reorders or trims the chain could act on a false "not supported" claim and break working `file_id` inputs.

## Fix

Remove the unreachable `FileIdInput` branch. The supported mapping earlier in the chain is unchanged, so behavior is identical.

## Testing

- No behavior change; the removed branch was never executed.
- `pytest test/beta/config/openai/` — 157 passed. `TestFileIdInput` (completions + responses) still passes, confirming `file_id` mapping is intact.