### PR TITLE
fix(docs): reserve sidebar scrollbar gutter so it doesn't overlap content

### DIFF
--- a/website/mkdocs/docs/stylesheets/extra.css
+++ b/website/mkdocs/docs/stylesheets/extra.css
@@ -695,3 +695,12 @@ height: 100%;
 border: 0;
 }
 /* User Story Page Ends */
+
+/* Reserve space for the sidebar scrollbar so classic (non-overlay) scrollbars
+   don't paint over the navigation/content. Only applies at the desktop
+   breakpoint where the sidebars are shown. */
+@media screen and (min-width: 76.25em) {
+    .md-sidebar__scrollwrap {
+        scrollbar-gutter: stable;
+    }
+}


### PR DESCRIPTION
## Problem
  The sidebar scrollbar overlaps the navigation/content with classic (non-overlay)
  scrollbars (#2306).

  ## Fix
  Add `scrollbar-gutter: stable` to the sidebar scroll container
  (`.md-sidebar__scrollwrap`) at the desktop breakpoint (`min-width: 76.25em`),
  reserving space so the scrollbar no longer paints over content.

  ## Notes
  Same approach as ag2ai/ag2#2516, which a maintainer approved but which was closed because
  its author couldn't sign the CLA ("please reopen if you can sign it"). Reopening
  with the CLA signed. CSS-only change.

  Fixes ag2ai/ag2classic#16.