### PR TITLE
fix(beta/config/gemini): concatenate multi-part text in non-streaming response

### DIFF
--- a/autogen/beta/config/gemini/gemini_client.py
+++ b/autogen/beta/config/gemini/gemini_client.py
@@ -141,7 +141,7 @@ class GeminiClient(LLMClient):
         response: types.GenerateContentResponse,
         context: "ConversationContext",
     ) -> ModelResponse:
-        model_msg: ModelMessage | None = None
+        full_content: str = ""
         calls: list[ToolCallEvent] = []
 
         for candidate in response.candidates or ():
@@ -151,8 +151,7 @@ class GeminiClient(LLMClient):
                     if part.thought and part.text:
                         await context.send(ModelReasoning(part.text))
                     elif part.text:
-                        model_msg = ModelMessage(part.text)
-                        await context.send(model_msg)
+                        full_content += part.text
                     elif part.function_call:
                         fc = part.function_call
                         calls.append(
@@ -185,6 +184,11 @@ class GeminiClient(LLMClient):
                 await context.send(
                     GeminiServerToolResultEvent.from_grounding(grounding, parent_id=gnd_call.id, name=name)
                 )
+
+        model_msg: ModelMessage | None = None
+        if full_content:
+            model_msg = ModelMessage(full_content)
+            await context.send(model_msg)
 
         usage = Usage()
         if response.usage_metadata:

--- a/test/beta/config/gemini/test_empty_text_parts.py
+++ b/test/beta/config/gemini/test_empty_text_parts.py
@@ -105,3 +105,57 @@ class TestProcessResponseSkipsEmptyTextParts:
         await client._process_response(response, ctx)
 
         assert [e for e in captured if isinstance(e, ModelMessage)] == []
+
+
+@pytest.mark.asyncio
+class TestProcessResponseConcatenatesTextParts:
+    """Regression: Gemini may split one answer across multiple ``Part(text=...)``.
+
+    A thinking model answering a ``response_schema`` call sometimes returns the
+    JSON object across several text parts. ``_process_response`` must concatenate
+    them into one ``ModelMessage`` — keeping only the last part drops the opening
+    ``{...`` prefix and feeds a tail slice (often starting at a ``[`` quoted in the
+    text) to the schema validator, raising a spurious ``json_invalid``.
+    """
+
+    async def test_multiple_text_parts_concatenated(
+        self,
+        client: GeminiClient,
+        memory_context: tuple[Context, MemoryStream, list[BaseEvent]],
+    ) -> None:
+        ctx, _, captured = memory_context
+        # JSON answer split mid-string; the second part begins at a ``[`` the
+        # model quoted inside ``reasoning``.
+        response = _response([
+            _candidate([
+                types.Part(text='{"mode": "A.5", "reasoning": "cut off at (\''),
+                types.Part(text="[util/env'), premature termination.\"}"),
+            ])
+        ])
+
+        result = await client._process_response(response, ctx)
+
+        expected = '{"mode": "A.5", "reasoning": "cut off at (\'[util/env\'), premature termination."}'
+        assert result.content == expected
+        assert [e for e in captured if isinstance(e, ModelMessage)] == [ModelMessage(expected)]
+
+    async def test_text_parts_concatenated_around_thought(
+        self,
+        client: GeminiClient,
+        memory_context: tuple[Context, MemoryStream, list[BaseEvent]],
+    ) -> None:
+        ctx, _, captured = memory_context
+        # A thought part interleaved between answer parts must not break the join.
+        response = _response([
+            _candidate([
+                types.Part(text="thinking...", thought=True),
+                types.Part(text='{"a": 1, '),
+                types.Part(text='"b": 2}'),
+            ])
+        ])
+
+        result = await client._process_response(response, ctx)
+
+        assert result.content == '{"a": 1, "b": 2}'
+        assert [e for e in captured if isinstance(e, ModelReasoning)] == [ModelReasoning("thinking...")]
+        assert [e for e in captured if isinstance(e, ModelMessage)] == [ModelMessage('{"a": 1, "b": 2}')]


### PR DESCRIPTION
## Why are these changes needed?

Gemini's non-streaming response handler kept only the last text part instead of concatenating them, so when a thinking model split a `response_schema` JSON answer across multiple parts the opening `{...` was dropped and a tail slice (often starting at a `[` quoted in the reasoning) reached the validator — this concatenates all text parts like the streaming path already does, eliminating the intermittent spurious `json_invalid` ValidationError.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
