### PR TITLE
fix(beta): keep tool cycles intact during compaction and render CompactionSummary correctly

### DIFF
--- a/autogen/beta/compact.py
+++ b/autogen/beta/compact.py
@@ -20,7 +20,14 @@ from fast_depends.pydantic import PydanticSerializer
 from autogen.beta.annotations import Context
 from autogen.beta.config import ModelConfig
 from autogen.beta.context import ConversationContext
-from autogen.beta.events import BaseEvent, ModelRequest, UsageEvent
+from autogen.beta.events import (
+    BaseEvent,
+    ModelRequest,
+    ModelResponse,
+    ToolResultEvent,
+    ToolResultsEvent,
+    UsageEvent,
+)
 from autogen.beta.stream import MemoryStream
 
 from .knowledge import EventLogWriter, KnowledgeStore
@@ -63,6 +70,27 @@ class CompactStrategy(Protocol):
         ...
 
 
+def _retained_is_self_contained(events: list[BaseEvent], cut: int) -> bool:
+    """True when no tool result in events[cut:] references a dropped tool call."""
+    have: set[str] = set()
+    need: set[str] = set()
+    for event in events[cut:]:
+        if isinstance(event, ModelResponse):
+            have.update(call.id for call in event.tool_calls.calls)
+        elif isinstance(event, ToolResultsEvent):
+            need.update(r.parent_id for r in event.results if r.parent_id)
+        elif isinstance(event, ToolResultEvent) and event.parent_id:
+            need.add(event.parent_id)
+    return need <= have
+
+
+def _snap_to_turn_boundary(events: list[BaseEvent], cut: int) -> int:
+    """Advance `cut` so a tool-cycle split by the boundary compacts whole."""
+    while cut < len(events) and not _retained_is_self_contained(events, cut):
+        cut += 1
+    return cut
+
+
 @dataclass(slots=True)
 class CompactTrigger:
     """Deterministic conditions for triggering compaction.
@@ -94,8 +122,12 @@ class TailWindowCompact:
         if len(events) <= self._target:
             return events
 
-        dropped = events[: -self._target]
-        retained = events[-self._target :]
+        cut = _snap_to_turn_boundary(events, len(events) - self._target)
+        dropped = events[:cut]
+        retained = events[cut:]
+
+        if not retained:
+            return events
 
         if store:
             writer = EventLogWriter(store)
@@ -131,8 +163,12 @@ class SummarizeCompact:
         if len(events) <= self._target:
             return events
 
-        old = events[: -self._target]
-        recent = events[-self._target :]
+        cut = _snap_to_turn_boundary(events, len(events) - self._target)
+        old = events[:cut]
+        recent = events[cut:]
+
+        if not recent:
+            return events
 
         # Persist full old events before dropping
         if store:

--- a/autogen/beta/config/anthropic/mappers.py
+++ b/autogen/beta/config/anthropic/mappers.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from fast_depends.library.serializer import SerializerProto
 
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.config.anthropic.events import AnthropicServerToolCallEvent, AnthropicServerToolResultEvent
 from autogen.beta.events import (
     BaseEvent,
@@ -457,6 +458,10 @@ def convert_messages(
                 else:
                     content = content_parts
                 result.append({"role": "user", "content": content})
+
+        elif isinstance(message, CompactionSummary):
+            # Surface the summary as a user turn so it stays visible and gives a valid opening turn
+            result.append({"role": "user", "content": f"[Summary of earlier conversation]\n{message.summary}"})
 
         elif isinstance(message, (ToolResultEvent, ToolErrorEvent)):
             # Fallback path — an individual result event without a

--- a/autogen/beta/config/bedrock/mappers.py
+++ b/autogen/beta/config/bedrock/mappers.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from fast_depends.library.serializer import SerializerProto
 
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.events import (
     BaseEvent,
     BinaryInput,
@@ -286,6 +287,10 @@ def convert_messages(
         elif isinstance(message, ModelRequest):
             blocks = [_input_to_block(inp, serializer) for inp in message.parts]
             _append_blocks(result, "user", blocks)
+
+        elif isinstance(message, CompactionSummary):
+            # Surface the summary as a user turn so it stays visible and gives a valid opening turn
+            _append_blocks(result, "user", [{"text": f"[Summary of earlier conversation]\n{message.summary}"}])
 
         elif isinstance(message, (ToolResultEvent, ToolErrorEvent)):
             # Loose result whose ToolResultsEvent wrapper never persisted.

--- a/autogen/beta/config/dashscope/mappers.py
+++ b/autogen/beta/config/dashscope/mappers.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from fast_depends.library.serializer import SerializerProto
 
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.events import (
     BaseEvent,
     BinaryInput,
@@ -90,6 +91,10 @@ def convert_messages(
                 result.append({"role": "user", "content": blocks[0]["text"]})
             else:
                 result.append({"role": "user", "content": blocks})
+
+        elif isinstance(message, CompactionSummary):
+            # Surface the summary as a user turn so it stays visible and gives a valid opening turn
+            result.append({"role": "user", "content": f"[Summary of earlier conversation]\n{message.summary}"})
 
         elif isinstance(message, ModelResponse):
             result.append(message.to_api())

--- a/autogen/beta/config/gemini/mappers.py
+++ b/autogen/beta/config/gemini/mappers.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 from fast_depends.library.serializer import SerializerProto
 from google.genai import types
 
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.events import (
     BaseEvent,
     BinaryInput,
@@ -296,6 +297,11 @@ def convert_messages(
 
             if parts:
                 result.append(types.Content(role="user", parts=parts))
+
+        elif isinstance(message, CompactionSummary):
+            # Surface the summary as a user turn so it stays visible and gives a valid opening turn
+            summary = types.Part.from_text(text=f"[Summary of earlier conversation]\n{message.summary}")
+            result.append(types.Content(role="user", parts=[summary]))
 
     return result
 

--- a/autogen/beta/config/ollama/mappers.py
+++ b/autogen/beta/config/ollama/mappers.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from fast_depends.library.serializer import SerializerProto
 
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.events import (
     BaseEvent,
     BinaryInput,
@@ -90,6 +91,10 @@ def convert_messages(
                     result[-1]["images"] = images
                 else:
                     result.append({"role": "user", "content": "", "images": images})
+
+        elif isinstance(message, CompactionSummary):
+            # Surface the summary as a user turn so it stays visible and gives a valid opening turn
+            result.append({"role": "user", "content": f"[Summary of earlier conversation]\n{message.summary}"})
 
         elif isinstance(message, ModelResponse):
             msg: dict[str, Any] = {

--- a/autogen/beta/config/openai/mappers.py
+++ b/autogen/beta/config/openai/mappers.py
@@ -10,6 +10,7 @@ from fast_depends.library.serializer import SerializerProto
 from openai.types import CompletionUsage
 from openai.types.responses import ResponseUsage
 
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.config.openai.events import OpenAIReasoningEvent, OpenAIServerToolCallEvent
 from autogen.beta.events import (
     BaseEvent,
@@ -272,6 +273,11 @@ def events_to_responses_input(
                 else:
                     raise UnsupportedInputError(type(inp).__name__, "openai-responses")
 
+        elif isinstance(message, CompactionSummary):
+            # Surface the summary as a user turn so it stays visible and gives a valid opening turn
+            text = f"[Summary of earlier conversation]\n{message.summary}"
+            result.append({"role": "user", "content": [{"type": "input_text", "text": text}]})
+
     return result
 
 
@@ -357,6 +363,10 @@ def convert_messages(
                 result.append({"role": "user", "content": parts[0]["text"]})
             else:
                 result.append({"role": "user", "content": parts})
+
+        elif isinstance(message, CompactionSummary):
+            # Surface the summary as a user turn so it stays visible and gives a valid opening turn
+            result.append({"role": "user", "content": f"[Summary of earlier conversation]\n{message.summary}"})
 
     return result
 

--- a/autogen/beta/config/xai/mappers.py
+++ b/autogen/beta/config/xai/mappers.py
@@ -33,6 +33,7 @@ from xai_sdk.chat import (
 )
 from xai_sdk.proto import usage_pb2
 
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.events import (
     BaseEvent,
     BinaryInput,
@@ -302,6 +303,10 @@ def convert_messages(
         elif isinstance(message, ModelRequest):
             contents: list[chat_pb2.Content] = [_content_from_input(p, serializer) for p in message.parts]
             result.append(user(*contents))
+
+        elif isinstance(message, CompactionSummary):
+            # Surface the summary as a user turn so it stays visible and gives a valid opening turn
+            result.append(user(f"[Summary of earlier conversation]\n{message.summary}"))
 
     return result, responses
 

--- a/test/beta/config/anthropic/test_convert_messages.py
+++ b/test/beta/config/anthropic/test_convert_messages.py
@@ -19,6 +19,7 @@ from dirty_equals import IsPartialDict
 from fast_depends.use import SerializerCls
 
 from autogen.beta import ToolResult
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.config.anthropic.events import AnthropicServerToolCallEvent, AnthropicServerToolResultEvent
 from autogen.beta.config.anthropic.mappers import convert_messages
 from autogen.beta.events import (
@@ -871,3 +872,11 @@ def test_hallucinated_tool_call_maps_with_error_text() -> None:
             ],
         }
     ]
+
+
+def test_compaction_summary_renders_as_user_turn() -> None:
+    summary = CompactionSummary(summary="Looked up Paris and Tokyo.", event_count=6)
+
+    result = convert_messages([summary], SerializerCls)
+
+    assert result == [{"role": "user", "content": "[Summary of earlier conversation]\nLooked up Paris and Tokyo."}]

--- a/test/beta/config/bedrock/test_convert_messages.py
+++ b/test/beta/config/bedrock/test_convert_messages.py
@@ -6,6 +6,7 @@ import pytest
 from fast_depends.use import SerializerCls
 
 from autogen.beta import ToolResult
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.config.bedrock.mappers import convert_messages
 from autogen.beta.events import (
     BinaryInput,
@@ -335,3 +336,13 @@ class TestOrphanFiltering:
             "role": "user",
             "content": [{"toolResult": {"toolUseId": "tc_1", "content": [{"text": "ok"}]}}],
         }
+
+
+def test_compaction_summary_renders_as_user_turn() -> None:
+    summary = CompactionSummary(summary="Looked up Paris and Tokyo.", event_count=6)
+
+    result = convert_messages([summary], SerializerCls)
+
+    assert result == [
+        {"role": "user", "content": [{"text": "[Summary of earlier conversation]\nLooked up Paris and Tokyo."}]}
+    ]

--- a/test/beta/config/dashscope/test_convert_messages.py
+++ b/test/beta/config/dashscope/test_convert_messages.py
@@ -8,6 +8,7 @@ import pytest
 from fast_depends.use import SerializerCls
 
 from autogen.beta import ToolResult
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.config.dashscope.mappers import convert_messages
 from autogen.beta.events import (
     AudioInput,
@@ -168,3 +169,11 @@ def test_hallucinated_tool_call_maps_with_error_text() -> None:
             "content": "autogen.beta.exceptions.ToolNotFoundError: Tool `ghost_tool` not found\n",
         }
     ]
+
+
+def test_compaction_summary_renders_as_user_turn() -> None:
+    summary = CompactionSummary(summary="Looked up Paris and Tokyo.", event_count=6)
+
+    result = convert_messages([], [summary], SerializerCls)
+
+    assert result == [{"role": "user", "content": "[Summary of earlier conversation]\nLooked up Paris and Tokyo."}]

--- a/test/beta/config/gemini/test_convert_messages.py
+++ b/test/beta/config/gemini/test_convert_messages.py
@@ -7,6 +7,7 @@ from fast_depends.use import SerializerCls
 from google.genai import types
 
 from autogen.beta import ToolResult
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.config.gemini.events import (
     GeminiServerToolCallEvent,
     GeminiServerToolResultEvent,
@@ -507,3 +508,31 @@ def test_hallucinated_tool_call_maps_with_error_text() -> None:
             }
         ],
     }
+
+
+class TestConvertMessagesCompactionSummary:
+    """A CompactionSummary must render as a user turn so the summary stays visible
+    and gives a valid opening turn (Gemini rejects a non-user first turn)."""
+
+    def test_summary_renders_as_user_text(self) -> None:
+        summary = CompactionSummary(summary="Earlier the user configured the project.", event_count=12)
+
+        [content] = convert_messages([summary], SerializerCls)
+
+        assert content.model_dump(exclude_none=True) == {
+            "role": "user",
+            "parts": [{"text": "[Summary of earlier conversation]\nEarlier the user configured the project."}],
+        }
+
+    def test_summary_leads_a_tool_cycle_with_a_user_turn(self) -> None:
+        summary = CompactionSummary(summary="Looked up Paris and Tokyo.", event_count=6)
+        call = ToolCallEvent(id="c9", name="get_weather", arguments='{"city": "NYC"}')
+        events = [
+            summary,
+            ModelResponse(tool_calls=ToolCallsEvent(calls=[call])),
+            ToolResultsEvent(results=[ToolResultEvent(parent_id="c9", name="get_weather", result=ToolResult("21C"))]),
+        ]
+
+        contents = convert_messages(events, SerializerCls)
+
+        assert contents[0].role == "user"

--- a/test/beta/config/ollama/test_convert_messages.py
+++ b/test/beta/config/ollama/test_convert_messages.py
@@ -8,6 +8,7 @@ import pytest
 from dirty_equals import IsPartialDict
 from fast_depends.use import SerializerCls
 
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.config.ollama.mappers import convert_messages
 from autogen.beta.events import (
     AudioInput,
@@ -172,3 +173,11 @@ def test_hallucinated_tool_call_maps_with_error_text() -> None:
     assert result == [
         {"role": "tool", "content": "autogen.beta.exceptions.ToolNotFoundError: Tool `ghost_tool` not found\n"}
     ]
+
+
+def test_compaction_summary_renders_as_user_turn() -> None:
+    summary = CompactionSummary(summary="Looked up Paris and Tokyo.", event_count=6)
+
+    result = convert_messages([], [summary], SerializerCls)
+
+    assert result == [{"role": "user", "content": "[Summary of earlier conversation]\nLooked up Paris and Tokyo."}]

--- a/test/beta/config/openai/test_convert_messages.py
+++ b/test/beta/config/openai/test_convert_messages.py
@@ -9,6 +9,7 @@ from dirty_equals import IsPartialDict
 from fast_depends.use import SerializerCls
 
 from autogen.beta import ToolResult
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.config.openai.mappers import convert_messages, events_to_responses_input
 from autogen.beta.events import (
     AudioInput,
@@ -619,3 +620,14 @@ def test_completions_hallucinated_tool_call_maps_with_error_text() -> None:
             "content": "autogen.beta.exceptions.ToolNotFoundError: Tool `ghost_tool` not found\n",
         },
     ]
+
+
+def test_compaction_summary_renders_as_user_turn() -> None:
+    summary = CompactionSummary(summary="Looked up Paris and Tokyo.", event_count=6)
+    text = "[Summary of earlier conversation]\nLooked up Paris and Tokyo."
+
+    completions = convert_messages([], [summary], SerializerCls)
+    assert completions[-1] == {"role": "user", "content": text}
+
+    responses = events_to_responses_input([summary], SerializerCls)
+    assert responses == [{"role": "user", "content": [{"type": "input_text", "text": text}]}]

--- a/test/beta/config/xai/test_convert_messages.py
+++ b/test/beta/config/xai/test_convert_messages.py
@@ -9,6 +9,7 @@ from fast_depends.use import SerializerCls
 from xai_sdk.chat import chat_pb2
 
 from autogen.beta import ToolResult
+from autogen.beta.compact import CompactionSummary
 from autogen.beta.config.xai.events import XAIAssistantEvent
 from autogen.beta.config.xai.mappers import convert_messages
 from autogen.beta.events import (
@@ -241,3 +242,13 @@ class TestAssistantRoundTrip:
         assert msg.role == chat_pb2.ROLE_ASSISTANT
         assert _content_texts(msg) == ["Hi"]
         assert replays == []
+
+
+def test_compaction_summary_renders_as_user_turn() -> None:
+    summary = CompactionSummary(summary="Looked up Paris and Tokyo.", event_count=6)
+
+    [msg], replays = convert_messages([], [summary], SerializerCls)
+
+    assert msg.role == chat_pb2.ROLE_USER
+    assert _content_texts(msg) == ["[Summary of earlier conversation]\nLooked up Paris and Tokyo."]
+    assert replays == []

--- a/test/beta/test_compact.py
+++ b/test/beta/test_compact.py
@@ -17,6 +17,11 @@ from autogen.beta.events import (
     ModelRequest,
     ModelResponse,
     TextInput,
+    ToolCallEvent,
+    ToolCallsEvent,
+    ToolResult,
+    ToolResultEvent,
+    ToolResultsEvent,
 )
 from autogen.beta.knowledge import MemoryKnowledgeStore
 from autogen.beta.stream import MemoryStream
@@ -63,6 +68,62 @@ class TestTailWindowCompact:
         ctx = Context(stream=MemoryStream())
         result = await compact.compact(events, ctx, None)
         assert len(result) == 3
+
+
+def _cycle(cid: str, name: str = "t") -> tuple[ModelResponse, ToolResultsEvent]:
+    """A (ModelResponse tool call, ToolResultsEvent) pair linked by id."""
+    call = ToolCallEvent(id=cid, name=name, arguments="{}")
+    mr = ModelResponse(tool_calls=ToolCallsEvent(calls=[call]))
+    res = ToolResultsEvent(results=[ToolResultEvent(parent_id=cid, name=name, result=ToolResult("ok"))])
+    return mr, res
+
+
+@pytest.mark.asyncio
+class TestTailWindowToolCycleBoundary:
+    """A tool-call/result cycle must never be split across the compaction
+    boundary — a retained orphan result would crash strict providers."""
+
+    async def test_split_cycle_compacts_whole(self) -> None:
+        mr, res = _cycle("c1")
+        events = [
+            ModelRequest([TextInput("u0")]),
+            mr,
+            res,
+            ModelRequest([TextInput("u1")]),
+            ModelResponse(ModelMessage("done")),
+        ]
+        # target=3 would cut between the call and its result
+        result = await TailWindowCompact(target=3).compact(events, Context(stream=MemoryStream()), None)
+        assert result == [events[3], events[4]]
+
+    async def test_clean_cycle_boundary_kept(self) -> None:
+        mr, res = _cycle("c1")
+        events = [ModelRequest([TextInput("u0")]), mr, res]
+        result = await TailWindowCompact(target=2).compact(events, Context(stream=MemoryStream()), None)
+        assert result == [mr, res]
+
+    async def test_split_second_of_chained_cycles(self) -> None:
+        mr1, res1 = _cycle("c1")
+        mr2, res2 = _cycle("c2")
+        events = [mr1, res1, mr2, res2, ModelResponse(ModelMessage("end"))]
+        # target=2 would cut between the second call and its result
+        result = await TailWindowCompact(target=2).compact(events, Context(stream=MemoryStream()), None)
+        assert result == [events[4]]
+
+    async def test_split_cycle_persisted_whole(self) -> None:
+        store = MemoryKnowledgeStore()
+        mr, res = _cycle("c1")
+        events = [
+            ModelRequest([TextInput("u0")]),
+            mr,
+            res,
+            ModelRequest([TextInput("u1")]),
+            ModelResponse(ModelMessage("done")),
+        ]
+        result = await TailWindowCompact(target=3).compact(events, Context(stream=MemoryStream()), store)
+        assert mr not in result and res not in result
+        entries = await store.list("/log/")
+        assert [e for e in entries if "dropped" in e]
 
 
 class TestCompactionSummary:

--- a/website/docs/beta/advanced/compaction.mdx
+++ b/website/docs/beta/advanced/compaction.mdx
@@ -101,6 +101,9 @@ retained = await compact.compact(events, ctx, store)
 
 The summarization model is independent from the agent's main model — pick a smaller / cheaper one. Token usage is recorded on the strategy instance as `#!python strategy.last_usage`.
 
+!!! note
+    Both built-ins snap the retained boundary to whole turns: a tool call and its result are never split. A tool cycle straddling the boundary is compacted as a unit, so the retained window can be slightly smaller than `target`. This keeps the retained history valid for providers that reject a tool result with no preceding call.
+
 ## CompactionSummary
 
 The synthetic event inserted by `SummarizeCompact` at the head of history.
@@ -114,7 +117,7 @@ summary = CompactionSummary(
 )
 ```
 
-`CompactionSummary` is on the allowlist of [`ConversationPolicy`](/docs/beta/advanced/assembly#conversationpolicy), so it passes through the assembly chain and reaches the LLM as context — without requiring special handling elsewhere.
+`CompactionSummary` is on the allowlist of [`ConversationPolicy`](/docs/beta/advanced/assembly#conversationpolicy), so it survives the assembly chain. Each provider mapper then renders it as a user turn, so the summary reaches the LLM as visible context at the head of history.
 
 ## Wiring onto an Agent
 


### PR DESCRIPTION
## Why are these changes needed?

History compaction had two latent defects that this PR fixes.

First, every provider mapper silently dropped the `CompactionSummary` event, so the summary that `SummarizeCompact` pays an LLM call to produce never reached the model, the compacted context was effectively lost, and on Gemini it additionally caused a `400 INVALID_ARGUMENT` because the rendered request then began with a non-user turn (a tool call or an orphaned tool result), which the API rejects.

Second, both built-in strategies (`TailWindowCompact` and `SummarizeCompact`) sliced the retained window by raw event count, which could split a `ModelResponse(tool_calls=...)` from its `ToolResultsEvent` and leave an orphaned tool result at the head of history. The fix renders `CompactionSummary` as a leading user turn in every provider mapper so the summary is visible to the model and supplies a valid opening turn, and snaps the compaction boundary to whole turns so a tool call and its results are always compacted as a unit and a retained window never starts on an orphaned result.

The behaviour is verified by unit tests for every provider mapper plus the compaction strategies, and confirmed live end-to-end against Gemini, OpenAI (Chat Completions and Responses), Anthropic, xAI, and Ollama.

## Model providers updated

- Gemini
- OpenAI (Chat Completions and Responses APIs)
- Anthropic
- Amazon Bedrock
- xAI (Grok)
- DashScope (Qwen)
- Ollama

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
