### PR TITLE
fix(nlip): require nlip-server>=0.1.3 to drop the fastapi<0.116 transitive pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,7 @@ ddgs = ["ddgs>=9.0.0,<10"]
 tavily = ["tavily-python>=0.7.4,<0.8"]
 perplexity = ["perplexityai>=0.30.0,<1"]
 
-nlip = ["nlip-sdk>=0.1.0, <1", "nlip-server>=0.1.0, <1"]
+nlip = ["nlip-sdk>=0.1.0, <1", "nlip-server>=0.1.3, <1"]
 
 ## dev dependencies
 


### PR DESCRIPTION
## Problem

The `nlip` extra pulled in `nlip-server` versions that carried a transitive `fastapi<0.116` pin (#2894), constraining FastAPI for the whole environment.

## Fix

`nlip-server` 0.1.3 widened its constraint to `fastapi[standard]>=0.115,<1`, removing the cap at the source. This bumps the `nlip` extra's floor to `nlip-server>=0.1.3` so the resolver cannot fall back to an older `0.1.x` that still carries the narrow pin.

One line, no vendored code. This supersedes the earlier approach of inlining the server — thanks to @ash-jyc for the upstream release.

Closes #2894.
