### PR TITLE
docs(beta): collapse double blank lines in code blocks and fix highlights

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -91,7 +91,8 @@ def greet(name: str) -> str:  # highlighted
 - **No double blank lines in the block.** Two or more consecutive blanks are collapsed at render time (see the warning above), which shifts every highlight below them. Confirm the block has only single blank-line separators before trusting any `hl_lines`.
 - **Line numbers are 1-indexed from the first code line** — the line immediately after the opening ```` ``` ```` fence is line `1`. The fence itself is not counted, and the count is independent of what `linenums="1"` starts the *displayed* numbering at.
 - **Recompute `hl_lines` whenever you edit a block.** Inserting or removing a line shifts every range below it, so an unrelated edit silently mis-highlights. After editing, re-count from the first code line and update the ranges.
-- **Highlight the lines that carry the point** — the construction, the call, the changed lines. Do not highlight blank lines, lone closing brackets, or unrelated imports; a range that includes them is a sign the numbers have drifted.
+- **Highlight the lines that carry the point** — the construction, the call, the changed lines. Do not highlight blank lines or unrelated imports; a range that includes them is a sign the numbers have drifted.
+- **Keep brackets balanced.** A highlight group must not open a bracket it doesn't close. If a highlighted line opens a multi-line `(`/`[`/`{`, either extend the range through its matching closing line (highlight the whole construct, closing bracket included) **or** highlight only the lines *inside* the brackets (excluding both the opener and the closer). A range that ends on a dangling open bracket — or a lone closing bracket with no matching open in the same group — renders as a visually unbalanced block.
 - **Verify before committing.** Open the block, count to each highlighted line, and confirm it lands on what the surrounding prose says it does.
 
 ### Code Examples

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -54,6 +54,10 @@ Code blocks use MkDocs Material syntax with these attributes:
 - **Line numbers**: add `linenums="1"` to show numbered lines.
 - **Line highlighting**: add `hl_lines="..."` to highlight specific lines. Supports single lines (`"6"`), multiple lines (`"4 9 15"`), and ranges (`"15-18"`). Can be combined (`"3-6 8"`).
 
+!!! warning "Single blank lines only — MkDocs collapses consecutive blanks"
+
+    MkDocs Material **collapses two or more consecutive blank lines inside a code block to a single blank line** when it renders. The source still counts every blank, so any `hl_lines` you author against the source silently mis-highlights once rendered — every highlighted line below a collapsed run shifts up. **Never put two or more blank lines in a row inside a code example.** Keep all code blocks to single blank-line separators so the source line numbers match the rendered output and `hl_lines` stays accurate. (This includes PEP 8's two-blank-lines-between-top-level-defs convention — use one blank line in docs examples.)
+
 Examples:
 
 ````
@@ -84,6 +88,7 @@ def greet(name: str) -> str:  # highlighted
 
 **Maintaining `hl_lines`** — these line numbers are easy to break:
 
+- **No double blank lines in the block.** Two or more consecutive blanks are collapsed at render time (see the warning above), which shifts every highlight below them. Confirm the block has only single blank-line separators before trusting any `hl_lines`.
 - **Line numbers are 1-indexed from the first code line** — the line immediately after the opening ```` ``` ```` fence is line `1`. The fence itself is not counted, and the count is independent of what `linenums="1"` starts the *displayed* numbering at.
 - **Recompute `hl_lines` whenever you edit a block.** Inserting or removing a line shifts every range below it, so an unrelated edit silently mis-highlights. After editing, re-count from the first code line and update the ranges.
 - **Highlight the lines that carry the point** — the construction, the call, the changed lines. Do not highlight blank lines, lone closing brackets, or unrelated imports; a range that includes them is a sign the numbers have drifted.

--- a/website/docs/beta/a2a/advanced.mdx
+++ b/website/docs/beta/a2a/advanced.mdx
@@ -9,7 +9,7 @@ Topics that aren't part of the day-to-day A2A path: human-in-the-loop, transpare
 
 When a server-side executor raises `#!python requires_input(...)` mid-task, the A2A server transitions the task to `#!python TASK_STATE_INPUT_REQUIRED` and surfaces the prompt to the client. The AG2 client invokes the local agent's `#!python hitl_hook` with the prompt and continues the same turn with the reply — the server prompt does **not** leak into the final response text.
 
-```python linenums="1" hl_lines="2 4 10"
+```python linenums="1" hl_lines="4-5 10"
 from autogen.beta import Agent
 from autogen.beta.a2a import A2AConfig
 
@@ -35,7 +35,7 @@ Streaming connections drop. Network blips, load balancer recycles, idle timeouts
 
 The A2A client keeps internal drive state across drops: on `#!python A2AClientError` mid-stream it issues a fresh `#!python subscribe` against the same `#!python task_id`, deduplicates artifacts already seen by `#!python artifact_id` (and messages by `#!python message_id`), and continues from where it failed. Application code sees a single uninterrupted reply.
 
-```python linenums="1" hl_lines="6-8"
+```python linenums="1" hl_lines="6-7"
 remote = Agent(
     "remote",
     config=A2AConfig(
@@ -97,7 +97,7 @@ Catch `#!python A2ATaskTerminalError` to handle any terminal failure uniformly; 
 
 `#!python autogen.beta.a2a.testing` provides utilities for in-process A2A tests — no real socket, no port binding.
 
-```python linenums="1" hl_lines="4 7"
+```python linenums="1" hl_lines="6-7"
 from autogen.beta import Agent
 from autogen.beta.a2a import A2AConfig, A2AServer
 from autogen.beta.a2a.testing import make_test_client_factory

--- a/website/docs/beta/a2a/advanced.mdx
+++ b/website/docs/beta/a2a/advanced.mdx
@@ -9,14 +9,12 @@ Topics that aren't part of the day-to-day A2A path: human-in-the-loop, transpare
 
 When a server-side executor raises `#!python requires_input(...)` mid-task, the A2A server transitions the task to `#!python TASK_STATE_INPUT_REQUIRED` and surfaces the prompt to the client. The AG2 client invokes the local agent's `#!python hitl_hook` with the prompt and continues the same turn with the reply — the server prompt does **not** leak into the final response text.
 
-```python linenums="1" hl_lines="2-4 9"
+```python linenums="1" hl_lines="2 4 10"
 from autogen.beta import Agent
 from autogen.beta.a2a import A2AConfig
 
-
 async def hitl_hook() -> str:
     return input("server asks input> ")
-
 
 remote = Agent(
     "remote",
@@ -61,11 +59,10 @@ When attempts are exhausted the client raises `#!python A2AReconnectError(attemp
 
 `#!python A2AServer` defaults to wrapping the supplied `#!python Agent` in AG2's standard `#!python AgentExecutor`. When you need behaviour that doesn't fit `#!python Agent.ask` — a HITL-first turn, a multi-agent pipeline, a non-standard task lifecycle — drop in your own executor:
 
-```python linenums="1" hl_lines="1 4-9 11"
+```python linenums="1" hl_lines="1 5-7 9-10 12"
 from a2a.server.agent_execution import AgentExecutor as A2AAgentExecutorBase
 
 from autogen.beta.a2a import A2AServer
-
 
 class MyExecutor(A2AAgentExecutorBase):
     async def execute(self, request_context, event_queue) -> None:
@@ -73,7 +70,6 @@ class MyExecutor(A2AAgentExecutorBase):
 
     async def cancel(self, request_context, event_queue) -> None:
         ...
-
 
 server = A2AServer(agent_stub, executor=MyExecutor())
 ```

--- a/website/docs/beta/a2a/client.mdx
+++ b/website/docs/beta/a2a/client.mdx
@@ -11,7 +11,6 @@ sidebarTitle: Client
 from autogen.beta import Agent
 from autogen.beta.a2a import A2AConfig
 
-
 async def main() -> None:
     remote = Agent(
         "remote",
@@ -58,18 +57,16 @@ The remote agent recovers the entire prior context on every turn — there is no
 
 Tools declared on the **client** are advertised to the server in the AG2 client-tools extension. When the remote LLM picks one, the call is routed back to the client and executed locally; the tool result is sent back into the server-side LLM loop. The server LLM never sees your local environment.
 
-```python linenums="1" hl_lines="9-14"
+```python linenums="1" hl_lines="7-9 14"
 from datetime import datetime
 
 from autogen.beta import Agent
 from autogen.beta.a2a import A2AConfig
 from autogen.beta.tools import tool
 
-
 @tool(description="Return the user's local wall-clock time as ISO-8601.")
 def get_local_time() -> str:
     return datetime.now().isoformat(timespec="seconds")
-
 
 remote = Agent(
     "remote",

--- a/website/docs/beta/a2a/client.mdx
+++ b/website/docs/beta/a2a/client.mdx
@@ -85,7 +85,7 @@ The same agent can mix client-side and server-side tools — server tools execut
 
 A remote A2A agent plugs into a local `#!python Agent` like any other delegate via `#!python Agent.as_tool()`. The local LLM decides when to delegate; the wrapper exposes a `#!python task_<name>` tool that takes an `objective` (and optional `context`).
 
-```python linenums="1" hl_lines="13"
+```python linenums="1" hl_lines="14"
 from autogen.beta import Agent
 from autogen.beta.a2a import A2AConfig
 from autogen.beta.config import AnthropicConfig

--- a/website/docs/beta/a2a/server.mdx
+++ b/website/docs/beta/a2a/server.mdx
@@ -58,7 +58,7 @@ After startup the agent card is reachable at `#!python http://127.0.0.1:8000/.we
 
 Tools attached to the wrapped `#!python Agent` execute on the server, just as they would for a local agent. The remote LLM picks them up automatically.
 
-```python linenums="1" hl_lines="11-14"
+```python linenums="1" hl_lines="10-12"
 from autogen.beta import Agent
 from autogen.beta.a2a import A2AServer
 from autogen.beta.config import AnthropicConfig
@@ -127,7 +127,7 @@ await grpc_server.wait_for_termination()
 
 The same `#!python A2AServer` instance can back any combination of transports. Build a single multi-transport `#!python AgentCard` and call each `#!python build_*` against it — they share one task store.
 
-```python linenums="1" hl_lines="3-9"
+```python linenums="1" hl_lines="7-9 12-14"
 from a2a.server.tasks import InMemoryPushNotificationConfigStore
 
 server = A2AServer(agent, push_config_store=InMemoryPushNotificationConfigStore())
@@ -171,7 +171,7 @@ await asyncio.gather(
 
 `#!python autogen.beta.a2a.security` ships factories for every A2A-recognised scheme. Each factory returns a typed `#!python Scheme` object that carries its card-level binding name. Pass them to `#!python require(...)` to build `#!python Requirement` entries; `#!python build_card` auto-derives the card's `#!python security_schemes` from the schemes referenced in `#!python security=` — no duplicate declarations.
 
-```python linenums="1" hl_lines="3 7-8 12-15"
+```python linenums="1" hl_lines="8-9 14"
 from autogen.beta.a2a import A2AServer, build_card
 from autogen.beta.a2a.security import (
     bearer_scheme,
@@ -254,7 +254,7 @@ require(custom)
 
 A2A doesn't define server-side middleware. Attach CORS, auth or tracing directly to the returned transport object:
 
-```python linenums="1" hl_lines="3"
+```python linenums="1" hl_lines="4"
 from starlette.middleware.cors import CORSMiddleware
 
 asgi = server.build_jsonrpc(url="http://127.0.0.1:8000")

--- a/website/docs/beta/a2a/server.mdx
+++ b/website/docs/beta/a2a/server.mdx
@@ -17,11 +17,9 @@ from autogen.beta.a2a import A2AServer, build_card
 from autogen.beta.config import AnthropicConfig
 from autogen.beta.tools import tool
 
-
 @tool(description="Add two integers and return the sum as a string.")
 async def calc_add(a: int, b: int) -> str:
     return f"{a + b}"
-
 
 async def main() -> None:
     agent = Agent(
@@ -34,7 +32,6 @@ async def main() -> None:
     asgi = server.build_jsonrpc(url="http://127.0.0.1:8000", card=card)
 
     await uvicorn.Server(uvicorn.Config(asgi, host="127.0.0.1", port=8000)).serve()
-
 
 ```
 

--- a/website/docs/beta/a2a/server.mdx
+++ b/website/docs/beta/a2a/server.mdx
@@ -58,7 +58,7 @@ After startup the agent card is reachable at `#!python http://127.0.0.1:8000/.we
 
 Tools attached to the wrapped `#!python Agent` execute on the server, just as they would for a local agent. The remote LLM picks them up automatically.
 
-```python linenums="1" hl_lines="10-12"
+```python linenums="1" hl_lines="10-13"
 from autogen.beta import Agent
 from autogen.beta.a2a import A2AServer
 from autogen.beta.config import AnthropicConfig

--- a/website/docs/beta/advanced/aggregation.mdx
+++ b/website/docs/beta/advanced/aggregation.mdx
@@ -29,7 +29,6 @@ from autogen.beta import Context
 from autogen.beta.events import BaseEvent
 from autogen.beta.knowledge import KnowledgeStore
 
-
 class AggregateStrategy(Protocol):
     async def aggregate(
         self,
@@ -211,7 +210,6 @@ Any object with an `async aggregate(events, ctx, store)` method satisfies the pr
 ```python linenums="1"
 from autogen.beta.events import BaseEvent, ModelResponse
 from autogen.beta.knowledge import KnowledgeStore
-
 
 class ResponseLengthAggregate:
     """Track the length of each model response for later analysis."""

--- a/website/docs/beta/advanced/aggregation.mdx
+++ b/website/docs/beta/advanced/aggregation.mdx
@@ -107,7 +107,7 @@ Unlike `ConversationSummaryAggregate`, this one is destructive toward its own pr
 
 The default prompt is journal-style: *preserve facts that are still relevant, drop outdated content*. For other memory shapes — procedural memory (what tactics worked), reflection (what to do differently next time), or task-state memory — pass a `prompt=` template with `{existing}` and `{events}` placeholders:
 
-```python linenums="1" hl_lines="3-7"
+```python linenums="1" hl_lines="3-8"
 strategy = WorkingMemoryAggregate(
     config=OpenAIConfig(model="gpt-5-mini"),
     prompt=(
@@ -144,7 +144,7 @@ The path constants (`WORKING_MEMORY_PATH`, `CONVERSATIONS_PREFIX`) are defined i
 
 Pass the strategy + trigger through [`KnowledgeConfig`](/docs/beta/agent_harness#knowledge-knowledgeconfig). The Agent wires a `_AggregationMiddleware` that fires `aggregate()` automatically according to the trigger.
 
-```python linenums="1" hl_lines="11-14"
+```python linenums="1" hl_lines="11-15"
 from autogen.beta import Agent, KnowledgeConfig
 from autogen.beta.aggregate import AggregateTrigger, ConversationSummaryAggregate
 from autogen.beta.config import OpenAIConfig

--- a/website/docs/beta/advanced/aggregation.mdx
+++ b/website/docs/beta/advanced/aggregation.mdx
@@ -67,7 +67,7 @@ Both built-ins are importable from `#!python autogen.beta.aggregate` and both ta
 
 Writes a timestamped summary of the conversation to `/memory/conversations/`. The companion to [`EpisodicMemoryPolicy`](/docs/beta/advanced/assembly#episodicmemorypolicy), which reads from that directory.
 
-```python linenums="1" hl_lines="8-11"
+```python linenums="1" hl_lines="6 9"
 from autogen.beta.aggregate import ConversationSummaryAggregate
 from autogen.beta.config import OpenAIConfig
 from autogen.beta.knowledge import MemoryKnowledgeStore
@@ -107,7 +107,7 @@ Unlike `ConversationSummaryAggregate`, this one is destructive toward its own pr
 
 The default prompt is journal-style: *preserve facts that are still relevant, drop outdated content*. For other memory shapes — procedural memory (what tactics worked), reflection (what to do differently next time), or task-state memory — pass a `prompt=` template with `{existing}` and `{events}` placeholders:
 
-```python linenums="1" hl_lines="3-8"
+```python linenums="1" hl_lines="3-7"
 strategy = WorkingMemoryAggregate(
     config=OpenAIConfig(model="gpt-5-mini"),
     prompt=(
@@ -144,7 +144,7 @@ The path constants (`WORKING_MEMORY_PATH`, `CONVERSATIONS_PREFIX`) are defined i
 
 Pass the strategy + trigger through [`KnowledgeConfig`](/docs/beta/agent_harness#knowledge-knowledgeconfig). The Agent wires a `_AggregationMiddleware` that fires `aggregate()` automatically according to the trigger.
 
-```python linenums="1" hl_lines="11-15"
+```python linenums="1" hl_lines="11-14"
 from autogen.beta import Agent, KnowledgeConfig
 from autogen.beta.aggregate import AggregateTrigger, ConversationSummaryAggregate
 from autogen.beta.config import OpenAIConfig

--- a/website/docs/beta/advanced/assembly.mdx
+++ b/website/docs/beta/advanced/assembly.mdx
@@ -215,10 +215,9 @@ AssemblerMiddleware.validate_order(policies)  # returns [] — good order
 
 Any object with a `name` and an `async apply(...)` method satisfies the protocol. Use it for domain-specific injection (project docs, RAG hits, on-call runbooks) or custom filtering:
 
-```python linenums="1" hl_lines="7 9 15"
+```python linenums="1" hl_lines="7 12 18"
 from autogen.beta import Context
 from autogen.beta.events import BaseEvent
-
 
 class RunbookPolicy:
     """Inject the on-call runbook as system context."""

--- a/website/docs/beta/advanced/assembly.mdx
+++ b/website/docs/beta/advanced/assembly.mdx
@@ -46,7 +46,7 @@ A policy receives the current `prompts` and `events`, returns modified copies. P
 
 Pass your policy list via the `assembly=` keyword when constructing an Agent. The Agent wires an internal `AssemblerMiddleware` at the outermost position of the middleware chain automatically.
 
-```python linenums="1" hl_lines="10-14"
+```python linenums="1" hl_lines="12-15"
 from autogen.beta import Agent
 from autogen.beta.policies import (
     AlertPolicy,
@@ -89,7 +89,7 @@ The rule: **injection before reduction**. If a reducer runs first, the injection
 
 `AssemblerMiddleware.validate_order()` catches known bad orderings and returns a list of warnings:
 
-```python linenums="1" hl_lines="6-9"
+```python linenums="1" hl_lines="5 8"
 from autogen.beta.assembly import AssemblerMiddleware
 from autogen.beta.policies import AlertPolicy, SlidingWindowPolicy
 
@@ -159,7 +159,7 @@ Takes no arguments. Dedup state lives on the instance — give each Agent its ow
 
 Reads `/memory/working.md` from the [KnowledgeStore](/docs/beta/advanced/knowledge_store) and injects it into the prompt. Working memory is the agent's persistent state — written between conversations by an aggregation strategy and read on every turn.
 
-```python linenums="1" hl_lines="7-12"
+```python linenums="1" hl_lines="6 11 12"
 from autogen.beta.assembly import AssemblerMiddleware
 from autogen.beta.policies import WorkingMemoryPolicy
 from autogen.beta.knowledge import KnowledgeStore, MemoryKnowledgeStore
@@ -193,7 +193,7 @@ Also requires a `KnowledgeStore` in `#!python context.dependencies`; a no-op oth
 
 Typical production ordering — injections first, then `AlertPolicy`, then reduce:
 
-```python linenums="1" hl_lines="8-14"
+```python linenums="1" hl_lines="9-13"
 from autogen.beta.assembly import AssemblerMiddleware
 from autogen.beta.policies import (
     AlertPolicy,

--- a/website/docs/beta/advanced/assembly.mdx
+++ b/website/docs/beta/advanced/assembly.mdx
@@ -46,7 +46,7 @@ A policy receives the current `prompts` and `events`, returns modified copies. P
 
 Pass your policy list via the `assembly=` keyword when constructing an Agent. The Agent wires an internal `AssemblerMiddleware` at the outermost position of the middleware chain automatically.
 
-```python linenums="1" hl_lines="12-15"
+```python linenums="1" hl_lines="12-16"
 from autogen.beta import Agent
 from autogen.beta.policies import (
     AlertPolicy,
@@ -193,7 +193,7 @@ Also requires a `KnowledgeStore` in `#!python context.dependencies`; a no-op oth
 
 Typical production ordering — injections first, then `AlertPolicy`, then reduce:
 
-```python linenums="1" hl_lines="9-13"
+```python linenums="1" hl_lines="9-14"
 from autogen.beta.assembly import AssemblerMiddleware
 from autogen.beta.policies import (
     AlertPolicy,
@@ -215,7 +215,7 @@ AssemblerMiddleware.validate_order(policies)  # returns [] — good order
 
 Any object with a `name` and an `async apply(...)` method satisfies the protocol. Use it for domain-specific injection (project docs, RAG hits, on-call runbooks) or custom filtering:
 
-```python linenums="1" hl_lines="7 12 18"
+```python linenums="1" hl_lines="7 12-18"
 from autogen.beta import Context
 from autogen.beta.events import BaseEvent
 

--- a/website/docs/beta/advanced/compaction.mdx
+++ b/website/docs/beta/advanced/compaction.mdx
@@ -65,7 +65,7 @@ Both built-ins are importable from `#!python autogen.beta.compact`.
 
 Keeps the last N events, drops the rest. Zero LLM cost. Suitable when old context has diminishing value and recency is what matters.
 
-```python linenums="1" hl_lines="6 9"
+```python linenums="1" hl_lines="5 7"
 from autogen.beta.compact import TailWindowCompact
 from autogen.beta.knowledge import MemoryKnowledgeStore
 
@@ -83,7 +83,7 @@ Passing a `KnowledgeStore` is optional. If provided, dropped events are persiste
 
 Summarizes the dropped portion via one LLM call, inserts a `CompactionSummary` event at the head of retained history. Use when you want to keep some sense of the old conversation instead of just forgetting it.
 
-```python linenums="1" hl_lines="8-12"
+```python linenums="1" hl_lines="6-8 11"
 from autogen.beta.compact import SummarizeCompact
 from autogen.beta.config import OpenAIConfig
 from autogen.beta.knowledge import MemoryKnowledgeStore
@@ -122,7 +122,7 @@ summary = CompactionSummary(
 
 Pass the strategy + trigger through [`KnowledgeConfig`](/docs/beta/agent_harness#knowledge-knowledgeconfig). The Agent wires a `_CompactionMiddleware` that fires the strategy automatically after each turn when the trigger threshold is crossed.
 
-```python linenums="1" hl_lines="10-14"
+```python linenums="1" hl_lines="10-13"
 from autogen.beta import Agent, KnowledgeConfig
 from autogen.beta.compact import CompactTrigger, TailWindowCompact
 from autogen.beta.config import OpenAIConfig

--- a/website/docs/beta/advanced/compaction.mdx
+++ b/website/docs/beta/advanced/compaction.mdx
@@ -83,7 +83,7 @@ Passing a `KnowledgeStore` is optional. If provided, dropped events are persiste
 
 Summarizes the dropped portion via one LLM call, inserts a `CompactionSummary` event at the head of retained history. Use when you want to keep some sense of the old conversation instead of just forgetting it.
 
-```python linenums="1" hl_lines="6-8 11"
+```python linenums="1" hl_lines="6-9 11"
 from autogen.beta.compact import SummarizeCompact
 from autogen.beta.config import OpenAIConfig
 from autogen.beta.knowledge import MemoryKnowledgeStore
@@ -122,7 +122,7 @@ summary = CompactionSummary(
 
 Pass the strategy + trigger through [`KnowledgeConfig`](/docs/beta/agent_harness#knowledge-knowledgeconfig). The Agent wires a `_CompactionMiddleware` that fires the strategy automatically after each turn when the trigger threshold is crossed.
 
-```python linenums="1" hl_lines="10-13"
+```python linenums="1" hl_lines="10-14"
 from autogen.beta import Agent, KnowledgeConfig
 from autogen.beta.compact import CompactTrigger, TailWindowCompact
 from autogen.beta.config import OpenAIConfig

--- a/website/docs/beta/advanced/compaction.mdx
+++ b/website/docs/beta/advanced/compaction.mdx
@@ -27,7 +27,6 @@ from autogen.beta import Context
 from autogen.beta.events import BaseEvent
 from autogen.beta.knowledge import KnowledgeStore
 
-
 class CompactStrategy(Protocol):
     async def compact(
         self,
@@ -181,7 +180,6 @@ Any object with an `async compact(events, ctx, store)` method satisfies the prot
 ```python linenums="1"
 from autogen.beta.events import BaseEvent, ToolCallEvent, ToolResultEvent
 from autogen.beta.knowledge import KnowledgeStore
-
 
 class DropOldToolEvents:
     """Keep conversation events; drop tool events older than the last K."""

--- a/website/docs/beta/advanced/observers.mdx
+++ b/website/docs/beta/advanced/observers.mdx
@@ -234,12 +234,11 @@ Severity levels live in `autogen.beta.events.Severity`: `INFO`, `WARNING`, `CRIT
 
 Subclass `BaseObserver`, pick a [Watch](/docs/beta/advanced/watches), implement `process()`:
 
-```python linenums="1" hl_lines="10 14 17"
+```python linenums="1" hl_lines="10 13 17"
 from autogen.beta import Context
 from autogen.beta.observer import BaseObserver
 from autogen.beta.watch import CadenceWatch
 from autogen.beta.events import BaseEvent, ModelResponse, ObserverAlert, Severity
-
 
 class AvgCompletionObserver(BaseObserver):
     """Every N responses, emit an INFO alert with the average completion-token count."""

--- a/website/docs/beta/advanced/observers.mdx
+++ b/website/docs/beta/advanced/observers.mdx
@@ -234,7 +234,7 @@ Severity levels live in `autogen.beta.events.Severity`: `INFO`, `WARNING`, `CRIT
 
 Subclass `BaseObserver`, pick a [Watch](/docs/beta/advanced/watches), implement `process()`:
 
-```python linenums="1" hl_lines="10 13 17-20"
+```python linenums="1" hl_lines="10 13 17-21"
 from autogen.beta import Context
 from autogen.beta.observer import BaseObserver
 from autogen.beta.watch import CadenceWatch

--- a/website/docs/beta/advanced/observers.mdx
+++ b/website/docs/beta/advanced/observers.mdx
@@ -10,7 +10,7 @@ Use observers when you want to monitor agent behavior (logging, metrics, debuggi
 
 Use the `#!python observer()` function to pair an event condition with a callback. The first argument is the event type (or condition) to match, the second is an optional callback:
 
-```python linenums="1" hl_lines="4"
+```python linenums="1" hl_lines="4-5"
 from autogen.beta import observer
 from autogen.beta.events import ModelResponse
 
@@ -234,7 +234,7 @@ Severity levels live in `autogen.beta.events.Severity`: `INFO`, `WARNING`, `CRIT
 
 Subclass `BaseObserver`, pick a [Watch](/docs/beta/advanced/watches), implement `process()`:
 
-```python linenums="1" hl_lines="10 13 17"
+```python linenums="1" hl_lines="10 13 17-20"
 from autogen.beta import Context
 from autogen.beta.observer import BaseObserver
 from autogen.beta.watch import CadenceWatch

--- a/website/docs/beta/advanced/stream.mdx
+++ b/website/docs/beta/advanced/stream.mdx
@@ -192,7 +192,7 @@ pip install "ag2[redis]"
 
 ### Basic Usage
 
-```python linenums="1" hl_lines="2 5"
+```python linenums="1" hl_lines="2 5 13"
 from autogen.beta import Agent
 from autogen.beta.streams.redis import RedisStream
 from autogen.beta.config import OpenAIConfig

--- a/website/docs/beta/ag-ui/backend-deepdive.mdx
+++ b/website/docs/beta/ag-ui/backend-deepdive.mdx
@@ -59,7 +59,7 @@ You often need to pass **per-request context** (user ID, org ID, plan, permissio
 
 AG2 supports this via `ContextVariables`. Your tool can accept a `context` parameter, and you provide values when dispatching.
 
-```python title="tools_context.py" linenums="1" hl_lines="1-2 6 20"
+```python title="tools_context.py" linenums="1" hl_lines="1 6-7 20"
 from autogen.beta import Agent, Context, tool
 from autogen.beta.ag_ui import AGUIStream, RunAgentInput
 from autogen.beta.config import OpenAIConfig

--- a/website/docs/beta/ag-ui/backend-deepdive.mdx
+++ b/website/docs/beta/ag-ui/backend-deepdive.mdx
@@ -33,7 +33,6 @@ agent = Agent(
 stream = AGUIStream(agent)
 app = FastAPI()
 
-
 @app.post("/chat")
 async def run_agent(
     message: RunAgentInput,
@@ -93,12 +92,10 @@ Example backend tool:
 from autogen.beta import Agent, tool
 from autogen.beta.config import OpenAIConfig
 
-
 @tool
 def calculate_sum(a: int, b: int) -> int:
     """Adds two numbers and returns the result."""
     return a + b
-
 
 agent = Agent(
     name="calculator",

--- a/website/docs/beta/ag-ui/index.mdx
+++ b/website/docs/beta/ag-ui/index.mdx
@@ -49,7 +49,7 @@ pip install "ag2[ag-ui]"
 
 Use the manual-dispatch pattern when you want full control over auth, logging, and middleware:
 
-```python title="run_ag_ui.py" linenums="1" hl_lines="14 17-24"
+```python title="run_ag_ui.py" linenums="1" hl_lines="14 17-25"
 from fastapi import FastAPI, Header
 from fastapi.responses import StreamingResponse
 

--- a/website/docs/beta/ag-ui/index.mdx
+++ b/website/docs/beta/ag-ui/index.mdx
@@ -49,7 +49,7 @@ pip install "ag2[ag-ui]"
 
 Use the manual-dispatch pattern when you want full control over auth, logging, and middleware:
 
-```python title="run_ag_ui.py" linenums="1" hl_lines="14 17-25"
+```python title="run_ag_ui.py" linenums="1" hl_lines="14 17-24"
 from fastapi import FastAPI, Header
 from fastapi.responses import StreamingResponse
 
@@ -65,7 +65,6 @@ agent = Agent(
 
 stream = AGUIStream(agent)
 app = FastAPI()
-
 
 @app.post("/chat")
 async def run_agent(

--- a/website/docs/beta/ag2_compatibility.mdx
+++ b/website/docs/beta/ag2_compatibility.mdx
@@ -231,7 +231,6 @@ def issue_tracker(
     context.variables["issue_count"] = issue_count
     return f"Issue tracked. Total issues: {issue_count}"
 
-
 local_agent = ConversableAgent(
     "local_agent",
     llm_config=LLMConfig({"model": "gpt-4o"}),

--- a/website/docs/beta/ag2_compatibility.mdx
+++ b/website/docs/beta/ag2_compatibility.mdx
@@ -12,7 +12,7 @@ This guide explains how to use the new Beta Agents across various chat topologie
 
 You can initiate a standard chat between a `ConversableAgent` and a Beta `Agent` by converting the beta agent into a conversable format. This enables direct, two-way communication.
 
-```python linenums="1" hl_lines="2 5-8 18"
+```python linenums="1" hl_lines="2 5-7 18"
 from autogen import ConversableAgent, LLMConfig
 from autogen.beta import Agent, config
 
@@ -42,7 +42,7 @@ await result.process()
 
 You can chain multiple chats together sequentially using `a_initiate_chats` (see the [Sequential Chat](/docs/user-guide/advanced-concepts/orchestration/sequential-chat) guide). The beta agents handle their respective tasks in order, acting as recipients in the chat sequence.
 
-```python linenums="1" hl_lines="15 21"
+```python linenums="1" hl_lines="13 15 21"
 from autogen import ConversableAgent, LLMConfig
 from autogen.beta import Agent, config
 
@@ -75,7 +75,7 @@ chat_results = await local_agent.a_initiate_chats([
 
 Beta agents fully support AG2's pattern-based [handoff mechanisms](/docs/user-guide/advanced-concepts/orchestration/group-chat/handoffs). You can use `AgentTarget` to explicitly dictate which agent should take over when the current agent completes its work.
 
-```python linenums="1" hl_lines="13-15 17-19"
+```python linenums="1" hl_lines="22-24"
 from autogen import ConversableAgent, LLMConfig
 from autogen.agentchat.group.multi_agent_chat import a_run_group_chat
 from autogen.agentchat.group import AgentTarget
@@ -121,7 +121,7 @@ Beta agent tools can trigger a handoff directly from inside a tool by returning 
 
 Use `final=True` alongside the target to end the agent's turn immediately after the tool runs, without invoking the LLM again for a follow-up reply.
 
-```python linenums="1" hl_lines="19-20 27-32"
+```python linenums="1" hl_lines="17-20"
 from autogen import ConversableAgent, LLMConfig
 from autogen.agentchat import a_run_group_chat
 from autogen.agentchat.group import AgentTarget
@@ -169,7 +169,7 @@ await result.process()
 
 You can build dynamic [group chats](/docs/user-guide/advanced-concepts/orchestration/group-chat/introduction) using `AutoPattern`, where multiple beta agents and standard agents participate in a shared environment.
 
-```python linenums="1" hl_lines="9-11 13-15"
+```python linenums="1" hl_lines="17-20"
 from autogen.agentchat.group.multi_agent_chat import a_run_group_chat
 from autogen.agentchat.group.patterns import AutoPattern
 from autogen.llm_config.config import LLMConfig

--- a/website/docs/beta/ag2_compatibility.mdx
+++ b/website/docs/beta/ag2_compatibility.mdx
@@ -12,7 +12,7 @@ This guide explains how to use the new Beta Agents across various chat topologie
 
 You can initiate a standard chat between a `ConversableAgent` and a Beta `Agent` by converting the beta agent into a conversable format. This enables direct, two-way communication.
 
-```python linenums="1" hl_lines="2 5-7 18"
+```python linenums="1" hl_lines="2 5-8 18"
 from autogen import ConversableAgent, LLMConfig
 from autogen.beta import Agent, config
 
@@ -42,7 +42,7 @@ await result.process()
 
 You can chain multiple chats together sequentially using `a_initiate_chats` (see the [Sequential Chat](/docs/user-guide/advanced-concepts/orchestration/sequential-chat) guide). The beta agents handle their respective tasks in order, acting as recipients in the chat sequence.
 
-```python linenums="1" hl_lines="13 15 21"
+```python linenums="1" hl_lines="15 21"
 from autogen import ConversableAgent, LLMConfig
 from autogen.beta import Agent, config
 
@@ -121,7 +121,7 @@ Beta agent tools can trigger a handoff directly from inside a tool by returning 
 
 Use `final=True` alongside the target to end the agent's turn immediately after the tool runs, without invoking the LLM again for a follow-up reply.
 
-```python linenums="1" hl_lines="17-20"
+```python linenums="1" hl_lines="17-21"
 from autogen import ConversableAgent, LLMConfig
 from autogen.agentchat import a_run_group_chat
 from autogen.agentchat.group import AgentTarget
@@ -169,7 +169,7 @@ await result.process()
 
 You can build dynamic [group chats](/docs/user-guide/advanced-concepts/orchestration/group-chat/introduction) using `AutoPattern`, where multiple beta agents and standard agents participate in a shared environment.
 
-```python linenums="1" hl_lines="17-20"
+```python linenums="1" hl_lines="17-21"
 from autogen.agentchat.group.multi_agent_chat import a_run_group_chat
 from autogen.agentchat.group.patterns import AutoPattern
 from autogen.llm_config.config import LLMConfig

--- a/website/docs/beta/agent_harness.mdx
+++ b/website/docs/beta/agent_harness.mdx
@@ -35,7 +35,7 @@ The loop-related parameters (`config`, `tools`, `middleware`, `observers`, `prom
 
 A list of [`AssemblyPolicy`](/docs/beta/advanced/assembly) instances. When non-empty, the Agent wires an internal `AssemblerMiddleware` at the outermost position of the middleware chain so your policies transform `(prompts, events)` before every LLM call.
 
-```python linenums="1" hl_lines="11-14"
+```python linenums="1" hl_lines="11-15"
 from autogen.beta import Agent
 from autogen.beta.policies import (
     AlertPolicy,
@@ -84,7 +84,7 @@ class KnowledgeConfig:
 | `aggregate` / `aggregate_trigger` | Wires an aggregation middleware that fires [`aggregate()`](/docs/beta/advanced/aggregation) on the configured cadence. Failures emit `AggregationFailed` on the stream — see [Aggregation › Wiring onto an Agent](/docs/beta/advanced/aggregation#wiring-onto-an-agent) for the full lifecycle event triple. |
 | `bootstrap` | Runs once on first use to seed the store. `None` falls back to `#!python DefaultBootstrap(mention_tool=expose_tool)`, so the generated SKILL.md text matches whether the LLM can actually call the `knowledge` tool. |
 
-```python linenums="1" hl_lines="13-18"
+```python linenums="1" hl_lines="13-19"
 from autogen.beta import Agent, KnowledgeConfig
 from autogen.beta.aggregate import AggregateTrigger, ConversationSummaryAggregate
 from autogen.beta.compact import CompactTrigger, TailWindowCompact
@@ -139,7 +139,7 @@ class TaskConfig:
 
 By default a sub-task Agent inherits **all** of the parent's user-supplied tools. Sub-tasks are themselves constructed with `tasks=False` (the Agent default), so they have no `run_subtask` / `run_subtasks` tools — recursive delegation is structurally impossible and no depth limit is needed.
 
-```python linenums="1" hl_lines="7-10"
+```python linenums="1" hl_lines="7-11"
 from autogen.beta import Agent, TaskConfig
 
 agent = Agent(

--- a/website/docs/beta/agent_harness.mdx
+++ b/website/docs/beta/agent_harness.mdx
@@ -35,7 +35,7 @@ The loop-related parameters (`config`, `tools`, `middleware`, `observers`, `prom
 
 A list of [`AssemblyPolicy`](/docs/beta/advanced/assembly) instances. When non-empty, the Agent wires an internal `AssemblerMiddleware` at the outermost position of the middleware chain so your policies transform `(prompts, events)` before every LLM call.
 
-```python linenums="1" hl_lines="10-14"
+```python linenums="1" hl_lines="11-14"
 from autogen.beta import Agent
 from autogen.beta.policies import (
     AlertPolicy,
@@ -84,7 +84,7 @@ class KnowledgeConfig:
 | `aggregate` / `aggregate_trigger` | Wires an aggregation middleware that fires [`aggregate()`](/docs/beta/advanced/aggregation) on the configured cadence. Failures emit `AggregationFailed` on the stream — see [Aggregation › Wiring onto an Agent](/docs/beta/advanced/aggregation#wiring-onto-an-agent) for the full lifecycle event triple. |
 | `bootstrap` | Runs once on first use to seed the store. `None` falls back to `#!python DefaultBootstrap(mention_tool=expose_tool)`, so the generated SKILL.md text matches whether the LLM can actually call the `knowledge` tool. |
 
-```python linenums="1" hl_lines="12-18"
+```python linenums="1" hl_lines="13-18"
 from autogen.beta import Agent, KnowledgeConfig
 from autogen.beta.aggregate import AggregateTrigger, ConversationSummaryAggregate
 from autogen.beta.compact import CompactTrigger, TailWindowCompact
@@ -139,7 +139,7 @@ class TaskConfig:
 
 By default a sub-task Agent inherits **all** of the parent's user-supplied tools. Sub-tasks are themselves constructed with `tasks=False` (the Agent default), so they have no `run_subtask` / `run_subtasks` tools — recursive delegation is structurally impossible and no depth limit is needed.
 
-```python linenums="1" hl_lines="8-12"
+```python linenums="1" hl_lines="7-10"
 from autogen.beta import Agent, TaskConfig
 
 agent = Agent(

--- a/website/docs/beta/code_examples/01_hello_agent.mdx
+++ b/website/docs/beta/code_examples/01_hello_agent.mdx
@@ -35,10 +35,8 @@ import asyncio
 from autogen.beta import Agent
 from autogen.beta.config import GeminiConfig
 
-
 def section(title: str) -> None:
     print(f"\n── {title} ───")
-
 
 async def main() -> None:
     config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
@@ -58,7 +56,6 @@ async def main() -> None:
 
     reply2 = await agent.ask("And a tip for learning poker, in one sentence.")
     print(reply2.body)
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/code_examples/02_recipe_builder.mdx
+++ b/website/docs/beta/code_examples/02_recipe_builder.mdx
@@ -40,23 +40,19 @@ from pydantic import BaseModel, Field
 from autogen.beta import Agent
 from autogen.beta.config import GeminiConfig
 
-
 def section(title: str) -> None:
     print(f"\n── {title} ───")
-
 
 class Ingredient(BaseModel):
     name: str
     quantity: float
     unit: str
 
-
 class Recipe(BaseModel):
     title: str = Field(description="Short human title for the recipe.")
     servings: int = Field(description="How many portions this recipe yields.")
     ingredients: list[Ingredient]
     steps: list[str] = Field(description="Ordered preparation steps.")
-
 
 def scale_ingredient(quantity: float, factor: float) -> float:
     """Return ``quantity`` multiplied by ``factor``, rounded to 2 decimals.
@@ -65,7 +61,6 @@ def scale_ingredient(quantity: float, factor: float) -> float:
     different number of servings.
     """
     return round(quantity * factor, 2)
-
 
 async def main() -> None:
     config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
@@ -105,7 +100,6 @@ async def main() -> None:
     print("Steps:")
     for i, step in enumerate(recipe.steps, 1):
         print(f"  {i}. {step}")
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/code_examples/03_travel_planner.mdx
+++ b/website/docs/beta/code_examples/03_travel_planner.mdx
@@ -36,10 +36,8 @@ import asyncio
 from autogen.beta import Agent
 from autogen.beta.config import GeminiConfig
 
-
 def section(title: str) -> None:
     print(f"\n── {title} ───")
-
 
 TURNS = [
     "I want to plan a 5-day trip to Japan in late April. Just cherry-blossom season.",
@@ -48,7 +46,6 @@ TURNS = [
     "Looks great. For day 3, swap the shopping stop for something outdoorsy in or near Kyoto.",
     "Summarize the final itinerary in a single bullet list, one line per day.",
 ]
-
 
 async def main() -> None:
     config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
@@ -71,7 +68,6 @@ async def main() -> None:
         section(f"Turn {i} — {question}")
         reply = await reply.ask(question)
         print(reply.body)
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/code_examples/04_token_watchdog.mdx
+++ b/website/docs/beta/code_examples/04_token_watchdog.mdx
@@ -47,10 +47,8 @@ from autogen.beta.observer import BaseObserver, LoopDetector, TokenMonitor
 from autogen.beta.stream import MemoryStream
 from autogen.beta.watch import EventWatch
 
-
 def section(title: str) -> None:
     print(f"\n── {title} ───")
-
 
 class AlertConsole(BaseObserver):
     """Watches the stream for ObserverAlerts and prints them to stdout."""
@@ -65,7 +63,6 @@ class AlertConsole(BaseObserver):
                 self.seen.append(event)
                 print(f"    [{event.severity.upper():<8}] {event.source}: {event.message}")
         return None  # Don't emit a follow-up alert
-
 
 async def main() -> None:
     config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
@@ -96,7 +93,6 @@ async def main() -> None:
     print()
     print(f"Total tokens tracked by TokenMonitor: {token_monitor.total_tokens}")
     print(f"Alerts emitted this run:              {len(console.seen)}")
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/code_examples/05_research_squad.mdx
+++ b/website/docs/beta/code_examples/05_research_squad.mdx
@@ -53,10 +53,8 @@ from autogen.beta.config import GeminiConfig
 from autogen.beta.events import TaskCompleted, TaskStarted
 from autogen.beta.stream import MemoryStream
 
-
 def section(title: str) -> None:
     print(f"\n── {title} ───")
-
 
 async def main() -> None:
     config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
@@ -123,7 +121,6 @@ async def main() -> None:
 
     reply2 = await coordinator2.ask("What is 237 times 19?")
     print(reply2.body)
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/code_examples/06_journal_companion.mdx
+++ b/website/docs/beta/code_examples/06_journal_companion.mdx
@@ -56,10 +56,8 @@ from autogen.beta.config import GeminiConfig
 from autogen.beta.knowledge import DiskKnowledgeStore
 from autogen.beta.policies import ConversationPolicy, WorkingMemoryPolicy
 
-
 def section(title: str) -> None:
     print(f"\n── {title} ───")
-
 
 async def main() -> None:
     config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
@@ -121,7 +119,6 @@ async def main() -> None:
         # because WorkingMemoryPolicy injected /memory/working.md as a prompt.
     finally:
         shutil.rmtree(workdir, ignore_errors=True)
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/code_examples/07_long_doc_chat.mdx
+++ b/website/docs/beta/code_examples/07_long_doc_chat.mdx
@@ -57,7 +57,6 @@ from autogen.beta.policies import (
 )
 from autogen.beta.stream import MemoryStream
 
-
 def section(title: str) -> None:
     print(f"\n── {title} ───")
 
@@ -69,7 +68,6 @@ QUESTIONS = [
     "Remember the word 'quartz'.",
     "Name the three most recent words I asked you to remember.",
 ]
-
 
 async def main() -> None:
     config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
@@ -113,7 +111,6 @@ async def main() -> None:
     print(f"Compactions fired during run: {len(compactions)}")
     for c in compactions:
         print(f"  - {c.strategy}: {c.events_before} → {c.events_after} events")
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/code_examples/08_safety_guard.mdx
+++ b/website/docs/beta/code_examples/08_safety_guard.mdx
@@ -55,21 +55,16 @@ from autogen.beta.policies import AlertPolicy
 from autogen.beta.stream import MemoryStream
 from autogen.beta.watch import EventWatch
 
-
 def section(title: str) -> None:
     print(f"\n── {title} ───")
 
-
 # ---- Tool under supervision -------------------------------------------------
-
 
 def write_file(path: str, content: str) -> str:
     """Pretend-write ``content`` to ``path``. This playground never touches disk."""
     return f"[ok] wrote {len(content)} bytes to {path}"
 
-
 # ---- Guardian observer ------------------------------------------------------
-
 
 class PathGuardian(BaseObserver):
     """Emits a FATAL alert if anything tries to write outside /tmp."""
@@ -90,7 +85,6 @@ class PathGuardian(BaseObserver):
                     message=f"blocked dangerous write: {event.arguments}",
                 )
         return None
-
 
 async def main() -> None:
     config = GeminiConfig(model="gemini-3-flash-preview", temperature=0)
@@ -137,7 +131,6 @@ async def main() -> None:
     print(f"HaltEvents seen:      {len(halt_events)}")
     for h in halt_events:
         print(f"  - source={h.source} reason={h.reason!r}")
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/context/human_in_the_loop.mdx
+++ b/website/docs/beta/context/human_in_the_loop.mdx
@@ -29,7 +29,7 @@ You can request human input directly from within a tool using the `Context` obje
 
 Here is an example of a tool that asks for human confirmation:
 
-```python linenums="1" hl_lines="6-8"
+```python linenums="1" hl_lines="6-9"
 from autogen.beta import Context, Agent, tool
 
 @tool

--- a/website/docs/beta/context/human_in_the_loop.mdx
+++ b/website/docs/beta/context/human_in_the_loop.mdx
@@ -29,7 +29,7 @@ You can request human input directly from within a tool using the `Context` obje
 
 Here is an example of a tool that asks for human confirmation:
 
-```python linenums="1" hl_lines="6-9"
+```python linenums="1" hl_lines="6-8"
 from autogen.beta import Context, Agent, tool
 
 @tool
@@ -64,7 +64,7 @@ A **HITL** hook is a callback function that consumes a `HumanInputRequest` event
 
 You can register a HITL hook by passing it as the `hitl_hook` argument when initializing the `Agent`.
 
-```python linenums="1" hl_lines="4-11 15"
+```python linenums="1" hl_lines="4 15"
 from autogen.beta import Agent
 from autogen.beta.events import HumanInputRequest, HumanMessage
 

--- a/website/docs/beta/context/variables.mdx
+++ b/website/docs/beta/context/variables.mdx
@@ -58,7 +58,7 @@ await agent.ask(
 
 The most straightforward way to access variables inside a tool is by requesting the `Context` object. By adding an argument annotated with `Context`, the framework will automatically inject the current execution context, which contains the `.variables` dictionary.
 
-```python linenums="1" hl_lines="1 4 6-7"
+```python linenums="1" hl_lines="4 6-7"
 from autogen.beta import Context, tool
 
 @tool
@@ -74,7 +74,7 @@ def process_data(context: Context) -> str:
 
 Instead of passing the entire `Context` object, you can instruct the framework to inject specific variables directly into your tool's arguments using the `Variable` annotation. This makes your tool's signature cleaner and more explicit.
 
-```python linenums="1" hl_lines="1-2 9"
+```python linenums="1" hl_lines="9"
 from typing import Annotated
 from autogen.beta import Variable, tool
 
@@ -147,7 +147,7 @@ Variables are mutable. If a tool updates the `context.variables` dictionary, tha
 
 This is highly useful for sharing state or caching results between different tools without requiring the LLM to pass the data back and forth.
 
-```python linenums="1" hl_lines="4 9 11-12"
+```python linenums="1" hl_lines="4 9"
 @tool
 def authenticate(context: Context) -> str:
     # Generate and store a token in the context variables

--- a/website/docs/beta/contribution_policy.mdx
+++ b/website/docs/beta/contribution_policy.mdx
@@ -130,7 +130,6 @@ Examples: https://github.com/ag2ai/build-with-ag2/extensions/acme-search-tool
 
 from autogen.beta.tools import Tool
 
-
 class AcmeSearch(Tool):
     """Tool that performs web searches via the Acme Search API.
 

--- a/website/docs/beta/depends.mdx
+++ b/website/docs/beta/depends.mdx
@@ -66,7 +66,7 @@ def fetch_records(
 
 A powerful pattern is to combine `Depends` with `Inject`. You can use `Inject` to retrieve a static configuration or persistent resource (like a database connection pool), and then use `Depends` to manage a short-lived resource (like a database session) based on that configuration.
 
-```python linenums="1" hl_lines="4 6-8 12 19"
+```python linenums="1" hl_lines="5 7-9 13 20"
 from typing import Annotated
 from autogen.beta import Depends, Inject, tool, Agent
 

--- a/website/docs/beta/depends.mdx
+++ b/website/docs/beta/depends.mdx
@@ -17,7 +17,7 @@ You can use `Depends` to execute side-effects before your tool runs—even if yo
 
 To do this, simply declare the dependency in your tool's signature. The framework will execute it, and you can safely ignore the injected value.
 
-```python linenums="1" hl_lines="2 13"
+```python linenums="1" hl_lines="13"
 from typing import Annotated
 from autogen.beta import Depends, tool
 
@@ -66,7 +66,7 @@ def fetch_records(
 
 A powerful pattern is to combine `Depends` with `Inject`. You can use `Inject` to retrieve a static configuration or persistent resource (like a database connection pool), and then use `Depends` to manage a short-lived resource (like a database session) based on that configuration.
 
-```python linenums="1" hl_lines="5 7-9 13 20"
+```python linenums="1" hl_lines="4 6-8 12 19"
 from typing import Annotated
 from autogen.beta import Depends, Inject, tool, Agent
 
@@ -115,7 +115,7 @@ def process_data(
 
 If you explicitly want the dependency to be re-calculated every single time it is injected, you can disable the cache by passing `use_cache=False`:
 
-```python linenums="1" hl_lines="4-5"
+```python linenums="1" hl_lines="3-4"
 @tool
 def random_tool(
     val1: Annotated[int, Depends(get_random_number, use_cache=False)],

--- a/website/docs/beta/evaluation/evaluation.mdx
+++ b/website/docs/beta/evaluation/evaluation.mdx
@@ -34,7 +34,7 @@ The rest of these docs cover each piece in depth. Read the quick-start below fir
 
 The simplest plausible eval. Two tasks, one custom scorer, one prebuilt.
 
-```python linenums="1" hl_lines="11-15 23-26 30-32 36-43"
+```python linenums="1" hl_lines="11-16 23-27 30-32 36-44"
 import asyncio
 from pathlib import Path
 
@@ -107,7 +107,7 @@ That's the whole framework in 30 lines. Everything else in these docs is variati
 
 You don't want your eval suite to depend on a live LLM in pre-merge CI — too slow, too expensive, too flaky. The framework uses [TestConfig](/docs/beta/testing/) cassettes to mock the model deterministically:
 
-```python linenums="1" hl_lines="3-5 12"
+```python linenums="1" hl_lines="3-6 12"
 from autogen.beta.testing import TestConfig
 
 cassettes = {

--- a/website/docs/beta/evaluation/evaluation.mdx
+++ b/website/docs/beta/evaluation/evaluation.mdx
@@ -34,7 +34,7 @@ The rest of these docs cover each piece in depth. Read the quick-start below fir
 
 The simplest plausible eval. Two tasks, one custom scorer, one prebuilt.
 
-```python linenums="1" hl_lines="11-16 23-26 30-32 36-43"
+```python linenums="1" hl_lines="11-15 23-26 30-32 36-43"
 import asyncio
 from pathlib import Path
 
@@ -107,7 +107,7 @@ That's the whole framework in 30 lines. Everything else in these docs is variati
 
 You don't want your eval suite to depend on a live LLM in pre-merge CI — too slow, too expensive, too flaky. The framework uses [TestConfig](/docs/beta/testing/) cassettes to mock the model deterministically:
 
-```python linenums="1" hl_lines="3-6 12"
+```python linenums="1" hl_lines="3-5 12"
 from autogen.beta.testing import TestConfig
 
 cassettes = {

--- a/website/docs/beta/evaluation/evaluation.mdx
+++ b/website/docs/beta/evaluation/evaluation.mdx
@@ -34,7 +34,7 @@ The rest of these docs cover each piece in depth. Read the quick-start below fir
 
 The simplest plausible eval. Two tasks, one custom scorer, one prebuilt.
 
-```python linenums="1" hl_lines="12-17 24-28 31-33 37-45"
+```python linenums="1" hl_lines="11-16 23-26 30-32 36-43"
 import asyncio
 from pathlib import Path
 
@@ -43,7 +43,6 @@ from autogen.beta.config import GeminiConfig
 from autogen.beta.events import ToolCallEvent
 from autogen.beta.eval import Suite, run_agent, scorer
 from autogen.beta.eval.scorers import tool_called
-
 
 # 1. Dataset — inline tasks (or Suite.from_jsonl("tasks.jsonl"))
 dataset = Suite.from_list([

--- a/website/docs/beta/evaluation/getting-started.mdx
+++ b/website/docs/beta/evaluation/getting-started.mdx
@@ -94,11 +94,9 @@ One check is rarely enough. A scorer is just a function that asks **one** questi
 from autogen.beta.eval import scorer
 from autogen.beta.eval.scorers import no_tool_errors, token_budget
 
-
 @scorer
 def answered_briefly(outputs) -> bool:
     return len(outputs["body"]) < 100      # outputs["body"] is the final answer text
-
 
 scorers = [
     final_answer_matches(field="answer", matcher="contains"),

--- a/website/docs/beta/evaluation/scorers.mdx
+++ b/website/docs/beta/evaluation/scorers.mdx
@@ -9,7 +9,7 @@ A scorer is a function that grades one agent run and produces a structured feedb
 
 Decorate a function with `#!python @scorer`. The framework calls it once per task; the return value becomes feedback.
 
-```python linenums="1" hl_lines="1 4"
+```python linenums="1" hl_lines="4-6"
 from autogen.beta.events import ToolCallEvent
 from autogen.beta.eval import scorer
 
@@ -128,7 +128,7 @@ Six ship under `autogen.beta.eval.scorers`. Four are simple, deterministic check
 
 Each is a *factory* — calling it returns a `Scorer`. Drop them straight into the `scorers=` list:
 
-```python linenums="1" hl_lines="8-13"
+```python linenums="1" hl_lines="8-12"
 from autogen.beta.eval.scorers import (
     final_answer_matches,
     no_tool_errors,

--- a/website/docs/beta/evaluation/scorers.mdx
+++ b/website/docs/beta/evaluation/scorers.mdx
@@ -128,7 +128,7 @@ Six ship under `autogen.beta.eval.scorers`. Four are simple, deterministic check
 
 Each is a *factory* — calling it returns a `Scorer`. Drop them straight into the `scorers=` list:
 
-```python linenums="1" hl_lines="8-12"
+```python linenums="1" hl_lines="8-13"
 from autogen.beta.eval.scorers import (
     final_answer_matches,
     no_tool_errors,

--- a/website/docs/beta/evaluation/scorers.mdx
+++ b/website/docs/beta/evaluation/scorers.mdx
@@ -9,10 +9,9 @@ A scorer is a function that grades one agent run and produces a structured feedb
 
 Decorate a function with `#!python @scorer`. The framework calls it once per task; the return value becomes feedback.
 
-```python linenums="1" hl_lines="1 5"
+```python linenums="1" hl_lines="1 4"
 from autogen.beta.events import ToolCallEvent
 from autogen.beta.eval import scorer
-
 
 @scorer
 def called_get_weather(trace) -> bool:
@@ -259,10 +258,8 @@ If you want a key independent of the function name, construct a `Scorer` yoursel
 ```python linenums="1"
 from autogen.beta.eval import Scorer, Trace
 
-
 def _check(trace: Trace) -> bool:
     return len(trace.events_of(ToolCallEvent, name="get_weather")) == 1
-
 
 my_scorer = Scorer(_check, key="weather-tool-used")
 ```

--- a/website/docs/beta/live/live.mdx
+++ b/website/docs/beta/live/live.mdx
@@ -49,7 +49,6 @@ agent = Agent(
     observers=[TTSObserver(config=OpenAITTSConfig(model="gpt-4o-mini-tts"))],
 )
 
-
 async def main() -> None:
     pipeline = OpenAITranscriber("gpt-4o-mini-transcribe").pipe(agent)
 
@@ -57,7 +56,6 @@ async def main() -> None:
         voice = SoundDeviceRecorder().record(duration=3)
         reply = await pipeline.ask(voice, stream=player.stream)
         print(reply.body)
-
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -84,7 +82,6 @@ agent = LiveAgent(
     ),
 )
 
-
 async def main() -> None:
     async with (
         agent.run() as context,
@@ -93,7 +90,6 @@ async def main() -> None:
     ):
         print("Starting...")
         await asyncio.Future()
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/live/live_agent.mdx
+++ b/website/docs/beta/live/live_agent.mdx
@@ -9,7 +9,7 @@ sidebarTitle: "LiveAgent"
 
 A `LiveAgent` holds a `RealtimeConfig` and is opened via `agent.run()`, which yields a `ConversationContext`. Peers (player, recorder, observers) share that context so they all read from and write to the same event stream.
 
-```python linenums="1" hl_lines="10-17 20-26"
+```python linenums="1" hl_lines="10-15 21-23"
 import asyncio
 
 from autogen.beta.live import (
@@ -87,7 +87,7 @@ if __name__ == "__main__":
 
 To keep the realtime session for its low-latency turn detection but disable audio output entirely, swap `AudioOutput` for `TextOutput`. The model returns raw text via `ModelMessageChunk` and never produces synthesized audio.
 
-```python linenums="1" hl_lines="13-16 25-27"
+```python linenums="1" hl_lines="13-15 25-27"
 import asyncio
 
 from autogen.beta.events import ModelMessageChunk
@@ -207,7 +207,7 @@ Available voices: `Aoede`, `Charon`, `Fenrir`, `Kore`, `Leda`, `Orus`, `Puck`, `
 
 **Full Gemini example with a tool**
 
-```python linenums="1" hl_lines="14-18 25-26"
+```python linenums="1" hl_lines="14-17 25-26"
 import asyncio
 
 from autogen.beta.events import ModelMessageChunk, TranscriptionChunkEvent

--- a/website/docs/beta/live/live_agent.mdx
+++ b/website/docs/beta/live/live_agent.mdx
@@ -9,7 +9,7 @@ sidebarTitle: "LiveAgent"
 
 A `LiveAgent` holds a `RealtimeConfig` and is opened via `agent.run()`, which yields a `ConversationContext`. Peers (player, recorder, observers) share that context so they all read from and write to the same event stream.
 
-```python linenums="1" hl_lines="10-15 21-23"
+```python linenums="1" hl_lines="10-17 21-23"
 import asyncio
 
 from autogen.beta.live import (
@@ -87,7 +87,7 @@ if __name__ == "__main__":
 
 To keep the realtime session for its low-latency turn detection but disable audio output entirely, swap `AudioOutput` for `TextOutput`. The model returns raw text via `ModelMessageChunk` and never produces synthesized audio.
 
-```python linenums="1" hl_lines="13-15 25-27"
+```python linenums="1" hl_lines="13-16 25-27"
 import asyncio
 
 from autogen.beta.events import ModelMessageChunk
@@ -207,7 +207,7 @@ Available voices: `Aoede`, `Charon`, `Fenrir`, `Kore`, `Leda`, `Orus`, `Puck`, `
 
 **Full Gemini example with a tool**
 
-```python linenums="1" hl_lines="14-17 25-26"
+```python linenums="1" hl_lines="14-18 25-26"
 import asyncio
 
 from autogen.beta.events import ModelMessageChunk, TranscriptionChunkEvent

--- a/website/docs/beta/live/stt_tts.mdx
+++ b/website/docs/beta/live/stt_tts.mdx
@@ -25,7 +25,7 @@ The recorder produces a `VoiceInput` containing 16-bit PCM bytes plus the sample
 
 `OpenAITranscriber` implements the `STTConfig` protocol and exposes a `.pipe(agent)` method that wraps an `Agent` in a `VoicePipeline`. Calling `pipeline.ask(voice)` transcribes the audio and forwards the text to the agent's normal `ask()` flow.
 
-```python linenums="1" hl_lines="14 18-19"
+```python linenums="1" hl_lines="13 18"
 import asyncio
 
 from autogen.beta import Agent, config
@@ -75,7 +75,7 @@ pipeline = OpenAITranslationTranscriber("whisper-1").pipe(agent)
 
 `TTSObserver` is an observer that listens to `ModelMessageChunk` events as the agent streams its response, batches them into sentence-sized chunks, calls a TTS provider, and emits `SynthesizedAudioEvent`s onto the stream. A `SoundDevicePlayer` attached to the same stream then plays them.
 
-```python linenums="1" hl_lines="6-13 16-18"
+```python linenums="1" hl_lines="10-11 16-18"
 import asyncio
 
 from autogen.beta import Agent, config
@@ -120,7 +120,7 @@ config = OpenAITTSConfig(
 
 The full round-trip — voice in, voice out — is just both halves wired up at once: pipe the agent through the transcriber, attach a `TTSObserver`, and share a stream with the player.
 
-```python linenums="1" hl_lines="16-17 22-23 25 28 31-32 36"
+```python linenums="1" hl_lines="16-17 22 25 28"
 import asyncio
 
 from autogen.beta import Agent, config

--- a/website/docs/beta/live/stt_tts.mdx
+++ b/website/docs/beta/live/stt_tts.mdx
@@ -75,7 +75,7 @@ pipeline = OpenAITranslationTranscriber("whisper-1").pipe(agent)
 
 `TTSObserver` is an observer that listens to `ModelMessageChunk` events as the agent streams its response, batches them into sentence-sized chunks, calls a TTS provider, and emits `SynthesizedAudioEvent`s onto the stream. A `SoundDevicePlayer` attached to the same stream then plays them.
 
-```python linenums="1" hl_lines="10-11 16-18"
+```python linenums="1" hl_lines="10-12 16-18"
 import asyncio
 
 from autogen.beta import Agent, config
@@ -120,7 +120,7 @@ config = OpenAITTSConfig(
 
 The full round-trip — voice in, voice out — is just both halves wired up at once: pipe the agent through the transcriber, attach a `TTSObserver`, and share a stream with the player.
 
-```python linenums="1" hl_lines="16-17 22 25 28"
+```python linenums="1" hl_lines="16-18 22 25 28"
 import asyncio
 
 from autogen.beta import Agent, config

--- a/website/docs/beta/live/stt_tts.mdx
+++ b/website/docs/beta/live/stt_tts.mdx
@@ -120,7 +120,7 @@ config = OpenAITTSConfig(
 
 The full round-trip — voice in, voice out — is just both halves wired up at once: pipe the agent through the transcriber, attach a `TTSObserver`, and share a stream with the player.
 
-```python linenums="1" hl_lines="16-18 22-23 25 28 31-32 35"
+```python linenums="1" hl_lines="16-17 22-23 25 28 31-32 36"
 import asyncio
 
 from autogen.beta import Agent, config
@@ -141,7 +141,6 @@ agent = Agent(
     ],
 )
 
-
 async def main():
     pipeline = OpenAITranscriber("gpt-4o-mini-transcribe").pipe(agent)
     recorder = SoundDeviceRecorder()
@@ -159,7 +158,6 @@ async def main():
         voice_input = recorder.record(duration=3)
         reply = await reply.ask(voice_input)
         print(reply.body)
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/middleware.mdx
+++ b/website/docs/beta/middleware.mdx
@@ -147,7 +147,7 @@ Use `on_human_input()` when you want to:
 
 To make middleware apply to every turn for an agent, pass it through the `middleware` argument when constructing the agent.
 
-```python linenums="1" hl_lines="3 10-11"
+```python linenums="1" hl_lines="9-11"
 from autogen.beta import Agent
 from autogen.beta.config import OpenAIConfig
 from autogen.beta.middleware import LoggingMiddleware, RetryMiddleware

--- a/website/docs/beta/middleware.mdx
+++ b/website/docs/beta/middleware.mdx
@@ -147,7 +147,7 @@ Use `on_human_input()` when you want to:
 
 To make middleware apply to every turn for an agent, pass it through the `middleware` argument when constructing the agent.
 
-```python linenums="1" hl_lines="9-11"
+```python linenums="1" hl_lines="9-12"
 from autogen.beta import Agent
 from autogen.beta.config import OpenAIConfig
 from autogen.beta.middleware import LoggingMiddleware, RetryMiddleware

--- a/website/docs/beta/middleware.mdx
+++ b/website/docs/beta/middleware.mdx
@@ -209,7 +209,6 @@ from autogen.beta.config import OpenAIConfig
 from autogen.beta.events import BaseEvent, ModelResponse
 from autogen.beta.middleware import AgentTurn, BaseMiddleware
 
-
 class A(BaseMiddleware):
     async def on_turn(
         self,
@@ -221,7 +220,6 @@ class A(BaseMiddleware):
         response = await call_next(event, context)
         print("exit A")
         return response
-
 
 class B(BaseMiddleware):
     async def on_turn(
@@ -235,7 +233,6 @@ class B(BaseMiddleware):
         print("exit B")
         return response
 
-
 class C(BaseMiddleware):
     async def on_turn(
         self,
@@ -247,7 +244,6 @@ class C(BaseMiddleware):
         response = await call_next(event, context)
         print("exit C")
         return response
-
 
 agent = Agent(
     "assistant",
@@ -286,7 +282,6 @@ from autogen.beta.config import OpenAIConfig
 from autogen.beta.events import BaseEvent, ModelResponse, ToolCallEvent
 from autogen.beta.middleware import BaseMiddleware, LLMCall, Middleware, ToolExecution
 
-
 class AuditMiddleware(BaseMiddleware):
     def __init__(
         self,
@@ -316,7 +311,6 @@ class AuditMiddleware(BaseMiddleware):
     ):
         self.logger.info("Executing tool: %s", event.name)
         return await call_next(event, context)
-
 
 agent = Agent(
     "assistant",

--- a/website/docs/beta/model_configuration.mdx
+++ b/website/docs/beta/model_configuration.mdx
@@ -224,7 +224,7 @@ config = VertexAIConfig(
   </Tab>
 
   <Tab title="Pre-built Credentials object">
-```python linenums="1" hl_lines="4-5 12"
+```python linenums="1" hl_lines="4-6 12"
 import google.auth
 from autogen.beta.config import VertexAIConfig
 
@@ -376,7 +376,7 @@ In many use cases, you may want to separate the logic of defining your agent (to
 
 You can accomplish this by passing the configuration to the `.ask()` method when interacting with the agent. This is especially useful for applications like web servers where the user might bring their own API key or choose a different model on the fly.
 
-```python linenums="1" hl_lines="15-17"
+```python linenums="1" hl_lines="15-18"
 from autogen.agent import Agent
 from autogen.beta.config import OpenAIConfig
 

--- a/website/docs/beta/model_configuration.mdx
+++ b/website/docs/beta/model_configuration.mdx
@@ -192,7 +192,7 @@ Authentication accepts any of the following:
 
 <Tabs>
   <Tab title="Service account key file">
-```python linenums="1" hl_lines="6"
+```python linenums="1" hl_lines="7"
 from autogen.beta.config import VertexAIConfig
 
 config = VertexAIConfig(
@@ -224,7 +224,7 @@ config = VertexAIConfig(
   </Tab>
 
   <Tab title="Pre-built Credentials object">
-```python linenums="1" hl_lines="4-6"
+```python linenums="1" hl_lines="4-5 12"
 import google.auth
 from autogen.beta.config import VertexAIConfig
 
@@ -277,7 +277,7 @@ Gemini 3 Pro models default to **dynamic / unbounded** thinking, which can cause
 
 Use `thinking_level` for **Gemini 3** models, or `thinking_budget` for **Gemini 2.5** models:
 
-```python linenums="1" hl_lines="6 13"
+```python linenums="1" hl_lines="6 14"
 from autogen.beta.config import GeminiConfig, VertexAIConfig
 
 # Gemini 3 — bound thinking with a level
@@ -376,7 +376,7 @@ In many use cases, you may want to separate the logic of defining your agent (to
 
 You can accomplish this by passing the configuration to the `.ask()` method when interacting with the agent. This is especially useful for applications like web servers where the user might bring their own API key or choose a different model on the fly.
 
-```python linenums="1" hl_lines="15-18"
+```python linenums="1" hl_lines="15-17"
 from autogen.agent import Agent
 from autogen.beta.config import OpenAIConfig
 

--- a/website/docs/beta/network/context_variables.mdx
+++ b/website/docs/beta/network/context_variables.mdx
@@ -53,9 +53,8 @@ rejected by `#!python validate_send`.
 
 Send the envelope from any participant via the existing `#!python Channel.send`:
 
-```python linenums="1" hl_lines="9 10 11 12 13 14"
+```python linenums="1" hl_lines="7-11"
 from autogen.beta.network import EV_CONTEXT_SET, ChannelInject
-
 
 async def set_route(route: str, channel: ChannelInject) -> str:
     """Record the routing decision for this channel."""
@@ -68,7 +67,6 @@ async def set_route(route: str, channel: ChannelInject) -> str:
         audience=[],   # context update; no participant needs notify
     )
     return f"route set to {route!r}"
-
 
 agent.tool(set_route)
 ```
@@ -114,7 +112,6 @@ idempotent), inject the State:
 ```python linenums="1"
 from autogen.beta.network import ChannelStateInject
 
-
 async def increment_counter(channel: ChannelInject, state: ChannelStateInject) -> str:
     """Demonstrates reading current state, then writing a new value."""
     if state is None or channel is None:
@@ -134,11 +131,10 @@ async def increment_counter(channel: ChannelInject, state: ChannelStateInject) -
 If `#!python ContextEquals` isn't enough, write a custom `#!python TransitionCondition`
 and register it. The Protocol is just two attributes:
 
-```python linenums="1" hl_lines="3 5 6 11"
+```python linenums="1" hl_lines="3 5 10"
 from typing import ClassVar
 from dataclasses import dataclass
 from autogen.beta.network import register_condition
-
 
 @dataclass(slots=True)
 class ContextThreshold:
@@ -151,7 +147,6 @@ class ContextThreshold:
     def evaluate(self, state, envelope) -> bool:
         value = state.context_vars.get(self.key, 0)
         return isinstance(value, (int, float)) and value >= self.threshold
-
 
 register_condition(ContextThreshold)
 ```

--- a/website/docs/beta/network/context_variables.mdx
+++ b/website/docs/beta/network/context_variables.mdx
@@ -53,7 +53,7 @@ rejected by `#!python validate_send`.
 
 Send the envelope from any participant via the existing `#!python Channel.send`:
 
-```python linenums="1" hl_lines="7-11"
+```python linenums="1" hl_lines="7-12"
 from autogen.beta.network import EV_CONTEXT_SET, ChannelInject
 
 async def set_route(route: str, channel: ChannelInject) -> str:

--- a/website/docs/beta/network/context_variables.mdx
+++ b/website/docs/beta/network/context_variables.mdx
@@ -131,7 +131,7 @@ async def increment_counter(channel: ChannelInject, state: ChannelStateInject) -
 If `#!python ContextEquals` isn't enough, write a custom `#!python TransitionCondition`
 and register it. The Protocol is just two attributes:
 
-```python linenums="1" hl_lines="3 5 10"
+```python linenums="1" hl_lines="11 13-15 17"
 from typing import ClassVar
 from dataclasses import dataclass
 from autogen.beta.network import register_condition

--- a/website/docs/beta/network/conversation.mdx
+++ b/website/docs/beta/network/conversation.mdx
@@ -77,7 +77,7 @@ await channel.send("Hi bob, what's a good first ML concept to learn?")
 
 Both default handlers run `#!python Agent.ask` on every inbound `#!python EV_TEXT`, so the conversation auto-drives. Two ways to halt:
 
-```python linenums="1" hl_lines="6 8"
+```python linenums="1" hl_lines="7 12-13"
 # Cap by message count, then explicit close.
 async def wait_for_text_count(hub, channel_id, expected, *, timeout=120.0):
     import asyncio

--- a/website/docs/beta/network/distributed.mdx
+++ b/website/docs/beta/network/distributed.mdx
@@ -38,7 +38,6 @@ import contextlib
 from autogen.beta.knowledge import MemoryKnowledgeStore
 from autogen.beta.network import Hub, serve_ws
 
-
 async def main() -> None:
     hub = await Hub.open(MemoryKnowledgeStore())
     async with serve_ws(hub, "0.0.0.0", 8765) as server:
@@ -47,7 +46,6 @@ async def main() -> None:
         with contextlib.suppress(asyncio.CancelledError):
             await asyncio.Future()  # serve until interrupted
     await hub.close()
-
 
 asyncio.run(main())
 ```
@@ -65,7 +63,6 @@ from autogen.beta import Agent
 from autogen.beta.config import AnthropicConfig
 from autogen.beta.network import HubClient, Passport, Resume, WsLink
 
-
 async def main() -> None:
     hub_client = HubClient(WsLink("ws://hub-host:8765"))
     await hub_client.open()  # WebSocket connect + handshake
@@ -75,7 +72,6 @@ async def main() -> None:
 
     print(f"registered as {bob.agent_id}; awaiting channels")
     await asyncio.Future()  # stay connected; default handler answers inbound consults
-
 
 asyncio.run(main())
 ```
@@ -93,7 +89,6 @@ from autogen.beta import Agent
 from autogen.beta.config import OpenAIConfig
 from autogen.beta.network import EV_TEXT, HubClient, Passport, Resume, WsLink
 from autogen.beta.network.adapters.consulting import CONSULTING_TYPE
-
 
 async def main() -> None:
     hub_client = HubClient(WsLink("ws://hub-host:8765"))
@@ -117,7 +112,6 @@ async def main() -> None:
     )
     print(reply.event_data["text"])  # 132
     await hub_client.close()
-
 
 asyncio.run(main())
 ```

--- a/website/docs/beta/network/envelopes_and_events.mdx
+++ b/website/docs/beta/network/envelopes_and_events.mdx
@@ -95,7 +95,7 @@ The hub processes higher-priority envelopes ahead of lower-priority ones in queu
 
 The `#!python channel.send(text, audience=...)` helper wraps the envelope construction for you. When you need a custom event type or to set fields the helper doesn't expose, build an `#!python Envelope` and post it directly:
 
-```python linenums="1" hl_lines="3-8 10"
+```python linenums="1" hl_lines="3-10"
 from autogen.beta.network import Envelope, EV_TEXT
 
 envelope = Envelope(

--- a/website/docs/beta/network/envelopes_and_events.mdx
+++ b/website/docs/beta/network/envelopes_and_events.mdx
@@ -95,7 +95,7 @@ The hub processes higher-priority envelopes ahead of lower-priority ones in queu
 
 The `#!python channel.send(text, audience=...)` helper wraps the envelope construction for you. When you need a custom event type or to set fields the helper doesn't expose, build an `#!python Envelope` and post it directly:
 
-```python linenums="1" hl_lines="3 4 5 6 7 8"
+```python linenums="1" hl_lines="3-8 10"
 from autogen.beta.network import Envelope, EV_TEXT
 
 envelope = Envelope(

--- a/website/docs/beta/network/expectations_and_audit.mdx
+++ b/website/docs/beta/network/expectations_and_audit.mdx
@@ -68,7 +68,7 @@ When the hub is open, an expectation sweeper task wakes every `expectation_sweep
 
 For deterministic tests / examples:
 
-```python linenums="1" hl_lines="4-6 10-11"
+```python linenums="1" hl_lines="4-7 10-11"
 from autogen.beta.network import Hub
 from autogen.beta.knowledge import MemoryKnowledgeStore
 

--- a/website/docs/beta/network/expectations_and_audit.mdx
+++ b/website/docs/beta/network/expectations_and_audit.mdx
@@ -68,7 +68,7 @@ When the hub is open, an expectation sweeper task wakes every `expectation_sweep
 
 For deterministic tests / examples:
 
-```python linenums="1" hl_lines="2 3 4 5 6 7"
+```python linenums="1" hl_lines="4-6 10-11"
 from autogen.beta.network import Hub
 from autogen.beta.knowledge import MemoryKnowledgeStore
 

--- a/website/docs/beta/network/migration_from_group_chat.mdx
+++ b/website/docs/beta/network/migration_from_group_chat.mdx
@@ -187,7 +187,6 @@ from autogen.beta.network import (
     Envelope, TransitionDecision, TransitionTarget, register_target,
 )
 
-
 @dataclass(slots=True)
 class TopicRouter(TransitionTarget):
     name: ClassVar[str] = "topic_router"
@@ -199,7 +198,6 @@ class TopicRouter(TransitionTarget):
         if "security" in text:
             return TransitionDecision(next_speaker=self.security_id)
         return TransitionDecision(next_speaker=self.general_id)
-
 
 register_target(TopicRouter)
 

--- a/website/docs/beta/network/migration_from_group_chat.mdx
+++ b/website/docs/beta/network/migration_from_group_chat.mdx
@@ -44,7 +44,7 @@ alice.initiate_chat(manager, message="Topic: should every dev learn Rust?")
 
 **Beta network:**
 
-```python linenums="1" hl_lines="6 7 8 9 11 12 13 14 15"
+```python linenums="1" hl_lines="6-8 11-14 16"
 from autogen.beta.network import (
     Hub, HubClient, LocalLink, Passport, Resume,
     TransitionGraph,
@@ -125,7 +125,7 @@ groupchat = GroupChat(agents=[triage, security_reviewer, general_responder])
 
 **Beta network:**
 
-```python linenums="1" hl_lines="2 3 4 5 6 7 8 9 10 11 12 13 14 15"
+```python linenums="1" hl_lines="6-26"
 from autogen.beta.network import (
     AgentTarget, Always, FromSpeaker, RevertToInitiatorTarget,
     TerminateTarget, ToolCalled, Transition, TransitionGraph,

--- a/website/docs/beta/network/migration_from_group_chat.mdx
+++ b/website/docs/beta/network/migration_from_group_chat.mdx
@@ -44,7 +44,7 @@ alice.initiate_chat(manager, message="Topic: should every dev learn Rust?")
 
 **Beta network:**
 
-```python linenums="1" hl_lines="6-8 11-14 16"
+```python linenums="1" hl_lines="6-9 11-16"
 from autogen.beta.network import (
     Hub, HubClient, LocalLink, Passport, Resume,
     TransitionGraph,
@@ -125,7 +125,7 @@ groupchat = GroupChat(agents=[triage, security_reviewer, general_responder])
 
 **Beta network:**
 
-```python linenums="1" hl_lines="6-26"
+```python linenums="1" hl_lines="6-27"
 from autogen.beta.network import (
     AgentTarget, Always, FromSpeaker, RevertToInitiatorTarget,
     TerminateTarget, ToolCalled, Transition, TransitionGraph,

--- a/website/docs/beta/network/pattern_cookbook/context_aware_routing.mdx
+++ b/website/docs/beta/network/pattern_cookbook/context_aware_routing.mdx
@@ -129,24 +129,20 @@ from autogen.beta.testing import TestConfig
 
 load_dotenv()
 
-
 async def classify_as_billing(reason: str) -> Handoff:
     """Classify the request as billing and route to the billing specialist."""
     print(f"  [tool] classify_as_billing({reason!r})")
     return Handoff(target="billing", reason=reason)
-
 
 async def classify_as_technical(reason: str) -> Handoff:
     """Classify as technical and route to the technical specialist."""
     print(f"  [tool] classify_as_technical({reason!r})")
     return Handoff(target="technical", reason=reason)
 
-
 async def classify_as_general(reason: str) -> Handoff:
     """Classify as general support and route to the general specialist."""
     print(f"  [tool] classify_as_general({reason!r})")
     return Handoff(target="general", reason=reason)
-
 
 async def main() -> None:
     config = AnthropicConfig(model="claude-sonnet-4-6")
@@ -281,7 +277,6 @@ async def main() -> None:
     await technical_hc.close()
     await general_hc.close()
     await hub_obj.close()
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/network/pattern_cookbook/coordinator.mdx
+++ b/website/docs/beta/network/pattern_cookbook/coordinator.mdx
@@ -40,7 +40,6 @@ async def handoff(to: Literal["researcher", "critic", "cost_analyst", "operator"
     """Hand off the conversation to a participant by name."""
     return ToolResult(Handoff(target=to, reason=reason), final=True)
 
-
 async def finish(summary: str = "") -> ToolResult:
     """End the conversation cleanly with a brief summary."""
     return ToolResult(Finish(summary=summary), final=True)
@@ -178,16 +177,13 @@ from autogen.beta.testing import TestConfig
 
 load_dotenv()
 
-
 async def handoff(to: Literal["researcher", "critic", "cost_analyst", "operator"], reason: str = "") -> ToolResult:
     """Hand off the conversation to a specialist by name."""
     return ToolResult(Handoff(target=to, reason=reason), final=True)
 
-
 async def finish(summary: str = "") -> ToolResult:
     """End the conversation with a summary recommendation."""
     return ToolResult(Finish(summary=summary), final=True)
-
 
 async def main() -> None:
     config = AnthropicConfig(
@@ -367,7 +363,6 @@ async def main() -> None:
     await cost_hc.close()
     await operator_hc.close()
     await hub_obj.close()
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/network/pattern_cookbook/escalation.mdx
+++ b/website/docs/beta/network/pattern_cookbook/escalation.mdx
@@ -130,7 +130,6 @@ from autogen.beta.testing import TestConfig
 
 load_dotenv()
 
-
 async def escalate_to_tier2(reason: str) -> Handoff:
     """Escalate to the tier-2 specialist. The returned Handoff
     carries the target's Passport.name; the framework resolves
@@ -138,12 +137,10 @@ async def escalate_to_tier2(reason: str) -> Handoff:
     print(f"  [tool] escalate_to_tier2({reason!r})")
     return Handoff(target="tier2", reason=reason)
 
-
 async def escalate_to_senior(reason: str) -> Handoff:
     """Escalate to senior support."""
     print(f"  [tool] escalate_to_senior({reason!r})")
     return Handoff(target="senior", reason=reason)
-
 
 async def resolve(answer: str, channel: ChannelInject) -> str:
     """Resolve the request. Stores the answer in
@@ -154,7 +151,6 @@ async def resolve(answer: str, channel: ChannelInject) -> str:
     print(f"  [tool] resolve({answer[:60]!r}…)")
     await set_context(channel, "resolution", answer)
     return "resolved"
-
 
 async def main() -> None:
     config = AnthropicConfig(model="claude-sonnet-4-6")
@@ -294,7 +290,6 @@ async def main() -> None:
     await tier2_hc.close()
     await senior_hc.close()
     await hub_obj.close()
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/network/pattern_cookbook/feedback_loop.mdx
+++ b/website/docs/beta/network/pattern_cookbook/feedback_loop.mdx
@@ -116,7 +116,6 @@ from autogen.beta.testing import TestConfig
 
 load_dotenv()
 
-
 async def approve(reason: str, channel: ChannelInject) -> str:
     """Mark the draft approved by setting done=True in context.
     The graph's ContextEquals(done, True) rule terminates the
@@ -128,7 +127,6 @@ async def approve(reason: str, channel: ChannelInject) -> str:
     print(f"  [tool] approve({reason!r})")
     await set_context(channel, "done", True)
     return f"approved: {reason}"
-
 
 async def main() -> None:
     config = AnthropicConfig(model="claude-sonnet-4-6")
@@ -253,7 +251,6 @@ async def main() -> None:
     await drafter_hc.close()
     await reviewer_hc.close()
     await hub.close()
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/network/pattern_cookbook/hierarchical.mdx
+++ b/website/docs/beta/network/pattern_cookbook/hierarchical.mdx
@@ -124,7 +124,6 @@ from autogen.beta.testing import TestConfig
 
 load_dotenv()
 
-
 async def delegate_researcher(reason: str) -> Handoff:
     """Send the work to the research specialist. The returned
     Handoff carries the target name; the framework resolves it
@@ -133,14 +132,12 @@ async def delegate_researcher(reason: str) -> Handoff:
     print(f"  [tool] delegate_researcher({reason!r})")
     return Handoff(target="researcher", reason=reason)
 
-
 async def delegate_writer(reason: str) -> Handoff:
     """Send the work to the writing specialist. Writer's reply is
     the terminal step — the graph closes the workflow on
     FromSpeaker(writer)."""
     print(f"  [tool] delegate_writer({reason!r})")
     return Handoff(target="writer", reason=reason)
-
 
 async def main() -> None:
     config = AnthropicConfig(model="claude-sonnet-4-6")
@@ -271,7 +268,6 @@ async def main() -> None:
     await researcher_hc.close()
     await writer_hc.close()
     await hub.close()
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/network/pattern_cookbook/pattern_cookbook.mdx
+++ b/website/docs/beta/network/pattern_cookbook/pattern_cookbook.mdx
@@ -99,7 +99,6 @@ adapter scope.
 ```python linenums="1" hl_lines="1"
 from autogen.beta.network.workflow_helpers import set_context
 
-
 async def classify_as_billing(reason: str, channel: ChannelInject) -> str:
     """Classify the request as billing. Sets context_vars['category']."""
     await set_context(channel, "category", "billing")

--- a/website/docs/beta/network/pattern_cookbook/pipeline.mdx
+++ b/website/docs/beta/network/pattern_cookbook/pipeline.mdx
@@ -99,7 +99,6 @@ from autogen.beta.testing import TestConfig
 
 load_dotenv()
 
-
 async def main() -> None:
     config = AnthropicConfig(model="claude-sonnet-4-6")
 
@@ -209,7 +208,6 @@ async def main() -> None:
     await enricher_hc.close()
     await fulfilment_hc.close()
     await hub.close()
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/network/pattern_cookbook/redundant.mdx
+++ b/website/docs/beta/network/pattern_cookbook/redundant.mdx
@@ -110,7 +110,6 @@ from autogen.beta.testing import TestConfig
 
 load_dotenv()
 
-
 async def main() -> None:
     config = AnthropicConfig(model="claude-sonnet-4-6")
 
@@ -236,7 +235,6 @@ async def main() -> None:
     await nerdy_hc.close()
     await evaluator_hc.close()
     await hub_obj.close()
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/network/pattern_cookbook/star.mdx
+++ b/website/docs/beta/network/pattern_cookbook/star.mdx
@@ -147,9 +147,7 @@ from autogen.beta.testing import TestConfig
 
 load_dotenv()
 
-
 _REQUIRED_SPOKES = ("weather", "sports", "finance")
-
 
 async def ask_spoke(spoke: str, query: str) -> Handoff:
     """Route a query to one of the spokes. Returns a typed
@@ -159,7 +157,6 @@ async def ask_spoke(spoke: str, query: str) -> Handoff:
     if spoke not in _REQUIRED_SPOKES:
         return Handoff(target="hub", reason=f"unknown spoke {spoke!r}")
     return Handoff(target=spoke, reason=query)
-
 
 async def synthesise(headline: str, channel: ChannelInject, hub: HubInject) -> "Finish | str":
     """Scan the WAL for spoke replies by sender identity, build synthesis.
@@ -196,7 +193,6 @@ async def synthesise(headline: str, channel: ChannelInject, hub: HubInject) -> "
 
     await set_context(channel, "synthesis", synthesis)
     return Finish(reason="answered")
-
 
 async def main() -> None:
     # Hub config: disable parallel tool calls so Sonnet emits exactly
@@ -352,7 +348,6 @@ async def main() -> None:
     await sports_hc.close()
     await finance_hc.close()
     await hub_obj.close()
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/network/pattern_cookbook/triage_with_tasks.mdx
+++ b/website/docs/beta/network/pattern_cookbook/triage_with_tasks.mdx
@@ -103,7 +103,7 @@ async def advance_task(channel: ChannelInject, state: ChannelStateInject) -> str
 The matching graph routes per task type and terminates when the queue
 is empty:
 
-```python linenums="1" hl_lines="4 5 6 7 8 11"
+```python linenums="1" hl_lines="4-10"
 graph = TransitionGraph(
     initial_speaker=triage.agent_id,
     transitions=[

--- a/website/docs/beta/network/pattern_cookbook/triage_with_tasks.mdx
+++ b/website/docs/beta/network/pattern_cookbook/triage_with_tasks.mdx
@@ -161,7 +161,6 @@ from autogen.beta.testing import TestConfig
 
 load_dotenv()
 
-
 async def main() -> None:
     config = AnthropicConfig(model="claude-sonnet-4-6")
 
@@ -300,7 +299,6 @@ async def main() -> None:
     await writer_hc.close()
     await reviewer_hc.close()
     await hub_obj.close()
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/website/docs/beta/network/quick_start.mdx
+++ b/website/docs/beta/network/quick_start.mdx
@@ -21,7 +21,6 @@ from autogen.beta.network import (
     Resume,
 )
 
-
 async def main() -> None:
     config = AnthropicConfig(model="claude-sonnet-4-6")
 
@@ -70,7 +69,6 @@ async def main() -> None:
     await alice_hc.close()
     await bob_hc.close()
     await hub.close()
-
 
 asyncio.run(main())
 ```

--- a/website/docs/beta/network/task_observation.mdx
+++ b/website/docs/beta/network/task_observation.mdx
@@ -134,7 +134,6 @@ async def research(topic: str, ctx: Context) -> str:
         # ...
     return f"researched {topic}"
 
-
 @worker.tool
 async def summarise(text: str, ctx: Context) -> str:
     async with worker.task("summarise", capability="summarisation", context=ctx) as t:

--- a/website/docs/beta/network/termination.mdx
+++ b/website/docs/beta/network/termination.mdx
@@ -77,9 +77,8 @@ The reason string flows on `#!python EV_CHANNEL_CLOSED.event_data["reason"]` —
 
 The LLM itself decides. Define a tool that injects the active `#!python Channel` and calls `#!python close(...)`.
 
-```python linenums="1" hl_lines="1 5 6 7"
+```python linenums="1" hl_lines="1 5-7"
 from autogen.beta.network.client.inject import ChannelInject
-
 
 async def end_conversation(reason: str, channel: ChannelInject) -> str:
     """Close the active discussion. The reason flows on EV_CHANNEL_CLOSED."""
@@ -87,7 +86,6 @@ async def end_conversation(reason: str, channel: ChannelInject) -> str:
         return "no active channel"
     await channel.close(reason=f"agent_close:{reason}")
     return f"closed: {reason}"
-
 
 alice_agent.tool(end_conversation)
 bob_agent.tool(end_conversation)
@@ -107,7 +105,7 @@ The default notify handler stamps the active `#!python Channel` into `#!python c
 
 Subclass the adapter, watch every accepted envelope for a sentinel, return `#!python CLOSING`. Closest analogue to classic `#!python is_termination_msg`.
 
-```python linenums="1" hl_lines="9 10 11 12 13 14 15"
+```python linenums="1" hl_lines="9-15"
 class TerminatingConversationAdapter(ConversationAdapter):
     """Auto-closes when an EV_TEXT body contains the configured keyword."""
 
@@ -125,7 +123,6 @@ class TerminatingConversationAdapter(ConversationAdapter):
                 auto_close_reason=f"terminate_keyword:{self.keyword}",
             )
         return super().on_accepted(metadata, envelope, state)
-
 
 hub.register_adapter(TerminatingConversationAdapter(keyword="TERMINATE"))
 ```

--- a/website/docs/beta/network/termination.mdx
+++ b/website/docs/beta/network/termination.mdx
@@ -105,7 +105,7 @@ The default notify handler stamps the active `#!python Channel` into `#!python c
 
 Subclass the adapter, watch every accepted envelope for a sentinel, return `#!python CLOSING`. Closest analogue to classic `#!python is_termination_msg`.
 
-```python linenums="1" hl_lines="9-11 13-15"
+```python linenums="1" hl_lines="9-16"
 class TerminatingConversationAdapter(ConversationAdapter):
     """Auto-closes when an EV_TEXT body contains the configured keyword."""
 

--- a/website/docs/beta/network/termination.mdx
+++ b/website/docs/beta/network/termination.mdx
@@ -51,7 +51,7 @@ The hub funnels every termination through one transition, so observers only have
 
 Your code holds a `#!python Channel` handle and calls `#!python close()` whenever it decides the channel is done. Most explicit, lowest ceremony, runs entirely outside the LLM turn.
 
-```python linenums="1" hl_lines="9 10"
+```python linenums="1" hl_lines="10"
 channel = await alice.open(
     type="discussion",
     target=[bob.agent_id, carol.agent_id],
@@ -77,7 +77,7 @@ The reason string flows on `#!python EV_CHANNEL_CLOSED.event_data["reason"]` —
 
 The LLM itself decides. Define a tool that injects the active `#!python Channel` and calls `#!python close(...)`.
 
-```python linenums="1" hl_lines="1 5-7"
+```python linenums="1" hl_lines="1 3 5-7"
 from autogen.beta.network.client.inject import ChannelInject
 
 async def end_conversation(reason: str, channel: ChannelInject) -> str:
@@ -105,7 +105,7 @@ The default notify handler stamps the active `#!python Channel` into `#!python c
 
 Subclass the adapter, watch every accepted envelope for a sentinel, return `#!python CLOSING`. Closest analogue to classic `#!python is_termination_msg`.
 
-```python linenums="1" hl_lines="9-15"
+```python linenums="1" hl_lines="9-11 13-15"
 class TerminatingConversationAdapter(ConversationAdapter):
     """Auto-closes when an EV_TEXT body contains the configured keyword."""
 
@@ -141,7 +141,7 @@ Three properties this gives you for free:
 
 In `workflow` channels, terminate is just another transition. Wire a condition that emits `#!python TerminateTarget(reason="...")`. The graph's `#!python max_turns` and `#!python default_target` provide the two implicit terminate paths.
 
-```python linenums="1" hl_lines="3 4 5 11"
+```python linenums="1" hl_lines="5 11 12"
 graph = TransitionGraph(
     initial_speaker=triage.agent_id,
     transitions=[
@@ -210,7 +210,7 @@ print(f"reason: {close_env.event_data.get('reason')!r}")
 
 Or stream live and return on the close envelope:
 
-```python linenums="1" hl_lines="11"
+```python linenums="1" hl_lines="12 13"
 async def stream_until_closed(hub, channel_id, name_by_id, *, timeout=180.0):
     seen: set[str] = set()
     deadline = asyncio.get_event_loop().time() + timeout

--- a/website/docs/beta/network/views_and_skills.mdx
+++ b/website/docs/beta/network/views_and_skills.mdx
@@ -87,7 +87,6 @@ from autogen.beta.network import (
     default_name_resolver,
 )
 
-
 class FromOneOnly(ViewPolicy):
     """Show only envelopes from a single named sender, prefixed with their name."""
     name: ClassVar[str] = "from_one_only"

--- a/website/docs/beta/network/workflow.mdx
+++ b/website/docs/beta/network/workflow.mdx
@@ -131,7 +131,7 @@ graph = TransitionGraph.sequence([
 
 ## Custom Graphs
 
-```python linenums="1" hl_lines="3 4 5 7 12"
+```python linenums="1" hl_lines="5 6 9 10 13"
 graph = TransitionGraph(
     initial_speaker=triage.agent_id,
     transitions=[
@@ -157,7 +157,7 @@ For dynamic routing (target depends on runtime state), a tool can return a typed
 
 For each `#!python ToolCalled(name) → AgentTarget(agent)` transition, attach an `#!python @tool`-decorated function with that exact name and have it return a typed `#!python Handoff(target=agent.agent_id)`:
 
-```python linenums="1" hl_lines="1 2 3"
+```python linenums="1" hl_lines="1 2 4"
 @triage.tool
 async def transfer_to_eng(reason: str = "") -> Handoff:
     """Transfer the conversation to the engineering specialist."""
@@ -170,7 +170,7 @@ The workflow adapter consumes the `#!python Handoff` from the agent's local-stre
 
 A tool can also end the channel cleanly by returning a typed `#!python Finish(summary="...", reason="...")`. The framework reads it from the agent's `#!python ToolResultEvent` and closes the channel — same effect as a `#!python TerminateTarget` rule firing, but the decision is made by the tool at runtime rather than by a static graph transition:
 
-```python linenums="1" hl_lines="1 2 3"
+```python linenums="1" hl_lines="1 2 4"
 @coord.tool
 async def finish(summary: str) -> Finish:
     """Wrap up — no further handoffs needed."""
@@ -208,7 +208,7 @@ The state is read on every fold of a substantive envelope (text or handoff). So 
 
 The 1-bit case: a tool sets a boolean, the transition routes on it. This is the modern `#!python is_termination_msg` analogue, but generalised to "is some condition met."
 
-```python linenums="1" hl_lines="2 3 4 5 11"
+```python linenums="1" hl_lines="5 7"
 graph = TransitionGraph(
     initial_speaker=intake.agent_id,
     transitions=[
@@ -229,7 +229,7 @@ Triage's tool flips `#!python urgent=True` when the ticket warrants paging. The 
 
 Three or more buckets, one `#!python ContextEquals` per branch. Order matters: lower-priority transitions are checked first, and ties resolve in *insertion order*. Put the more specific rules first so they win:
 
-```python linenums="1" hl_lines="3 4 5 6"
+```python linenums="1" hl_lines="4-6"
 graph = TransitionGraph(
     initial_speaker=triage.agent_id,
     transitions=[
@@ -314,7 +314,7 @@ register_condition(ContextThreshold)
 
 ## Opening a Workflow Channel
 
-```python linenums="1" hl_lines="6 7 8 9 10"
+```python linenums="1" hl_lines="6-9"
 graph = TransitionGraph.round_robin(
     participants=[alice.agent_id, bob.agent_id, carol.agent_id],
     max_turns=6,

--- a/website/docs/beta/network/workflow.mdx
+++ b/website/docs/beta/network/workflow.mdx
@@ -314,7 +314,7 @@ register_condition(ContextThreshold)
 
 ## Opening a Workflow Channel
 
-```python linenums="1" hl_lines="6-9"
+```python linenums="1" hl_lines="6-10"
 graph = TransitionGraph.round_robin(
     participants=[alice.agent_id, bob.agent_id, carol.agent_id],
     max_turns=6,

--- a/website/docs/beta/network/workflow.mdx
+++ b/website/docs/beta/network/workflow.mdx
@@ -290,11 +290,10 @@ The first fix is the more common pattern — terminate transitions are cheap, th
 
 `#!python ContextEquals` is the only context-driven condition shipped today. For richer predicates, register your own — the Protocol is `#!python evaluate(state, envelope) -> bool`:
 
-```python linenums="1" hl_lines="6 7 8 9 10 11 12 13 17"
+```python linenums="1" hl_lines="5-7 9-11 13-15 17"
 from typing import ClassVar
 from dataclasses import dataclass
 from autogen.beta.network import register_condition
-
 
 @dataclass(slots=True)
 class ContextThreshold:
@@ -307,7 +306,6 @@ class ContextThreshold:
     def evaluate(self, state, envelope) -> bool:
         value = state.context_vars.get(self.key, 0)
         return isinstance(value, (int, float)) and value >= self.threshold
-
 
 register_condition(ContextThreshold)
 ```
@@ -378,7 +376,6 @@ from autogen.beta.network import (
     register_target,
 )
 
-
 @dataclass(slots=True)
 class HighestRankedReviewer(TransitionTarget):
     name: ClassVar[str] = "highest_ranked_reviewer"
@@ -387,7 +384,6 @@ class HighestRankedReviewer(TransitionTarget):
     def resolve(self, state, envelope: Envelope) -> TransitionDecision:
         # ...look up the next reviewer based on your domain logic...
         return TransitionDecision(next_speaker=chosen_id)
-
 
 register_target(HighestRankedReviewer)
 ```

--- a/website/docs/beta/structured_output.mdx
+++ b/website/docs/beta/structured_output.mdx
@@ -56,7 +56,7 @@ The following patterns mirror how structured output is used in applications: tri
 
 Route incoming text into fields your helpdesk or CRM already understands:
 
-```python linenums="1" hl_lines="18 26"
+```python linenums="1" hl_lines="7 10-12 18"
 from typing import Annotated
 from pydantic import BaseModel, Field
 
@@ -90,7 +90,7 @@ triage = await reply.content()
 
 Turn natural language into something your scheduling layer can consume:
 
-```python linenums="1" hl_lines="17 23"
+```python linenums="1" hl_lines="6-11 17"
 from dataclasses import dataclass
 
 from autogen.beta import Agent
@@ -120,7 +120,7 @@ window = await reply.content()
 
 Use a primitive schema when the payload is a single JSON value and your prompt defines the scale:
 
-```python linenums="1" hl_lines="8 14"
+```python linenums="1" hl_lines="6 8"
 from autogen.beta import Agent
 from autogen.beta.config import OpenAIConfig
 
@@ -155,7 +155,7 @@ result = await reply.content()
 
 ### Dataclasses
 
-```python linenums="1" hl_lines="8"
+```python linenums="1" hl_lines="3-6 8"
 from dataclasses import dataclass
 
 @dataclass
@@ -171,7 +171,7 @@ result = await reply.content()
 
 ### Pydantic models
 
-```python linenums="1" hl_lines="7"
+```python linenums="1" hl_lines="3-5 7"
 from pydantic import BaseModel
 
 class Sentiment(BaseModel):
@@ -251,7 +251,7 @@ result = await reply.content()
 
 ### Async validator: enrich after JSON parse
 
-```python linenums="1" hl_lines="4"
+```python linenums="1" hl_lines="4 6-7"
 import json
 
 @response_schema
@@ -355,7 +355,7 @@ Parameters with a Python default (plain value or `Field(default, ...)`) are usua
 
 Validators participate in the same dependency injection model as tools. Inject [`Context`](/docs/beta/context/variables) to read `variables`, tie validation to session state, or perform lookups:
 
-```python linenums="1" hl_lines="4"
+```python linenums="1" hl_lines="4 6"
 from autogen.beta import Context, response_schema
 
 @response_schema
@@ -389,7 +389,7 @@ result = await reply.content()
 
 You can keep a **single** schema definition (type, `ResponseSchema`, or `@response_schema` callable) and **only wrap it when** you need prompt-based delivery. The inner `validate` logic and JSON shape stay the same; `PromptedSchema` swaps how the schema reaches the model (system-prompt text instead of API `response_format`).
 
-```python linenums="1" hl_lines="7 15 22 23"
+```python linenums="1" hl_lines="7 15 22"
 from autogen.beta import Agent, PromptedSchema, ResponseSchema, response_schema
 from autogen.beta.config import OpenAIConfig
 

--- a/website/docs/beta/system_prompts.mdx
+++ b/website/docs/beta/system_prompts.mdx
@@ -9,7 +9,7 @@ sidebarTitle: Prompt Management
 
 Agents can be initialized with a static system prompt. You can provide a single string or a list of strings:
 
-```python linenums="1" hl_lines="6 12-14"
+```python linenums="1" hl_lines="6 12-15"
 from autogen.beta import Agent
 
 # Single string prompt
@@ -38,7 +38,7 @@ Dynamic prompt functions support the same powerful execution context capabilitie
 
 Dynamic prompts are evaluated only once at the beginning of the conversation, and their results are appended to the static prompts and reused for subsequent turns.
 
-```python linenums="1" hl_lines="5-10"
+```python linenums="1" hl_lines="5-11"
 from autogen.beta import Agent, Context
 
 agent = Agent("assistant")

--- a/website/docs/beta/system_prompts.mdx
+++ b/website/docs/beta/system_prompts.mdx
@@ -9,7 +9,7 @@ sidebarTitle: Prompt Management
 
 Agents can be initialized with a static system prompt. You can provide a single string or a list of strings:
 
-```python linenums="1" hl_lines="6 12-15"
+```python linenums="1" hl_lines="6 12-14"
 from autogen.beta import Agent
 
 # Single string prompt
@@ -38,7 +38,7 @@ Dynamic prompt functions support the same powerful execution context capabilitie
 
 Dynamic prompts are evaluated only once at the beginning of the conversation, and their results are appended to the static prompts and reused for subsequent turns.
 
-```python linenums="1" hl_lines="5-11"
+```python linenums="1" hl_lines="5-10"
 from autogen.beta import Agent, Context
 
 agent = Agent("assistant")
@@ -54,7 +54,7 @@ async def dynamic_sysprompt(ctx: Context) -> str:
 
 Alternatively, you can pass a callable directly to the `prompt` parameter, or mix static strings and callables in a list:
 
-```python linenums="1" hl_lines="8"
+```python linenums="1" hl_lines="9"
 from autogen.beta import Agent
 
 def get_sysprompt() -> str:

--- a/website/docs/beta/task_delegation.mdx
+++ b/website/docs/beta/task_delegation.mdx
@@ -96,7 +96,7 @@ coordinator = Agent(
 
 An agent can delegate to itself to break complex work into independent sub-tasks. Each sub-task runs as a fresh copy of the agent with its own stream and history.
 
-```python linenums="1" hl_lines="12-15"
+```python linenums="1" hl_lines="12-17"
 analyst = Agent(
     "analyst",
     prompt=(

--- a/website/docs/beta/task_delegation.mdx
+++ b/website/docs/beta/task_delegation.mdx
@@ -23,7 +23,7 @@ Breaking work across multiple agents gives you:
 
 Use `#!python Agent.as_tool()` to make one agent available as a tool for another.
 
-```python linenums="1" hl_lines="23-26"
+```python linenums="1" hl_lines="24-25"
 from autogen.beta import Agent
 from autogen.beta.config import AnthropicConfig
 
@@ -96,7 +96,7 @@ coordinator = Agent(
 
 An agent can delegate to itself to break complex work into independent sub-tasks. Each sub-task runs as a fresh copy of the agent with its own stream and history.
 
-```python linenums="1" hl_lines="12-17"
+```python linenums="1" hl_lines="12-15"
 analyst = Agent(
     "analyst",
     prompt=(
@@ -124,7 +124,7 @@ The analyst's LLM may call `sub_task` multiple times — one per aspect — then
 
 `#!python dynamic_agent()` lets the calling LLM **construct** an ephemeral agent at runtime — picking a name, system prompt, and a subset of available tools per objective — instead of pre-defining each delegate as a named `#!python as_tool()`. Use it when the orchestrator should compose a focused worker on demand for each sub-task.
 
-```python linenums="1" hl_lines="2 16-19"
+```python linenums="1" hl_lines="2 17"
 from autogen.beta import Agent
 from autogen.beta.tools.dynamic import dynamic_agent
 from autogen.beta.config import OpenAIConfig
@@ -214,7 +214,7 @@ It stores the stream ID in `#!python context.dependencies` keyed by `#!python f"
 
 For full control, pass any callable matching `#!python StreamFactory = Callable[[Agent, Context], Stream]`:
 
-```python linenums="1" hl_lines="4-6 9"
+```python linenums="1" hl_lines="4-5 9"
 from autogen.beta import Agent, Context
 from autogen.beta.streams.redis import RedisStream
 

--- a/website/docs/beta/tasks.mdx
+++ b/website/docs/beta/tasks.mdx
@@ -137,7 +137,7 @@ except ValueError as exc:
 
 Subscribe directly on the bound stream to capture every lifecycle event in order.
 
-```python linenums="1" hl_lines="6 7 8"
+```python linenums="1" hl_lines="6-9"
 from autogen.beta.events import TaskCompleted, TaskProgress, TaskStarted
 
 stream = MemoryStream()

--- a/website/docs/beta/tasks.mdx
+++ b/website/docs/beta/tasks.mdx
@@ -102,7 +102,7 @@ Returns an unentered `#!python Task`. Use as `#!python async with agent.task(...
 
 ## Bound Context vs. Standalone
 
-```python linenums="1" hl_lines="3 6"
+```python linenums="1" hl_lines="4 6"
 from autogen.beta.context import ConversationContext
 from autogen.beta.stream import MemoryStream
 
@@ -124,7 +124,7 @@ The `#!python async with` block has these guarantees:
 - **Exception inside the block** -> auto `#!python fail(exc)`, then the exception propagates.
 - **Already terminal at exit time** -> nothing further happens.
 
-```python linenums="1" hl_lines="4"
+```python linenums="1" hl_lines="3 5"
 try:
     async with agent.task("flaky") as task:
         raise ValueError("boom")
@@ -172,7 +172,7 @@ async with agent.task("work", context=ctx) as task:
 
 `#!python TaskInject` is a fast_depends-resolvable annotation that injects the active Task into any function the dependency-injection machinery resolves — most usefully a `#!python @tool` body.
 
-```python linenums="1" hl_lines="1 5"
+```python linenums="1" hl_lines="2 5"
 from autogen.beta import tool
 from autogen.beta.task import TaskInject
 
@@ -192,7 +192,7 @@ Setting `#!python ttl_seconds=N` populates `#!python metadata.expires_at` but **
 
 For self-contained TTL behaviour, wire up a sweeper in your application:
 
-```python linenums="1" hl_lines="6 7"
+```python linenums="1" hl_lines="3 4"
 async def sweep(task: Task, deadline: datetime) -> None:
     while task.state == TaskState.RUNNING:
         if datetime.now(timezone.utc) >= deadline:

--- a/website/docs/beta/testing.mdx
+++ b/website/docs/beta/testing.mdx
@@ -37,7 +37,7 @@ You can also use `TestConfig` to yield tool calls. This allows you to test both 
 
 To test a successful tool execution, pass a `ToolCallEvent` followed by the final answer you expect the LLM to provide after the tool executes.
 
-```python linenums="1" hl_lines="16-18 24"
+```python linenums="1" hl_lines="16-19 24"
 import pytest
 
 from autogen.beta import Agent

--- a/website/docs/beta/testing.mdx
+++ b/website/docs/beta/testing.mdx
@@ -37,7 +37,7 @@ You can also use `TestConfig` to yield tool calls. This allows you to test both 
 
 To test a successful tool execution, pass a `ToolCallEvent` followed by the final answer you expect the LLM to provide after the tool executes.
 
-```python linenums="1" hl_lines="16-19 21"
+```python linenums="1" hl_lines="16-18 24"
 import pytest
 
 from autogen.beta import Agent

--- a/website/docs/beta/tools/approval_required.mdx
+++ b/website/docs/beta/tools/approval_required.mdx
@@ -57,7 +57,7 @@ Typing **y** lets the tool run. Any other input denies it — the agent receives
 
 Override the `message` parameter to tailor the approval prompt:
 
-```python linenums="1" hl_lines="2-5"
+```python linenums="1" hl_lines="2-4"
 @tool(
     middleware=[approval_required(
         message="⚠️ The agent wants to run `{tool_name}` with {tool_arguments}. Allow? (y/n)",

--- a/website/docs/beta/tools/approval_required.mdx
+++ b/website/docs/beta/tools/approval_required.mdx
@@ -57,7 +57,7 @@ Typing **y** lets the tool run. Any other input denies it — the agent receives
 
 Override the `message` parameter to tailor the approval prompt:
 
-```python linenums="1" hl_lines="2-4"
+```python linenums="1" hl_lines="2-5"
 @tool(
     middleware=[approval_required(
         message="⚠️ The agent wants to run `{tool_name}` with {tool_arguments}. Allow? (y/n)",

--- a/website/docs/beta/tools/code_execution.mdx
+++ b/website/docs/beta/tools/code_execution.mdx
@@ -113,7 +113,6 @@ Safety defaults are deliberately strict:
 from autogen.beta.tools import SandboxCodeTool
 from autogen.beta.tools.code import CodeEnvironment, CodeLanguage, CodeRunResult
 
-
 class MyEnvironment(CodeEnvironment):
     @property
     def supported_languages(self) -> tuple[CodeLanguage, ...]:
@@ -123,7 +122,6 @@ class MyEnvironment(CodeEnvironment):
         # ship code to wherever you run it; return stdout + exit code
         ...
         return CodeRunResult(output="...", exit_code=0)
-
 
 sandbox = SandboxCodeTool(MyEnvironment())
 ```

--- a/website/docs/beta/tools/tools.mdx
+++ b/website/docs/beta/tools/tools.mdx
@@ -82,7 +82,6 @@ def fetch_data_sync(url: str) -> str:
     import requests
     return requests.get(url).text
 
-
 # This native asynchronous tool runs directly in the main event loop
 @tool
 async def fetch_data_async(url: str) -> str:
@@ -349,7 +348,6 @@ def get_exchange_rate(currency: str) -> ToolResult:
         DataInput({"currency": currency, "rate": 1.23, "base": "USD"}),
         final=True,
     )
-
 
 agent = Agent(name="SupportBot", tools=[handoff_to_human])
 

--- a/website/docs/beta/tools/tools.mdx
+++ b/website/docs/beta/tools/tools.mdx
@@ -130,7 +130,7 @@ def math_op(a: int, b: int) -> int:
 
 Under the hood, arguments are serialized and validated using [Pydantic](https://docs.pydantic.dev/latest/){.external-link target="_blank"} schemas. This means you can use standard `pydantic.Field` annotations to deeply customize individual schema parameters, providing the LLM with strict guidelines on what values are acceptable.
 
-```python linenums="1" hl_lines="8-12 17-20"
+```python linenums="1" hl_lines="8-13 17-21"
 from typing import Annotated
 from pydantic import Field
 
@@ -162,7 +162,7 @@ def set_temperature(
 
 A complete example combining custom tool properties and strict parameter validation looks like this:
 
-```python linenums="1" hl_lines="6 7 12-16 21-24"
+```python linenums="1" hl_lines="6-7 12-17 21-25"
 from typing import Annotated
 from pydantic import Field
 from autogen.beta import tool

--- a/website/docs/beta/tools/tools.mdx
+++ b/website/docs/beta/tools/tools.mdx
@@ -130,7 +130,7 @@ def math_op(a: int, b: int) -> int:
 
 Under the hood, arguments are serialized and validated using [Pydantic](https://docs.pydantic.dev/latest/){.external-link target="_blank"} schemas. This means you can use standard `pydantic.Field` annotations to deeply customize individual schema parameters, providing the LLM with strict guidelines on what values are acceptable.
 
-```python linenums="1" hl_lines="8-13 17-21"
+```python linenums="1" hl_lines="8-12 17-20"
 from typing import Annotated
 from pydantic import Field
 
@@ -162,7 +162,7 @@ def set_temperature(
 
 A complete example combining custom tool properties and strict parameter validation looks like this:
 
-```python linenums="1" hl_lines="6 7 12-17 21-25"
+```python linenums="1" hl_lines="6 7 12-16 21-24"
 from typing import Annotated
 from pydantic import Field
 from autogen.beta import tool


### PR DESCRIPTION
## Why are these changes needed?

The beta docs code-block highlights were broken in two compounding ways. This PR fixes both and prevents recurrence.

**1. MkDocs collapses consecutive blank lines.** MkDocs Material renders two or more consecutive blank lines inside a code block as a single blank line. The source still counts every blank, so any `hl_lines` authored against the source silently mis-highlights once rendered.

- Collapsed all consecutive blank lines to single separators across the beta code examples — 135 blank lines removed across 45 files. Only content inside ``` ``` ``` fences was touched; prose is untouched. Verified: 0 double-blanks remain.
- Documented the pitfall in `website/AGENTS.md` (and `CLAUDE.md`, a symlink): a `!!! warning` admonition plus a "Maintaining `hl_lines`" checklist item.

**2. Stale highlights throughout.** Beyond the blank-line drift, many `hl_lines` ranges were simply out of date — pointing at a lone closing bracket, a blank line, a boilerplate import, or an arbitrary subset that no longer matched the code (e.g. the `Declaring Authentication` block highlighting lines `3, 8, 11–15`).

- Audited **every** `hl_lines` block in the beta docs — 174 blocks across 42 files — and reset each to mark the lines the surrounding prose actually makes a point about (the definition, the key call, the wired-in argument). ~94 blocks updated across 35 files.
- Highlights now consistently land on load-bearing lines and never on blank lines or trailing lone brackets.

### Verification

- A script confirms no code block contains consecutive blank lines.
- A script confirms no `hl_lines` entry points at a blank, an out-of-bounds, or a standalone/trailing bracket line.
- A line-by-line diff against the base confirms **only `hl_lines` attribute values and blank lines changed — no code logic or prose was altered**.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)