### PR TITLE
fix(beta/tools): emit a valid empty-object JSON Schema for zero-argument tools

### DIFF
--- a/autogen/beta/tools/final/function_tool.py
+++ b/autogen/beta/tools/final/function_tool.py
@@ -179,17 +179,24 @@ def tool(
             call_model,
             name=name or f.__name__,
             description=description or f.__doc__ or "",
-            schema=schema
-            or get_schema(
-                call_model,
-                exclude=(CONTEXT_OPTION_NAME,),
-            ),
+            schema=_normalize_parameters(schema, call_model),
             middleware=middleware,
         )
 
     if function:
         return make_tool(function)
     return make_tool
+
+
+def _normalize_parameters(schema: FunctionParameters | None, call_model: CallModel) -> FunctionParameters:
+    if schema is not None:
+        return schema
+    # A no-arg callable yields {"type": "null"}, invalid as a JSON Schema object for tool
+    # `parameters` for some LLM providers.
+    generated = get_schema(call_model, exclude=(CONTEXT_OPTION_NAME,))
+    if generated.get("type") != "object":
+        return {"type": "object", "properties": {}}
+    return generated
 
 
 def _wrap_middleware(hook: "ToolMiddleware", inner: "ToolExecution") -> "ToolExecution":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ ag-ui = ["ag-ui-protocol>=0.1.15,<0.2"]
 diskcache = ["diskcache"]
 
 # providers
-openai = ["openai>=2.41.0,<3.0"]
+openai = ["openai>=2.43.0,<3.0"]
 openai-realtime = ["ag2[openai]", "openai[realtime]"]
 
 deepseek = ["ag2[openai]"]

--- a/test/beta/tools/test_naming.py
+++ b/test/beta/tools/test_naming.py
@@ -146,6 +146,24 @@ def test_empty_args() -> None:
     }
 
 
+def test_explicit_schema_is_preserved() -> None:
+    explicit = {"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]}
+
+    @tool(schema=explicit)
+    def my_tool() -> str:
+        """Tool description."""
+        return ""
+
+    assert asdict(my_tool.schema) == {
+        "function": {
+            "description": "Tool description.",
+            "name": "my_tool",
+            "parameters": explicit,
+        },
+        "type": "function",
+    }
+
+
 @pytest.mark.xfail()
 def test_create_dynamic_options() -> None:
     @tool

--- a/test/beta/tools/test_naming.py
+++ b/test/beta/tools/test_naming.py
@@ -138,7 +138,8 @@ def test_empty_args() -> None:
             "description": "Tool description.",
             "name": "my_tool",
             "parameters": {
-                "type": "null",
+                "type": "object",
+                "properties": {},
             },
         },
         "type": "function",


### PR DESCRIPTION
## Why are these changes needed?

A no-arg @tool generated `{"type": "null"}` for its parameters (from fast_depends/pydantic), which OpenAI realtime rejects, invalidating the entire tools array and silently disabling tool calling. Fixed at the source so every provider benefits:

In `autogen/beta/tools/final/function_tool.py`, added a new `_normalize_parameters` helper coerces a generated non-object schema (i.e. the no-arg null case) to `{"type": "object", "properties": {}}`. An explicit user-supplied `schema=` is passed through untouched.

This was created to support OpenAI which fails with the no arg tools. Have tested this against OpenAI (chat completions and responses API), Anthropic, Gemini, and xAI.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
