### PR TITLE
Docs: Add TealTiger to ecosystem sidebar navigation

### DIFF
--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -575,6 +575,7 @@
         "docs/ecosystem/pgvector",
         "docs/ecosystem/portkey",
         "docs/ecosystem/promptflow",
+        "docs/ecosystem/tealtiger",
         "docs/ecosystem/waldiez"
       ]
     },


### PR DESCRIPTION
The TealTiger ecosystem page was merged in #2962 but was not added to the sidebar navigation in `mint-json-template.json.jinja`.

This one-line fix adds `"docs/ecosystem/tealtiger"` to the Ecosystem navigation group (alphabetically between promptflow and waldiez), so it appears in the sidebar alongside the other ecosystem integrations.

Page is live at https://docs.ag2.ai/latest/docs/ecosystem/tealtiger but currently only accessible via direct URL.
