### PR TITLE
fix(reasoning): cache node rating regardless of value

### DIFF
--- a/autogen/agents/experimental/reasoning/reasoning_agent.py
+++ b/autogen/agents/experimental/reasoning/reasoning_agent.py
@@ -586,7 +586,7 @@ Final Answer:
         Returns:
             float: Normalized score between 0 and 1 indicating trajectory quality
         """
-        if node.value > 0 and node.rating_details:
+        if node.rating_details:
             # we already calculated the rating for the node
             return node.value
 
@@ -760,7 +760,7 @@ Rating: <rating>
         rewards = []
         # Get rewards and assign rating details to corresponding nodes
         for node, rating, details in zip(nodes, ratings, options_with_ratings):
-            if node.value > 0 and node.rating_details:
+            if node.rating_details:
                 # we already calculated the rating for the node
                 rewards.append(node.value)
                 continue

--- a/test/agents/experimental/reasoning/test_reasoning_agent.py
+++ b/test/agents/experimental/reasoning/test_reasoning_agent.py
@@ -495,6 +495,31 @@ def test_rate_batch_nodes_invalid_response(mock_credentials: Credentials) -> Non
         assert rewards == [0.0, 0.0]
 
 
+def test_rate_node_caches_zero_value(mock_credentials: Credentials) -> None:
+    """A node already graded to 0.0 (e.g. the worst rating of 1) must hit the
+    rating cache and not call the grader again.
+
+    The cache sentinel is `rating_details`; keying the early return on
+    `value > 0` skipped the cache for any legitimately zero-valued node and
+    re-invoked the grader.
+    """
+    node = ThinkNode(content="The capital of France is Paris.")
+    # State of a node that was already graded with the worst rating (1 -> 0.0).
+    node.rating_details = "Rating: 1 - requires a survey, not executable."
+    node.value = 0.0
+
+    with patch("autogen.agentchat.conversable_agent.ConversableAgent.generate_oai_reply") as mock_oai_reply:
+        agent = ReasoningAgent(
+            "test_agent",
+            llm_config=mock_credentials.llm_config,
+        )
+
+        reward = agent.rate_node(node)
+
+    assert reward == 0.0
+    mock_oai_reply.assert_not_called()
+
+
 def test_execute_node_with_cached_output(mock_credentials: Credentials, think_node: ThinkNode) -> None:
     """
     Test that execute_node returns the cached output if it exists.


### PR DESCRIPTION
## Why are these changes needed?

`ReasoningAgent` caches a node's grade so it isn't re-sent to the grader on repeat visits. The guard required the cached value to be positive in addition to the real sentinel `rating_details`:

```python
if node.value > 0 and node.rating_details:
    return node.value
```

`rating_details` is set exactly when a node is graded; `node.value` is the normalized reward `(rating - 1.0) / (rating_scale - 1.0)`. A trajectory that legitimately receives the worst rating of `1` normalizes to `value = 0.0` (an unparseable grader response also defaults to `0.0`). In those cases `rating_details` is set but `value > 0` is `False`, so the cache misses and the node is graded a second time — an extra grader/LLM call — and the "already calculated" fast path is unreachable for any zero-valued node.

The same guard is duplicated in `rate_batch_nodes`. This change keys the cache on `rating_details` alone at both sites, so an already-graded node is never re-graded regardless of its value.

## Related issue number

Closes ag2ai/ag2classic#4

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [ ] I understand the changes in this PR and can explain them in my own words.
- [ ] I have verified that the PR description accurately reflects the actual diff.
- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
