### PR TITLE
ci(docs): squash gh-pages commits to stop history bloat

### DIFF
--- a/.github/workflows/build-mkdocs.yml
+++ b/.github/workflows/build-mkdocs.yml
@@ -50,7 +50,7 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-      - name: Deploy docs to GH Pages
+      - name: Build docs and squash gh-pages commits
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.9'
         run: |
           . .venv/bin/activate
@@ -66,9 +66,34 @@ jobs:
           echo $VERSION
           echo $IS_RC
 
+          # mike commits the freshly built site locally (no --push). The commits it
+          # creates each carry a full site snapshot, so we soft-reset them away and let
+          # the commit step below force-push a single squashed commit. This keeps the
+          # gh-pages branch from accumulating large historical commits.
           if [ "$IS_RC" == "False" ] || [ "$VERSION" == "0.9.1post0" ]; then
-            cd website/mkdocs && mike deploy -F mkdocs.yml --update-aliases $VERSION latest
-            mike set-default --push --allow-empty -F mkdocs.yml latest
+            cd website/mkdocs
+            mike deploy -F mkdocs.yml --update-aliases $VERSION latest
+            mike set-default --allow-empty -F mkdocs.yml latest
+
+            # Doc commits are large, keep only the last one
+            git checkout gh-pages
+            git reset --soft HEAD~3
           else
-            cd website/mkdocs && mike deploy --push -F mkdocs.yml --update-aliases $VERSION
+            cd website/mkdocs
+            mike deploy -F mkdocs.yml --update-aliases $VERSION
+
+            # Doc commits are large, keep only the last one
+            git checkout gh-pages
+            git reset --soft HEAD~2
           fi
+
+      - name: Force-push squashed docs to GH Pages
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.9'
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+        with:
+          branch: gh-pages
+          push_options: "--force"  # force push to keep gh-pages history clear
+          commit_message: "docs: deploy docs"
+          commit_user_name: github-actions[bot]
+          commit_user_email: github-actions[bot]@users.noreply.github.com
+          commit_author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
## Why are these changes needed?

The `gh-pages` branch had accumulated **~1,391 commits**, each carrying a full ~7.8 GB versioned-docs snapshot, which bloated the repository. The cause: `mike` was pushing every commit it creates (`mike deploy --push` / `mike set-default --push`).

This PR adopts the pattern already proven in [ag2ai/faststream](https://github.com/ag2ai/faststream/blob/main/.github/workflows/docs_build.yaml):

- Remove `--push` from the `mike` commands so the build is committed only locally.
- After building, `git checkout gh-pages` and `git reset --soft HEAD~3` (non-RC) / `HEAD~2` (RC) to collapse the large commits `mike` just created.
- Force-push a **single** squashed commit per deploy via `stefanzweifel/git-auto-commit-action` (pinned by SHA, `--force`).

Result: `gh-pages` grows by one commit per release instead of three, and history can no longer re-accumulate.

> Note: the existing bloated history was separately reset out-of-band — `gh-pages` was recreated as a single orphan commit (live site and all `mike` versions preserved: `CNAME`, `versions.json`, all 52,880 files). This PR ensures the bloat does not come back.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. (N/A — CI-only change; not unit-testable.)
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)