### PR TITLE
feat(beta): push messages into a running agent's inbox

### DIFF
--- a/autogen/beta/agent.py
+++ b/autogen/beta/agent.py
@@ -75,6 +75,7 @@ from .middleware.base import (
 from .observers import Observer
 from .plugin import Plugin, PluginTarget, PromptType
 from .response import ResponseProto, ResponseSchema
+from .run import RunHandle, RunRegistry
 from .stream import MemoryStream, Stream
 from .task import CheckpointStore, Task, TaskSpec
 from .tools.final import FunctionTool, FunctionToolSchema, Toolkit, tool
@@ -653,6 +654,57 @@ class Agent(PluginTarget, Generic[TResult]):
             response_schema=response_schema,
             hitl_hook=hitl_hook,
         )
+
+    def run(
+        self,
+        *msg: SendableMessage | Input,
+        stream: Stream | None = None,
+        registry: "RunRegistry | None" = None,
+        dependencies: dict[Any, Any] | None = None,
+        variables: dict[Any, Any] | None = None,
+        prompt: Iterable[str] = (),
+        config: ModelConfig | None = None,
+        tools: Iterable[Tool] = (),
+        middleware: Iterable[MiddlewareFactory] = (),
+        observers: Iterable[Observer] = (),
+        response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
+        hitl_hook: HumanHook | None = None,
+    ) -> "RunHandle[Any]":
+        """Start a turn in the background and return a :class:`RunHandle`.
+
+        Unlike :meth:`ask` (which you await to completion), ``run`` schedules
+        the turn as an ``asyncio.Task`` and returns immediately. The returned
+        handle lets a producer push follow-up messages into the live run's
+        inbox via ``handle.send(...)``; they are consumed at the next step
+        boundary (between tool rounds / after the model is done), never
+        mid-LLM-call. The handle's ``task_id`` is the underlying stream id.
+
+        Must be called from within a running event loop. If ``stream`` is
+        omitted a fresh :class:`MemoryStream` is created and owned by the run;
+        pass your own to share the inbox/history. When ``registry`` is given the
+        handle is registered under its ``task_id`` for external addressing.
+        """
+        stream = stream or MemoryStream()
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(
+            self.ask(
+                *msg,
+                stream=stream,
+                dependencies=dependencies,
+                variables=variables,
+                prompt=prompt,
+                config=config,
+                tools=tools,
+                middleware=middleware,
+                observers=observers,
+                response_schema=response_schema,
+                hitl_hook=hitl_hook,
+            )
+        )
+        handle: RunHandle[Any] = RunHandle(stream, task, loop)
+        if registry is not None:
+            registry.register(handle)
+        return handle
 
     async def resume(
         self,

--- a/autogen/beta/run.py
+++ b/autogen/beta/run.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Generic
+
+from typing_extensions import TypeVar as TypeVar313
+
+from .context import Stream, StreamId
+from .events import Input
+from .types import SendableMessage
+
+if TYPE_CHECKING:
+    from .agent import AgentReply
+
+__all__ = ("RunHandle", "RunRegistry")
+
+TResult = TypeVar313("TResult", default=str)
+
+
+class RunHandle(Generic[TResult]):
+    """A handle to an agent turn started via :meth:`Agent.run`.
+
+    The handle exposes:
+
+    - :attr:`task_id` — the stream id, used to address this run in a registry.
+    - :meth:`send` — push a follow-up message into the live run's inbox. It is
+      read at the next step boundary; it does **not** interrupt the current
+      model call. Safe to call from any thread.
+    - :meth:`result` — await the turn's final :class:`AgentReply`.
+    - :meth:`done` / :meth:`cancel`.
+
+    ``send`` after the run has already finished is **not** an error: the message
+    is durably appended to ``stream.pending_messages`` and consumed by the next
+    ``ask``/``run`` on the same stream. Check :meth:`done` if you need to know.
+    """
+
+    __slots__ = ("stream", "_task", "_loop")
+
+    def __init__(
+        self,
+        stream: Stream,
+        task: "asyncio.Task[AgentReply[TResult, Any]]",
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        self.stream = stream
+        self._task = task
+        self._loop = loop
+
+    @property
+    def task_id(self) -> StreamId:
+        """Stable id of this run — the underlying stream's id."""
+        return self.stream.id
+
+    def send(self, *content: "SendableMessage | Input") -> None:
+        """Push follow-up content into the running turn's inbox (thread-safe).
+
+        Read at the next step boundary, not mid-LLM-call. When invoked from a
+        thread other than the run's event loop, the enqueue is marshalled onto
+        that loop via ``call_soon_threadsafe`` so the plain-list inbox is only
+        ever mutated from its owning loop.
+        """
+        if not content:
+            return
+
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+
+        if running is self._loop:
+            self.stream.enqueue(*content)
+        else:
+            self._loop.call_soon_threadsafe(self._enqueue, content)
+
+    def _enqueue(self, content: "tuple[SendableMessage | Input, ...]") -> None:
+        # call_soon_threadsafe passes a single positional arg; unpack here so
+        # the scheduled callback runs on the owning loop.
+        self.stream.enqueue(*content)
+
+    def done(self) -> bool:
+        """Whether the underlying turn has finished (completed/failed/cancelled)."""
+        return self._task.done()
+
+    def cancel(self) -> bool:
+        """Request cancellation of the underlying turn."""
+        return self._task.cancel()
+
+    async def result(self) -> "AgentReply[TResult, Any]":
+        """Await and return the turn's final :class:`AgentReply`."""
+        return await self._task
+
+    def __await__(self) -> "Any":
+        return self._task.__await__()
+
+
+class RunRegistry:
+    """Maps ``task_id`` to the live :class:`RunHandle` for in-flight runs.
+
+    Instantiate one per server (not a module global) to avoid leaking run state
+    across servers or tests. Handles are auto-removed when their turn finishes.
+    """
+
+    __slots__ = ("_runs",)
+
+    def __init__(self) -> None:
+        self._runs: dict[StreamId, RunHandle[Any]] = {}
+
+    def register(self, handle: "RunHandle[Any]") -> None:
+        """Track ``handle`` and arrange auto-removal when its turn finishes."""
+        self._runs[handle.task_id] = handle
+        handle._task.add_done_callback(lambda _t, tid=handle.task_id: self._runs.pop(tid, None))
+
+    def get(self, task_id: StreamId) -> "RunHandle[Any] | None":
+        return self._runs.get(task_id)
+
+    def send(self, task_id: StreamId, *content: "SendableMessage | Input") -> bool:
+        """Route ``content`` to the run with ``task_id``.
+
+        Returns ``True`` if a live run was found and the message was pushed,
+        ``False`` if no such run is registered (e.g. already finished/removed).
+        """
+        handle = self._runs.get(task_id)
+        if handle is None:
+            return False
+        handle.send(*content)
+        return True
+
+    def active(self) -> "list[StreamId]":
+        """Ids of currently-registered (in-flight) runs."""
+        return list(self._runs)

--- a/test/beta/agent/test_run_handle.py
+++ b/test/beta/agent/test_run_handle.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the public mid-run message injection API (Agent.run / RunHandle).
+
+These exercise the in-process layer over the existing stream inbox: a producer
+pushes a follow-up message into a *live* run and the agent picks it up at the
+next step boundary (between tool rounds), never mid-LLM-call.
+
+The tool announces it has started (``started`` event) so the test injects while
+the tool is genuinely in flight — otherwise an injection sent before the run
+begins would be drained into the very first request (drain at turn start) and
+never reach the LLM as a standalone follow-up.
+
+Delivery is asserted via ``TrackingConfig``: it records the last message handed
+to the LLM on each call, so we can check the injected text actually reached the
+model rather than inspecting internal stream state.
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+from autogen.beta import Agent, Context, tool
+from autogen.beta.events import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    ToolCallEvent,
+)
+from autogen.beta.run import RunHandle, RunRegistry
+from autogen.beta.testing import TestConfig, TrackingConfig
+
+
+def _reached_llm(tracking: TrackingConfig, text: str) -> bool:
+    """Whether any request the framework sent to the LLM carried ``text``."""
+    sent = [call.args[0] for call in tracking.mock.call_args_list]
+    return any(isinstance(m, ModelRequest) and TextInput(text) in m.parts for m in sent)
+
+
+def _injectable_agent(started: asyncio.Event) -> tuple[Agent, TrackingConfig]:
+    """Agent whose tool signals start then yields until an externally-injected
+    message lands in the inbox, then a final reply. Returns the agent and the
+    TrackingConfig used to assert what reached the LLM."""
+    tracking = TrackingConfig(
+        TestConfig(
+            ToolCallEvent(name="wait_for_injection", arguments="{}"),
+            ModelResponse(ModelMessage("Done.")),
+        )
+    )
+
+    @tool
+    async def wait_for_injection(ctx: Context) -> str:
+        """Yield until the externally-injected message reaches the inbox."""
+        started.set()
+        for _ in range(300):
+            if ctx.pending_messages:
+                return "ok"
+            await asyncio.sleep(0.01)
+        raise AssertionError("injected message never arrived")
+
+    agent = Agent("agent", config=tracking, tools=[wait_for_injection])
+    return agent, tracking
+
+
+@pytest.mark.asyncio
+class TestRunHandle:
+    async def test_send_mid_run_reaches_llm(self) -> None:
+        """A message pushed via handle.send() during a tool round is delivered
+        to the LLM on the following call."""
+        injected = "URGENT: also summarize in French"
+        started = asyncio.Event()
+        agent, tracking = _injectable_agent(started)
+
+        handle = agent.run("Start the task")
+        await asyncio.wait_for(started.wait(), timeout=3.0)
+        handle.send(injected)  # pushed while the tool is in flight
+
+        reply = await asyncio.wait_for(handle.result(), timeout=3.0)
+        assert reply.body == "Done."
+        assert _reached_llm(tracking, injected)
+
+    async def test_task_id_is_stream_id(self) -> None:
+        agent = Agent("agent", config=TestConfig(ModelResponse(ModelMessage("hi"))))
+        handle = agent.run("hello")
+        assert isinstance(handle, RunHandle)
+        assert handle.task_id == handle.stream.id
+        await asyncio.wait_for(handle.result(), timeout=3.0)
+        assert handle.done()
+
+    async def test_registry_routes_and_autoremoves(self) -> None:
+        """RunRegistry.send routes by task_id; the handle is auto-removed when
+        the run finishes, after which send() returns False."""
+        injected = "extra instruction via registry"
+        started = asyncio.Event()
+        agent, tracking = _injectable_agent(started)
+
+        registry = RunRegistry()
+        handle = agent.run("Start", registry=registry)
+        assert handle.task_id in registry.active()
+
+        await asyncio.wait_for(started.wait(), timeout=3.0)
+        assert registry.send(handle.task_id, injected) is True
+
+        reply = await asyncio.wait_for(handle.result(), timeout=3.0)
+        assert reply.body == "Done."
+        assert _reached_llm(tracking, injected)
+
+        # Auto-removed after completion (done-callback runs on the loop).
+        await asyncio.sleep(0)
+        assert handle.task_id not in registry.active()
+        assert registry.send(handle.task_id, "too late") is False
+
+    async def test_send_from_other_thread(self) -> None:
+        """handle.send() from a non-loop thread is marshalled onto the run's
+        loop via call_soon_threadsafe and still reaches the LLM."""
+        injected = "pushed from a worker thread"
+        started = asyncio.Event()
+        agent, tracking = _injectable_agent(started)
+
+        handle = agent.run("Start")
+        await asyncio.wait_for(started.wait(), timeout=3.0)
+        threading.Thread(target=handle.send, args=(injected,)).start()
+
+        reply = await asyncio.wait_for(handle.result(), timeout=3.0)
+        assert reply.body == "Done."
+        assert _reached_llm(tracking, injected)


### PR DESCRIPTION
## Summary

Adds a public API to push a follow-up message into an agent **while it is working**. The message is read at the next step boundary (between tool rounds / after the model is done), without interrupting the current LLM call.

## What's added

- `autogen/beta/run.py`:
  - `RunHandle` — handle to a background run: `task_id`, `send(*content)`
    (thread-safe), `result()`, `done()`, `cancel()`, awaitable.
  - `RunRegistry` — maps `task_id` → live run so external code can address a
    run by id (`registry.send(task_id, ...)`). Auto-removes on completion.
- `Agent.run(...)` — schedules a turn as an `asyncio.Task` and returns a
  `RunHandle` immediately.

```python
handle = agent.run("Start the task")
handle.send("also add a security section")   # picked up at next step boundary
reply = await handle.result()

# address by id (basis for the upcoming network layer):
registry = RunRegistry()
handle = agent.run("task", registry=registry)
registry.send(handle.task_id, "mind the budget")
```