### PR TITLE
ci(docs): squash gh-pages relative to origin/gh-pages

### DIFF
--- a/.github/workflows/build-mkdocs.yml
+++ b/.github/workflows/build-mkdocs.yml
@@ -73,26 +73,19 @@ jobs:
           echo $VERSION
           echo $IS_RC
 
-          # mike commits the freshly built site locally (no --push). The commits it
-          # creates each carry a full site snapshot, so we soft-reset them away and let
-          # the commit step below force-push a single squashed commit. This keeps the
-          # gh-pages branch from accumulating large historical commits.
+          # mike commits the built site locally; the force-push step below squashes it.
           if [ "$IS_RC" == "False" ] || [ "$VERSION" == "0.9.1post0" ]; then
             cd website/mkdocs
             mike deploy -F mkdocs.yml --update-aliases $VERSION latest
             mike set-default --allow-empty -F mkdocs.yml latest
-
-            # Doc commits are large, keep only the last one
-            git checkout gh-pages
-            git reset --soft HEAD~3
           else
             cd website/mkdocs
             mike deploy -F mkdocs.yml --update-aliases $VERSION
-
-            # Doc commits are large, keep only the last one
-            git checkout gh-pages
-            git reset --soft HEAD~2
           fi
+
+          # Collapse mike's commits into one staged change on top of published gh-pages.
+          git checkout gh-pages
+          git reset --soft origin/gh-pages
 
       - name: Force-push squashed docs to GH Pages
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/0.9'


### PR DESCRIPTION
## Why are these changes needed?

Deployment was failing due to trying to undo to commits that didn't exist on `gh-pages`.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
