### PR TITLE
fix: key rating cache on rating_details alone in ReasoningAgent

### DIFF
--- a/autogen/agents/experimental/reasoning/reasoning_agent.py
+++ b/autogen/agents/experimental/reasoning/reasoning_agent.py
@@ -586,7 +586,7 @@ Final Answer:
         Returns:
             float: Normalized score between 0 and 1 indicating trajectory quality
         """
-        if node.value > 0 and node.rating_details:
+        if node.rating_details:
             # we already calculated the rating for the node
             return node.value
 
@@ -760,7 +760,7 @@ Rating: <rating>
         rewards = []
         # Get rewards and assign rating details to corresponding nodes
         for node, rating, details in zip(nodes, ratings, options_with_ratings):
-            if node.value > 0 and node.rating_details:
+            if node.rating_details:
                 # we already calculated the rating for the node
                 rewards.append(node.value)
                 continue


### PR DESCRIPTION
## Summary

\`rate_node\` and \`rate_batch_nodes\` guard the already-graded fast-path with:

\`\`\`python
if node.value > 0 and node.rating_details:
\`\`\`

\`node.value\` is the normalized reward \`(rating - 1) / (scale - 1)\`, which is \`0.0\` when the grader returns the **worst rating of 1** and also when the grader response fails to parse (defaulting to \`0.0\`). In both cases \`rating_details\` is already set (the node was graded), but the guard does not fire, so the grader is called a second time unnecessarily.

The correct cache sentinel is \`rating_details\` alone — it is set exactly once, when a node finishes grading.

## Changes

- \`autogen/agents/experimental/reasoning/reasoning_agent.py\` — drop \`node.value > 0 and\` from the cache guard in both \`rate_node\` (line 589) and \`rate_batch_nodes\` (line 763)

Fixes ag2ai/ag2classic#4