### PR TITLE
fix: substitute bare ${var} even when the same var is used inside len()

### DIFF
--- a/autogen/agentchat/group/context_expression.py
+++ b/autogen/agentchat/group/context_expression.py
@@ -191,12 +191,10 @@ class ContextExpression:
             full_match = match.group(0)
             eval_expr = eval_expr.replace(full_match, str(length_value))
 
-        # Then replace remaining variable references with their values
+        # Then replace remaining variable references with their values. The len() pass above
+        # already substituted every len(${var}) occurrence, so a variable can still have bare
+        # ${var} references left here even if it was also used inside len(); do not skip it.
         for var_name in self._variable_names:
-            # Skip variables that were already processed in len() expressions
-            if any(m.group(1) == var_name for m in len_matches):
-                continue
-
             # Check if variable exists in context, raise KeyError if not
             if not context_variables.contains(var_name):
                 raise KeyError(f"Missing context variable: '{var_name}'")

--- a/test/agentchat/group/test_context_expression.py
+++ b/test/agentchat/group/test_context_expression.py
@@ -454,6 +454,24 @@ class TestContextExpressionNewSyntax:
             is True
         )
 
+    def test_variable_used_in_len_and_bare_reference(self) -> None:
+        """A variable used both inside len() and as a bare reference must still be substituted.
+
+        Previously the bare ${var} was skipped whenever the same name appeared in a len()
+        match, so the literal ${var} survived into eval() and raised a ValueError.
+        """
+        context = ContextVariables(
+            data={
+                "items": [1, 2, 3],
+                "empty": [],
+            }
+        )
+
+        assert ContextExpression("len(${items}) > 0 and ${items}").evaluate(context) is True
+        assert ContextExpression("len(${empty}) == 0 or ${empty}").evaluate(context) is True
+        # bare reference appearing before the len() use
+        assert ContextExpression("${items} and len(${items}) == 3").evaluate(context) is True
+
     def test_string_injection_prevention(self) -> None:
         """Regression test for GHSA-9fvw-gr53-m7fw: string context vars must not allow eval injection.
 


### PR DESCRIPTION
## Why are these changes needed?

`ContextExpression.evaluate()` substitutes `len(${var})` occurrences first, then replaces the remaining bare `${var}` references. The second pass skips any variable whose name appeared in a `len()` match:

```python
for var_name in self._variable_names:
    # Skip variables that were already processed in len() expressions
    if any(m.group(1) == var_name for m in len_matches):
        continue
    ...
    eval_expr = eval_expr.replace(f"${{{var_name}}}", formatted_value)
```

So a variable used **both** inside `len()` and as a bare reference, e.g. `len(${items}) > 0 and ${items}`, never gets its bare `${items}` substituted. The literal `${items}` survives into `eval()`, which raises a `SyntaxError` that is re-wrapped as `ValueError`. The expression validates fine at construction, so this is a latent runtime failure on an ordinary pattern (check a collection is non-empty, then use it).

The `len()` pass above has already replaced every `len(${var})` substring with its numeric length, so by the time the bare-reference loop runs there is no `len(${var})` text left for these variables; the skip is unnecessary and is what causes the bug. Removing it makes the bare `${var}` get replaced correctly, and it is a harmless no-op for variables that only ever appeared inside `len()` (no bare `${var}` remains to replace).

## Related issue number

Found via code review; no existing issue.

## Checks

- [ ] I've included any doc changes needed (no documentation changes are needed for this bug fix).
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
