### PR TITLE
test(beta): skip a2ui ag-ui e2e test when ag_ui is not installed

### DIFF
--- a/test/beta/a2ui/transports/test_e2e_ag_ui.py
+++ b/test/beta/a2ui/transports/test_e2e_ag_ui.py
@@ -18,8 +18,10 @@ from typing import Annotated, Any
 
 import httpx
 import pytest
-from ag_ui.core import RunAgentInput
 from dirty_equals import IsPartialDict
+
+pytest.importorskip("ag_ui")
+from ag_ui.core import RunAgentInput
 
 from autogen.beta import Agent, Depends
 from autogen.beta.a2ui import A2UIServer, a2ui_action


### PR DESCRIPTION
## Why are these changes needed?

Skips A2UI AG-UI end-to-end test when `ag_ui` is not installed.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [ ] I understand the changes in this PR and can explain them in my own words.
- [ ] I have verified that the PR description accurately reflects the actual diff.
- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
