### PR TITLE
chore: Support 'package' as OpenAI parameter and bump minimum openai version

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -214,6 +214,7 @@ OPENAI_FALLBACK_KWARGS = {
     "http_client",
     "_strict_response_validation",
     "webhook_secret",
+    "provider",
     "workload_identity",
     "_enforce_credentials",
     "admin_api_key",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ ag-ui = ["ag-ui-protocol>=0.1.15,<0.2"]
 diskcache = ["diskcache"]
 
 # providers
-openai = ["openai>=2.43.0,<3.0"]
+openai = ["openai>=2.44.0,<3.0"]
 openai-realtime = ["ag2[openai]", "openai[realtime]"]
 
 deepseek = ["ag2[openai]"]


### PR DESCRIPTION
## Why are these changes needed?

Support the package parameter for OpenAI API. Bumps minimum version to align.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [ ] I understand the changes in this PR and can explain them in my own words.
- [ ] I have verified that the PR description accurately reflects the actual diff.
- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
