### PR TITLE
test(beta): Fix flaky discussion round-robin smoke test

### DIFF
--- a/test/beta/providers/anthropic/test_network_smoke.py
+++ b/test/beta/providers/anthropic/test_network_smoke.py
@@ -117,6 +117,7 @@ async def test_peers_then_delegate_consults_a_specialist(
 
 @pytest.mark.anthropic
 @pytest.mark.asyncio()
+@pytest.mark.timeout(120)
 async def test_5way_discussion_round_robin(
     anthropic_config: AnthropicConfig,
 ) -> None:

--- a/test/beta/providers/anthropic/test_session_smoke.py
+++ b/test/beta/providers/anthropic/test_session_smoke.py
@@ -165,21 +165,35 @@ async def test_conversation_bidirectional_real_llm(anthropic_config: AnthropicCo
 
 @pytest.mark.anthropic
 @pytest.mark.asyncio
+@pytest.mark.timeout(90)
 async def test_discussion_round_robin_three_real_agents(anthropic_config: AnthropicConfig) -> None:
     """3-way discussion. Each agent's default handler engages only
     when the adapter's ``expected_next_speaker`` matches them (via the
     ``can_send`` probe), so the rotation is naturally synchronous.
+
+    Four sequential real LLM round-trips (alice → bob → carol → alice)
+    exceed the suite-wide 45s ``pytest-timeout``, so this test carries
+    its own 90s marker. Prompts give each agent a concrete opinion to
+    state so every turn yields a substantive non-empty reply — an empty
+    reply posts no envelope and would dead-stall the rotation.
     """
+    _opinion_prompt = (
+        "You are {name}, a participant in a round-robin discussion about "
+        "whether remote work is good for software teams. When it is your "
+        "turn, reply with exactly one short opinion (one sentence) as "
+        "plain text. Do not ask questions and do not call any tools — just "
+        "state your opinion."
+    )
     hub = await Hub.open(MemoryKnowledgeStore(), ttl_sweep_interval=0, expectation_sweep_interval=0)
 
     alice = await hub.register(
-        _agent("alice", "You are alice. Reply briefly in one sentence.", anthropic_config),
+        _agent("alice", _opinion_prompt.format(name="alice"), anthropic_config),
     )
     bob = await hub.register(
-        _agent("bob", "You are bob. Reply briefly in one sentence.", anthropic_config),
+        _agent("bob", _opinion_prompt.format(name="bob"), anthropic_config),
     )
     carol = await hub.register(
-        _agent("carol", "You are carol. Reply briefly in one sentence.", anthropic_config),
+        _agent("carol", _opinion_prompt.format(name="carol"), anthropic_config),
     )
 
     channel = await alice.open(
@@ -187,11 +201,13 @@ async def test_discussion_round_robin_three_real_agents(anthropic_config: Anthro
         target=["bob", "carol"],
         knobs={"ordering": "round_robin"},
     )
-    await channel.send("Each of you say hello with your name.")
+    await channel.send("Let's debate: is remote work good for software teams?")
 
     # Expect alice (kickoff) → bob → carol → alice (cycle wraps).
-    # Stop at 4 EV_TEXT envelopes.
-    wal = await _wait_text_count(hub, channel.channel_id, expected=4, timeout=60.0)
+    # Stop at 4 EV_TEXT envelopes. Poll budget sits under the 90s
+    # per-test timeout marker so a stall surfaces the assertion below
+    # rather than a signal kill.
+    wal = await _wait_text_count(hub, channel.channel_id, expected=4, timeout=75.0)
     text_envelopes = [e for e in wal if e.event_type == EV_TEXT]
     senders = [e.sender_id for e in text_envelopes[:4]]
     assert senders == [alice.agent_id, bob.agent_id, carol.agent_id, alice.agent_id], (

--- a/test/beta/providers/anthropic/test_session_smoke.py
+++ b/test/beta/providers/anthropic/test_session_smoke.py
@@ -170,12 +170,6 @@ async def test_discussion_round_robin_three_real_agents(anthropic_config: Anthro
     """3-way discussion. Each agent's default handler engages only
     when the adapter's ``expected_next_speaker`` matches them (via the
     ``can_send`` probe), so the rotation is naturally synchronous.
-
-    Four sequential real LLM round-trips (alice → bob → carol → alice)
-    exceed the suite-wide 45s ``pytest-timeout``, so this test carries
-    its own 90s marker. Prompts give each agent a concrete opinion to
-    state so every turn yields a substantive non-empty reply — an empty
-    reply posts no envelope and would dead-stall the rotation.
     """
     _opinion_prompt = (
         "You are {name}, a participant in a round-robin discussion about "


### PR DESCRIPTION
## Why are these changes needed?

The round-robin test in the LLM integration tests can exceed the timeout and, possibly, a bug with agents not responding and halting the flow. This addresses the timeout and increases the agents likelihood of responding.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [ ] I understand the changes in this PR and can explain them in my own words.
- [ ] I have verified that the PR description accurately reflects the actual diff.
- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
