### PR TITLE
feat(beta): add ZAI Files API support

### DIFF
--- a/autogen/beta/config/zai/__init__.py
+++ b/autogen/beta/config/zai/__init__.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .config import ZAIConfig
+from .files import ZAIFilesClient
 from .zai_client import ZAIClient
 
 __all__ = (
     "ZAIClient",
     "ZAIConfig",
+    "ZAIFilesClient",
 )

--- a/autogen/beta/config/zai/config.py
+++ b/autogen/beta/config/zai/config.py
@@ -10,6 +10,7 @@ from typing_extensions import Unpack
 
 from autogen.beta.config.config import ModelConfig
 
+from .files import ZAIFilesClient
 from .zai_client import CreateOptions, ZAIClient
 
 
@@ -79,6 +80,9 @@ class ZAIConfig(ModelConfig):
 
     def copy(self, /, **overrides: Unpack[ZAIConfigOverrides]) -> "ZAIConfig":
         return replace(self, **overrides)
+
+    def create_files_client(self) -> ZAIFilesClient:
+        return ZAIFilesClient(self)
 
     def create(self) -> ZAIClient:
         options = CreateOptions(

--- a/autogen/beta/config/zai/files.py
+++ b/autogen/beta/config/zai/files.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from io import BytesIO
+from typing import TYPE_CHECKING, Any
+
+from zai import ZaiClient
+
+from autogen.beta.files.types import FileContent, FileProvider, UploadedFile, _created_at_to_float
+
+if TYPE_CHECKING:
+    from autogen.beta.config.zai.config import ZAIConfig
+
+_DEFAULT_PURPOSE = "retrieval"
+
+
+class ZAIFilesClient:
+    """Files API client for Z.AI."""
+
+    __slots__ = ("_client",)
+
+    def __init__(self, config: "ZAIConfig") -> None:
+        kwargs: dict[str, Any] = {}
+        if config.api_key is not None:
+            kwargs["api_key"] = config.api_key
+        if config.base_url is not None:
+            kwargs["base_url"] = config.base_url
+        if config.timeout is not None:
+            kwargs["timeout"] = config.timeout
+        kwargs["max_retries"] = config.max_retries
+        if config.http_client is not None:
+            kwargs["http_client"] = config.http_client
+        if config.custom_headers is not None:
+            kwargs["custom_headers"] = config.custom_headers
+        kwargs["disable_token_cache"] = config.disable_token_cache
+        if config.source_channel is not None:
+            kwargs["source_channel"] = config.source_channel
+        self._client = ZaiClient(**kwargs)
+
+    async def upload(self, data: bytes, filename: str, purpose: str | None = None) -> UploadedFile:
+        result = await asyncio.to_thread(
+            self._client.files.create,
+            file=(filename, BytesIO(data)),
+            purpose=purpose or _DEFAULT_PURPOSE,
+        )
+        return UploadedFile(
+            file_id=result.id,
+            filename=result.filename,
+            provider=FileProvider.ZAI,
+            bytes_count=result.bytes,
+            purpose=result.purpose,
+            created_at=_created_at_to_float(result.created_at),
+        )
+
+    async def read(self, file_id: str) -> FileContent:
+        # The zai SDK exposes only raw content (no metadata-by-id endpoint), so the
+        # filename and media type are unavailable here.
+        response = await asyncio.to_thread(self._client.files.content, file_id)
+        return FileContent(name=None, data=response.content, media_type=None)
+
+    async def list(self) -> list[UploadedFile]:
+        result = await asyncio.to_thread(self._client.files.list)
+        return [
+            UploadedFile(
+                file_id=f.id,
+                filename=f.filename,
+                provider=FileProvider.ZAI,
+                bytes_count=f.bytes,
+                purpose=f.purpose,
+                created_at=_created_at_to_float(f.created_at),
+            )
+            for f in result.data
+        ]
+
+    async def delete(self, file_id: str) -> None:
+        await asyncio.to_thread(self._client.files.delete, file_id)

--- a/autogen/beta/config/zai/files.py
+++ b/autogen/beta/config/zai/files.py
@@ -13,11 +13,26 @@ from autogen.beta.files.types import FileContent, FileProvider, UploadedFile, _c
 if TYPE_CHECKING:
     from autogen.beta.config.zai.config import ZAIConfig
 
-_DEFAULT_PURPOSE = "retrieval"
+# Default upload purpose; see ZAIFilesClient.upload for why "batch".
+_DEFAULT_PURPOSE = "batch"
+
+# Purposes that GET /files can enumerate without extra params; see ZAIFilesClient.list.
+_LISTABLE_PURPOSES = ("batch", "fine-tune", "voice-clone-input")
 
 
 class ZAIFilesClient:
-    """Files API client for Z.AI."""
+    """Files API client for Z.AI.
+
+    Unlike OpenAI/xAI, Z.AI's Files API is *purpose-bound* — it is not a general blob
+    store, and each ``purpose`` has its own rules:
+
+    - ``"batch"``     — a ``.jsonl``/``.xlsx`` batch-input file; the only purpose that
+      supports the full upload/list/read(download)/delete round-trip.
+    - ``"fine-tune"`` — a conversational ``.jsonl``; upload/list/delete work, but the
+      server rejects content download.
+    - ``"retrieval"`` — Doc/Docx/PDF/Xlsx/URL, but it REQUIRES a ``knowledge_id`` (a
+      pre-existing knowledge base) or the server returns 400 "知识库id不能为空".
+    """
 
     __slots__ = ("_client",)
 
@@ -39,11 +54,33 @@ class ZAIFilesClient:
             kwargs["source_channel"] = config.source_channel
         self._client = ZaiClient(**kwargs)
 
-    async def upload(self, data: bytes, filename: str, purpose: str | None = None) -> UploadedFile:
+    async def upload(
+        self,
+        data: bytes,
+        filename: str,
+        purpose: str | None = None,
+        *,
+        knowledge_id: str | None = None,
+        sentence_size: int | None = None,
+        custom_separator: list[str] | None = None,
+    ) -> UploadedFile:
+        """Upload a file. Defaults to the "batch" purpose so a plain upload works out of
+        the box; pass another ``purpose`` (and ``knowledge_id``/``sentence_size``/
+        ``custom_separator`` for "retrieval") to opt into the other modes.
+        """
+        # Forward only the extras the caller actually set; the SDK rejects unexpected None.
+        extra: dict[str, Any] = {}
+        if knowledge_id is not None:
+            extra["knowledge_id"] = knowledge_id
+        if sentence_size is not None:
+            extra["sentence_size"] = sentence_size
+        if custom_separator is not None:
+            extra["custom_separator"] = custom_separator
         result = await asyncio.to_thread(
             self._client.files.create,
             file=(filename, BytesIO(data)),
             purpose=purpose or _DEFAULT_PURPOSE,
+            **extra,
         )
         return UploadedFile(
             file_id=result.id,
@@ -61,7 +98,17 @@ class ZAIFilesClient:
         return FileContent(name=None, data=response.content, media_type=None)
 
     async def list(self) -> list[UploadedFile]:
-        result = await asyncio.to_thread(self._client.files.list)
+        """List uploaded files.
+
+        Z.AI's GET /files requires a ``purpose`` filter (an unfiltered list returns
+        nothing), and "retrieval" additionally needs a ``knowledge_id``. So we query
+        each purpose that is listable without extra params and merge the results;
+        "retrieval" files are not enumerable here.
+        """
+        results = await asyncio.gather(
+            *(asyncio.to_thread(self._client.files.list, purpose=p) for p in _LISTABLE_PURPOSES),
+            return_exceptions=True,
+        )
         return [
             UploadedFile(
                 file_id=f.id,
@@ -71,6 +118,8 @@ class ZAIFilesClient:
                 purpose=f.purpose,
                 created_at=_created_at_to_float(f.created_at),
             )
+            for result in results
+            if not isinstance(result, BaseException)
             for f in result.data
         ]
 

--- a/autogen/beta/files/api.py
+++ b/autogen/beta/files/api.py
@@ -4,6 +4,7 @@
 
 from os import PathLike
 from pathlib import Path
+from typing import Any
 
 from autogen.beta.config.config import ModelConfig
 
@@ -24,8 +25,14 @@ class FilesAPI(FilesClient):
         data: bytes | None = None,
         filename: str | None = None,
         purpose: str | None = None,
+        **provider_options: Any,
     ) -> UploadedFile:
-        """Upload a file to the provider."""
+        """Upload a file to the provider.
+
+        Provider-specific options can be passed as keyword arguments and are
+        forwarded to the underlying client (e.g. ``knowledge_id`` for Z.AI's
+        ``retrieval`` purpose). Clients ignore options they do not recognize.
+        """
         if path is not None:
             p = Path(path)
             data = p.read_bytes()
@@ -34,7 +41,7 @@ class FilesAPI(FilesClient):
             raise ValueError("Either 'path' or 'data' must be provided.")
         if filename is None:
             raise ValueError("'filename' is required when using 'data' without 'path'.")
-        return await self._client.upload(data, filename, purpose)
+        return await self._client.upload(data, filename, purpose, **provider_options)
 
     async def read(self, file_id: str) -> FileContent:
         """Download file content by ID."""

--- a/autogen/beta/files/types.py
+++ b/autogen/beta/files/types.py
@@ -26,6 +26,7 @@ class FileProvider(str, Enum):
     ANTHROPIC = "anthropic"
     GEMINI = "gemini"
     XAI = "xai"
+    ZAI = "zai"
 
 
 class UploadedFile(FileIdInput):

--- a/test/beta/config/zai/conftest.py
+++ b/test/beta/config/zai/conftest.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def zai_config() -> MagicMock:
+    config = MagicMock()
+    config.api_key = "test-key"
+    config.base_url = None
+    config.timeout = None
+    config.max_retries = 3
+    config.http_client = None
+    config.custom_headers = None
+    config.disable_token_cache = True
+    config.source_channel = None
+    return config

--- a/test/beta/config/zai/test_files.py
+++ b/test/beta/config/zai/test_files.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autogen.beta.config.zai.files import ZAIFilesClient
+from autogen.beta.files.types import FileContent, FileProvider, UploadedFile
+
+
+@patch("autogen.beta.config.zai.files.ZaiClient")
+def test_files_client_construction_omits_none_options(mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
+    ZAIFilesClient(zai_config)
+
+    mock_zai_client.assert_called_once_with(
+        api_key="test-key",
+        max_retries=3,
+        disable_token_cache=True,
+    )
+
+
+@pytest.mark.asyncio
+class TestZAIFilesClient:
+    # The zai SDK is synchronous (wrapped via asyncio.to_thread), so the inner client is a
+    # MagicMock, not an AsyncMock.
+
+    @patch("autogen.beta.config.zai.files.ZaiClient")
+    async def test_upload_defaults_to_retrieval(self, mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_zai_client.return_value = mock_client
+        mock_client.files.create.return_value = SimpleNamespace(
+            id="file_123",
+            filename="hello.txt",
+            bytes=5,
+            purpose="retrieval",
+            created_at=123,
+        )
+
+        result = await ZAIFilesClient(zai_config).upload(b"hello", "hello.txt")
+
+        assert result == UploadedFile(
+            file_id="file_123",
+            filename="hello.txt",
+            provider=FileProvider.ZAI,
+            bytes_count=5,
+            purpose="retrieval",
+            created_at=123.0,
+        )
+        kwargs = mock_client.files.create.call_args.kwargs
+        assert kwargs["purpose"] == "retrieval"
+        name, buffer = kwargs["file"]
+        assert name == "hello.txt"
+        assert buffer.read() == b"hello"
+
+    @patch("autogen.beta.config.zai.files.ZaiClient")
+    async def test_upload_with_explicit_purpose(self, mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_zai_client.return_value = mock_client
+        mock_client.files.create.return_value = SimpleNamespace(
+            id="file_123",
+            filename="data.jsonl",
+            bytes=10,
+            purpose="batch",
+            created_at=1,
+        )
+
+        result = await ZAIFilesClient(zai_config).upload(b"payload---", "data.jsonl", "batch")
+
+        assert result == UploadedFile(
+            file_id="file_123",
+            filename="data.jsonl",
+            provider=FileProvider.ZAI,
+            bytes_count=10,
+            purpose="batch",
+            created_at=1.0,
+        )
+        assert mock_client.files.create.call_args.kwargs["purpose"] == "batch"
+
+    @patch("autogen.beta.config.zai.files.ZaiClient")
+    async def test_read_returns_bytes_without_metadata(self, mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_zai_client.return_value = mock_client
+        mock_client.files.content.return_value = SimpleNamespace(content=b"file-bytes")
+
+        result = await ZAIFilesClient(zai_config).read("file_123")
+
+        assert result == FileContent(name=None, data=b"file-bytes", media_type=None)
+        mock_client.files.content.assert_called_once_with("file_123")
+
+    @patch("autogen.beta.config.zai.files.ZaiClient")
+    async def test_list(self, mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_zai_client.return_value = mock_client
+        mock_client.files.list.return_value = SimpleNamespace(
+            data=[
+                SimpleNamespace(
+                    id="file_1",
+                    filename="a.jsonl",
+                    bytes=100,
+                    purpose="retrieval",
+                    created_at=123,
+                ),
+            ]
+        )
+
+        result = await ZAIFilesClient(zai_config).list()
+
+        assert result == [
+            UploadedFile(
+                file_id="file_1",
+                filename="a.jsonl",
+                provider=FileProvider.ZAI,
+                bytes_count=100,
+                purpose="retrieval",
+                created_at=123.0,
+            ),
+        ]
+
+    @patch("autogen.beta.config.zai.files.ZaiClient")
+    async def test_delete(self, mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_zai_client.return_value = mock_client
+
+        await ZAIFilesClient(zai_config).delete("file_123")
+
+        mock_client.files.delete.assert_called_once_with("file_123")

--- a/test/beta/config/zai/test_files.py
+++ b/test/beta/config/zai/test_files.py
@@ -28,32 +28,57 @@ class TestZAIFilesClient:
     # MagicMock, not an AsyncMock.
 
     @patch("autogen.beta.config.zai.files.ZaiClient")
-    async def test_upload_defaults_to_retrieval(self, mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
+    async def test_upload_defaults_to_batch(self, mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
         mock_client = MagicMock()
         mock_zai_client.return_value = mock_client
         mock_client.files.create.return_value = SimpleNamespace(
             id="file_123",
-            filename="hello.txt",
+            filename="hello.jsonl",
             bytes=5,
-            purpose="retrieval",
+            purpose="batch",
             created_at=123,
         )
 
-        result = await ZAIFilesClient(zai_config).upload(b"hello", "hello.txt")
+        result = await ZAIFilesClient(zai_config).upload(b"hello", "hello.jsonl")
 
         assert result == UploadedFile(
             file_id="file_123",
-            filename="hello.txt",
+            filename="hello.jsonl",
             provider=FileProvider.ZAI,
             bytes_count=5,
-            purpose="retrieval",
+            purpose="batch",
             created_at=123.0,
         )
         kwargs = mock_client.files.create.call_args.kwargs
-        assert kwargs["purpose"] == "retrieval"
+        assert kwargs["purpose"] == "batch"
+        # Provider-specific extras are omitted unless the caller sets them.
+        assert "knowledge_id" not in kwargs
         name, buffer = kwargs["file"]
-        assert name == "hello.txt"
+        assert name == "hello.jsonl"
         assert buffer.read() == b"hello"
+
+    @patch("autogen.beta.config.zai.files.ZaiClient")
+    async def test_upload_forwards_retrieval_options(self, mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_zai_client.return_value = mock_client
+        mock_client.files.create.return_value = SimpleNamespace(
+            id="file_123", filename="doc.pdf", bytes=5, purpose="retrieval", created_at=1
+        )
+
+        await ZAIFilesClient(zai_config).upload(
+            b"hello",
+            "doc.pdf",
+            "retrieval",
+            knowledge_id="kb-123",
+            sentence_size=256,
+            custom_separator=["\n"],
+        )
+
+        kwargs = mock_client.files.create.call_args.kwargs
+        assert kwargs["purpose"] == "retrieval"
+        assert kwargs["knowledge_id"] == "kb-123"
+        assert kwargs["sentence_size"] == 256
+        assert kwargs["custom_separator"] == ["\n"]
 
     @patch("autogen.beta.config.zai.files.ZaiClient")
     async def test_upload_with_explicit_purpose(self, mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
@@ -91,20 +116,19 @@ class TestZAIFilesClient:
         mock_client.files.content.assert_called_once_with("file_123")
 
     @patch("autogen.beta.config.zai.files.ZaiClient")
-    async def test_list(self, mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
+    async def test_list_aggregates_across_purposes(self, mock_zai_client: MagicMock, zai_config: MagicMock) -> None:
         mock_client = MagicMock()
         mock_zai_client.return_value = mock_client
-        mock_client.files.list.return_value = SimpleNamespace(
-            data=[
-                SimpleNamespace(
-                    id="file_1",
-                    filename="a.jsonl",
-                    bytes=100,
-                    purpose="retrieval",
-                    created_at=123,
-                ),
-            ]
-        )
+
+        # GET /files needs a purpose filter, so the client queries each listable purpose
+        # and merges the results.
+        per_purpose = {
+            "batch": [SimpleNamespace(id="file_1", filename="a.jsonl", bytes=100, purpose="batch", created_at=1)],
+            "fine-tune": [
+                SimpleNamespace(id="file_2", filename="b.jsonl", bytes=200, purpose="fine-tune", created_at=2)
+            ],
+        }
+        mock_client.files.list.side_effect = lambda *, purpose: SimpleNamespace(data=per_purpose.get(purpose, []))
 
         result = await ZAIFilesClient(zai_config).list()
 
@@ -114,8 +138,16 @@ class TestZAIFilesClient:
                 filename="a.jsonl",
                 provider=FileProvider.ZAI,
                 bytes_count=100,
-                purpose="retrieval",
-                created_at=123.0,
+                purpose="batch",
+                created_at=1.0,
+            ),
+            UploadedFile(
+                file_id="file_2",
+                filename="b.jsonl",
+                provider=FileProvider.ZAI,
+                bytes_count=200,
+                purpose="fine-tune",
+                created_at=2.0,
             ),
         ]
 

--- a/test/beta/config/zai/test_zai_config.py
+++ b/test/beta/config/zai/test_zai_config.py
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fast_depends.use import SerializerCls
 from zai.api_resource.chat.completions import Completions as RealCompletions
 
 import autogen.beta.config.zai.zai_client as zai_client_module
-from autogen.beta.config.zai import ZAIClient, ZAIConfig
+from autogen.beta.config.zai import ZAIClient, ZAIConfig, ZAIFilesClient
 from autogen.beta.events import ModelRequest, TextInput
 from test.beta.config.zai._helpers import FakeCompletions, FakeZAIClient, make_call_context
 
@@ -198,11 +199,13 @@ async def test_client_connection_params_reach_sdk_client(monkeypatch: pytest.Mon
     }
 
 
-def test_create_files_client_not_supported() -> None:
+@patch("autogen.beta.config.zai.files.ZaiClient")
+def test_create_files_client(_mock_zai_client: MagicMock) -> None:
     config = ZAIConfig(model="glm-5.2")
 
-    with pytest.raises(NotImplementedError, match="ZAIConfig does not support Files API"):
-        config.create_files_client()
+    client = config.create_files_client()
+
+    assert isinstance(client, ZAIFilesClient)
 
 
 def test_unsupported_penalty_fields_are_rejected() -> None:


### PR DESCRIPTION
## Summary

Adds a Z.AI (GLM) Files API client to the `beta` provider layer, wired into the
provider-agnostic `FilesAPI`. Supports `upload`, `read`, `list`, and `delete`,
exposed via `ZAIConfig.create_files_client()`.

Z.AI's Files API is **purpose-bound** — unlike OpenAI/xAI it is not a general blob
store, and every upload is tied to a `purpose` with its own constraints. This PR
handles those rules so basic usage works out of the box while still allowing the
advanced modes.

## What's included

- **`ZAIFilesClient`** (`autogen/beta/config/zai/files.py`) wrapping the synchronous
  `zai` SDK via `asyncio.to_thread`:
  - `upload` defaults to the **`batch`** purpose — the only purpose that supports the
    full upload/list/read(download)/delete round-trip without a knowledge base.
  - Forwards provider-specific options (`knowledge_id`, `sentence_size`,
    `custom_separator`) only when set, so the `retrieval` (RAG) path is reachable.
  - `list` queries each **listable** purpose (`batch`, `fine-tune`,
    `voice-clone-input`) and merges the results, because `GET /files` requires a
    `purpose` filter (an unfiltered list returns nothing) and `retrieval` additionally
    needs a `knowledge_id`.
- **`FilesAPI.upload`** now forwards `**provider_options` to the underlying client,
  so callers can pass `knowledge_id=…` through the provider-agnostic API.
- **`FileProvider.ZAI`** enum value.
- Registration via `ZAIConfig.create_files_client` and the `zai` package exports.
- Tests for client construction and each file operation (defaults, explicit purpose,
  retrieval-option forwarding, list aggregation, read, delete) plus a shared conftest
  fixture.

## Why `batch` is the default

The other purposes each fail a plain upload: `retrieval` returns
`400 "知识库id不能为空"` without a pre-existing `knowledge_id`, and `fine-tune`/`batch`
require structured `.jsonl`. Only `batch` supports the complete round-trip (and content
download), so it's the sensible default; the others remain opt-in.

## Testing

- `pytest test/beta/config/zai/` — all green.
- Manually verified end-to-end against the live Z.AI API: upload → list (file present)
  → read (byte-for-byte round-trip) → delete.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
