### PR TITLE
fix(beta): exclude UsageEvent telemetry from history compaction via __conversational__ marker

### DIFF
--- a/ag2/agent.py
+++ b/ag2/agent.py
@@ -48,6 +48,7 @@ from .events import (
     ToolCallsEvent,
     ToolResultsEvent,
     UsageEvent,
+    is_conversational,
 )
 from .events.lifecycle import (
     AggregationCompleted,
@@ -1786,9 +1787,9 @@ class _CompactionMiddleware(BaseMiddleware):
         result = await call_next(event, context)
 
         events = list(await context.stream.history.get_events())
-        # Count only non-transient events — transient events (chunks, lifecycle)
-        # should not influence compaction decisions even if persist_all=True.
-        conversation_events = [e for e in events if not getattr(type(e), "__transient__", False)]
+        # Count only conversational events — transient artifacts and persisted
+        # telemetry (UsageEvent) must not drive compaction, even if persist_all.
+        conversation_events = [e for e in events if is_conversational(e)]
         event_count = len(conversation_events)
 
         # Prevent double compaction — skip if count hasn't grown since last
@@ -1828,7 +1829,7 @@ class _CompactionMiddleware(BaseMiddleware):
                 return result
 
             await context.stream.history.replace(compacted)
-            self._last_compact_event_count = len([e for e in compacted if not getattr(type(e), "__transient__", False)])
+            self._last_compact_event_count = len([e for e in compacted if is_conversational(e)])
 
             usage = getattr(self._strategy, "last_usage", {})
             await context.send(

--- a/ag2/compact.py
+++ b/ag2/compact.py
@@ -27,6 +27,7 @@ from ag2.events import (
     ToolResultEvent,
     ToolResultsEvent,
     UsageEvent,
+    is_conversational,
 )
 from ag2.stream import MemoryStream
 
@@ -91,6 +92,20 @@ def _snap_to_turn_boundary(events: list[BaseEvent], cut: int) -> int:
     return cut
 
 
+def _cut_for_target(events: list[BaseEvent], target: int) -> int:
+    """Index such that ``events[cut:]`` holds the last ``target`` conversational
+    events. Interleaved telemetry rides along free (kept for ``UsageReport``);
+    returns 0 when there are fewer than ``target`` conversational events.
+    """
+    seen = 0
+    for i in range(len(events) - 1, -1, -1):
+        if is_conversational(events[i]):
+            seen += 1
+            if seen == target:
+                return i
+    return 0
+
+
 @dataclass(slots=True)
 class CompactTrigger:
     """Deterministic conditions for triggering compaction.
@@ -119,10 +134,11 @@ class TailWindowCompact:
         context: Context,
         store: KnowledgeStore | None,
     ) -> list[BaseEvent]:
-        if len(events) <= self._target:
+        cut = _cut_for_target(events, self._target)
+        if cut == 0:
             return events
 
-        cut = _snap_to_turn_boundary(events, len(events) - self._target)
+        cut = _snap_to_turn_boundary(events, cut)
         dropped = events[:cut]
         retained = events[cut:]
 
@@ -160,10 +176,11 @@ class SummarizeCompact:
         context: Context,
         store: KnowledgeStore | None,
     ) -> list[BaseEvent]:
-        if len(events) <= self._target:
+        cut = _cut_for_target(events, self._target)
+        if cut == 0:
             return events
 
-        cut = _snap_to_turn_boundary(events, len(events) - self._target)
+        cut = _snap_to_turn_boundary(events, cut)
         old = events[:cut]
         recent = events[cut:]
 
@@ -187,7 +204,8 @@ class SummarizeCompact:
         client = self._config.create()
         prompt_event = ModelRequest.ensure_request([
             "Summarize the following conversation history concisely, "
-            "preserving key decisions, findings, and context:\n\n" + "\n".join(str(e) for e in events)
+            "preserving key decisions, findings, and context:\n\n"
+            + "\n".join(str(e) for e in events if is_conversational(e))
         ])
         response = await client(
             [prompt_event],

--- a/ag2/events/__init__.py
+++ b/ag2/events/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .alert import HaltEvent, ObserverAlert, Severity
-from .base import BaseEvent, Field
+from .base import BaseEvent, Field, is_conversational
 from .conditions import Condition
 from .input_events import (
     AudioInput,
@@ -129,4 +129,5 @@ __all__ = (
     "Usage",
     "UsageEvent",
     "VideoInput",
+    "is_conversational",
 )

--- a/ag2/events/base.py
+++ b/ag2/events/base.py
@@ -38,6 +38,17 @@ def truncate_repr(value: Any, max_len: int = _REPR_MAX_LEN) -> str:
     return repr(value)
 
 
+def is_conversational(event: Any) -> bool:
+    """True for events that drive history management (compaction, summary input).
+
+    "Conversational" means the durable transcript replayed to the model — model
+    and human turns, tool calls/results, summaries — not transient artifacts
+    (chunks) or persisted telemetry (``UsageEvent``).
+    """
+    cls = type(event)
+    return not getattr(cls, "__transient__", False) and getattr(cls, "__conversational__", True)
+
+
 class Field:
     def __init__(
         self,
@@ -162,6 +173,10 @@ class BaseEvent(metaclass=_ConditionMeta):
     # lifecycle bookkeeping.
     # NOTE: no type annotation — must NOT be processed as an event Field.
     __transient__ = False
+
+    # True = durable transcript replayed to the model (drives history management).
+    # Persisted telemetry sets False (e.g. UsageEvent). No type annotation.
+    __conversational__ = True
 
     # Auto-populated Unix timestamp (seconds since epoch) for every event.
     # compare=False: timestamps don't affect equality checks.

--- a/ag2/events/types.py
+++ b/ag2/events/types.py
@@ -161,7 +161,11 @@ class UsageEvent(BaseEvent):
     truth, so there is no double counting.
 
     Persisted (not transient): the report reads it back from history.
+    Not conversational: telemetry, so it must not drive history management
+    (compaction trigger, retention window, summary input).
     """
+
+    __conversational__ = False
 
     usage: Usage = Field(default_factory=Usage, kw_only=False)
     kind: str = Field(default="model_call")

--- a/docs/adr/0010-history-management-keys-on-conversational-not-transient.md
+++ b/docs/adr/0010-history-management-keys-on-conversational-not-transient.md
@@ -1,0 +1,91 @@
+---
+status: accepted
+date: 2026-06-29
+---
+
+# History management keys on `__conversational__`, not `__transient__`
+
+Surfaced while tracing why `UsageEvent` (token-usage telemetry) was being counted
+as a real turn by history compaction. The fix is one new marker; this ADR records
+why a second axis was needed rather than reusing `__transient__`.
+
+## Context
+
+Two `BaseEvent` flags now describe an event, and they answer different questions:
+
+- **`__transient__`** (existing) answers *"should this be persisted?"* Transient
+  events (`ModelMessageChunk`, `TaskProgress`) are streaming/lifecycle artifacts
+  superseded by a durable event, so the storage layer (`ag2/stream.py`) drops
+  them. Everything else persists.
+
+- **`__conversational__`** (new) answers *"is this real conversation that should
+  drive history management?"* — i.e. count toward the compaction trigger, occupy
+  a slot in the retained window, and be fed to the summarizer.
+
+The bug was that these two questions had been **conflated onto one flag**.
+`UsageEvent` is deliberately non-transient: it persists so `UsageReport` can read
+token spend back from history. But compaction asked "is this work?" by reusing
+the persistence flag — `[e for e in events if not __transient__]` — so every
+persisted `UsageEvent` counted as a turn. Concretely:
+
+- **Trigger drift.** Each LLM call emits one `UsageEvent`, so it was ~⅓ of
+  "conversational" events — compaction fired meaningfully early on `max_events`
+  and the `max_tokens` char estimate.
+- **Window shrinkage.** `TailWindowCompact(target=N)` retains by raw position, so
+  interleaved `UsageEvent`s pushed real turns out of the kept window.
+- **Summary pollution.** `SummarizeCompact` stringified `UsageEvent`s into the
+  summarization prompt.
+
+Meanwhile the **aggregation** path had already diverged the other way — it counts
+a hard-coded allowlist `(ModelRequest, ModelResponse, ToolCallsEvent,
+ToolResultsEvent)` and explicitly excludes telemetry. Two filters, same question,
+two answers — the classic drift that an inspection-only equivalence invites.
+
+## Decision
+
+**Add `__conversational__` as a second, orthogonal axis, and route every
+history-management decision through one predicate.**
+
+- `BaseEvent.__conversational__ = True` by default; telemetry sets it `False`.
+  `UsageEvent.__conversational__ = False`.
+- `is_conversational(event)` (`ag2/events/base.py`, exported from `ag2.events`)
+  is the single predicate: `not __transient__ and __conversational__`. Both the
+  compaction trigger and the retention budget call it, so "what counts as
+  conversation" has one source of truth and cannot drift again.
+- **Retention budgets by conversational count, but does not delete telemetry.**
+  `_cut_for_target` (`ag2/compact.py`) finds the cut so the retained span holds
+  the last `target` *conversational* events; interleaved telemetry rides along in
+  that span for free. `TailWindowCompact(target=N)` again means N real turns.
+- The summarizer prompt filters non-conversational events out of its input only;
+  dropped telemetry is still persisted to the store like any other dropped event.
+
+## Consequences / things that look wrong but are deliberate
+
+- **Two near-synonym flags coexist on purpose.** `__transient__` and
+  `__conversational__` look redundant but are independent axes. The combination
+  that motivated the split — *persisted yet not conversational* (`UsageEvent`) —
+  has no single-flag encoding. `is_conversational` ANDs both because a transient
+  artifact is never conversation either.
+
+- **Aggregation keeps its narrow allowlist; it is not migrated to the marker.**
+  Aggregation's `every_n_events` counts a 4-type "turn of work" set, which is
+  *narrower* than "conversational" (it excludes `HumanMessage`,
+  `CompactionSummary`, …). Switching it to `is_conversational` would silently
+  broaden its cadence. Both paths are now robust to *new* telemetry — compaction
+  via the marker, aggregation via its allowlist — which is the drift the original
+  bug was about; unifying the conversational-but-not-work distinction was not
+  required to fix it.
+
+- **Retained `UsageEvent`s stay in live history by design.** The tempting fix —
+  strip telemetry from the list handed to `compact()` — is unsafe: compaction's
+  result replaces history (`history.replace(compacted)`), so stripping would
+  delete the `UsageEvent`s and (because `UsageReport` reads live history, not the
+  dropped-event store) break usage accounting for the kept window. Keeping them in
+  the retained span preserves that.
+
+- **Usage for the *dropped* span is still lost across compaction — unchanged and
+  out of scope.** `agent.usage()` reads live history only, so events compacted
+  away (telemetry included) leave the report. This pre-existed the change; this
+  ADR neither fixes nor worsens it. Closing it is a separate decision: document
+  `usage()` as a live-window report, or have `UsageReport` also read the persisted
+  dropped log. The marker design does not depend on which is chosen.

--- a/test/test_compact.py
+++ b/test/test_compact.py
@@ -8,7 +8,7 @@ import pytest
 
 from ag2 import Agent, Context
 from ag2.agent import KnowledgeConfig
-from ag2.compact import CompactTrigger, CompactionSummary, TailWindowCompact
+from ag2.compact import CompactTrigger, CompactionSummary, SummarizeCompact, TailWindowCompact
 from ag2.events import (
     CompactionCompleted,
     CompactionFailed,
@@ -22,10 +22,12 @@ from ag2.events import (
     ToolResult,
     ToolResultEvent,
     ToolResultsEvent,
+    Usage,
+    UsageEvent,
 )
 from ag2.knowledge import MemoryKnowledgeStore
 from ag2.stream import MemoryStream
-from ag2.testing import TestConfig
+from ag2.testing import TestConfig, TrackingConfig
 
 
 class TestTailWindowCompact:
@@ -124,6 +126,63 @@ class TestTailWindowToolCycleBoundary:
         assert mr not in result and res not in result
         entries = await store.list("/log/")
         assert [e for e in entries if "dropped" in e]
+
+
+@pytest.mark.asyncio
+class TestTelemetryNotConversational:
+    """UsageEvent is persisted telemetry, not conversation — it must not consume
+    the retention window, leak into the summary, or trigger compaction."""
+
+    async def test_usage_events_do_not_consume_window(self) -> None:
+        events: list = []
+        for i in range(3):
+            events.append(ModelRequest([TextInput(f"u{i}")]))
+            events.append(UsageEvent(Usage(total_tokens=10)))
+        result = await TailWindowCompact(target=2).compact(events, Context(stream=MemoryStream()), None)
+
+        conv = [e for e in result if isinstance(e, ModelRequest)]
+        assert [e.parts[0].content for e in conv] == ["u1", "u2"]
+        # Retained telemetry rides along so UsageReport keeps the window's usage
+        assert any(isinstance(e, UsageEvent) for e in result)
+
+    async def test_telemetry_alone_is_no_op(self) -> None:
+        events: list = [ModelRequest([TextInput("only")])]
+        events += [UsageEvent(Usage(total_tokens=1)) for _ in range(10)]
+        result = await TailWindowCompact(target=3).compact(events, Context(stream=MemoryStream()), None)
+        assert result == events
+
+    async def test_summarizer_prompt_excludes_telemetry(self) -> None:
+        tracking = TrackingConfig(TestConfig(ModelResponse(ModelMessage("summary"))))
+        events: list = [
+            ModelRequest([TextInput("keep-this-text")]),
+            UsageEvent(Usage(total_tokens=313373)),
+            ModelResponse(ModelMessage("and-this-text")),
+            ModelRequest([TextInput("recent")]),
+        ]
+        await SummarizeCompact(target=1, config=tracking).compact(events, Context(stream=MemoryStream()), None)
+
+        prompt = tracking.mock.call_args.args[0].parts[0].content
+        assert "keep-this-text" in prompt and "and-this-text" in prompt
+        assert "313373" not in prompt
+
+    async def test_usage_events_do_not_advance_trigger(self) -> None:
+        # One turn = ModelRequest + ModelResponse (2 conversational) + UsageEvent.
+        # max_events=2 must NOT fire: counting the UsageEvent would push it to 3.
+        stream = MemoryStream()
+        completions: list[CompactionCompleted] = []
+        stream.where(CompactionCompleted).subscribe(lambda e: completions.append(e))
+
+        agent = Agent(
+            "compactor",
+            config=TestConfig(ModelResponse(ModelMessage("a"), usage=Usage(total_tokens=5))),
+            knowledge=KnowledgeConfig(
+                store=MemoryKnowledgeStore(),
+                compact=TailWindowCompact(target=2),
+                compact_trigger=CompactTrigger(max_events=2),
+            ),
+        )
+        await agent.ask("once", stream=stream)
+        assert completions == []
 
 
 class TestCompactionSummary:


### PR DESCRIPTION
## Why are these changes needed?

Introduces a __conversational__ marker to help distinguish events that the agent harness compaction uses. This is orthogonal to the current __transient__ marker.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
