### PR TITLE
fix(beta): correctly size history from event content

### DIFF
--- a/ag2/agent.py
+++ b/ag2/agent.py
@@ -48,6 +48,7 @@ from .events import (
     ToolCallsEvent,
     ToolResultsEvent,
     UsageEvent,
+    estimated_tokens,
 )
 from .events.lifecycle import (
     AggregationCompleted,
@@ -1799,7 +1800,7 @@ class _CompactionMiddleware(BaseMiddleware):
         if self._trigger.max_events > 0 and event_count > self._trigger.max_events:
             should_compact = True
         if self._trigger.max_tokens > 0:
-            estimated = sum(len(str(e)) for e in conversation_events) // self._trigger.chars_per_token
+            estimated = sum(estimated_tokens(e, self._trigger.chars_per_token) for e in conversation_events)
             if estimated > self._trigger.max_tokens:
                 should_compact = True
 

--- a/ag2/aggregate.py
+++ b/ag2/aggregate.py
@@ -19,7 +19,7 @@ from fast_depends.pydantic import PydanticSerializer
 
 from .annotations import Context
 from .config import ModelConfig
-from .events import BaseEvent, ModelRequest, UsageEvent
+from .events import BaseEvent, ModelRequest, UsageEvent, render_for_prompt
 from .knowledge import CONVERSATIONS_PREFIX, WORKING_MEMORY_PATH, KnowledgeStore
 from .stream import MemoryStream
 
@@ -92,7 +92,7 @@ class ConversationSummaryAggregate:
         client = self._config.create()
         prompt_event = ModelRequest.ensure_request([
             "Summarize this conversation. Include key decisions, "
-            "findings, outcomes, and any unfinished work:\n\n" + "\n".join(str(e) for e in events)
+            "findings, outcomes, and any unfinished work:\n\n" + "\n".join(render_for_prompt(e) for e in events)
         ])
         response = await client(
             [prompt_event],
@@ -188,7 +188,7 @@ class WorkingMemoryAggregate:
         client = self._config.create()
         prompt = self._prompt_template.format(
             existing=existing or "(empty)",
-            events="\n".join(str(e) for e in events),
+            events="\n".join(render_for_prompt(e) for e in events),
         )
         response = await client(
             [ModelRequest.ensure_request([prompt])],

--- a/ag2/compact.py
+++ b/ag2/compact.py
@@ -27,6 +27,7 @@ from ag2.events import (
     ToolResultEvent,
     ToolResultsEvent,
     UsageEvent,
+    render_for_prompt,
 )
 from ag2.stream import MemoryStream
 
@@ -187,7 +188,7 @@ class SummarizeCompact:
         client = self._config.create()
         prompt_event = ModelRequest.ensure_request([
             "Summarize the following conversation history concisely, "
-            "preserving key decisions, findings, and context:\n\n" + "\n".join(str(e) for e in events)
+            "preserving key decisions, findings, and context:\n\n" + "\n".join(render_for_prompt(e) for e in events)
         ])
         response = await client(
             [prompt_event],

--- a/ag2/events/__init__.py
+++ b/ag2/events/__init__.py
@@ -32,6 +32,7 @@ from .lifecycle import (
     ObserverStarted,
     UnknownEvent,
 )
+from .sizing import estimated_tokens, render_for_prompt
 from .task_events import (
     TaskCancelled,
     TaskCompleted,
@@ -129,4 +130,6 @@ __all__ = (
     "Usage",
     "UsageEvent",
     "VideoInput",
+    "estimated_tokens",
+    "render_for_prompt",
 )

--- a/ag2/events/sizing.py
+++ b/ag2/events/sizing.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Content-size estimation and prompt rendering for history management.
+
+Sizes and renders an event from its full content (never the truncated repr):
+text verbatim, non-text parts by a flat per-modality token budget.
+"""
+
+from collections.abc import Iterator
+
+from .base import BaseEvent
+from .input_events import BinaryInput, BinaryType, DataInput, FileIdInput, ModelRequest, TextInput, UrlInput
+from .tool_events import ToolResultsEvent
+from .types import ModelResponse
+
+# One flat per-modality token budget for all providers. A rough heuristic: real
+# image cost tracks pixel dimensions and differs per provider, so it isn't exact.
+_MODALITY_TOKENS = {
+    "image": 1000,
+    "audio": 1000,
+    "video": 2000,
+    "document": 2000,
+    "binary": 1000,
+}
+
+# (kind, payload) where kind is "text" (payload is the text) or "media"
+# (payload is a modality key into _MODALITY_TOKENS).
+_Piece = tuple[str, str]
+
+_LABELS = ((ModelRequest, "User: "), (ModelResponse, "Assistant: "), (ToolResultsEvent, "Tool: "))
+
+
+def _modality(kind: BinaryType | None, media_type: str | None) -> str:
+    if kind is not None and kind != BinaryType.BINARY:
+        return kind.value
+    if media_type:
+        return media_type.split("/", 1)[0]
+    return "binary"
+
+
+def _part_pieces(parts: list) -> Iterator[_Piece]:
+    for p in parts:
+        if isinstance(p, TextInput):
+            yield ("text", p.content)
+        elif isinstance(p, DataInput):
+            yield ("text", str(p.data))
+        elif isinstance(p, BinaryInput):
+            yield ("media", _modality(p.kind, p.media_type))
+        elif isinstance(p, UrlInput):
+            yield ("media", _modality(p.kind, None))
+        elif isinstance(p, FileIdInput):
+            yield ("media", "binary")
+        else:
+            yield ("text", str(p))
+
+
+def _content_pieces(event: BaseEvent) -> Iterator[_Piece]:
+    if isinstance(event, ModelRequest):
+        yield from _part_pieces(event.parts)
+    elif isinstance(event, ToolResultsEvent):
+        for r in event.results:
+            yield from _part_pieces(r.result.parts)
+    elif isinstance(event, ModelResponse):
+        if event.message and event.message.content:
+            yield ("text", event.message.content)
+        for call in event.tool_calls.calls:
+            yield ("text", f"{call.name}({call.arguments})")
+        for _ in event.files:
+            yield ("media", "binary")
+    else:
+        # Duck-typed content/summary covers HumanMessage, CompactionSummary, etc.;
+        # str() is the last resort for any other type.
+        for attr in ("content", "summary"):
+            value = getattr(event, attr, None)
+            if isinstance(value, str):
+                yield ("text", value)
+                return
+        yield ("text", str(event))
+
+
+def estimated_tokens(event: BaseEvent, chars_per_token: int = 4) -> int:
+    """Rough token size of an event's content, never truncated.
+
+    Text counts as ``len // chars_per_token``; each non-text part counts as a
+    flat per-modality budget. A size heuristic, not an exact tokenizer.
+    """
+    total = 0
+    for kind, payload in _content_pieces(event):
+        if kind == "text":
+            total += len(payload) // chars_per_token
+        else:
+            total += _MODALITY_TOKENS.get(payload, _MODALITY_TOKENS["binary"])
+    return total
+
+
+def render_for_prompt(event: BaseEvent) -> str:
+    """Full, untruncated text of an event for a summarizer/memory prompt.
+
+    Text parts are rendered in full; non-text parts become ``[modality]``
+    placeholders. Prefixed with a role label where one applies.
+    """
+    pieces = [payload if kind == "text" else f"[{payload}]" for kind, payload in _content_pieces(event)]
+    body = " ".join(p for p in pieces if p)
+    if not body:
+        return str(event)
+    label = next((lbl for cls, lbl in _LABELS if isinstance(event, cls)), "")
+    return f"{label}{body}"

--- a/ag2/middleware/builtin/token_limiter.py
+++ b/ag2/middleware/builtin/token_limiter.py
@@ -5,15 +5,16 @@
 from collections.abc import Sequence
 
 from ag2.annotations import Context
-from ag2.events import BaseEvent, ModelRequest, ModelResponse, ToolResultsEvent
+from ag2.events import BaseEvent, ModelRequest, ModelResponse, ToolResultsEvent, estimated_tokens
 from ag2.middleware.base import BaseMiddleware, LLMCall, MiddlewareFactory
 
 
 class TokenLimiter(MiddlewareFactory):
     """Truncate message history to fit within a token budget.
 
-    Uses a simple character-based estimate (``chars_per_token`` chars per token)
-    unless a custom tokenizer is provided.
+    Sizes each event with the shared content estimate (text by
+    ``chars_per_token``, non-text by a per-modality budget) — never the
+    truncated ``str(event)`` repr.
     """
 
     def __init__(self, max_tokens: int, chars_per_token: int = 4) -> None:
@@ -21,10 +22,11 @@ class TokenLimiter(MiddlewareFactory):
             raise ValueError("max_tokens must be greater than 0")
         if chars_per_token < 1:
             raise ValueError("chars_per_token must be greater than 0")
-        self._max_chars = max_tokens * chars_per_token
+        self._max_tokens = max_tokens
+        self._chars_per_token = chars_per_token
 
     def __call__(self, event: "BaseEvent", context: "Context") -> "BaseMiddleware":
-        return _TokenLimiter(event, context, self._max_chars)
+        return _TokenLimiter(event, context, self._max_tokens, self._chars_per_token)
 
 
 class _TokenLimiter(BaseMiddleware):
@@ -32,10 +34,12 @@ class _TokenLimiter(BaseMiddleware):
         self,
         event: "BaseEvent",
         context: "Context",
-        max_chars: int,
+        max_tokens: int,
+        chars_per_token: int,
     ) -> None:
         super().__init__(event, context)
-        self._max_chars = max_chars
+        self._max_tokens = max_tokens
+        self._chars_per_token = chars_per_token
 
     @staticmethod
     def _skip_leading_tool_results(events: Sequence[BaseEvent], start: int) -> int:
@@ -49,20 +53,20 @@ class _TokenLimiter(BaseMiddleware):
         events: Sequence[BaseEvent],
         context: Context,
     ) -> ModelResponse:
-        event_lengths = [len(str(event)) for event in events]
-        if sum(event_lengths) <= self._max_chars:
+        event_tokens = [estimated_tokens(event, self._chars_per_token) for event in events]
+        if sum(event_tokens) <= self._max_tokens:
             return await call_next(events, context)
 
         prefix_length = 1 if isinstance(events[0], ModelRequest) else 0
-        current_chars = event_lengths[0] if prefix_length else 0
+        current_tokens = event_tokens[0] if prefix_length else 0
         retained_start = len(events)
 
         for idx in range(len(events) - 1, prefix_length - 1, -1):
-            event_chars = event_lengths[idx]
+            event_token_count = event_tokens[idx]
             # Always preserve the most recent event, even if it exceeds the remaining budget.
-            if retained_start == len(events) or current_chars + event_chars <= self._max_chars:
+            if retained_start == len(events) or current_tokens + event_token_count <= self._max_tokens:
                 retained_start = idx
-                current_chars += event_chars
+                current_tokens += event_token_count
             else:
                 break
 

--- a/docs/adr/0011-history-sizing-uses-content-not-truncated-repr.md
+++ b/docs/adr/0011-history-sizing-uses-content-not-truncated-repr.md
@@ -1,0 +1,92 @@
+---
+status: accepted
+date: 2026-06-29
+---
+
+# History sizing and prompt rendering use event content, not `str(event)`
+
+Surfaced from a report that a `max_tokens` compaction trigger "never fires" —
+traced to history-management code reusing the truncated `__repr__` as a stand-in
+for both token size and prompt content.
+
+## Context
+
+`BaseEvent.__repr__` renders each field through `truncate_repr`, which caps
+`str`/`bytes` fields at 80 chars so logs stay readable. `str(event)` falls back
+to that repr (there is no `__str__`). Five history-management call sites reused
+`str(event)` for one of two things it was never meant to do:
+
+- **Size estimation:** the compaction trigger (`agent.py`) and `TokenLimiter`
+  middleware sized history as `len(str(event)) // chars_per_token`.
+- **Prompt content:** `SummarizeCompact` and both aggregation strategies built
+  their summarizer/memory prompts as `"\n".join(str(e) for e in events)`.
+
+Both are misuses of a display helper. Measured with a 10,000-char payload:
+
+| Event | real content | `len(str(e))` |
+|---|---|---|
+| `ModelRequest` (user) | 10,000 | 137 |
+| `ToolResultsEvent` (tool) | 10,000 | 237 |
+| `ModelResponse` (assistant) | 10,000 | 10,023 |
+
+`ModelResponse` is the lone exception — its own `__repr__` emits full content.
+So the estimate undercounts user/tool turns ~70× and is wildly asymmetric: a
+`max_tokens` trigger effectively never fires on request/tool-heavy histories, and
+the summarizer/memory LLM only ever sees the first 80 chars of each non-assistant
+turn.
+
+## Decision
+
+**Size and render from event *content*, never from the repr. Two helpers, because
+the two needs diverge on multimodal.** Both live in `ag2/events/sizing.py`.
+
+- `estimated_tokens(event, chars_per_token=4) -> int` — text counts as
+  `len // chars_per_token`; each non-text part counts as a flat per-modality
+  budget (`_MODALITY_TOKENS`). Used by the compaction trigger and `TokenLimiter`.
+- `render_for_prompt(event) -> str` — full, untruncated text, with non-text parts
+  as `[modality]` placeholders and a role label. Used by the three
+  summarizer/memory prompts.
+
+They share one content walk (`_content_pieces`), so size and rendering can't
+disagree about what an event contains.
+
+**Multimodal is sized by a flat per-modality constant, deliberately.** A single
+text rendering cannot serve both needs: an image carries ~0 text but real token
+cost, so a text-derived size would count it as ~0 (the same bug), and a
+placeholder like `[image]` is ~4 tokens though the image costs ~1,000. So
+estimation is modality-aware and returns a number; rendering is text + placeholder.
+The constant is a *heuristic* — image tokens track pixel dimensions, not bytes or
+count, and the exact figure is provider-specific — so anything finer needs a real
+tokenizer, which is out of scope (see below).
+
+`TokenLimiter` is migrated from char math (`max_chars`) to token math
+(`max_tokens` + `estimated_tokens`); its trimming semantics are unchanged, only
+the per-event size is now content-based.
+
+## Consequences / things that look wrong but are deliberate
+
+- **`truncate_repr` / `__repr__` stay exactly as they are.** They are correct for
+  their job (readable logs). The fix is to stop *other* code from borrowing them
+  as a size/content proxy — not to change the repr.
+
+- **The size estimate is a coarse heuristic, and that is the right altitude.**
+  Text is already "chars ÷ 4" — no real tokenizer is wired in anywhere — so
+  precise provider-specific image tokenization would be inconsistent precision.
+  The bug being fixed is that media counted as ~0; a non-zero flat budget fixes
+  that. The principled long-term answer is a pluggable tokenizer seam (text +
+  media); `TokenLimiter`'s docstring already gestured at "unless a custom
+  tokenizer is provided," though none was ever wired up. That seam is a larger
+  design, intentionally deferred.
+
+- **`TokenLimiter`'s effective budget shifts.** It now sizes message *content*,
+  not the repr (which included `ModelResponse(content=…)` scaffolding and
+  truncated the payload). For the same `max_tokens` a caller may now retain a
+  different number of turns — a behavior change, but the previous numbers were an
+  artifact of repr length, not content. Its tests were recalibrated against
+  `estimated_tokens`, not re-pinned to repr lengths.
+
+- **`render_for_prompt` is intentionally text-only today.** Non-text parts become
+  `[image]` / `[audio]` placeholders rather than being passed to the summarizer as
+  real media. Feeding actual image/audio to a multimodal summarizer is an additive
+  extension (the summarizer here is a plain `ModelConfig` call), deferred until
+  there's a need.

--- a/test/events/test_sizing.py
+++ b/test/events/test_sizing.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for content-size estimation and prompt rendering (ag2.events.sizing)."""
+
+from ag2.events import (
+    ImageInput,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    ToolResult,
+    ToolResultEvent,
+    ToolResultsEvent,
+    estimated_tokens,
+    render_for_prompt,
+)
+
+BIG = "x" * 10_000
+
+
+def test_estimate_is_not_truncated_and_symmetric() -> None:
+    # The same 10k payload must estimate the same regardless of event type —
+    # str(event)/truncate_repr gave 137 / 10023 / 237 here.
+    mr = ModelRequest([TextInput(BIG)])
+    resp = ModelResponse(ModelMessage(BIG))
+    tr = ToolResultsEvent(results=[ToolResultEvent(parent_id="c1", name="t", result=ToolResult(BIG))])
+
+    assert estimated_tokens(mr) == 2500
+    assert estimated_tokens(resp) == 2500
+    assert estimated_tokens(tr) == 2500
+
+
+def test_chars_per_token_scales_estimate() -> None:
+    assert estimated_tokens(ModelRequest([TextInput(BIG)]), chars_per_token=1) == 10_000
+
+
+def test_image_counts_a_flat_budget_not_zero() -> None:
+    text_only = ModelRequest([TextInput("hi")])
+    with_image = ModelRequest([TextInput("hi"), ImageInput(data=b"\x89PNG" + b"0" * 5000, media_type="image/png")])
+
+    assert estimated_tokens(with_image) - estimated_tokens(text_only) == 1000
+
+
+def test_render_preserves_full_text() -> None:
+    rendered = render_for_prompt(ModelRequest([TextInput(BIG)]))
+    assert BIG in rendered
+    assert rendered.startswith("User: ")
+
+
+def test_render_uses_placeholder_for_non_text() -> None:
+    rendered = render_for_prompt(
+        ModelRequest([TextInput("look"), ImageInput(data=b"\x89PNG0000", media_type="image/png")])
+    )
+    assert rendered == "User: look [image]"
+    assert "PNG" not in rendered  # raw bytes never leak into the prompt

--- a/test/middleware/builtins/test_token_limiter.py
+++ b/test/middleware/builtins/test_token_limiter.py
@@ -17,6 +17,7 @@ from ag2.events import (
     ToolCallsEvent,
     ToolResultEvent,
     ToolResultsEvent,
+    estimated_tokens,
 )
 from ag2.middleware import TokenLimiter
 
@@ -46,7 +47,8 @@ async def test_token_limiter_keeps_first_request_while_trimming(mock: MagicMock)
         ModelResponse(ModelMessage("drop-me-2")),
         ModelResponse(ModelMessage("keep-me-too")),
     ]
-    middleware = TokenLimiter(max_tokens=30, chars_per_token=1)(events[-1], mock)
+    # content tokens (cpt=1): 7 + 9 + 9 + 11. Budget fits first(7)+last(11) but not a middle.
+    middleware = TokenLimiter(max_tokens=20, chars_per_token=1)(events[-1], mock)
 
     async def llm_call(history: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
         mock.llm_call(history)
@@ -67,7 +69,8 @@ async def test_token_limiter_trims_from_front_without_initial_request(mock: Magi
         ModelResponse(ModelMessage("drop-me-2")),
         ModelResponse(ModelMessage("keep-me")),
     ]
-    middleware = TokenLimiter(max_tokens=20, chars_per_token=1)(events[-1], mock)
+    # content tokens (cpt=1): 9 + 9 + 7. Budget fits only the most recent.
+    middleware = TokenLimiter(max_tokens=10, chars_per_token=1)(events[-1], mock)
 
     async def llm_call(history: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
         mock.llm_call(history)
@@ -88,7 +91,9 @@ async def test_token_limiter_drops_tool_results_without_parent_message(mock: Mag
         ModelResponse(ModelMessage("answer 1")),
         ModelRequest([TextInput("turn 2")]),
     ]
-    budget_after_dropping_tool_call = sum(len(str(event)) for event in [events[0], events[2], events[3], events[4]])
+    budget_after_dropping_tool_call = sum(
+        estimated_tokens(event, 1) for event in [events[0], events[2], events[3], events[4]]
+    )
     middleware = TokenLimiter(max_tokens=budget_after_dropping_tool_call, chars_per_token=1)(events[-1], mock)
 
     async def llm_call(history: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
@@ -114,7 +119,7 @@ async def test_token_limiter_drops_tool_results_without_parent_message_and_no_in
         ToolResultsEvent([ToolResultEvent.from_call(tool_call, result="ok")]),
         ModelResponse(ModelMessage("answer 1")),
     ]
-    budget_after_dropping_tool_call = sum(len(str(event)) for event in [events[1], events[2]])
+    budget_after_dropping_tool_call = sum(estimated_tokens(event, 1) for event in [events[1], events[2]])
     middleware = TokenLimiter(max_tokens=budget_after_dropping_tool_call, chars_per_token=1)(events[-1], mock)
 
     async def llm_call(history: Sequence[BaseEvent], ctx: Context) -> ModelResponse:

--- a/test/test_compact.py
+++ b/test/test_compact.py
@@ -206,6 +206,28 @@ class TestCompactionWiredOnAgent:
 
         assert completions == []
 
+    @pytest.mark.asyncio
+    async def test_max_tokens_fires_on_large_content(self) -> None:
+        # A single large turn (~2500 est. tokens) must cross max_tokens. The old
+        # truncated str(event) estimate capped it near zero and never fired.
+        store = MemoryKnowledgeStore()
+        stream = MemoryStream()
+        completions: list[CompactionCompleted] = []
+        stream.where(CompactionCompleted).subscribe(lambda e: completions.append(e))
+
+        agent = Agent(
+            "compactor",
+            config=TestConfig(ModelResponse(ModelMessage("ok"))),
+            knowledge=KnowledgeConfig(
+                store=store,
+                compact=TailWindowCompact(target=1),
+                compact_trigger=CompactTrigger(max_tokens=1000),
+            ),
+        )
+        await agent.ask("x" * 10_000, stream=stream)
+
+        assert len(completions) >= 1
+
 
 class _RaisingCompact:
     """CompactStrategy that always raises — for failure-path tests."""


### PR DESCRIPTION
## Why are these changes needed?

History-management code sized and rendered events via `str(event)`, which routes through `BaseEvent.__repr__/truncate_repr` - a display helper that caps each field at 80 characters for readable logs. Reusing it as a size proxy meant a 10,000-character user turn or tool result estimated at ~137 and ~237 characters respectively (while an assistant turn, which has its own non-truncating `repr`, counted at the full ~10,023), so the compaction `max_tokens` trigger drastically undercounted and effectively never fired on request/tool-heavy histories; the same `str(event)` was also feeding the summarizer and working-memory prompts only the first 80 characters of each non-assistant turn.

This change introduces `ag2/events/sizing.py` with two helpers that work from an event's full content instead:

- `estimated_tokens(event, chars_per_token)` - text by length, each non-text part by a flat per-modality token budget
- `render_for_prompt(event)` - full untruncated text with [modality] placeholders for non-text parts).

All affected sites are switched over:

1. Compaction trigger
2. SummarizeCompact prompt
3. both aggregation prompts
4. TokenLimiter middleware (migrated from char math to token math).

Multimodal parts are sized by a single flat per-modality constant - a deliberate rough heuristic, since exact image cost tracks pixel dimensions and is provider-specific (the principled per-provider/tokenizer seam is noted as deferred in ADR 0011).

Behaviour, rationale, and the deferred work are documented in docs/adr/0011-history-sizing-uses-content-not-truncated-repr.md; the change is covered by new sizing unit tests, a new end-to-end test asserting the max_tokens trigger now fires on a single large turn, and recalibrated TokenLimiter tests (whose budgets were previously pinned to repr length).

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
