### PR TITLE
fix: export __version__ at ag2 top level

### DIFF
--- a/ag2/__init__.py
+++ b/ag2/__init__.py
@@ -24,6 +24,7 @@ from .spec import AgentSpec
 from .stream import MemoryStream
 from .task import Task, TaskInject, TaskSpec
 from .tools import ToolResult, Toolkit, tool
+from .version import __version__
 
 __all__ = (
     "Agent",
@@ -54,6 +55,7 @@ __all__ = (
     "Toolkit",
     "Variable",
     "VideoInput",
+    "__version__",
     "observer",
     "response_schema",
     "tool",


### PR DESCRIPTION
## Why are these changes needed?

Export __version__ at ag2 module's top-level.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [ ] I understand the changes in this PR and can explain them in my own words.
- [ ] I have verified that the PR description accurately reflects the actual diff.
- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
