### PR TITLE
fix(test): de-flake test_cancelling_result_cancels_turn_inline

### DIFF
--- a/test/agent/test_run.py
+++ b/test/agent/test_run.py
@@ -226,11 +226,13 @@ class TestEnqueue:
 
 @pytest.mark.asyncio
 async def test_cancelling_result_cancels_turn_inline() -> None:
+    started = asyncio.Event()
     cancelled = asyncio.Event()
 
     @tool
     async def block() -> str:
         """Blocks forever, flagging if it is cancelled."""
+        started.set()
         try:
             await asyncio.Event().wait()
         except asyncio.CancelledError:
@@ -248,9 +250,13 @@ async def test_cancelling_result_cancels_turn_inline() -> None:
     )
 
     async with agent.run("Hi!") as run:
-        with pytest.raises(asyncio.TimeoutError):
-            # asyncio.wait_for (vs asyncio.timeout) keeps this runnable on Python 3.10.
-            await asyncio.wait_for(run.result(), timeout=0.2)
+        # result() drives the turn inline; cancel it only once the tool is in
+        # flight, so the assertion is about propagation, not turn-startup speed.
+        result_task = asyncio.ensure_future(run.result())
+        await asyncio.wait_for(started.wait(), timeout=5)
+        result_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await result_task
 
     assert cancelled.is_set(), "cancelling the result() await must cancel the in-flight turn"
 


### PR DESCRIPTION
## Why are these changes needed?

The test gave the turn a fixed 0.2s (asyncio.wait_for) to reach the blocking tool before cancelling. On GitHub's ubuntu runners with the py3.14 toolcache build, coverage + full-suite conditions push turn startup past that deadline, so the tool never starts and its CancelledError handler can never run — failing the assertion deterministically on CI while cancellation propagation itself is fine.

Gate the cancel on the tool actually being in flight instead: the tool sets a `started` event, the test drives result() as a task, waits for `started`, then cancels and expects CancelledError. Same property under test (result() drives the turn inline; cancelling that await cancels the in-flight turn), no wall-clock dependency, and faster (~30ms vs always paying the 0.2s timeout).

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
