### PR TITLE
fix(mcp): warn when MCPServer starts without authentication

### DIFF
--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -3,10 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib.metadata
+import logging
+import warnings
 from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
+
+_logger = logging.getLogger(__name__)
 
 from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
 from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend, RequireAuthMiddleware
@@ -169,6 +173,18 @@ class MCPServer:
             context_provider=context_provider,
             session_store=self._session_store,
         )
+        if security is None:
+            warnings.warn(
+                "MCPServer is running without authentication (security=None). "
+                "Any network client can invoke the agent's tools without credentials. "
+                "Pass a security=Requirement(...) to enable OAuth 2.0 bearer auth.",
+                UserWarning,
+                stacklevel=2,
+            )
+            _logger.warning(
+                "MCPServer started without authentication — all tool invocations are unauthenticated"
+            )
+
         self._server = self._build_server()
         routes, manager = self._streamable_routes(
             path=path, stateless=stateless, json_response=json_response, security=security


### PR DESCRIPTION
## Summary

When `security=None` (the default), the MCP HTTP endpoint serves without any authentication middleware — any network client can invoke the agent's tools (shell, code execution, web fetch) without credentials.

This PR emits a `UserWarning` and a `logging.warning` at construction time so deployers are aware of the risk. The default behavior is **unchanged** — this is not a breaking change, just a loud warning.

## Security Impact

**High** — An exposed MCP server with default settings allows unauthenticated tool invocation. Combined with prompt injection, this enables:
- Unauthenticated shell command execution
- Unauthenticated code execution  
- SSRF via web_fetch to internal services / cloud metadata

## Changes

- Add `warnings.warn()` + `logging.warning()` in `MCPServer.__init__` when `security is None`
- Import `logging` and `warnings` modules

## Testing

- Existing tests pass (no behavioral change)
- Warning is emitted on default construction

## Exploit Chain

Unauthenticated MCP client → prompt injection → agent executes shell command or fetches cloud metadata. See [CHAIN-001] in our analysis.

## Remediation Options (for future PRs)

1. Make `security` a required parameter (breaking change)
2. Default to `Requirement` with API key from env var
3. Bind to localhost only by default when unauthenticated