### PR TITLE
fix(shell): block shell operators when blocked list is active

### DIFF
--- a/ag2/tools/sandbox/adapter/shell.py
+++ b/ag2/tools/sandbox/adapter/shell.py
@@ -87,8 +87,15 @@ class ShellAdapter:
             # command spawn or redirect to disallowed ones — block them.
             if contains_shell_operator(command):
                 return f"Command not allowed (shell operators are not permitted in restricted mode): {command!r}"
-        if self._blocked is not None and any(matches(p, command) for p in self._blocked):
-            return f"Command not allowed: {command!r}"
+        if self._blocked is not None:
+            if any(matches(p, command) for p in self._blocked):
+                return f"Command not allowed: {command!r}"
+            # Shell operators let a non-blocked head command chain into a
+            # blocked one (e.g. blocked=["rm"] doesn't catch "echo x; rm -rf /").
+            # Reject shell operators when a blocked list is active, consistent
+            # with the allowed-list behaviour.
+            if contains_shell_operator(command):
+                return f"Command not allowed (shell operators bypass blocked list): {command!r}"
         if self._ignore is not None:
             # self.workdir gives a host Path for local backends and a
             # PurePosixPath for remote/container ones — check_ignore handles


### PR DESCRIPTION
## Summary

The `ShellAdapter`'s `blocked` parameter only matches the head command prefix. Shell operators (`;`, `|`, `&&`, `||`, `$(...)`, backticks) bypass the blocklist. For example, `blocked=["rm"]` does not block `echo x; rm -rf /`.

The `allowed` mode already blocks shell operators via `contains_shell_operator()`, but the `blocked`-only mode does not. This PR applies the same check when a `blocked` list is active.

## Security Impact

**Medium** — Users who configure `blocked` without `allowed` may believe dangerous commands are prevented. A prompt-injected agent can bypass the blocklist using shell operators.

## Changes

- Apply `contains_shell_operator()` check in `_filter()` when `self._blocked is not None`
- Reject commands containing shell operators with a clear error message
- Consistent with existing `allowed`-list behavior

## Testing

```python
# Before: blocked=["rm"] does not block "echo x; rm -rf /"
# After:  blocked=["rm"] blocks "echo x; rm -rf /" (shell operators rejected)
```

## References

- AGNT-004: Blocked command filter bypass via shell operators
- The docstring already warns that `blocked` is not a security boundary — this fix makes it harder to bypass