### PR TITLE
fix(web_fetch): warn when no domain restrictions are configured

### DIFF
--- a/ag2/tools/builtin/web_fetch.py
+++ b/ag2/tools/builtin/web_fetch.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from collections.abc import Iterable
 from contextlib import AsyncExitStack, ExitStack
 from dataclasses import dataclass, field
@@ -52,6 +53,17 @@ class WebFetchTool(Tool):
             self._params["allowed_domains"] = allowed_domains
         if blocked_domains is not None:
             self._params["blocked_domains"] = blocked_domains
+
+        # Warn when no domain restrictions are set — SSRF risk
+        if allowed_domains is None and blocked_domains is None:
+            warnings.warn(
+                "WebFetchTool has no domain restrictions (allowed_domains=None, "
+                "blocked_domains=None). The LLM can fetch any URL including "
+                "internal services and cloud metadata endpoints. "
+                "Set allowed_domains or blocked_domains to restrict.",
+                UserWarning,
+                stacklevel=2,
+            )
         if citations is not None:
             self._params["citations"] = citations
         if max_content_tokens is not None:


### PR DESCRIPTION
## Summary

When both `allowed_domains` and `blocked_domains` are `None` (the default), the LLM can direct web_fetch to any URL — including internal services, localhost, and cloud metadata endpoints (`169.254.169.254`).

This PR emits a `UserWarning` at construction time. No behavioral change.

## Security Impact

**Medium** — SSRF via LLM-controlled web_fetch URLs. Combined with prompt injection, an attacker can cause the agent to fetch cloud metadata credentials or probe internal services.

## Changes

- Add `warnings.warn()` in `WebFetchTool.__init__` when both domain lists are None
- Import `warnings` module

## Testing

- Existing tests pass (no behavioral change)
- Warning emitted on default construction

## References

- AGNT-005: web_fetch tool has no URL validation or private-IP blocklist