### PR TITLE
chore: sync uv.lock with 1.0.0b0 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 
 [[package]]
 name = "ag2"
-version = "0.14.0"
+version = "1.0.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Why are these changes needed?

#3043 bumped the project version in `pyproject.toml` to `1.0.0b0`, but the lock file was not regenerated, so the `ag2` entry in `uv.lock` is still pinned at `0.14.0`. This PR updates the lock file to match the released version.

## Related issue number

Follow-up to #3043.

## Checks

- [x] I've included any doc changes needed for <https://docs.ag2.ai/>. See <https://docs.ag2.ai/latest/docs/contributor-guide/documentation/> to build and test documentation locally. *(not applicable — lock file only)*
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. *(not applicable — lock file only)*
- [x] I've made sure all auto checks have passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)