### PR TITLE
docs(triage): maintainer-authored issues enter at status:confirmed

### DIFF
--- a/.github/review/TRIAGE_POLICY.md
+++ b/.github/review/TRIAGE_POLICY.md
@@ -121,6 +121,7 @@ Rules for closing without merging/fixing:
 ```mermaid
 stateDiagram-v2
     [*] --> needs_triage : opened (issue form / PR workflow, automatic)
+    [*] --> confirmed : opened by a maintainer / Triage Team (self-triaged)
 
     state "Triage gates — nobody reviews until cleared" as gates {
         needs_template
@@ -182,6 +183,8 @@ The AI Triage Bot then runs a first pass:
 | It is a usage question | set `type:question`, comment pointing to GitHub Discussions, recommend closing |
 
 The bot **comments and labels; it does not confirm, prioritize, or close.**
+
+**Maintainer shortcut.** Issues opened by maintainers or Triage Team members are self-triaged: they enter at `status:confirmed` instead of `status:needs-triage`, and the author assigns `priority:*` at creation. The intake bot checks above still run (duplicates, areas, type sync).
 
 ### Stage I2 — Triage (Triage Team)
 


### PR DESCRIPTION
## Why are these changes needed?

Follow-up to the Triage Policy (#3050): issues opened by maintainers or Triage Team members do not need to pass the triage queue they themselves operate. This codifies the maintainer shortcut — such issues enter at `status:confirmed` with the author assigning `priority:*` at creation. The state diagram gets the corresponding entry edge.

Already applied in practice: #3039 and #3021 were moved to `status:confirmed` during the label migration.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)