### PR TITLE
ci(dependabot): add area labels to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       default-days: 7
     labels:
       - "type:maintenance"
+      - "area:deps"
+      - "area:actions"
     groups:
       github-actions:
         patterns:
@@ -29,6 +31,7 @@ updates:
       default-days: 7
     labels:
       - "type:maintenance"
+      - "area:deps"
     groups:
       uv:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
       default-days: 7
     labels:
       - "type:maintenance"
-      - "area:deps"
       - "area:actions"
     groups:
       github-actions:


### PR DESCRIPTION
## Why are these changes needed?

Per the Triage Policy, dependabot PRs should carry `area:*` routing labels, and setting them in the dependabot config is more reliable than the path-based labeler: uv updates get `area:deps`; GitHub Actions updates get `area:actions`.

`area:deps` is reserved for Python package dependencies (`pyproject.toml`, `uv.lock`) — action version bumps touch only `.github/workflows/` and are fully described by `area:actions`. The `area:deps` label description was updated accordingly.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)