### PR TITLE
docs(triage): canned replies, AI task runbook, core-module areas

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,6 +24,18 @@ body:
         4. See error
       placeholder: How can we replicate the issue?
   - type: textarea
+    id: mre
+    attributes:
+      label: Minimal reproducible example
+      description: A minimal, self-contained code snippet that reproduces the problem. This is the fastest way to get the bug triaged — reports without it are asked to add one.
+      render: python
+      placeholder: |
+        from ag2 import Agent
+
+        # smallest possible code that triggers the bug
+    validations:
+      required: true
+  - type: textarea
     id: modelused
     attributes:
       label: Model Used

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,6 +41,43 @@ area:extensions:
       - test/extensions/**
       - website/docs/user-guide/extensions/**
 
+area:core:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ag2/*.py
+      - ag2/events/**
+      - ag2/response/**
+      - ag2/streams/**
+      - test/agent/**
+      - test/events/**
+      - test/stream/**
+      - test/response/**
+
+area:tools:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ag2/tools/**
+      - test/tools/**
+
+area:providers:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ag2/config/**
+      - test/config/**
+      - test/providers/**
+
+area:middleware:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ag2/middleware/**
+      - test/middleware/**
+
+area:eval:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ag2/eval/**
+      - test/eval/**
+
 area:docs:
   - changed-files:
     - any-glob-to-any-file:

--- a/.github/review/TRIAGE_AI_TASKS.md
+++ b/.github/review/TRIAGE_AI_TASKS.md
@@ -1,0 +1,125 @@
+# AI Triage Tasks
+
+Recurring triage work that automation owns. Every task follows the same shape:
+
+- **Query** — which issues/PRs to pick up (a search filter, so the task is re-runnable at any time);
+- **Criteria** — the checks to evaluate, **in order**;
+- **Decision** — labels to set and which [canned reply](replies/) to post.
+
+The rules of the game are defined by the [Triage Policy](TRIAGE_POLICY.md) — this file only operationalizes it.
+
+## Global guardrails
+
+These override anything below:
+
+- **Never**: set `priority:*`, set `status:confirmed` (except the maintainer shortcut in T1), close items (except the stale flow in T6), merge, or edit someone's code.
+- **One check — one message.** Criteria are evaluated in the listed order; the first failing check decides the outcome, and the task **stops there** — no piling several demands into one pass. Gate precedence: **CLA > template > conflicts**.
+- **Idempotency**: before acting, check current labels and comments — never repeat a comment that is already present and still applicable.
+- **Sync rule**: any change to a `type:*` label or an Issue Type updates the other side (mapping in [Policy §1](TRIAGE_POLICY.md#type--classification)).
+- **Invariants**: exactly one `type:*`; exactly one `status:*` (plus `status:stale` stacked on a gate); permission matrix in [Policy §8](TRIAGE_POLICY.md#8-who-may-do-what).
+- When in doubt — label nothing, comment with the observation, and mention the maintainers.
+
+---
+
+## T1. Issue intake
+
+**Query:** open issues with no `status:*` label.
+
+**Criteria, in order — first hit decides:**
+
+| # | Check | Decision |
+|---|---|---|
+| 1 | Looks like a security vulnerability | add `security` + `status:needs-triage`, post [`security-report`](replies/security-report.md), notify maintainers; **stop** — no further public analysis |
+| 2 | Usage question, not a work item | set `type:question` (no Issue Type), post [`redirect-question`](replies/redirect-question.md) suggesting a Discussion, add `status:needs-triage` — do not close |
+| 3 | Duplicate of an existing open/recently-closed item | add `resolution:duplicate` as a **proposal** + `status:needs-triage`, post [`duplicate-suspect`](replies/duplicate-suspect.md) with `{{original}}` — **never close**; the author, Triage Team, or a maintainer closes if they agree |
+| 4 | Description doesn't follow the template — sections missing/placeholder; **bug reports must include a minimal reproducible example (MRE)**, required by the bug form | set `status:needs-template`, post [`needs-template-issue`](replies/needs-template-issue.md) with `{{missing_sections}}` |
+| 5 | All checks passed | author is a maintainer / Triage Team member → `status:confirmed` (shortcut, no comment); otherwise `status:needs-triage` |
+
+**Non-blocking enrichment** (same pass, no extra comments): sync Issue Type ↔ `type:*` if misfiled; infer `area:*` from the text.
+
+## T2. PR intake
+
+**Query:** open PRs with no `status:*` label.
+
+**Criteria, in order — first failing check decides, later checks are not evaluated:**
+
+| # | Check | Decision |
+|---|---|---|
+| 1 | `license/cla` check not passing (drafts included) | set `status:needs-cla`, post [`needs-cla`](replies/needs-cla.md) |
+| 2 | Description doesn't follow [the PR template](../PULL_REQUEST_TEMPLATE.md) — no real "why", doesn't reflect the diff, no validation info ([AI policy](../AI_POLICY.md)) | set `status:needs-template`, post [`needs-template-pr`](replies/needs-template-pr.md); if the cause is unverified AI-generated content, post [`ai-slop`](replies/ai-slop.md) with `{{observations}}` instead |
+| 3 | Merge conflicts with `main` — **skip this check for drafts** | set `status:changes-requested`, post [`merge-conflict`](replies/merge-conflict.md) |
+| 4 | All checks passed | draft → `status:in-progress`; ready → `status:needs-review`. No comment — except a first-time contributor, who gets [`welcome-first-pr`](replies/welcome-first-pr.md) |
+
+**Non-blocking enrichment:** verify `type:*` matches the diff (`fix:` → `type:bug`, docs-only → `type:docs`); add `area:*` the path-based labeler can't infer.
+
+## T3. Return from `needs-cla` / `needs-template`
+
+**Query:** open issues and PRs with `status:needs-cla` or `status:needs-template` where the author acted **after** the gate was set (signed the CLA, edited the description, pushed).
+
+**Criteria:** re-run the specific check behind the gate (`license/cla` state; template completeness incl. MRE for bugs).
+
+**Decision:**
+
+- Check now passes → remove the gate label and `status:stale` if present, then **re-run the intake cascade** (T1/T2 criteria) — the next gate in precedence order may apply (CLA signed, but the description is still gutted), or the item lands in `status:needs-triage` / `status:in-progress` / `status:needs-review`.
+- Check still fails → one reply stating exactly what is still missing (only if not already said); the gate stays.
+
+## T4. Return from `awaiting-response`
+
+**Query:** issues with `status:awaiting-response` where the author replied after the question was asked.
+
+**Decision:** remove the gate and `status:stale` if present → `status:needs-triage` (back into the Triage Team queue). No reply from the author → do nothing; the clock is T5's job.
+
+## T5. Mark gated items stale
+
+**Query:** open issues **and** PRs with a gate label (`needs-template` / `needs-cla` / `awaiting-response` / `changes-requested`), without `status:stale`, where the last author activity is older than the gate's window ([Policy §5](TRIAGE_POLICY.md#5-gates-and-the-stale-mechanism)):
+
+| Gate | Window |
+|---|---|
+| `status:needs-template` | 7 days |
+| `status:needs-cla` | 3 days |
+| `status:awaiting-response` | 10 days |
+| `status:changes-requested` | 30 days |
+
+**Decision:** add `status:stale` **on top of** the gate (the gate stays — it is the visible reason), post [`stale-warning`](replies/stale-warning.md) with `{{gate_label}}`.
+
+## T6. Resolve stale items: close or unmark
+
+**Query:** open issues and PRs with `status:stale`.
+
+**Criteria, in order:**
+
+| # | Check | Decision |
+|---|---|---|
+| 1 | Author acted after the stale mark | remove `status:stale`; the gate stays — its fate is T3/T4's job |
+| 2 | 7+ days of silence since the stale mark | close as *not planned*, post [`stale-close`](replies/stale-close.md); all labels remain for auditability |
+
+## T7. Conflict sweep of working PRs
+
+**Query:** open PRs with `status:needs-review` or `status:in-progress`, **excluding drafts**; run on every push to `main` and daily. GitHub computes mergeability lazily — re-query while the state is `UNKNOWN`.
+
+**Criteria:** `mergeable == CONFLICTING`.
+
+**Decision:** replace the status with `status:changes-requested`, post [`merge-conflict`](replies/merge-conflict.md). Gated PRs are **not** in the query — their gate has precedence; the conflict resurfaces via T3's re-run of the intake cascade.
+
+## T8. Return from `changes-requested`
+
+**Query:** PRs with `status:changes-requested` where, after the trigger that set the label, the author pushed commits or answered all review threads — or, when the label came from a merge conflict, the conflict is resolved.
+
+**Decision:** replace with `status:needs-review`, no comment — the PR reappears in the reviewers' queue.
+
+---
+
+## Stays manual
+
+By design these remain with humans (see [Policy §8](TRIAGE_POLICY.md#8-who-may-do-what)):
+
+- **Closing** anything outside the stale flow — including confirmed duplicates (T1 only proposes).
+- `status:confirmed` and `priority:*` — Triage Team / maintainers, during triage.
+- `status:needs-review` → `status:changes-requested` on review — the reviewer sets it together with the review itself.
+- Merging (Policy §4 P4 conditions).
+
+## Future automation (not scheduled)
+
+- Extension routing: ping the named maintainer from the module docstring on `area:extensions` items ([`extension-maintainer-ping`](replies/extension-maintainer-ping.md)); archival watchlist.
+- Weekly consistency audit: label invariants, Issue Type ↔ label drift, `confirmed` without priority.
+- Weekly queue-health digest for maintainers.

--- a/.github/review/TRIAGE_POLICY.md
+++ b/.github/review/TRIAGE_POLICY.md
@@ -22,7 +22,7 @@ Every label belongs to a class. The class prefix tells you what question the lab
 | `status:*` | Where is it in the lifecycle? | exactly one (see stale exception) | Automation + Triage Team + maintainers |
 | `priority:*` | When should we work on it? | at most one | **Humans only** (Triage Team, maintainers) |
 | `area:*` | Which part of the repository does it touch, and who should look? | any number | `actions/labeler` by file paths; bot for issues |
-| `resolution:*` | Why was it closed? | at most one, on closed items | **Humans only** |
+| `resolution:*` | Why was it closed? | at most one | **Humans close**; the bot may apply `resolution:duplicate` to an open item as a proposal |
 
 Standalone labels outside the classes: `good first issue` and `help wanted` (kept with their exact GitHub-standard names so they surface in GitHub's contribution UI) and `security` (cross-cutting flag; see [§7](#7-security-issues)).
 
@@ -117,7 +117,7 @@ Rules for closing without merging/fixing:
 - Set the `resolution:*` label **and** the matching native close reason.
 - Always leave a closing comment explaining why — start from the matching [canned reply](replies/) (`close-duplicate`, `close-wontfix`, `close-invalid`). For duplicates, link the original.
 - Issues fixed by a merged PR need no `resolution:*` label — close as *completed* (linked PRs do this automatically).
-- The bot may **recommend** a resolution in a comment but never closes items itself. (The one exception is the stale automation, [§5](#5-gates-and-the-stale-mechanism).)
+- The bot may apply `resolution:duplicate` to an **open** item as a proposal (with the [`duplicate-suspect`](replies/duplicate-suspect.md) comment), but never closes items itself — the author, Triage Team, or a maintainer closes if they agree. (The one exception is the stale automation, [§5](#5-gates-and-the-stale-mechanism).)
 
 ---
 
@@ -153,7 +153,7 @@ stateDiagram-v2
     changes_requested --> needs_review : author pushed updates
     needs_review --> closed : merged
 
-    needs_template --> stale : 3 days of silence — +stale, gate label stays
+    needs_template --> stale : 7 days of silence — +stale, gate label stays
     needs_cla --> stale : 3 days of silence — +stale, gate label stays
     awaiting_response --> stale : 10 days of silence — +stale, gate label stays
     changes_requested --> stale : 30 days of silence — +stale, gate label stays
@@ -181,7 +181,7 @@ The AI Triage Bot then runs a first pass:
 | Check | Outcome |
 |---|---|
 | Description does not follow the template (sections gutted, no reproduction for bugs) | set `status:needs-template`, comment listing what is missing |
-| Looks like a duplicate | comment linking candidates, recommend `resolution:duplicate` |
+| Looks like a duplicate | apply `resolution:duplicate` as a proposal + [`duplicate-suspect`](replies/duplicate-suspect.md) comment; a human closes |
 | Type mismatch (e.g. a feature request filed as a bug) | fix the `type:*` label and Issue Type, keeping them in sync |
 | Area detectable from the text | add `area:*` labels |
 | It is a usage question | set `type:question`, comment pointing to GitHub Discussions, recommend closing |
@@ -262,8 +262,8 @@ Gate labels (`status:needs-template`, `status:needs-cla`, `status:awaiting-respo
 
 | Gate | Days to `status:stale` | Rationale |
 |---|---|---|
-| `status:needs-template` | **3** | Fixing a description is minutes of work; a fast window filters out low-effort and AI-slop submissions |
-| `status:needs-cla` | **3** | Signing the CLA is one click; same slop filter |
+| `status:needs-template` | **7** | Fixing a description is quick, but writing a good reproduction or validation section can take a sitting |
+| `status:needs-cla` | **3** | Signing the CLA is one click; a fast window filters out low-effort submissions |
 | `status:awaiting-response` | **10** | Answering a question may require checking an environment or reproducing locally |
 | `status:changes-requested` | **30** | Addressing review feedback is real work — code, tests, docs |
 
@@ -302,7 +302,8 @@ Suspected vulnerabilities must not be triaged in public. Per [SECURITY.md](../SE
 | Set `status:confirmed` | ❌ | ✅ | ✅ |
 | Set `priority:*` | ❌ | ✅ | ✅ |
 | Set `status:changes-requested` | on review submission | ❌ | ✅ (as reviewer) |
-| Close with `resolution:*` | ❌ (recommend only) | ✅ | ✅ |
+| Propose `resolution:duplicate` (label + comment, item stays open) | ✅ | ✅ | ✅ |
+| Close with `resolution:*` | ❌ | ✅ | ✅ |
 | Close stale gated items | `actions/stale` only | ✅ | ✅ |
 | Merge | ❌ | ❌ | ✅ |
 
@@ -319,5 +320,7 @@ Suspected vulnerabilities must not be triaged in public. Per [SECURITY.md](../SE
 | `actions/stale` | The per-gate stale windows ([§5](#5-gates-and-the-stale-mechanism)); configured to act only on gate labels |
 | AI Triage Bot | Template gate, duplicate detection, type/area inference, Issue Type ↔ label sync, gate-clearing on author activity, Extension-maintainer routing, `status:needs-review` transitions |
 | [Canned replies](replies/) | Template messages for every scripted comment above — see the [index](replies/README.md) mapping each situation to its file, placeholders, and accompanying action |
+
+Operational instructions for the bot's recurring tasks — triggers, steps, and which replies/labels each task uses — live in [TRIAGE_AI_TASKS.md](TRIAGE_AI_TASKS.md).
 
 Any new automation that touches labels must respect the class invariants in [§1](#1-label-taxonomy) and the permission matrix in [§8](#8-who-may-do-what).

--- a/.github/review/TRIAGE_POLICY.md
+++ b/.github/review/TRIAGE_POLICY.md
@@ -86,6 +86,11 @@ Area answers "which part of the repository does this touch, and therefore who sh
 
 | Label | Covers |
 |---|---|
+| `area:core` | Agent runtime core: `ag2/*.py`, `ag2/events`, `ag2/response`, `ag2/streams` |
+| `area:tools` | Tool system, builtin tools, subagents: `ag2/tools` |
+| `area:providers` | LLM provider clients and mappers: `ag2/config` |
+| `area:middleware` | Middleware system and builtins: `ag2/middleware` |
+| `area:eval` | Offline evaluation framework: `ag2/eval` |
 | `area:a2a` | `ag2/a2a`, A2A protocol support |
 | `area:a2ui` | `ag2/a2ui` |
 | `area:acp` | `ag2/acp`, ACP support for CLI coding agents |
@@ -110,7 +115,7 @@ On PRs, areas are applied automatically by `actions/labeler` from changed file p
 Rules for closing without merging/fixing:
 
 - Set the `resolution:*` label **and** the matching native close reason.
-- Always leave a closing comment explaining why. For duplicates, link the original.
+- Always leave a closing comment explaining why — start from the matching [canned reply](replies/) (`close-duplicate`, `close-wontfix`, `close-invalid`). For duplicates, link the original.
 - Issues fixed by a merged PR need no `resolution:*` label — close as *completed* (linked PRs do this automatically).
 - The bot may **recommend** a resolution in a comment but never closes items itself. (The one exception is the stale automation, [§5](#5-gates-and-the-stale-mechanism).)
 
@@ -181,7 +186,7 @@ The AI Triage Bot then runs a first pass:
 | Area detectable from the text | add `area:*` labels |
 | It is a usage question | set `type:question`, comment pointing to GitHub Discussions, recommend closing |
 
-The bot **comments and labels; it does not confirm, prioritize, or close.**
+The bot **comments and labels; it does not confirm, prioritize, or close.** All bot comments use the [canned replies](replies/) with placeholders substituted; humans use the same templates as copy-paste starting points and personalize where it helps.
 
 ### Stage I2 — Triage (Triage Team)
 
@@ -215,7 +220,9 @@ On open, a workflow applies `status:needs-triage`, and `actions/labeler` applies
 | `status:needs-cla` | the CLA check fails | the author signs; the CLA workflow removes the label |
 | `status:needs-template` | the PR description guts [the template](../PULL_REQUEST_TEMPLATE.md) (missing "Why are these changes needed?", unchecked mandatory checks, no validation info — see [AI policy](../AI_POLICY.md)) | the author fixes the description; the bot verifies and removes the label |
 
-While any gate label is present, **no human reviews the PR.** The bot posts one comment per gate explaining exactly what is required.
+While any gate label is present, **no human reviews the PR.** The bot posts one comment per gate explaining exactly what is required, using the matching [canned reply](replies/) (`needs-cla`, `needs-template-pr`).
+
+**Gates apply to draft PRs too.** A draft without a signed CLA carries `status:needs-cla`, not `status:in-progress` — the gate takes precedence, and its stale window runs even while the PR is a draft. There is no reason to invest work in a PR that cannot be accepted.
 
 ### Stage P2 — Ready for review
 
@@ -260,9 +267,9 @@ Gate labels (`status:needs-template`, `status:needs-cla`, `status:awaiting-respo
 | `status:awaiting-response` | **10** | Answering a question may require checking an environment or reproducing locally |
 | `status:changes-requested` | **30** | Addressing review feedback is real work — code, tests, docs |
 
-1. After the gate's grace period with no author activity → `actions/stale` adds `status:stale` **on top of** the gate label (the gate label is *not* removed — it is the visible reason) and posts a warning comment.
+1. After the gate's grace period with no author activity → `actions/stale` adds `status:stale` **on top of** the gate label (the gate label is *not* removed — it is the visible reason) and posts the [`stale-warning`](replies/stale-warning.md) comment.
 2. Any author activity → `status:stale` is removed; the gate label stays until its own clearing condition is met.
-3. **7 more days** of silence → the item is closed as *not planned*. Both labels remain on the closed item so we can audit why things get dropped.
+3. **7 more days** of silence → the item is closed as *not planned* with the [`stale-close`](replies/stale-close.md) comment. Both labels remain on the closed item so we can audit why things get dropped.
 
 Exempt from stale: everything that is not gated — `status:needs-triage` (a slow queue is our problem, not the author's), `status:confirmed`, `status:in-progress`, `status:blocked`, `status:needs-review`.
 
@@ -311,5 +318,6 @@ Suspected vulnerabilities must not be triaged in public. Per [SECURITY.md](../SE
 | CLA workflow | Set/remove `status:needs-cla` from the check result |
 | `actions/stale` | The per-gate stale windows ([§5](#5-gates-and-the-stale-mechanism)); configured to act only on gate labels |
 | AI Triage Bot | Template gate, duplicate detection, type/area inference, Issue Type ↔ label sync, gate-clearing on author activity, Extension-maintainer routing, `status:needs-review` transitions |
+| [Canned replies](replies/) | Template messages for every scripted comment above — see the [index](replies/README.md) mapping each situation to its file, placeholders, and accompanying action |
 
 Any new automation that touches labels must respect the class invariants in [§1](#1-label-taxonomy) and the permission matrix in [§8](#8-who-may-do-what).

--- a/.github/review/replies/README.md
+++ b/.github/review/replies/README.md
@@ -1,0 +1,28 @@
+# Canned replies
+
+Template responses for the situations defined in the [Triage Policy](../TRIAGE_POLICY.md). Used by the AI Triage Bot verbatim (with placeholders substituted) and by maintainers / the Triage Team as copy-paste starting points — personalize when it helps.
+
+Conventions:
+
+- Placeholders use `{{name}}` syntax. Common ones: `{{author}}` (GitHub login without `@`), `{{missing_sections}}`, `{{original}}` (issue/PR reference), `{{reason}}`, `{{maintainer}}`, `{{extension}}`.
+- The HTML comment at the top of each file documents when to use it and which label/action accompanies the message. It is not part of the reply.
+- Gate messages embed their own stale timeline (per-gate windows from [Triage Policy §5](../TRIAGE_POLICY.md#5-gates-and-the-stale-mechanism)); the `+status:stale` flip posts `stale-warning.md`.
+
+| File | Situation | Accompanying action |
+|---|---|---|
+| `needs-template-issue.md` | Issue doesn't follow the template | `status:needs-template` |
+| `needs-template-pr.md` | PR description doesn't follow the template | `status:needs-template` |
+| `needs-cla.md` | CLA not signed (drafts included) | `status:needs-cla` |
+| `merge-conflict.md` | PR conflicts with `main` | `status:changes-requested` |
+| `stale-warning.md` | Gated item passed its grace period | add `status:stale` on top of the gate |
+| `stale-close.md` | Closing a gated item after the stale window | close as *not planned* |
+| `needs-reproduction.md` | Bug cannot be reproduced / info missing | `status:awaiting-response` |
+| `redirect-question.md` | Usage question filed as an issue | close as *not planned* |
+| `close-duplicate.md` | Duplicate of an existing item | `resolution:duplicate` + close as *duplicate* |
+| `close-wontfix.md` | Valid but deliberately not planned | `resolution:wontfix` + close as *not planned* |
+| `close-invalid.md` | Not actionable / not a real issue | `resolution:invalid` + close as *not planned* |
+| `security-report.md` | Possible vulnerability filed publicly | `security` label, notify maintainers |
+| `extension-suggestion.md` | Feature belongs as an Extension, not in Core | — |
+| `extension-maintainer-ping.md` | Issue/PR touches a community Extension | `status:awaiting-response` |
+| `ai-slop.md` | Signs of unverified AI-generated content | `status:needs-template` |
+| `welcome-first-pr.md` | First-time contributor opened a PR | — |

--- a/.github/review/replies/README.md
+++ b/.github/review/replies/README.md
@@ -18,6 +18,7 @@ Conventions:
 | `stale-close.md` | Closing a gated item after the stale window | close as *not planned* |
 | `needs-reproduction.md` | Bug cannot be reproduced / info missing | `status:awaiting-response` |
 | `redirect-question.md` | Usage question filed as an issue | close as *not planned* |
+| `duplicate-suspect.md` | Intake found a likely duplicate (stays open) | `resolution:duplicate` as a proposal; humans close |
 | `close-duplicate.md` | Duplicate of an existing item | `resolution:duplicate` + close as *duplicate* |
 | `close-wontfix.md` | Valid but deliberately not planned | `resolution:wontfix` + close as *not planned* |
 | `close-invalid.md` | Not actionable / not a real issue | `resolution:invalid` + close as *not planned* |

--- a/.github/review/replies/ai-slop.md
+++ b/.github/review/replies/ai-slop.md
@@ -1,0 +1,18 @@
+<!--
+Use when: a PR or issue shows signs of unverified AI-generated content — description doesn't match the diff, invented APIs, boilerplate reasoning, claims of testing with no evidence.
+Action: set `status:needs-template`. Stale window: 3 days, then closed 7 days later. Stay respectful: AI assistance is welcome, unverified output is not.
+-->
+
+Hi @{{author}}. AI-assisted contributions are welcome in AG2 — but per our [AI policy](https://github.com/ag2ai/ag2/blob/main/.github/AI_POLICY.md), **you remain responsible for everything you submit**, and this submission shows signs that its content wasn't verified:
+
+{{observations}}
+
+To move this forward, please:
+
+1. explain in your own words what problem this solves and how the change works,
+2. make the description accurately reflect the actual diff,
+3. include how you validated it — commands run, tests executed, observed output.
+
+We ask this of every contribution flagged this way; unverified submissions cost reviewers more than they save authors. Once the description meets the bar, the `status:needs-template` label is removed and the normal flow continues.
+
+⏳ Without an update within **3 days**, this will be marked stale and closed **7 days** after that.

--- a/.github/review/replies/ai-slop.md
+++ b/.github/review/replies/ai-slop.md
@@ -1,6 +1,6 @@
 <!--
 Use when: a PR or issue shows signs of unverified AI-generated content — description doesn't match the diff, invented APIs, boilerplate reasoning, claims of testing with no evidence.
-Action: set `status:needs-template`. Stale window: 3 days, then closed 7 days later. Stay respectful: AI assistance is welcome, unverified output is not.
+Action: set `status:needs-template`. Stale window: 7 days, then closed 7 days later. Stay respectful: AI assistance is welcome, unverified output is not.
 -->
 
 Hi @{{author}}. AI-assisted contributions are welcome in AG2 — but per our [AI policy](https://github.com/ag2ai/ag2/blob/main/.github/AI_POLICY.md), **you remain responsible for everything you submit**, and this submission shows signs that its content wasn't verified:
@@ -15,4 +15,4 @@ To move this forward, please:
 
 We ask this of every contribution flagged this way; unverified submissions cost reviewers more than they save authors. Once the description meets the bar, the `status:needs-template` label is removed and the normal flow continues.
 
-⏳ Without an update within **3 days**, this will be marked stale and closed **7 days** after that.
+⏳ Without an update within **7 days**, this will be marked stale and closed **7 days** after that.

--- a/.github/review/replies/close-duplicate.md
+++ b/.github/review/replies/close-duplicate.md
@@ -1,0 +1,8 @@
+<!--
+Use when: the issue/PR is already tracked elsewhere.
+Action: set `resolution:duplicate`, close as *duplicate*.
+-->
+
+Thanks @{{author}}! This is already tracked in {{original}}, so I'm closing this one as a duplicate to keep the discussion in a single place.
+
+Please follow and contribute to {{original}} — subscribing there is the best way to stay updated. If you believe this is actually a different problem, comment here with what distinguishes it and we'll reopen.

--- a/.github/review/replies/close-invalid.md
+++ b/.github/review/replies/close-invalid.md
@@ -1,0 +1,10 @@
+<!--
+Use when: the item is not actionable — not reproducible after asking, works as documented, or filed against the wrong project.
+Action: set `resolution:invalid`, close as *not planned*. Always state the concrete reason.
+-->
+
+Thanks @{{author}}. After looking into this, we're closing it as invalid:
+
+{{reason}}
+
+If we've misread the situation, comment with the missing details (ideally a minimal reproduction against the latest release) and we'll reopen and take another look.

--- a/.github/review/replies/close-wontfix.md
+++ b/.github/review/replies/close-wontfix.md
@@ -1,0 +1,12 @@
+<!--
+Use when: the request is valid and understood, but deliberately not planned.
+Action: set `resolution:wontfix`, close as *not planned*. Always state the concrete reason.
+-->
+
+Thanks @{{author}} — this is a reasonable request, and we've considered it. We're deliberately **not planning** to do it:
+
+{{reason}}
+
+For context: AG2 v1.0 keeps Core intentionally small and dependable (see the [Contribution Policy](https://docs.ag2.ai/latest/docs/user-guide/contribution_policy/)), so requests that expand its surface face a high bar.
+
+Closing as *not planned*. If circumstances change — new evidence, wide demand, or a maintainer willing to own it — we're open to revisiting; comment here and we can reopen the discussion.

--- a/.github/review/replies/duplicate-suspect.md
+++ b/.github/review/replies/duplicate-suspect.md
@@ -1,0 +1,11 @@
+<!--
+Use when: intake analysis finds an existing issue/PR tracking the same problem. The bot marks but never closes — closing is a human decision (author, Triage Team, or maintainer).
+Action: add `resolution:duplicate` as a proposal; the item stays open.
+-->
+
+Hi @{{author}} — this looks like a duplicate of {{original}}, so it's been marked `resolution:duplicate` as a proposal.
+
+- If you agree, feel free to close this issue and follow {{original}} — subscribing there is the best way to stay updated.
+- If this is actually a **different** problem, comment with what distinguishes it and the Triage Team will remove the mark.
+
+A maintainer or Triage Team member will otherwise make the call during triage. Nothing is closed automatically.

--- a/.github/review/replies/extension-maintainer-ping.md
+++ b/.github/review/replies/extension-maintainer-ping.md
@@ -1,0 +1,10 @@
+<!--
+Use when: an issue or PR touches a community-maintained Extension (area:extensions).
+Action: set `status:awaiting-response` (applies to the Extension maintainer, not the reporter). Stale window: 10 days.
+-->
+
+This concerns the **{{extension}}** Extension, which is maintained by @{{maintainer}} — pinging for a look, per the [Contribution Policy](https://docs.ag2.ai/latest/docs/user-guide/contribution_policy/).
+
+@{{maintainer}}: as the named maintainer, responding to issues and PRs for this Extension sits with you. If you can no longer maintain it, just tell us here — we'll look for a new maintainer or move it to the archive, no hard feelings.
+
+Note: a broken Extension with an unresponsive maintainer enters the 30-day archival notice process defined in the policy.

--- a/.github/review/replies/extension-suggestion.md
+++ b/.github/review/replies/extension-suggestion.md
@@ -1,0 +1,16 @@
+<!--
+Use when: a feature request or PR expands Core's surface (new integration, third-party SDK dependency) and belongs as an Extension instead.
+Action: explain the Core/Extension split; for PRs, request the change be restructured under ag2/extensions/.
+-->
+
+Thanks @{{author}}! This is useful functionality — and it's a textbook fit for an **Extension** rather than Core.
+
+AG2 v1.0 keeps Core intentionally small: reliance on a third-party SDK, or an integration best owned by someone closer to it, is exactly what our [Contribution Policy](https://docs.ag2.ai/latest/docs/user-guide/contribution_policy/) routes to Extensions. Extensions are first-class: same quality bar, same docs standards — the difference is that a **named maintainer** (you, or your team) commits to keeping it working.
+
+What an Extension contribution needs:
+
+- code under `ag2/extensions/`, with third-party packages declared as additional dependencies (guarded via `missing_additional_dependency`, not pyproject extras),
+- tests and documentation (module docstring with a `Maintainer: <github-handle>` line, plus a page under the Extensions docs section),
+- your commitment to respond to issues and keep it compatible with Core releases.
+
+If you're up for maintaining it, we'll gladly review — the policy page above has the full checklist.

--- a/.github/review/replies/merge-conflict.md
+++ b/.github/review/replies/merge-conflict.md
@@ -1,0 +1,10 @@
+<!--
+Use when: a PR has merge conflicts with main.
+Action: set `status:changes-requested` (remove `status:needs-review`). Stale window: 30 days, then closed 7 days later.
+-->
+
+Hi @{{author}} — this PR now has **merge conflicts with `main`** and has been moved to `status:changes-requested`.
+
+Please rebase onto the current `main` and resolve the conflicts. Once you push the updated branch, the PR will return to the review queue automatically.
+
+⏳ If there's no update within **30 days**, this PR will be marked stale and closed **7 days** after that.

--- a/.github/review/replies/needs-cla.md
+++ b/.github/review/replies/needs-cla.md
@@ -1,0 +1,12 @@
+<!--
+Use when: the `license/cla` check is not passing. Applies to draft PRs too.
+Action: set `status:needs-cla`. Stale window: 3 days, then closed 7 days later.
+-->
+
+Hi @{{author}}, thanks for the contribution!
+
+Before we can review or merge this PR, you need to sign our **Contributor License Agreement** — the `license/cla` check on this PR has the signing link. This applies to draft PRs as well: we don't want you to invest work into a change we can't accept.
+
+Once the CLA is signed, the check turns green, the `status:needs-cla` label is removed, and the PR proceeds through the normal flow.
+
+⏳ If the CLA isn't signed within **3 days**, this PR will be marked stale and closed **7 days** after that. Signing later and reopening is always an option.

--- a/.github/review/replies/needs-reproduction.md
+++ b/.github/review/replies/needs-reproduction.md
@@ -1,0 +1,17 @@
+<!--
+Use when: a bug report can't be reproduced or is missing key information.
+Action: set `status:awaiting-response`. Stale window: 10 days, then closed 7 days later.
+-->
+
+Hi @{{author}}, thanks for the report — we couldn't reproduce this from the current description.
+
+To move forward, please share:
+
+- the `ag2` version (`python -c "import ag2; print(ag2.__version__)"`) and Python version,
+- a **minimal, self-contained script** that triggers the problem,
+- the full traceback or unexpected output,
+- the LLM provider/model in use, if relevant.
+
+Once you reply, the issue goes back into the triage queue automatically.
+
+⏳ If there's no response within **10 days**, this issue will be marked stale and closed **7 days** after that — reopening with the details is always welcome.

--- a/.github/review/replies/needs-template-issue.md
+++ b/.github/review/replies/needs-template-issue.md
@@ -1,6 +1,6 @@
 <!--
 Use when: an issue's description doesn't follow the issue template (sections missing/gutted, no reproduction for bugs).
-Action: set `status:needs-template`. Stale window: 3 days, then closed 7 days later.
+Action: set `status:needs-template`. Stale window: 7 days, then closed 7 days later.
 -->
 
 Hi @{{author}}, thanks for opening this issue!
@@ -11,4 +11,4 @@ Its description doesn't follow our issue template, and maintainers don't pick up
 
 Please **edit the issue description** (don't post the details as a comment) using the [issue forms](https://github.com/ag2ai/ag2/issues/new/choose) as the reference structure. Once it's fixed, the `status:needs-template` label will be removed and the issue will enter the triage queue.
 
-⏳ If there's no update within **3 days**, this issue will be marked stale and closed **7 days** after that. It can always be reopened once the description is completed.
+⏳ If there's no update within **7 days**, this issue will be marked stale and closed **7 days** after that. It can always be reopened once the description is completed.

--- a/.github/review/replies/needs-template-issue.md
+++ b/.github/review/replies/needs-template-issue.md
@@ -1,0 +1,14 @@
+<!--
+Use when: an issue's description doesn't follow the issue template (sections missing/gutted, no reproduction for bugs).
+Action: set `status:needs-template`. Stale window: 3 days, then closed 7 days later.
+-->
+
+Hi @{{author}}, thanks for opening this issue!
+
+Its description doesn't follow our issue template, and maintainers don't pick up items until the description is complete — this is what's missing:
+
+{{missing_sections}}
+
+Please **edit the issue description** (don't post the details as a comment) using the [issue forms](https://github.com/ag2ai/ag2/issues/new/choose) as the reference structure. Once it's fixed, the `status:needs-template` label will be removed and the issue will enter the triage queue.
+
+⏳ If there's no update within **3 days**, this issue will be marked stale and closed **7 days** after that. It can always be reopened once the description is completed.

--- a/.github/review/replies/needs-template-pr.md
+++ b/.github/review/replies/needs-template-pr.md
@@ -1,0 +1,16 @@
+<!--
+Use when: a PR description doesn't follow .github/PULL_REQUEST_TEMPLATE.md (missing "Why are these changes needed?", no validation info, unchecked mandatory sections).
+Action: set `status:needs-template`. Stale window: 3 days, then closed 7 days later.
+-->
+
+Hi @{{author}}, thanks for the contribution!
+
+The PR description doesn't follow our [pull request template](https://github.com/ag2ai/ag2/blob/main/.github/PULL_REQUEST_TEMPLATE.md), and PRs aren't reviewed until it does — this is what's missing:
+
+{{missing_sections}}
+
+In particular, per our [AI-assisted contribution policy](https://github.com/ag2ai/ag2/blob/main/.github/AI_POLICY.md), the description must explain the real problem this solves, accurately reflect the diff, and include how the change was validated and tested.
+
+Please **edit the PR description** to fill in the template. Once it's fixed, the `status:needs-template` label will be removed and the PR will enter the review queue.
+
+⏳ If there's no update within **3 days**, this PR will be marked stale and closed **7 days** after that.

--- a/.github/review/replies/needs-template-pr.md
+++ b/.github/review/replies/needs-template-pr.md
@@ -1,6 +1,6 @@
 <!--
 Use when: a PR description doesn't follow .github/PULL_REQUEST_TEMPLATE.md (missing "Why are these changes needed?", no validation info, unchecked mandatory sections).
-Action: set `status:needs-template`. Stale window: 3 days, then closed 7 days later.
+Action: set `status:needs-template`. Stale window: 7 days, then closed 7 days later.
 -->
 
 Hi @{{author}}, thanks for the contribution!
@@ -13,4 +13,4 @@ In particular, per our [AI-assisted contribution policy](https://github.com/ag2a
 
 Please **edit the PR description** to fill in the template. Once it's fixed, the `status:needs-template` label will be removed and the PR will enter the review queue.
 
-⏳ If there's no update within **3 days**, this PR will be marked stale and closed **7 days** after that.
+⏳ If there's no update within **7 days**, this PR will be marked stale and closed **7 days** after that.

--- a/.github/review/replies/redirect-question.md
+++ b/.github/review/replies/redirect-question.md
@@ -1,0 +1,14 @@
+<!--
+Use when: an issue is a usage question rather than a bug report or feature request.
+Action: set `type:question`, answer briefly if quick, close as *not planned*.
+-->
+
+Hi @{{author}}! This looks like a usage question rather than a bug or feature request, so I'm closing the issue — the issue tracker is reserved for actionable work items.
+
+The right places to get help:
+
+- **[GitHub Discussions](https://github.com/ag2ai/ag2/discussions)** — best for how-to questions; answers stay searchable for others.
+- **[Documentation](https://docs.ag2.ai)** — guides and API reference.
+- **[Discord](https://discord.com/invite/pAbnFJrkgZ)** — for interactive help.
+
+If while digging you find that the behavior is actually broken or undocumented, please open a bug report with a reproduction — that we'll gladly triage.

--- a/.github/review/replies/security-report.md
+++ b/.github/review/replies/security-report.md
@@ -1,0 +1,10 @@
+<!--
+Use when: a publicly filed issue looks like a security vulnerability.
+Action: add `security`, notify maintainers immediately, avoid discussing exploit details in the thread.
+-->
+
+Hi @{{author}}, thank you for the report — this looks like it may be a **security vulnerability**, and those must not be triaged in public.
+
+Please report it through our private channel instead, as described in [SECURITY.md](https://github.com/ag2ai/ag2/blob/main/.github/SECURITY.md). If exploit details are already in this issue, we may edit or minimize them to protect users while a fix is prepared.
+
+Maintainers have been notified. Please don't post proof-of-concept code or exploitation steps in this thread — everything else about the report is welcome through the private flow, and we appreciate you flagging it.

--- a/.github/review/replies/stale-close.md
+++ b/.github/review/replies/stale-close.md
@@ -1,0 +1,11 @@
+<!--
+Use when: a gated item (needs-template / needs-cla / awaiting-response / changes-requested) passed its stale window plus 7 days with no author activity.
+Action: close as *not planned*. Both the gate label and `status:stale` stay on the closed item.
+-->
+
+Closing this as **not planned**: it has been waiting on author action (`{{gate_label}}`) past the grace period with no activity.
+
+This is routine queue hygiene, not a judgment on the idea itself. If you'd like to pick it up again:
+
+- resolve what the gate label asked for, and
+- comment here or open a fresh issue/PR referencing this one — we'll gladly reopen and continue from where it stopped.

--- a/.github/review/replies/stale-warning.md
+++ b/.github/review/replies/stale-warning.md
@@ -1,0 +1,10 @@
+<!--
+Use when: a gated item passed its gate's grace period with no author activity and is being marked stale.
+Action: add `status:stale` on top of the gate label (the gate label stays). Posted by the stale automation.
+-->
+
+Hi @{{author}} — this is still waiting on your action (`{{gate_label}}`) and has passed its grace period, so it's now marked **stale**.
+
+⏳ Without activity it will be **closed in 7 days** as *not planned*.
+
+Any response resets this: resolve what the gate label asks for — or comment if you need help or more time — and the stale mark is removed.

--- a/.github/review/replies/welcome-first-pr.md
+++ b/.github/review/replies/welcome-first-pr.md
@@ -1,0 +1,14 @@
+<!--
+Use when: a first-time contributor opens a PR.
+Action: none — informational. Can be combined with a gate message if a gate applies.
+-->
+
+Welcome @{{author}}, and thanks for your first contribution to AG2! 🎉
+
+A quick tour of what happens next:
+
+- Automation applies labels and checks the basics: the [PR template](https://github.com/ag2ai/ag2/blob/main/.github/PULL_REQUEST_TEMPLATE.md) is filled in, and the **CLA** is signed (the `license/cla` check has the link).
+- Once the checks pass, the PR enters the review queue (`status:needs-review`) and a maintainer will take a look.
+- If the reviewer requests changes, push updates to the same branch — the PR returns to the queue automatically.
+
+Useful links: [Contributing guide](https://docs.ag2.ai/latest/docs/contributor-guide/contributing), [Contribution Policy](https://docs.ag2.ai/latest/docs/user-guide/contribution_policy/) (Core vs Extensions), [Discord](https://discord.com/invite/pAbnFJrkgZ).


### PR DESCRIPTION
## Why are these changes needed?

Second installment of the Triage Policy (#3050): everything the AI Triage Bot and the Triage Team need to actually run the process.

- **`.github/review/replies/`** — 17 canned replies covering every scripted comment in the flow (gates, stale, closing, duplicates, security, extensions, AI policy), with an index README and `{{placeholder}}` conventions. Referenced from every policy section that prescribes a comment.
- **`.github/review/TRIAGE_AI_TASKS.md`** — the bot's runbook: eight query-driven tasks (issue/PR intake, gate returns, stale mark/resolve, conflict sweep, changes-requested return), each as *query → ordered criteria → decision + reply*. First failing check stops the pass; gate precedence CLA > template > conflicts. Explicit "stays manual" and "future automation" sections.
- **Duplicate flow** — the bot applies `resolution:duplicate` to *open* issues as a proposal (`duplicate-suspect` reply); closing remains a human decision. Policy §1/§3/§8 updated accordingly.
- **Five module `area:*` labels** (`core`, `tools`, `providers`, `middleware`, `eval`) with labeler path rules — previously PRs to the package core carried no routing label at all.
- **Bug form** — required "Minimal reproducible example" field (`render: python`).
- **Stale window tuning** — `needs-template` relaxed 3 → 7 days; CLA stays 3.
- Policy addenda: gates apply to draft PRs (CLA takes precedence over `in-progress`), per-gate windows in the state diagram.

The process was dry-run against all 17 open PRs: labels + 13 gate comments (4 CLA, 9 merge-conflict) are already live, pre-policy PRs with substantive descriptions were grandfathered from the template gate.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)