### PR TITLE
fix(knowledge): serialize SqliteKnowledgeStore read paths with the connection lock

### DIFF
--- a/ag2/knowledge/sqlite.py
+++ b/ag2/knowledge/sqlite.py
@@ -166,7 +166,8 @@ class SqliteKnowledgeStore:
 
     async def read(self, path: str) -> str | None:
         normalized = _normalize(path)
-        return await self._run(functools.partial(self._sync_read, normalized))
+        async with self._lock:
+            return await self._run(functools.partial(self._sync_read, normalized))
 
     async def write(self, path: str, content: str) -> None:
         normalized = _normalize(path)
@@ -177,7 +178,8 @@ class SqliteKnowledgeStore:
 
     async def list(self, path: str = "/") -> list[str]:
         prefix = _normalize(path).rstrip("/") + "/"
-        return await self._run(functools.partial(self._sync_list, prefix))
+        async with self._lock:
+            return await self._run(functools.partial(self._sync_list, prefix))
 
     async def delete(self, path: str) -> None:
         normalized = _normalize(path)
@@ -188,7 +190,8 @@ class SqliteKnowledgeStore:
     async def exists(self, path: str) -> bool:
         normalized = _normalize(path)
         prefix = normalized.rstrip("/") + "/"
-        return await self._run(functools.partial(self._sync_exists, normalized, prefix))
+        async with self._lock:
+            return await self._run(functools.partial(self._sync_exists, normalized, prefix))
 
     async def append(self, path: str, content: str) -> int:
         normalized = _normalize(path)
@@ -199,7 +202,8 @@ class SqliteKnowledgeStore:
 
     async def read_range(self, path: str, start: int, end: int | None = None) -> str:
         normalized = _normalize(path)
-        return await self._run(functools.partial(self._sync_read_range, normalized, start, end))
+        async with self._lock:
+            return await self._run(functools.partial(self._sync_read_range, normalized, start, end))
 
     async def list_versions_under(self, prefix: str) -> dict[str, int]:
         """Return ``{path: version}`` for every key under ``prefix``.
@@ -210,7 +214,8 @@ class SqliteKnowledgeStore:
         diff loop O(keys-under-prefix).
         """
         normalized = _normalize(prefix).rstrip("/")
-        return await self._run(functools.partial(self._sync_list_versions, normalized))
+        async with self._lock:
+            return await self._run(functools.partial(self._sync_list_versions, normalized))
 
     async def on_change(self, path: str, callback: ChangeCallback) -> ChangeSubscription:
         watcher = PollingChangeWatcher(

--- a/test/knowledge/test_knowledge.py
+++ b/test/knowledge/test_knowledge.py
@@ -543,6 +543,44 @@ class TestSqliteKnowledgeStore:
         finally:
             store2.close()
 
+    async def test_concurrent_reads_and_writes_do_not_corrupt_connection(self, tmp_path: Path) -> None:
+        """Interleaved reads and writes share one connection and must serialize.
+
+        The single ``sqlite3.connect(check_same_thread=False)`` connection is
+        dispatched across the default executor's thread pool. Without the
+        ``asyncio.Lock`` on the read paths a concurrent read and write land on
+        the connection at the same time and sqlite3 misbehaves — either raising
+        ``sqlite3.InterfaceError: bad parameter or other API misuse`` or leaving
+        a cursor wedged so sibling executor threads block forever. Hammer the
+        store with ~200 interleaved operations on one instance to catch it.
+
+        The whole storm is wrapped in ``asyncio.wait_for`` so a corrupted
+        connection surfaces as a deterministic failure (``TimeoutError`` or the
+        raised ``InterfaceError``) instead of hanging the suite.
+        """
+        store = SqliteKnowledgeStore(str(tmp_path / "store.db"))
+        try:
+            ops = []
+            for i in range(50):
+                path = f"/t/{i}"
+                ops.append(store.write(path, f"value-{i}"))
+                ops.append(store.read(path))
+                ops.append(store.exists(path))
+                ops.append(store.list("/t/"))
+            # gather does not swallow exceptions here; an InterfaceError from
+            # any interleaving propagates and fails the test. wait_for guards
+            # against the wedged-connection hang the bug can also produce.
+            await asyncio.wait_for(asyncio.gather(*ops), timeout=15.0)
+
+            # Store is still consistent after the storm.
+            assert await store.read("/t/0") == "value-0"
+            assert await store.read("/t/49") == "value-49"
+            assert await store.exists("/t/25") is True
+            listing = await store.list("/t/")
+            assert len(listing) == 50
+        finally:
+            store.close()
+
 
 class _FakeLock:
     """Minimal Lock protocol implementation for LockedKnowledgeStore tests."""


### PR DESCRIPTION
## Why are these changes needed?

SqliteKnowledgeStore only locked its writes; reads hit the same sqlite connection from other executor threads. Under concurrency it raises InterfaceError, and occasionally caused a segfault.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
