### PR TITLE
docs(acp): document authentication & billing model for CLI agents

### DIFF
--- a/ag2/acp/config.py
+++ b/ag2/acp/config.py
@@ -43,8 +43,12 @@ class ACPConfig:
         command: Executable + base args launching the agent in ACP mode,
             e.g. ``["claude-agent-acp"]``. The first element is the executable.
         cwd: Workspace root passed to ``session/new``.
-        env: Extra environment variables for the subprocess (auth typically
-            lives here or is inherited from the parent process).
+        env: Extra environment variables for the subprocess. The subprocess does
+            NOT inherit the full parent environment: only a small whitelist
+            (``HOME``, ``LOGNAME``, ``PATH``, ``SHELL``, ``TERM``, ``USER``) is
+            inherited, merged with this mapping. So API-key auth must be passed
+            here explicitly (a shell ``export`` of the key is not inherited); a
+            disk login under ``$HOME`` (e.g. ``~/.claude``) works without it.
         model: Agent model selection, when the CLI supports it.
         permission_policy: How to answer ``session/request_permission``:
             ``"ask"`` routes to the agent's ``hitl_hook``/``context.input``,
@@ -106,8 +110,12 @@ class ClaudeCodeConfig(ACPConfig):
     Launches the ``@agentclientprotocol/claude-agent-acp`` bin, which must be on
     ``PATH`` (install globally, or override ``command`` to run it via
     ``npx -y @agentclientprotocol/claude-agent-acp``). The adapter wraps the
-    Claude Agent SDK; authenticate by setting ``ANTHROPIC_API_KEY`` in ``env``
-    or by pointing ``CLAUDE_CONFIG_DIR`` at an existing Claude Code login.
+    Claude Agent SDK. Authenticate either by passing ``ANTHROPIC_API_KEY`` in
+    ``env`` (billed per-token by the Anthropic API), or via an existing Claude
+    Code login under ``$HOME`` -- ``~/.claude``, or a custom dir via
+    ``CLAUDE_CONFIG_DIR`` passed in ``env`` -- which uses that login's plan.
+    Only a small env whitelist is inherited, so a shell ``export`` of the key
+    does not reach the subprocess; put it in ``env`` (see ``ACPConfig.env``).
     Select the model via the adapter's ``ANTHROPIC_MODEL`` env var (the
     ``model`` field is currently response metadata only, not sent to the agent).
     """
@@ -121,8 +129,11 @@ class CodexConfig(ACPConfig):
 
     Launches the ``@agentclientprotocol/codex-acp`` bin, which must be on
     ``PATH`` (install globally, or override ``command`` to run it via
-    ``npx -y @agentclientprotocol/codex-acp``). Authenticate by setting
-    ``CODEX_API_KEY`` (takes precedence) or ``OPENAI_API_KEY`` in ``env``.
+    ``npx -y @agentclientprotocol/codex-acp``). Authenticate by passing
+    ``CODEX_API_KEY`` (takes precedence) or ``OPENAI_API_KEY`` in ``env`` --
+    billed per-token by the provider's API. Only a small env whitelist is
+    inherited, so a shell ``export`` does not reach the subprocess; put the key
+    in ``env`` (see ``ACPConfig.env``).
     Select the model via the adapter's ``MODEL_PROVIDER`` env var (the
     ``model`` field is currently response metadata only, not sent to the agent).
     """
@@ -135,7 +146,10 @@ class OpenCodeConfig(ACPConfig):
     """``ACPConfig`` preset for the OpenCode ACP adapter.
 
     Launches ``opencode acp``, which must be on ``PATH``. Authenticate with
-    ``opencode auth login`` (or env / ``.env``). Select the model in OpenCode's
+    ``opencode auth login``; its credentials are stored on disk under ``$HOME``
+    (inherited automatically), so no ``env`` is needed. Billing follows the
+    provider that login is on (an API key or a subscription). Select the model
+    in OpenCode's
     config (``opencode.json``: ``"model": "provider/model"``); the ``acp``
     subcommand takes no ``--model`` flag, and the ``model`` field here is
     response metadata only, not sent to the agent.

--- a/website/docs/user-guide/cli_agents.mdx
+++ b/website/docs/user-guide/cli_agents.mdx
@@ -25,8 +25,8 @@ launch defaults for each adapter (`ClaudeCodeConfig`, `CodexConfig`,
 ## Basic Usage
 
 ```python linenums="1"
-from autogen import Agent
-from autogen.acp import ClaudeCodeConfig
+from ag2 import Agent
+from ag2.acp import ClaudeCodeConfig
 
 agent = Agent("coder", config=ClaudeCodeConfig(cwd="/path/to/repo"))
 
@@ -44,8 +44,8 @@ Each adapter is a preset with its own launch command and authentication:
 <Tabs>
   <Tab title="Claude Code">
 ```python linenums="1"
-from autogen import Agent
-from autogen.acp import ClaudeCodeConfig
+from ag2 import Agent
+from ag2.acp import ClaudeCodeConfig
 
 # Launches `claude-agent-acp`; auth via ANTHROPIC_API_KEY (env) or CLAUDE_CONFIG_DIR.
 agent = Agent("coder", config=ClaudeCodeConfig(cwd="/path/to/repo"))
@@ -54,8 +54,8 @@ agent = Agent("coder", config=ClaudeCodeConfig(cwd="/path/to/repo"))
 
   <Tab title="Codex">
 ```python linenums="1"
-from autogen import Agent
-from autogen.acp import CodexConfig
+from ag2 import Agent
+from ag2.acp import CodexConfig
 
 # Launches `codex-acp`; auth via CODEX_API_KEY or OPENAI_API_KEY (env).
 agent = Agent("coder", config=CodexConfig(cwd="/path/to/repo"))
@@ -64,8 +64,8 @@ agent = Agent("coder", config=CodexConfig(cwd="/path/to/repo"))
 
   <Tab title="OpenCode">
 ```python linenums="1"
-from autogen import Agent
-from autogen.acp import OpenCodeConfig
+from ag2 import Agent
+from ag2.acp import OpenCodeConfig
 
 # Launches `opencode acp`; auth via `opencode auth login` (or env / .env).
 # Pick the model in OpenCode's own config (opencode.json: "model": "provider/model").
@@ -83,16 +83,44 @@ agent = Agent("coder", config=OpenCodeConfig(cwd="/path/to/repo"))
     provider, OpenCode falls back to the first model of its built-in `opencode`
     provider (OpenCode Zen).
 
+## Authentication & billing
+
+AG2 does not meter or bill ACP usage itself — it only launches the CLI agent as a
+subprocess. **How the run is billed is determined entirely by how the underlying
+CLI agent is authenticated**, and that authentication lives in the agent's own
+environment (`env` on the config, or inherited from the parent process), not in AG2.
+
+Two modes are possible, depending on the credential you provide:
+
+| Authentication | Billing |
+| :--- | :--- |
+| **API key** (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY` / `CODEX_API_KEY`, or a provider key for OpenCode) | The provider's **API** — pay-per-token against that API account |
+| **Existing CLI login** (`CLAUDE_CONFIG_DIR` pointing at a Claude Code login, or `opencode auth login`) | Whatever **plan that login is on** — which may be a subscription rather than the pay-per-token API |
+
+So "API or subscription" is not a property of ACP or AG2: it follows the
+credential you hand the agent. Point the adapter at an API key and usage is billed
+per-token by the provider's API; point it at an existing subscription-backed login
+and it draws on that subscription.
+
+!!! note
+
+    The Codex adapter, as configured here, authenticates via `CODEX_API_KEY` /
+    `OPENAI_API_KEY` — i.e. API billing. Subscription-backed logins apply to the
+    adapters that read an existing login (Claude Code via `CLAUDE_CONFIG_DIR`,
+    OpenCode via `opencode auth login`). Exact plan names, quotas, and whether a
+    given plan permits programmatic use are set by each provider, not by AG2 —
+    check the provider's terms.
+
 ## Observing the agent's work
 
 Subscribe to the run's stream to see thoughts, tool calls, and plans live:
 
 ```python linenums="1"
-from autogen import Agent
-from autogen.acp import ClaudeCodeConfig
-from autogen.events import ModelMessageChunk, ModelReasoning
-from autogen.events.tool_events import BuiltinToolCallEvent
-from autogen.acp.events import ACPPlan
+from ag2 import Agent
+from ag2.acp import ClaudeCodeConfig
+from ag2.events import ModelMessageChunk, ModelReasoning
+from ag2.events.tool_events import BuiltinToolCallEvent
+from ag2.acp.events import ACPPlan
 
 agent = Agent("coder", config=ClaudeCodeConfig(cwd="/path/to/repo"))
 
@@ -145,8 +173,8 @@ Because each CLI agent is an `Agent`, you can compose them — including as tool
 of one another via `.as_tool()`:
 
 ```python linenums="1"
-from autogen import Agent
-from autogen.acp import ClaudeCodeConfig
+from ag2 import Agent
+from ag2.acp import ClaudeCodeConfig
 
 reviewer = Agent("reviewer", config=ClaudeCodeConfig(cwd="/repo"))
 manager = Agent(

--- a/website/docs/user-guide/cli_agents.mdx
+++ b/website/docs/user-guide/cli_agents.mdx
@@ -47,7 +47,8 @@ Each adapter is a preset with its own launch command and authentication:
 from ag2 import Agent
 from ag2.acp import ClaudeCodeConfig
 
-# Launches `claude-agent-acp`; auth via ANTHROPIC_API_KEY (env) or CLAUDE_CONFIG_DIR.
+# Launches `claude-agent-acp`. Auth: pass ANTHROPIC_API_KEY in env={...}, or use
+# an existing ~/.claude login. See "Authentication & billing" below.
 agent = Agent("coder", config=ClaudeCodeConfig(cwd="/path/to/repo"))
 ```
   </Tab>
@@ -57,7 +58,8 @@ agent = Agent("coder", config=ClaudeCodeConfig(cwd="/path/to/repo"))
 from ag2 import Agent
 from ag2.acp import CodexConfig
 
-# Launches `codex-acp`; auth via CODEX_API_KEY or OPENAI_API_KEY (env).
+# Launches `codex-acp`. Auth: pass CODEX_API_KEY or OPENAI_API_KEY in env={...}.
+# See "Authentication & billing" below.
 agent = Agent("coder", config=CodexConfig(cwd="/path/to/repo"))
 ```
   </Tab>
@@ -67,7 +69,8 @@ agent = Agent("coder", config=CodexConfig(cwd="/path/to/repo"))
 from ag2 import Agent
 from ag2.acp import OpenCodeConfig
 
-# Launches `opencode acp`; auth via `opencode auth login` (or env / .env).
+# Launches `opencode acp`. Auth: `opencode auth login` (stored under $HOME).
+# See "Authentication & billing" below.
 # Pick the model in OpenCode's own config (opencode.json: "model": "provider/model").
 agent = Agent("coder", config=OpenCodeConfig(cwd="/path/to/repo"))
 ```
@@ -85,31 +88,58 @@ agent = Agent("coder", config=OpenCodeConfig(cwd="/path/to/repo"))
 
 ## Authentication & billing
 
-AG2 does not meter or bill ACP usage itself — it only launches the CLI agent as a
-subprocess. **How the run is billed is determined entirely by how the underlying
-CLI agent is authenticated**, and that authentication lives in the agent's own
-environment (`env` on the config, or inherited from the parent process), not in AG2.
+AG2 never meters or bills a run itself — it only launches the CLI agent as a
+subprocess and streams its output. **Who is billed, and whether it's per-token API
+usage or a subscription, is decided entirely by the credential the agent
+authenticates with — not by AG2 or ACP.**
 
-Two modes are possible, depending on the credential you provide:
+### How the agent's environment is built
 
-| Authentication | Billing |
-| :--- | :--- |
-| **API key** (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY` / `CODEX_API_KEY`, or a provider key for OpenCode) | The provider's **API** — pay-per-token against that API account |
-| **Existing CLI login** (`CLAUDE_CONFIG_DIR` pointing at a Claude Code login, or `opencode auth login`) | Whatever **plan that login is on** — which may be a subscription rather than the pay-per-token API |
+This is the part that trips people up. AG2 does **not** hand the agent your full
+shell environment. The ACP subprocess starts from a *trimmed* environment — only
+`HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, and `USER` are inherited — merged with
+whatever you pass explicitly in the config's `env` field:
 
-So "API or subscription" is not a property of ACP or AG2: it follows the
-credential you hand the agent. Point the adapter at an API key and usage is billed
-per-token by the provider's API; point it at an existing subscription-backed login
-and it draws on that subscription.
+```text
+agent environment  =  { HOME, LOGNAME, PATH, SHELL, TERM, USER }  +  config.env
+```
+
+The practical consequence: **`export ANTHROPIC_API_KEY=...` in your shell does not
+reach the agent.** An API key takes effect only if you put it in `env`:
+
+```python linenums="1"
+from ag2 import Agent
+from ag2.acp import ClaudeCodeConfig
+
+agent = Agent("coder", config=ClaudeCodeConfig(
+    cwd="/repo",
+    env={"ANTHROPIC_API_KEY": "sk-ant-..."},  # a shell export would NOT be inherited
+))
+```
+
+A disk-based login is different: it lives under `$HOME` (e.g. Claude Code's
+`~/.claude`, or the credentials written by `opencode auth login`), and `HOME` *is*
+inherited — so it works without setting `env` at all.
+
+### The two paths, and how each is billed
+
+| You authenticate with… | How to set it | Billing |
+| :--- | :--- | :--- |
+| **An API key** (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY` / `CODEX_API_KEY`, or a provider key for OpenCode) | Pass it in `config.env` — a shell `export` is **not** inherited | The provider's **API**: pay-per-token against that API account |
+| **An existing CLI login** on the host (Claude Code `~/.claude`, `opencode auth login`) | Nothing to set — inherited via `$HOME` | Whatever **plan that login is on**, which may be a **subscription** |
+
+So "API or subscription" is not a property of ACP or AG2 — it follows the
+credential. By default (no `env`), the agent uses whatever login already exists on
+the host; pass an API key in `env` to bill against the provider's API instead.
 
 !!! note
 
-    The Codex adapter, as configured here, authenticates via `CODEX_API_KEY` /
-    `OPENAI_API_KEY` — i.e. API billing. Subscription-backed logins apply to the
-    adapters that read an existing login (Claude Code via `CLAUDE_CONFIG_DIR`,
-    OpenCode via `opencode auth login`). Exact plan names, quotas, and whether a
-    given plan permits programmatic use are set by each provider, not by AG2 —
-    check the provider's terms.
+    The Codex adapter here authenticates only via `CODEX_API_KEY` / `OPENAI_API_KEY`
+    (API billing). The subscription/login path applies to the adapters that read a
+    disk login — Claude Code (`~/.claude`, or a custom location via
+    `CLAUDE_CONFIG_DIR` passed in `env`) and OpenCode (`opencode auth login`). Exact
+    plan names, quotas, and whether a plan permits programmatic use are set by each
+    provider, not by AG2 — check the provider's terms.
 
 ## Observing the agent's work
 


### PR DESCRIPTION
## Why are these changes needed?

Documents how ACP-backed CLI agents (Claude Code, Codex, OpenCode) are billed, and
corrects an inaccuracy about how the agent's environment is populated — neither was
covered correctly before.

Adds an **"Authentication & billing"** section to `website/docs/user-guide/cli_agents.mdx`:

- AG2 does not meter or bill a run itself — it only launches the CLI agent as a subprocess.
- **The subprocess does not inherit your full shell environment.** Only a small whitelist
  (`HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`) is inherited, merged with the
  config's `env`. So `export ANTHROPIC_API_KEY=...` in your shell does **not** reach the
  agent — an API key must be passed in `config.env`.
- Billing follows the credential:
  - **API key** (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY` / `CODEX_API_KEY`, or a provider
    key for OpenCode), passed via `config.env` → the provider's API, pay-per-token.
  - **Existing on-disk login** under `$HOME` (Claude Code `~/.claude`, `opencode auth
    login`), inherited automatically → whatever plan that login is on, which may be a
    subscription.

Also:
- Fixes the same env-inheritance inaccuracy in the `ACPConfig` / preset docstrings in
  `ag2/acp/config.py` (docstring changes only — no behavior change).
- Switches the page's example imports from the `autogen` module path to `ag2`, per the
  docs style guide (`website/CLAUDE.md`).

Documentation only (Markdown + docstrings); no runtime / API / behavior changes.
