### PR TITLE
feat(anthropic): support new web_fetch/web_search tool versions

### DIFF
--- a/ag2/tools/builtin/web_fetch.py
+++ b/ag2/tools/builtin/web_fetch.py
@@ -26,7 +26,9 @@ class WebFetchToolSchema(ToolSchema):
     blocked_domains: list[str] | None = None
     citations: bool | None = None
     max_content_tokens: int | None = None
-    web_fetch_version: Literal["web_fetch_20250910", "web_fetch_20260209"] = "web_fetch_20250910"
+    web_fetch_version: Literal[
+        "web_fetch_20250910", "web_fetch_20260209", "web_fetch_20260309", "web_fetch_20260318"
+    ] = "web_fetch_20250910"
 
 
 class WebFetchTool(Tool):
@@ -43,7 +45,9 @@ class WebFetchTool(Tool):
         blocked_domains: list[str] | Variable | None = None,
         citations: bool | Variable | None = None,
         max_content_tokens: int | Variable | None = None,
-        version: Literal["web_fetch_20250910", "web_fetch_20260209"] | Variable | None = None,
+        version: Literal["web_fetch_20250910", "web_fetch_20260209", "web_fetch_20260309", "web_fetch_20260318"]
+        | Variable
+        | None = None,
     ) -> None:
         self._params: dict[str, object] = {}
         if max_uses is not None:

--- a/ag2/tools/builtin/web_search.py
+++ b/ag2/tools/builtin/web_search.py
@@ -34,7 +34,9 @@ class WebSearchToolSchema(ToolSchema):
     user_location: UserLocation | None = None
     allowed_domains: list[str] | None = None
     blocked_domains: list[str] | None = None
-    web_search_version: Literal["web_search_20250305", "web_search_20260209"] = "web_search_20250305"
+    web_search_version: Literal["web_search_20250305", "web_search_20260209", "web_search_20260318"] = (
+        "web_search_20250305"
+    )
 
 
 class WebSearchTool(Tool):
@@ -51,7 +53,7 @@ class WebSearchTool(Tool):
         user_location: UserLocation | Variable | None = None,
         allowed_domains: list[str] | Variable | None = None,
         blocked_domains: list[str] | Variable | None = None,
-        version: Literal["web_search_20250305", "web_search_20260209"] | Variable | None = None,
+        version: Literal["web_search_20250305", "web_search_20260209", "web_search_20260318"] | Variable | None = None,
     ) -> None:
         self._params: dict[str, object] = {}
         if search_context_size is not None:


### PR DESCRIPTION
## Why are these changes needed?

Anthropic released new dated versions of the web tools. This extends the
accepted `version` literals so users can pin them:

- `WebFetchTool`: adds `web_fetch_20260309` and `web_fetch_20260318`
- `WebSearchTool`: adds `web_search_20260318`

The mapper already passes the version through to the tool `type` field, so no
mapping logic changes — only the accepted-version type surface widens. Mapping
tests cover each new version.

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/.
- [ ] I've added tests corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
