### PR TITLE
docs(blog): restore Blog tab with the AG2 Beta posts

### DIFF
--- a/website/docs/_blogs/2026-03-16-AG2-Beta/img/ag2-beta-banner.webp
+++ b/website/docs/_blogs/2026-03-16-AG2-Beta/img/ag2-beta-banner.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f78901884dad68b973ddd471973d9ef584aefdc19d98ea53df27e4edc05a033d
+size 203548

--- a/website/docs/_blogs/2026-03-16-AG2-Beta/img/agent-chat.png
+++ b/website/docs/_blogs/2026-03-16-AG2-Beta/img/agent-chat.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88f6d345f77496a5491b51409d0452d80fda0aa0994fabb61ee39461d5f9eca0
+size 285365

--- a/website/docs/_blogs/2026-03-16-AG2-Beta/img/agent-history.png
+++ b/website/docs/_blogs/2026-03-16-AG2-Beta/img/agent-history.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a0e47c2a32b8fac0f62bd8c3127ba3b52644d373ad65da01beb7d4e46a241d8
+size 182403

--- a/website/docs/_blogs/2026-03-16-AG2-Beta/index.mdx
+++ b/website/docs/_blogs/2026-03-16-AG2-Beta/index.mdx
@@ -1,0 +1,462 @@
+---
+title: "AG2 Beta: Stronger Foundation for Real-World Agents"
+authors: [Lancetnik]
+tags: [AG2 Beta, Single-Agent, Memory, Telegram]
+date: 2026-03-12
+slug: ag2-beta-real-world-agents
+---
+
+![AG2 Beta](img/ag2-beta-banner.webp)
+
+The original **AutoGen** and later **AG2** architecture helped define the early agent ecosystem. It enabled real systems, shaped how many developers thought about agent orchestration, and gave us firsthand experience building and operating agent applications in practice.
+
+That experience also made the limits of the original design clearer over time. As the agent ecosystem matured, expectations changed. Agents increasingly needed to fit into real application environments with concurrent users, explicit session boundaries, platform identities, persistence layers, and integration points that could not be treated as incidental details.
+
+We found that some of these needs were challenging to address cleanly inside the original framework model. In many cases, shipping more production-suitable behavior meant adding complexity around the edges instead of improving the core abstraction itself, taking the focus of developers away from building agentic capabilities. That is a big part of why we decided to create **AG2 Beta**: a new framework track built around lessons we learned from the original AG2 to better support modern, real-world agentic systems.
+
+You can read more about the motivation behind **AG2 Beta** in the [AG2 Beta overview](/docs/user-guide/motivation/).
+
+<!-- more -->
+
+One of the clearest examples of that shift is *conversation state*.
+
+## The Problem with Stateful Agent Instances
+
+In the previous implementation, an agent instance effectively carried the active conversation with it. That was convenient for small examples, but it became impractical in real applications:
+
+- one agent instance could not be cleanly reused across concurrent users
+- isolating conversations required extra coordination outside the agent API
+- integrating agents into chat platforms, web apps, and background workers was hard
+
+These gaps appear when you move from demos to production.
+
+In a real-world application, the agent definition should be reusable. The conversation should be isolated. The application should decide how sessions are created, persisted, resumed, and discarded.
+
+## The Core Idea: `MemoryStream`
+
+**AG2 Beta** introduces `MemoryStream` as the conversation boundary.
+
+Instead of storing the current conversation history on the agent instance, you create a fresh stream for each conversation. To continue that conversation, you pass the same stream into the next `ask()` call.
+
+That provides a better model for real systems:
+
+- the agent definition is reusable
+- each conversation is isolated by its own stream
+- concurrent users can share the same agent safely while keeping separate histories
+- the application can decide when to persist or discard a conversation
+
+If you want to explore the details of how streams work as the event bus behind a conversation, see [Events Streaming](/docs/user-guide/advanced/stream).
+
+## Basic Example: One Agent, Two Sequential Turns
+
+Here is the simplest form of the new model:
+
+```python linenums="1" hl_lines="12 16 22 27 31"
+from ag2 import Agent, MemoryStream
+from ag2.config import OpenAIConfig
+
+agent = Agent(
+    "assistant",
+    prompt="You are a concise assistant.",
+    config=OpenAIConfig("gpt-5-nano"),
+)
+
+async def main() -> None:
+    # Conversation A
+    stream_a = MemoryStream()
+
+    reply_1 = await agent.ask(
+        "My name is Anna. Please remember it.",
+        stream=stream_a,
+    )
+    print(reply_1.content)
+
+    reply_2 = await agent.ask(
+        "What is my name?",
+        stream=stream_a,
+    )
+    print(reply_2.content)
+
+    # Conversation B starts fresh because it uses a different stream
+    stream_b = MemoryStream()
+
+    reply_3 = await agent.ask(
+        "What is my name?",
+        stream=stream_b,
+    )
+    print(reply_3.content)
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())
+```
+
+The important detail is not the model call, it is the ownership of state.
+
+The same `agent` instance serves both conversations. The memory lives in `stream_a` and `stream_b`, not in the agent itself. That is the key property that makes the API significantly easier to embed into real applications.
+
+## From Sequential Turns to Real Applications
+
+This architecture becomes even more useful when the agent is connected to a real communication channel.
+
+To demonstrate that, here's a Telegram-based integration. The structure is intentionally simple:
+
+- keep one reusable agent definition
+- create one `MemoryStream` per Telegram chat
+- pass the same stream back into `agent.ask(...)` on each new message
+
+That is enough to turn the same agent into a multi-user ambient application without mixing conversation histories.
+
+The first, minimal, version focuses on the session boundary and message flow. We pass `user_id` into the conversation variables so the next iteration of the conversation can use that identity inside tools.
+
+```python linenums="1" hl_lines="18 20-23 36-41"
+import asyncio
+
+from aiogram import Bot, Dispatcher, F
+from aiogram.client.default import DefaultBotProperties
+from aiogram.enums import ParseMode
+from aiogram.filters import CommandStart
+from aiogram.types import Message
+
+from ag2 import Agent, MemoryStream
+from ag2.config import OpenAIConfig
+
+agent = Agent(
+    "ambient-agent",
+    config=OpenAIConfig("gpt-5-nano", reasoning_effort="low"),
+)
+
+dp = Dispatcher()
+chat_state: dict[int, MemoryStream] = {}
+
+def get_or_create_stream(chat_id: int) -> MemoryStream:
+    if chat_id not in chat_state:
+        chat_state[chat_id] = MemoryStream()
+    return chat_state[chat_id]
+
+@dp.message(CommandStart())
+async def cmd_start(message: Message) -> None:
+    get_or_create_stream(message.chat.id)
+    await message.answer("Hi! Send me a message and I'll reply using AG2 Beta.")
+
+@dp.message(F.text)
+async def on_text(message: Message) -> None:
+    chat_stream = get_or_create_stream(message.chat.id)
+
+    status = await message.answer("Thinking…")
+    try:
+        reply = await agent.ask(
+            message.text,
+            stream=chat_stream,
+            # pass the `user_id` as a variable to the conversation
+            variables={"user_id": message.chat.id},
+        )
+        text = reply.content or "(no response)"
+
+        await status.edit_text(text)
+    except Exception as e:
+        await status.edit_text(f"Error: {e}")
+
+if __name__ == "__main__":
+    bot = Bot(
+        token="...",
+        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+    )
+    asyncio.run(dp.start_polling(bot))
+```
+
+The resulting interaction looks like this in Telegram: one chat, one stream, and each new message continues the same conversation context.
+
+![Telegram conversation using one `MemoryStream` per chat](img/agent-chat.png)
+
+## Adding Long-Term Memory on Top
+
+Short-term conversation state is handled by `MemoryStream`, but real assistants often need more than that. They also need a lightweight way to recall what happened earlier, even after the in-memory conversation is cleared.
+
+The Telegram example shows one practical pattern:
+
+1. keep the live conversation in a `MemoryStream`
+2. save the completed conversation to a per-user file such as `./memory/<user_id>/YYYY-MM-DD.md`
+3. expose a tool that can load that saved history back into context when needed
+
+The next snippet adds to the previous to do this, showing the additional pieces needed for long-term memory: a tool that can read saved history, a `/clear` command that persists the current stream before dropping it, and a helper that writes the conversation transcript to disk.
+
+```python linenums="1" hl_lines="40 49-53"
+import asyncio
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Annotated
+
+from aiogram import Dispatcher
+from aiogram.filters import Command
+from aiogram.types import Message
+from pydantic import Field
+
+from ag2 import Agent, MemoryStream, Variable, tool
+from ag2.config import OpenAIConfig
+from ag2.events import ModelRequest, ModelResponse
+
+MEMORY_DIR = Path("./memory")
+
+@tool
+def read_conversation_history(
+    date: Annotated[
+        date,
+        Field(
+            default_factory=lambda: datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            description="The date to read the conversation history for",
+        ),
+    ],
+    # get the `user_id` from the conversation context
+    user_id: Annotated[int, Variable()],
+) -> str:
+    """Read current user's conversation history for the given date (summaries from previous sessions).
+    Use this when the user asks what was discussed earlier on the given date or to recall prior context.
+    """
+    path = MEMORY_DIR / str(user_id) / date.strftime("%Y-%m-%d.md")
+    if not path.exists():
+        return "No conversation history saved for today yet."
+    return path.read_text()
+
+agent = Agent(
+    "ambient-agent",
+    config=OpenAIConfig("gpt-5-nano", reasoning_effort="low"),
+    tools=[read_conversation_history],
+)
+
+dp = Dispatcher()
+chat_state: dict[int, MemoryStream] = {}
+
+# add `/clear` command to clear the conversation and save the history to memory
+@dp.message(Command("clear"))
+async def cmd_clear(message: Message) -> None:
+    # remove current conversation stream
+    stream = chat_state.pop(message.chat.id, None)
+    if stream is not None:
+        # append it to `./memory/<user_id>/YYYY-MM-DD.md`
+        await write_conversation_to_memory(message.chat.id, stream)
+    await message.answer("Context dropped. The next message starts a new conversation.")
+
+async def write_conversation_to_memory(user_id: int, stream: MemoryStream) -> None:
+    # summarise the conversation
+    events = await stream.history.get_events()
+    lines: list[str] = []
+
+    for event in events:
+        if isinstance(event, ModelRequest):
+            lines.append(f"**user:** {event.content}")
+        elif isinstance(event, ModelResponse) and event.content:
+            lines.append(f"**assistant:** {event.content}")
+
+    if not lines:
+        return
+
+    # use `./memory/<user_id>/YYYY-MM-DD.md` as the todays conversation history file
+    now = datetime.now(timezone.utc)
+    user_dir = MEMORY_DIR / str(user_id)
+    user_dir.mkdir(parents=True, exist_ok=True)
+    path = user_dir / f"{now:%Y-%m-%d}.md"
+
+    def _write() -> None:
+        # append current history to the file
+        with path.open("a") as file:
+            if file.tell() != 0:
+                file.write("\n\n---\n\n")
+            file.write(f"## {now:%H:%M:%S} UTC\n\n")
+            file.write("\n\n".join(lines))
+
+    await asyncio.to_thread(_write)
+
+# The rest of Telegram bot code from above...
+...
+```
+
+After calling `/clear`, the bot can still recover the saved context through the history-loading tool:
+
+![Telegram conversation recovering saved context after `/clear`](img/agent-history.png)
+
+Taken together, the two snippets describe the full pattern: the first establishes per-chat conversation streams, and the second adds persistence and recall on top of that same structure. It does not require a complex orchestration layer to feel production-shaped.
+
+The application (Telegram Bot) owns session lifecycle. The agent owns reasoning and tool use. `MemoryStream` bridges the two.
+
+<details markdown="1">
+<summary>`ambient.py` — full source (click to expand)</summary>
+
+```python linenums="1"
+import asyncio
+import logging
+import os
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Annotated
+
+from aiogram import Bot, Dispatcher, F
+from aiogram.client.default import DefaultBotProperties
+from aiogram.enums import ParseMode
+from aiogram.filters import Command, CommandStart
+from aiogram.types import Message
+from pydantic import Field
+
+from ag2 import Agent, MemoryStream, Variable
+from ag2.config import OpenAIConfig
+from ag2.events import ModelRequest, ModelResponse
+from ag2.middleware import LoggingMiddleware
+
+MEMORY_DIR = Path("./memory")
+
+logging.basicConfig(level=logging.INFO)
+
+agent = Agent(
+    "test-agent",
+    config=OpenAIConfig(
+        "gpt-5-nano",
+        reasoning_effort="low",
+        streaming=True,
+    ),
+    middleware=[LoggingMiddleware()],
+)
+
+@agent.tool
+def read_conversation_history(
+    date: Annotated[
+        date,
+        Field(
+            default_factory=lambda: datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            description="The date to read the conversation history for",
+        ),
+    ],
+    user_id: Annotated[int, Variable()],
+) -> str:
+    """Read current user's conversation history for the given date (summaries from previous sessions).
+    Use this when the user asks what was discussed earlier on the given date or to recall prior context.
+    """
+    path = MEMORY_DIR / str(user_id) / date.strftime("%Y-%m-%d.md")
+    if not path.exists():
+        return "No conversation history saved for today yet."
+    return path.read_text(encoding="utf-8")
+
+dp = Dispatcher()
+chat_state: dict[int, MemoryStream] = {}
+
+def _get_or_create_chat(chat_id: int) -> MemoryStream:
+    if chat_id not in chat_state:
+        chat_state[chat_id] = MemoryStream()
+    return chat_state[chat_id]
+
+@dp.message(CommandStart())
+async def cmd_start(message: Message) -> None:
+    _get_or_create_chat(message.chat.id)
+    await message.answer("Hi, there! Send me any message and I'll reply using the agent.")
+
+@dp.message(Command("clear"))
+async def cmd_clear(message: Message) -> None:
+    stream = chat_state.pop(message.chat.id, None)
+    if stream is not None:
+        await _write_conversation_to_memory(message.chat.id, stream)
+    await message.answer("Context dropped. Next message will start a new conversation.")
+
+@dp.message(F.text)
+async def on_text(message: Message) -> None:
+    if not message.text:
+        return
+    chat_stream = _get_or_create_chat(message.chat.id)
+
+    status = await message.answer("Thinking…")
+    try:
+        reply = await agent.ask(
+            message.text,
+            stream=chat_stream,
+            variables={"user_id": message.chat.id},
+        )
+        text = reply.content or "(no response)"
+
+        await status.edit_text(text)
+    except Exception as e:
+        await status.edit_text(f"Error: {e}")
+
+async def _write_conversation_to_memory(user_id: int, stream: MemoryStream) -> None:
+    """Write current conversation transcript to folder-based memory."""
+    # summarise the conversation
+    events = await stream.history.get_events()
+    lines: list[str] = []
+    for ev in events:
+        if isinstance(ev, ModelRequest):
+            lines.append(f"**user:** {ev.content}")
+        elif isinstance(ev, ModelResponse) and ev.content:
+            lines.append(f"**assistant:** {ev.content}")
+    if not lines:
+        return
+
+    # use `./memory/user_id/YYYY-MM-DD.md` as the todays conversation history file
+    now = datetime.now(timezone.utc)
+    user_dir = MEMORY_DIR / str(user_id)
+    user_dir.mkdir(parents=True, exist_ok=True)
+    path = user_dir / now.strftime("%Y-%m-%d.md")
+    content = "\n\n".join(lines)
+
+    def _write() -> None:
+        # append current history to the file
+        with path.open("a", encoding="utf-8") as f:
+            if f.tell() != 0:
+                f.write("\n\n---\n\n")
+            f.write(f"## {now.strftime('%H:%M:%S')} UTC\n\n")
+            f.write(content)
+
+    await asyncio.to_thread(_write)
+
+if __name__ == "__main__":
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    bot = Bot(token=token, default=DefaultBotProperties(parse_mode=ParseMode.HTML))
+
+    asyncio.run(dp.start_polling(bot))
+```
+</details>
+
+## Why This Matters
+
+This design is a better fit for how real applications are actually built:
+
+- Chat sessions, web sessions, and background jobs already have their own identity model
+- session state often needs to be persisted independently from the agent definition
+- developers need a simple way to resume, archive, or discard conversations
+
+That is why `MemoryStream` is an important primitive in **AG2 Beta**. It moves conversation ownership to the same layer that manages users and sessions.
+
+## A Pattern You May Recognize from OpenClaw
+
+If you have looked at [OpenClaw](https://github.com/openclaw/openclaw){.external-link target="_blank"}, this architecture should feel familiar.
+
+The shared idea is simple: keep the runtime session outside the reusable agent definition. The application manages per-user or per-channel conversation state, while the agent logic stays portable.
+
+## Start with Single-Agent Systems
+
+Right now, **AG2 Beta** is especially strong for single-agent applications and integrations. That is deliberate.
+
+We want to make the most common real-world cases easy first:
+
+- one reusable agent
+- one conversation stream per user or session
+- optional persistence and memory tools when the application needs them
+
+That model is already enough to power ambient assistants, bots, web co-pilots, and background workers in a clean way.
+
+<Note>
+Ready for multi-agent workflows? They're on the way, but you can start experimenting with Beta agents in existing AG2 workflows right now. Beta agents can be converted to ConversableAgents using `as_conversable()`. This allows them to be used in existing group chats, sequential workflows, and with handoffs. See the AG2 Compatibility guide for the current integration path.
+
+You can introduce new agents from the Beta API right into your current AG2 chat topologies.
+</Note>
+
+## Try AG2 Beta
+
+**AG2 Beta** is available today inside the `ag2` package. Just `pip install ag2` like you already do and check out the [docs](/docs/user-guide/motivation/).
+
+Here's a suggested mental model to get started:
+
+1. Define one reusable agent
+2. Create a new `MemoryStream` for each conversation
+3. Pass the same stream back into each new turn
+4. Add persistence only where your application actually needs it
+
+It's a small API shift, but it unlocks a strong foundation for real-world systems.
+
+If your current agent application needs isolated conversations, concurrent users, or lightweight long-term memory, give **AG2 Beta** a try!

--- a/website/docs/_blogs/2026-05-12-LiveAgent/img/live-agent-hero.png
+++ b/website/docs/_blogs/2026-05-12-LiveAgent/img/live-agent-hero.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f15a7c7046dcc73a08d8b4268207803775885732a83dacc99799cf9f394a169
+size 1533540

--- a/website/docs/_blogs/2026-05-12-LiveAgent/index.mdx
+++ b/website/docs/_blogs/2026-05-12-LiveAgent/index.mdx
@@ -1,0 +1,165 @@
+---
+title: "Building low-latency voice agents in 3 lines of code with GPT Realtime 2"
+authors: [Lancetnik]
+tags: [AG2 Beta, LiveAgent, Voice, Realtime, OpenAI, Gemini]
+date: 2026-05-13
+slug: voice-agents-with-gpt-realtime-2
+---
+
+![LiveAgent on AG2 Beta](img/live-agent-hero.png)
+
+OpenAI recently announced [advanced voice intelligence in the API](https://openai.com/index/advancing-voice-intelligence-with-new-models-in-the-api/){.external-link target="_blank"}, including **GPT Realtime 2** for lower-latency, more natural spoken interactions. **AG2 Beta** wraps that class of model behind **`LiveAgent`**: one bidirectional session, continuous audio in and out, and provider-side voice activity detection so users can speak and interrupt like on a phone call—not like a walkie-talkie app.
+
+In this post we walk through why that matters, how **`LiveAgent`** compares to the classic **STT → Agent → TTS** stack, and how to add **tools** and **subagent-style** delegation without giving up the realtime voice surface.
+
+<!-- more -->
+
+## Why voice agents matter
+
+Voice is often the lowest-friction channel for **hands-busy** or **eyes-busy** tasks: driving, cooking, field work, accessibility, and quick “just tell me” moments on a phone. Users expect **low latency**, **natural turn-taking**, and the ability to **cut in** when the model goes wrong or when new information arrives. If every utterance waits for a full record → transcribe → reason → synthesize cycle, it feels like filling out a form, not a conversation.
+
+Provider **realtime** APIs push much of that rhythm into the model and transport layer: streaming audio, built-in **VAD** (Voice Activity Detection), and **barge-in** semantics (where supported) so the application is not re-implementing half of a telephony stack in user space.
+
+## Basic code sample
+
+Once you've installed...
+
+```bash
+pip install "ag2[openai] sounddevice[numpy]"
+```
+
+..., import **`LiveAgent`**, **`SoundDevicePlayer`**, **`SoundDeviceRecorder`**, and the **`openai`** config helpers from **`ag2.live`**. The **running** session is then just **three lines**: construct the agent, open the session and shared I/O on one **`async with`**, then block until you cancel.
+
+```python linenums="1" hl_lines="1-3"
+agent = LiveAgent("assistant", "You are a helpful voice assistant.", config=openai.RealTimeConfig("gpt-realtime-2", output=openai.AudioOutput(voice="ballad")))
+async with agent.run() as context, SoundDevicePlayer(context=context), SoundDeviceRecorder(context=context):
+    await asyncio.Future()  # run until cancelled
+```
+
+That is the whole “wire microphone and speaker to GPT Realtime 2” loop. A self-contained script (imports and `asyncio.run`) looks like this:
+
+```python linenums="1" hl_lines="12-18 22-29"
+"""The same 3 lines with formatting and imports"""
+import asyncio
+
+from ag2.live import (
+    LiveAgent,
+    SoundDevicePlayer,
+    SoundDeviceRecorder,
+    openai,
+)
+
+# line 1
+agent = LiveAgent(
+    name="assistant",
+    prompt="You are a helpful voice assistant.",
+    config=openai.RealTimeConfig(
+        "gpt-realtime-2",
+        output=openai.AudioOutput(voice="ballad", speed=1.2),
+    ),
+)
+
+# line 2
+async def main() -> None:
+    async with (
+        agent.run() as context,
+        SoundDevicePlayer(context=context),
+        SoundDeviceRecorder(context=context),
+    ):
+        # line 3
+        await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Beyond the defaults, you can tune how the assistant **sounds** and **when it speaks**: OpenAI realtime **`AudioOutput`** accepts **`voice`** and **`speed`**, and **`InputConfig`** carries **VAD / turn-detection** options (for example semantic VAD with interruption). See the [Providers (OpenAI) documentation](/docs/user-guide/live/live_agent#providers){target="_blank"} for voices and configs.
+
+## How it works with tools and subagents
+
+### Tools
+
+`LiveAgent` uses the same **`@agent.tool`** decorator as a text **`Agent`**. Calls go through AG2’s normal tool executor; results are sent back into the realtime session automatically—so middleware and HITL patterns you use elsewhere can stay aligned with the rest of your stack.
+
+```python linenums="1" hl_lines="9-12"
+from ag2.live import LiveAgent, OpenAIRealTimeConfig, SoundDevicePlayer, SoundDeviceRecorder
+
+agent = LiveAgent(
+    name="assistant",
+    prompt="You are a helpful voice assistant.",
+    config=OpenAIRealTimeConfig("gpt-realtime-2"),
+)
+
+@agent.tool
+async def sum_numbers(a: int, b: int) -> int:
+    """Add two integers and return the result."""
+    return a + b
+
+# async with agent.run() as context, SoundDevicePlayer(...), SoundDeviceRecorder(...): ...
+```
+
+More detail: [Tools in a realtime session](/docs/user-guide/live/live_agent#tools-in-a-realtime-session){target="_blank"} and [Tools](/docs/user-guide/tools/tools){target="_blank"}.
+
+### Subagents (delegation)
+
+**`LiveAgent`** is built around a **realtime audio session**, not the same **`ask()`** loop as a text **`Agent`**. When the voice surface needs **deeper reasoning**, **longer context work**, or **tooling you prefer to keep on the text side**, expose a separate **`Agent`** as a callable tool with **`Agent.as_tool()`** and pass it into **`LiveAgent`** via **`tools=[...]`**. The realtime model issues a tool call; AG2 runs that nested **`Agent`** and sends the result back into the live session.
+
+```python linenums="1" hl_lines="11-13 19"
+from ag2 import Agent
+from ag2.config import OpenAIConfig
+from ag2.live import LiveAgent, OpenAIRealTimeConfig, SoundDevicePlayer, SoundDeviceRecorder
+
+researcher = Agent(
+    name="researcher",
+    prompt="You research topics thoroughly and return concise bullet facts.",
+    config=OpenAIConfig("gpt-4o-mini"),
+)
+
+research_tool = researcher.as_tool(
+    description="Use for multi-step research or when the user needs cited-style facts in text form.",
+)
+
+voice = LiveAgent(
+    name="voice",
+    prompt="You are a low-latency voice assistant. Call research when the user needs deep fact-finding.",
+    config=OpenAIRealTimeConfig("gpt-realtime-2"),
+    tools=[research_tool],
+)
+
+# async with voice.run() as context, SoundDevicePlayer(...), SoundDeviceRecorder(...): ...
+```
+
+That gives you **subagent-style delegation** without pretending the realtime session is a full **`Agent.ask`** loop. See [LiveAgent vs Agent](/docs/user-guide/live/live_agent#liveagent-vs-agent){target="_blank"}.
+
+## Supported providers
+
+`LiveAgent` accepts any **`RealtimeConfig`**. AG2 Beta ships **OpenAI** and **Gemini** implementations today.
+
+- **OpenAI** — **`gpt-realtime-2`** with **`AudioOutput`** for **`voice`** and **`speed`**, or **`TextOutput`** for text-only replies; **`InputConfig`** controls **VAD and turn detection** (defaults lean toward semantic VAD with interruption).
+- **Gemini** — e.g. **`gemini-3.1-flash-live-preview`** with live audio.
+
+OpenAI and Gemini voices and config snippets: [Providers](/docs/user-guide/live/live_agent#providers){target="_blank"}.
+
+Broader install and I/O notes: [Voice & Realtime overview](/docs/user-guide/live/live){target="_blank"}.
+
+## LiveAgent or STT–TTS
+
+AG2 Beta supports **two** voice patterns:
+
+| | **STT → Agent → TTS** | **`LiveAgent` (realtime)** |
+| --- | --- | --- |
+| Shape | Discrete turns: transcribe, call a text **`Agent`**, synthesize | One **full-duplex** session for the whole conversation |
+| Typical latency | on the order of **1–3 s** per turn | **sub-500 ms** in many setups |
+| Turn detection | Your app decides when a “turn” ends | **Provider-driven** (e.g. semantic VAD, interruption) |
+| Best when… | You need every **`Agent`** feature each turn (structured output, rich middleware, arbitrary model routing) | You need **phone-call-like** experience: continuous audio, interruption, minimal glue code |
+
+The two are complementary, not competing. Reach for **STT–TTS** when the text agent must be the source of truth for each step. Reach for **`LiveAgent`** when **latency and conversational flow** matter most and you are happy to drive the session through a **realtime** model such as **`gpt-realtime-2`**.
+
+## What's next
+
+- **Read the docs** — start with [LiveAgent — Realtime Voice Sessions](/docs/user-guide/live/live_agent){target="_blank"} and the [Voice & Realtime overview](/docs/user-guide/live/live){target="_blank"}.
+- **Install and try** — `pip install "ag2[openai] sounddevice[numpy]"`, then run the sketches under **`examples/live_playground/`** in the [AG2 repo](https://github.com/ag2ai/ag2/tree/main/examples/live_playground){.external-link target="_blank"}.
+- **Star the repo** — if **`LiveAgent`** is useful, a star on [github.com/ag2ai/ag2](https://github.com/ag2ai/ag2){.external-link target="_blank"} helps others find the project.
+- **Join the community** — share builds, ask questions, and compare notes on the [AG2 Discord](https://discord.gg/pAbnFJrkgZ){.external-link target="_blank"}.
+
+We are excited to get your feedback on LiveAgent.

--- a/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-banner.webp
+++ b/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-banner.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17b86b207f6510655180955ef7df276dbe370fb16986b45eed2901543938d48d
+size 234540

--- a/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-consulting.webp
+++ b/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-consulting.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fcc10041eb9f63e269df25468f0114d4855385186e8788a494677cf6f78de75
+size 147188

--- a/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-conversation.webp
+++ b/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-conversation.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ff2f1a91f2edd154f611659309a9a1db966a93c7b7bf881f5463c06303a4e61
+size 77970

--- a/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-discussion.webp
+++ b/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-discussion.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3128c967917b144a1ba9e0c9cb78eaa87f27357e32223a00bdcc60f3a1ccacc
+size 83462

--- a/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-mismatch.webp
+++ b/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-mismatch.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c46ba4048c1b4425ee86e517334d8b6b0cdbdfe0ad20fc961ea1e7c3fcd38440
+size 113590

--- a/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-primitives.webp
+++ b/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-primitives.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:851b98c37a119b5bf689be2e6c46a456fc36caa5c451743b27df13fdf9eb0daf
+size 167086

--- a/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-workflow.webp
+++ b/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/img/n1-workflow.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82c4db0634d64b6aca52051932676a9bab5f66fc53f3ad3a8f84aa8ff99f5957
+size 135434

--- a/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/index.mdx
+++ b/website/docs/_blogs/2026-05-14-AG2-Action-Driven-Network/index.mdx
@@ -1,0 +1,382 @@
+---
+title: "One Coherent Agent Isn't Enough — Action-Driven Networking with AG2"
+authors: [marklysze]
+tags: [AG2 Beta, Network, Multi-Agent, Choreography, Action-driven]
+date: 2026-05-14
+slug: ag2-network-one-coherent-agent
+---
+
+![AG2 Network — One Coherent Agent Isn't Enough](img/n1-banner.webp)
+
+A single agent is a great starting point, but real work extends beyond just one.
+
+Real work spans people, teams, services, and machines. A support escalation touches a triage bot, a knowledge agent, an on-call engineer, and a postmortem writer. None of them is "in charge" — they each take a turn, in the open, over a shared thread that outlives any one of them.
+
+That's what the **AG2 Network** is built for: a layer where stateful, identity-bound, choreographed *actions* live. By the end of this post you'll have run all four conversation shapes the network ships with — and have a flavor for AG2's new multi-agent network, which we'll expand on in upcoming posts.
+
+<!-- more -->
+
+This is the first post in a four-part series introducing the AG2 Network:
+
+1. **One Coherent Agent Isn't Enough** *(this post)* — the action-driven multi-agent network, the key primitives, and the four conversation shapes.
+2. [**Choreography You Can Dial In**](/docs/blog/2026/05/15/AG2-Network-Choreography-Dial/) — setting expectations, audience addressing, deeper choreography patterns, and the orchestration cookbook.
+3. [**What Survives, Survives Exactly**](/docs/blog/2026/05/16/AG2-Network-What-Survives/) — the substrate: write-ahead log + fold + hub restart, plus identity (Passport / Resume / SKILL.md) and the audit log.
+4. [**Networks You Can Deploy**](/docs/blog/2026/06/16/AG2-Network-Networks-You-Can-Deploy/) — WebSocket transport, authentication, at-least-once delivery, and dynamic membership.
+
+In parallel, to build strong and capable agents, a companion post, **The Agent Harness: An Agent Is More Than a Loop**, zooms *inside* a single agent to make them long-running and knowledge-centric.
+
+## One Coherent Agent Isn't Enough
+
+![Two shapes of state — left: a client/server bouncing requests and responses, with state living in the client. Right: alice and carol, both stateless, with envelopes converging into a shared channel whose write-ahead log (WAL) ticks light up as messages land.](img/n1-mismatch.webp)
+
+The instinct when you have many agents is to add a *coordinator*: one agent (or one Python loop) that decides who runs next, collects the output, and decides again. That works in the demo. Then it has to ship, and the coordinator turns out to be a bottleneck, a single point of failure, and the place where all the state lives in memory until the process restarts and the conversation is gone.
+
+The deeper issue: **the internet wasn't drawn for this either**. HTTP, REST, MCP, A2A — they all work because the *client* has memory, in its head or its harness. A single agent talking to tools through MCP fits that mold perfectly. But two agents collaborating across processes don't. Both ends are stateless. The state has to live somewhere — and it can't live in either harness, because neither side can see the whole conversation alone.
+
+The natural home for that state is **the channel itself** — a durable, addressable thread that participants take turns writing to. Nobody on either end "owns" it. The hub that hosts the channel is a thin, stateless router: it stamps every message, appends it to the channel's log, fans it out. Restart the hub and it re-derives every channel from disk, byte for byte.
+
+That gives the network a fundamentally different *shape* from the request-response world we inherited.
+
+> *The harness above each agent doesn't scale across processes. The natural home is the channel itself.*
+
+## The Four Primitives
+
+AG2's Network introduces primitives to support all levels of multi-agent engagements. We'll explore them over the next few blogs, but let's start with four key primitives to get you up and running.
+
+![The four primitives — HubClients in, Hub at the center, channels routed through the adapter, WAL spine along the bottom](img/n1-primitives.webp)
+
+- **Hub** — the only authoritative state. Registry of agents, write-ahead log per channel, audit log, the adapter registry. Stateless in the sense that the *application* puts no logic here — the hub just routes envelopes and folds them. Crash it, restart it: state is re-derived from disk.
+- **HubClient** — one duplex connection to the hub per process boundary. In a real deployment each agent lives in its own process with one `HubClient`. Locally they can share a process for clarity.
+- **Channel** — the unit of conversation. Durable, addressable by ID, identity-scoped. Lifecycle: `INVITED → ACTIVE → CLOSING → CLOSED`. Every channel is governed by exactly one **adapter**.
+- **Adapter** — bound one-to-one with a channel, the adapter is the key orchestration definition. Stateless code that decides "what's allowed next" — *who can speak*, *when does this auto-close*. Four adapters ship; you'll meet all four below. Adapter state is a pure fold of the channel's WAL, which is why a hub restart is a non-event.
+
+A `Passport` (an agent's identity record) and an `Envelope` (the wire message) slip through every example below. When you see `Passport(name="alice")`, that's an immutable identity stamp the hub will assign an `agent_id` to; when you see `EV_TEXT` or `EV_CHANNEL_CLOSED`, those are envelope event types riding on the channel's WAL.
+
+## Four Shapes of Orchestration
+
+Adapters lay the foundation for you to choose, or create, the orchestration that works for your task. Opening a channel with an adapter sets the **protocol your agents must be orchestrated by.**
+
+We've started with four adapters. As noted, they're derived from a protocol and you can roll your own.
+
+| Adapter | Shape | Turn order | Closes |
+|---|---|---|---|
+| `consulting` | 1 ↔ 1, one round | ask → answer | auto-closes after the reply |
+| `conversation` | 1 ↔ 1, free-form | none | explicit `close()` or TTL |
+| `discussion` | N participants | round-robin | explicit `close()` or TTL |
+| `workflow` | N participants | a declared `TransitionGraph` | when the graph terminates |
+
+Note: The `workflow` adapter correlates closely with AG2's classic group chat with handoffs.
+
+Let's run through each one.
+
+### `consulting` — 1Q1R, the smallest viable network
+
+![consulting — INVITE / ACK / Q / R / auto-close](img/n1-consulting.webp)
+
+The simplest possible network: one agent asks another a single question, gets a single answer, and the channel auto-closes.
+
+```python linenums="1"
+import asyncio
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.knowledge import MemoryKnowledgeStore
+from ag2.network import (
+    EV_CHANNEL_CLOSED,
+    EV_TEXT,
+    Hub,
+)
+
+
+async def main() -> None:
+    config = AnthropicConfig(model="claude-sonnet-4-6")
+
+    # Hub: registry + WAL + audit log + adapters live here.
+    hub = await Hub.open(MemoryKnowledgeStore(), ttl_sweep_interval=0)
+
+    alice = await hub.register(
+        Agent("alice", prompt="Ask one focused question and stop.", config=config),
+    )
+    bob = await hub.register(
+        Agent("bob", prompt="Answer in one short sentence.", config=config),
+    )
+
+    # Strict 1Q1R; the adapter auto-closes on bob's reply.
+    channel = await alice.open(type="consulting", target="bob")
+    await channel.send(
+        "What's the single most important property of a distributed system?",
+        audience=[bob.agent_id],
+    )
+
+    # Wait for the consulting round to close.
+    close_env = await alice.wait_for_channel_event(
+        channel_id=channel.channel_id,
+        predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED,
+        timeout=60.0,
+    )
+    print(f"closed: {close_env.event_data.get('reason')!r}")
+
+    # Replay the conversation from the channel's write-ahead log.
+    for env in await hub.read_wal(channel.channel_id):
+        if env.event_type == EV_TEXT:
+            speaker = "alice" if env.sender_id == alice.agent_id else "bob"
+            print(f"{speaker}: {env.event_data['text']}")
+
+    await hub.close()
+
+
+asyncio.run(main())
+```
+
+Output example:
+
+```text
+closed: 'consulting_complete'
+alice: What's the single most important property of a distributed system?
+bob: Fault tolerance — because a system that can't survive partial failures defeats its entire purpose.
+```
+
+Reach for `consulting` when you want a tool-like agent call: a single specialist invocation with a structured boundary. See [Consulting Adapter](/docs/user-guide/network/consulting) for the full surface.
+
+### `conversation` — 1:1 free-form
+
+A 2-party channel with no turn ordering. Either side can speak. Useful for an agent + a human, or two agents in a back-and-forth.
+
+![conversation — alice (green) and bob (red) take turns, no enforced order; the channel accumulates messages from both sides](img/n1-conversation.webp)
+
+```python linenums="1"
+import asyncio
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.knowledge import MemoryKnowledgeStore
+from ag2.network import (
+    EV_TEXT,
+    Hub,
+)
+
+
+async def wait_for_text_count(hub: Hub, channel_id: str, expected: int) -> None:
+    """Tail the channel's WAL; return after `expected` EV_TEXT envelopes.
+    Used to close the channel when we reach a certain number of messages."""
+    seen: set[str] = set()
+    count = 0
+    while count < expected:
+        for env in await hub.read_wal(channel_id):
+            if env.envelope_id in seen:
+                continue
+            seen.add(env.envelope_id)
+            if env.event_type == EV_TEXT:
+                count += 1
+        await asyncio.sleep(0.05)
+
+
+async def main() -> None:
+    config = AnthropicConfig(model="claude-sonnet-4-6")
+    hub = await Hub.open(MemoryKnowledgeStore(), ttl_sweep_interval=0)
+
+    alice = await hub.register(
+        Agent("alice", prompt="You are alice. Ask follow-ups, one short sentence at a time.", config=config),
+    )
+    bob = await hub.register(
+        Agent("bob", prompt="You are bob. Answer in one short sentence; ask one follow-up.", config=config),
+    )
+
+    channel = await alice.open(type="conversation", target="bob")
+    await channel.send("How would you explain consensus to a curious novice?")
+
+    # Let them go four turns, then close from the application side.
+    await wait_for_text_count(hub, channel.channel_id, expected=4)
+    await channel.close()
+
+    for env in await hub.read_wal(channel.channel_id):
+        if env.event_type == EV_TEXT:
+            speaker = "alice" if env.sender_id == alice.agent_id else "bob"
+            print(f"{speaker}: {env.event_data['text']}")
+
+    await hub.close()
+```
+
+(`wait_for_text_count` is a small helper that tails the WAL until it sees N `EV_TEXT` envelopes — `conversation` and `discussion` don't auto-terminate, so the application decides when enough has been said.)
+
+`conversation` doesn't auto-terminate. The application decides when the work is done. See [Conversation Adapter](/docs/user-guide/network/conversation).
+
+### `discussion` — N-party round-robin
+
+![discussion — two full rounds of round-robin (a1, b2, c3, a4, b5, c6); the expected_next_speaker pointer rotates and out-of-turn participants skip the LLM call](img/n1-discussion.webp)
+
+Three agents — an optimist, a realist, a skeptic — debate a topic, round-robin, with no coordinator deciding turns. The adapter enforces the order; each agent's default handler skips the LLM call entirely when it's not its turn (`hc.can_send` returns false).
+
+```python linenums="1"
+import asyncio
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.knowledge import MemoryKnowledgeStore
+from ag2.network import (
+    EV_TEXT,
+    ORDERING_ROUND_ROBIN,
+    Hub,
+)
+
+
+async def wait_for_text_count(hub: Hub, channel_id: str, expected: int) -> None:
+    """Tail the channel's WAL; return after `expected` EV_TEXT envelopes.
+    Used to close the channel when we reach a certain number of messages."""
+    seen: set[str] = set()
+    count = 0
+    while count < expected:
+        for env in await hub.read_wal(channel_id):
+            if env.envelope_id in seen:
+                continue
+            seen.add(env.envelope_id)
+            if env.event_type == EV_TEXT:
+                count += 1
+        await asyncio.sleep(0.05)
+
+
+async def main() -> None:
+    config = AnthropicConfig(model="claude-sonnet-4-6")
+    hub = await Hub.open(MemoryKnowledgeStore(), ttl_sweep_interval=0)
+
+    alice = await hub.register(
+        Agent("alice", prompt="You are the optimist. One short sentence.", config=config),
+    )
+    bob = await hub.register(
+        Agent("bob", prompt="You are the realist. One short sentence.", config=config),
+    )
+    carol = await hub.register(
+        Agent("carol", prompt="You are the skeptic. One short sentence.", config=config),
+    )
+
+    channel = await alice.open(
+        type="discussion",
+        target=[bob.agent_id, carol.agent_id],
+        knobs={"ordering": ORDERING_ROUND_ROBIN},
+    )
+    await channel.send("Topic: should every developer learn Rust? Keep it brief.")
+
+    # 6 messages = two full round-robin cycles. Then close to halt the chain.
+    await wait_for_text_count(hub, channel.channel_id, expected=6)
+    await channel.close()
+
+    names = {alice.agent_id: "alice", bob.agent_id: "bob", carol.agent_id: "carol"}
+    for env in await hub.read_wal(channel.channel_id):
+        if env.event_type == EV_TEXT:
+            print(f"{names[env.sender_id]:>6}: {env.event_data['text']}")
+
+    await hub.close()
+
+
+asyncio.run(main())
+```
+
+Reach for `discussion` when you want a fixed cast taking turns — brainstorms, panel reviews, devil's-advocate debates. See [Discussion Adapter](/docs/user-guide/network/discussion).
+
+### `workflow` — graph-driven
+
+![workflow — researcher → writer → reviewer with a conditional loop-back to writer when the reviewer's tool call returns Handoff(target=writer); approval routes to terminate](img/n1-workflow.webp)
+
+`workflow` is the most expressive adapter: speaker order is governed by a declarative `TransitionGraph` you pass in at channel-open together with handoffs from tools. Two convenience factories ship for the simple cases — `TransitionGraph.sequence([...])` for a linear pipeline, and `TransitionGraph.round_robin([...], max_turns=N)` for a hard-capped rotation — but the real power is in **conditional handoffs**: each `Transition` says *"when this condition fires, hand off to that target."*
+
+In this example: researcher gathers facts, writer drafts, reviewer either approves or kicks the draft back to the writer. The reviewer's two routing tools illustrate the **two ways** workflow lets you drive routing:
+
+- **Dynamic** — `request_revision` returns `Handoff(target="writer", reason=...)`. The tool *itself* picks the next speaker at call time. No graph rule needed; a returned `Handoff` supersedes any matching `ToolCalled` rule. Use this when the target depends on runtime state (load balancing, content-driven dispatch, "ask whichever specialist is registered for X").
+- **Static** — `approve` returns a plain string and is matched by `ToolCalled("approve")` → `TerminateTarget("approved")`. The graph owns the decision. Use this when routing is fixed at channel-open time.
+
+```python linenums="1" hl_lines="9 10 11 12 41 42 43 44 45 46 47 48 49"
+from ag2 import Agent, tool
+from ag2.network import (
+    AgentTarget, FromSpeaker, Handoff, TerminateTarget,
+    ToolCalled, Transition, TransitionGraph,
+)
+# ... imports + hub setup as above ...
+
+@tool
+def request_revision(reason: str) -> Handoff:
+    """Send the draft back to the writer for revision."""
+    return Handoff(target="writer", reason=reason)
+
+@tool
+def approve() -> str:
+    """Approve the draft and end the workflow."""
+    return "Approved."
+
+researcher = await hub.register(
+    Agent("researcher", prompt="Given a topic, list 3 concrete factual bullets.", config=config),
+    Passport(name="researcher"), Resume(claimed_capabilities=["research"]),
+)
+writer = await hub.register(
+    Agent("writer", prompt="Given research bullets, draft a 2-sentence explanation for a novice.", config=config),
+    Passport(name="writer"), Resume(claimed_capabilities=["writing"]),
+)
+reviewer = await hub.register(
+    Agent(
+        "reviewer",
+        prompt=(
+            "You are a strict-but-fair reviewer. "
+            "On the FIRST draft, always call request_revision with one concrete suggestion. "
+            "On the REVISED draft, always call approve(). "
+            "Exactly one revision round, then approve."
+        ),
+        config=config,
+        tools=[request_revision, approve],
+    ),
+    Passport(name="reviewer"), Resume(claimed_capabilities=["reviewing"]),
+)
+
+# Conditional graph — `request_revision` doesn't appear here: it routes
+# itself via the Handoff it returns. The graph only owns the static rules:
+# the terminator and the default forward flow.
+graph = TransitionGraph(
+    initial_speaker=researcher.agent_id,
+    transitions=[
+        Transition(when=ToolCalled("approve"),            then=TerminateTarget("approved")),
+        Transition(when=FromSpeaker(researcher.agent_id), then=AgentTarget(writer.agent_id)),
+        Transition(when=FromSpeaker(writer.agent_id),     then=AgentTarget(reviewer.agent_id)),
+    ],
+)
+
+channel = await researcher.open(
+    type="workflow",
+    target=[writer.agent_id, reviewer.agent_id],
+    knobs={"graph": graph.to_dict()},
+)
+await channel.send("Topic: how does HTTPS keep traffic private?")
+
+# Auto-terminates with reason="approved" once the reviewer is happy.
+await researcher.wait_for_channel_event(
+    channel_id=channel.channel_id,
+    predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED,
+    timeout=180.0,
+)
+```
+
+Note that `Handoff(target="writer", ...)` uses the participant's `Passport.name` rather than its `agent_id` — tool code stays decoupled from runtime IDs and portable across channels.
+
+The four conditions — `ToolCalled`, `FromSpeaker`, `ContextEquals`, and `Always` — cover most routing needs out of the box. For graphs that need to inspect arbitrary state, you can write a custom `TransitionCondition` and register it.
+
+Reach for `workflow` when "who speaks next" is structured — pipelines, escalation, conditional routing. See [Workflow Adapter](/docs/user-guide/network/workflow).
+
+## The Bigger Picture
+
+You've now run all four conversation shapes. There are three more layers the network adds on top, each covered in an upcoming post:
+
+- **A choreography dial** — same primitive, more knobs. *Expectations* like `reply_within(30s, auto_close)` give the channel a deterministic response when a participant misses a deadline. *Audience* on each envelope (`audience=[a, b]`) lets a single channel carry private side-channels for free. Deeper `TransitionGraph` patterns — conditional handoffs, dynamic `Handoff` returns, context-aware routing — sit alongside. **Post 2: [Choreography You Can Dial In](/docs/blog/2026/05/15/AG2-Network-Choreography-Dial/).**
+- **A trustworthy substrate** — what's written down and who you are. The hub's WAL is the source of truth: kill the hub, restart it, every channel comes back byte-for-byte. Identity is three records (`Passport` + `Resume` + `SKILL.md`), not a name string. The audit log records every envelope. **Post 3: [What Survives, Survives Exactly](/docs/blog/2026/05/16/AG2-Network-What-Survives/).**
+- **Cross-boundary deployment** — what lets you actually ship this. A single channel can span two organizations through Passport + Visa. Participants register and unregister dynamically. Text, audio, image, and video ride the same fan-out. And a real production-incident demo ties it all together. **Post 4: [Networks You Can Deploy](/docs/blog/2026/06/16/AG2-Network-Networks-You-Can-Deploy/).**
+
+## Interactive Playground
+
+Jump into [AG2's Playground](https://playground.ag2.ai/) to take an interactive tour of the AG2 Network and run Beta examples live.
+
+## The full series
+
+- [**Choreography You Can Dial In**](/docs/blog/2026/05/15/AG2-Network-Choreography-Dial/) *(orchestration deep-dive)*
+- [**What Survives, Survives Exactly**](/docs/blog/2026/05/16/AG2-Network-What-Survives/) *(the substrate)*
+- [**Networks You Can Deploy**](/docs/blog/2026/06/16/AG2-Network-Networks-You-Can-Deploy/) *(WebSocket, auth, at-least-once delivery)*
+
+A deeper dive into agents:
+- [**The Agent Harness**](/docs/blog/2026/06/17/AG2-Agent-Harness/) *(knowledge, long-context memory)*
+
+Docs: [Network Quick Start](/docs/user-guide/network/quick_start) · [Channel Adapters Overview](/docs/user-guide/network/adapters_overview) · [Hub & Identity](/docs/user-guide/network/hub_and_identity) · [Migrating from Group Chat](/docs/user-guide/network/migration_from_group_chat)

--- a/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-audience.webp
+++ b/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-audience.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5afeecd5df39442f369426a95ed9b6a4e54021d6bafec7cda60c411e28270e8
+size 177782

--- a/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-banner-animated.webp
+++ b/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-banner-animated.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2ff9398bd695057e9b3be4f135290403485f4091796b91b5806ebcaa6ec2092
+size 605032

--- a/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-centerpiece.webp
+++ b/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-centerpiece.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b5d3f05ab6de4c3cfe2c47b62a0f43197660f8c5c6326347c9b65db15baa447
+size 828816

--- a/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-dial.webp
+++ b/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-dial.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4065228dfa736498aa178d5f75daccb2c2f56e4b46ad8bba7e0d0cf3dba3281
+size 581576

--- a/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-expectations.webp
+++ b/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-expectations.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8f5a2b5885a035097d775c5af922887eb250002311f6653bb3c15e8fb74a41c
+size 180472

--- a/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-transitions.webp
+++ b/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/img/n2-transitions.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e90e66b30f7d4c8b0e685e8577ea1910012b7cd73c439200981239e81f1c853
+size 255246

--- a/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/index.mdx
+++ b/website/docs/_blogs/2026-05-15-AG2-Network-Choreography-Dial/index.mdx
@@ -1,0 +1,358 @@
+---
+title: "Choreography You Can Dial In"
+authors: [marklysze]
+tags: [AG2 Beta, Network, Multi-Agent, Choreography, Expectations, TransitionGraph]
+date: 2026-05-15
+slug: ag2-network-choreography-dial
+---
+
+![AG2 Network — Choreography You Can Dial In](img/n2-banner-animated.webp)
+
+We've touched on the four built-in conversation shapes; now you need to make them survive contact with the real world.
+
+In the first post — [*One Coherent Agent Isn't Enough*](/docs/blog/2026/05/14/AG2-Action-Driven-Network/) — you opened a channel, watched agents take turns, and saw the hub fold envelopes into a durable thread. That's the *shape*. This post is about the *dials* on top of that shape — the knobs that turn a loose multi-agent free-for-all into something you'd actually run when an agent goes quiet at 2am, a step needs to time out, or a sub-conversation has to stay off the main thread.
+
+<!-- more -->
+
+If you haven't run the first post's examples yet, start there — every snippet below builds on the same `Hub` / `HubClient` / `Channel` / `Adapter` primitives.
+
+This is the second post in a four-part series introducing the AG2 Network:
+
+1. [**One Coherent Agent Isn't Enough**](/docs/blog/2026/05/14/AG2-Action-Driven-Network/) — the action-driven multi-agent network, the key primitives, and the four conversation shapes.
+2. **Choreography You Can Dial In** *(this post)* — setting expectations, audience addressing, deeper choreography patterns, and the orchestration cookbook.
+3. [**What Survives, Survives Exactly**](/docs/blog/2026/05/16/AG2-Network-What-Survives/) — the substrate: write-ahead log + fold + hub restart, plus identity (Passport / Resume / SKILL.md) and the audit log.
+4. [**Networks You Can Deploy**](/docs/blog/2026/06/16/AG2-Network-Networks-You-Can-Deploy/) — WebSocket transport, authentication, at-least-once delivery, and dynamic membership.
+
+In parallel, to build strong and capable agents, a companion post, [**The Agent Harness: An Agent Is More Than a Loop**](/docs/blog/2026/06/17/AG2-Agent-Harness/), zooms *inside* a single agent to make them long-running and knowledge-centric.
+
+## Choreography you can dial in
+
+![A dial sweeping from "pure choreography" on the left to "full orchestration" on the right. As expectations and TransitionGraph edges are added, the indicator slides right.](img/n2-dial.webp)
+
+> *Pure choreography is loose; full orchestration is rigid. The framework offers control as a dial: pick how much, where, and when.*
+
+The four adapters from the first post each sit at a different position on that dial. `consulting` is the leftmost notch — one question, one answer, hard close. `conversation` is one click right — two parties, free-form, until someone closes the channel. `discussion` lives near the middle — a fixed cast taking turns in a deterministic round-robin. `workflow` is the rightmost notch — a `TransitionGraph` declared up front that decides who speaks next on every turn. Same primitives end to end; what changes is how much of the routing you write down.
+
+But the starting notch isn't the only dial. Two more sit on top of every adapter, and you reach for them when "what conversation shape do I want?" turns into "when two participants need a side bar, or when the next speaker depends on what the previous one returned?":
+
+- **Audience addressing** — every envelope carries an `audience` list, so two participants can open a private side-channel without polluting the main thread. The WAL keeps both cleanly separated.
+- **Deeper TransitionGraph rules** — `FromSpeaker`, `ContextEquals`, `ToolCalled`, and dynamic `Handoff` returns let a workflow react to *what* was said, not just *who* said it.
+
+The adapters also ship built-in time-based SLAs — expectations that govern how long any step can stall before the hub acts. The next section covers those; the two dials follow.
+
+The next three sections walk through built-in expectations, then each dial, ending with a centerpiece that combines both. Every concept lands as a first-class envelope on the channel's write-ahead log — so the choreography you dial in survives a fold replay, the same way the conversation does.
+
+## Built-in expectations
+
+![A channel timeline with acks_within(30s, auto_close) armed: the invite is sent, no ACK arrives, the countdown expires, an EV_CHANNEL_CLOSED envelope appears on the WAL.](img/n2-expectations.webp)
+
+Every adapter ships built-in time-based SLAs — expectations that fire when a channel stalls. `consulting` arms two: `acks_within(30s, auto_close)` (the invitee must ACK within 30 seconds) and `reply_within(600s, auto_close)` (the respondent must reply within 10 minutes). `conversation` arms `max_silence(3600s, audit)` — the hub logs silence but leaves the channel open. The hub evaluates all expectations on a 10-second sweep; the sweep is stateless and re-derives every timer from the WAL, so a hub restart never loses a deadline.
+
+Three evaluators ship today:
+
+| Evaluator | Fires when… |
+|---|---|
+| `acks_within` | an invitee hasn't ACKed within `seconds` of the channel invite |
+| `reply_within` | the respondent hasn't replied within `seconds` of the initiator's question |
+| `max_silence` | no participant has posted a substantive envelope for `seconds` |
+
+Three handlers decide what happens when an evaluator fires:
+
+| Handler | Effect |
+|---|---|
+| `auto_close` | close the channel immediately with reason `expectation_violated:<name>` |
+| `notify_channel` | broadcast `ag2.expectation.violated` to every participant and stay open |
+| `audit` | record to the audit log and do nothing visible |
+
+When the `consulting` adapter's `acks_within(30s, auto_close)` fires, the hub closes the channel before `open()` returns — the close reason `expectation_violated:acks_within` lands in the WAL and is visible to any listener awaiting `EV_CHANNEL_CLOSED`. The centerpiece at the end of this post shows the full lifecycle (open → content → close) with both dials live.
+
+## Audience addressing and private side-channels
+
+![A shared channel with three participants; one envelope is broadcast to all three (arrows light up everywhere), then a sub-channel envelope addressed to only two participants is highlighted, while the main thread keeps moving in the background.](img/n2-audience.webp)
+
+Every envelope carries an optional `audience` field — a list of participant IDs that should receive the message. Omit it and the hub broadcasts to everyone. Set it and only those participants see the envelope. The WAL records both variants identically; the audience filter is applied at dispatch time, not write time, so the full log stays durable even if a participant was excluded.
+
+Private side-channels use the same primitive: open a second channel with a restricted participant list. The two channels run on separate WALs that never intersect. An agent on the main channel cannot discover that the side-channel exists, let alone read its messages.
+
+The example below has three participants on a discussion channel. After a public exchange, alice opens a private `consulting` channel with carol — bob is not invited and never sees that conversation.
+
+```python linenums="1"
+import asyncio
+
+from ag2.knowledge import MemoryKnowledgeStore
+from ag2.network import (
+    EV_CHANNEL_CLOSED, EV_TEXT,
+    Hub, HubClient, LocalLink, Passport,
+)
+
+
+async def main() -> None:
+    hub = await Hub.open(MemoryKnowledgeStore(), ttl_sweep_interval=0)
+    link = LocalLink(hub)
+
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+    carol_hc = HubClient(link, hub=hub)
+
+    alice = await alice_hc.register_human(Passport(name="alice", kind="human"))
+    bob = await bob_hc.register_human(Passport(name="bob", kind="human"))
+    carol = await carol_hc.register_human(Passport(name="carol", kind="human"))
+
+    # ── Main discussion channel: alice, bob, carol ──────────────────────────
+    main_ch = await alice.open(
+        type="discussion",
+        target=[bob.agent_id, carol.agent_id],
+    )
+    await main_ch.send("alice (main): topic — should we adopt the new infra?")
+
+    await bob.next_envelope(
+        predicate=lambda e: e.channel_id == main_ch.channel_id and e.event_type == EV_TEXT,
+        timeout=10.0,
+    )
+    await bob.send(main_ch.channel_id, "bob (main): I need more context before deciding.")
+
+    await carol.next_envelope(
+        predicate=lambda e: e.channel_id == main_ch.channel_id and e.sender_id == bob.agent_id,
+        timeout=10.0,
+    )
+
+    # ── Private side-channel: alice ↔ carol (bob excluded) ─────────────────
+    side_ch = await alice.open(type="consulting", target=carol.agent_id)
+    await side_ch.send("carol (private): off the record — do you trust the vendor?")
+
+    await carol.next_envelope(
+        predicate=lambda e: e.channel_id == side_ch.channel_id and e.event_type == EV_TEXT,
+        timeout=10.0,
+    )
+    await carol.send(side_ch.channel_id, "alice (private reply): between us — not yet.")
+
+    await alice.next_envelope(
+        predicate=lambda e: e.channel_id == side_ch.channel_id and e.event_type == EV_CHANNEL_CLOSED,
+        timeout=10.0,
+    )
+    await carol.send(main_ch.channel_id, "carol (main): let's request a reference check first.")
+
+    # ── Show both WALs ──────────────────────────────────────────────────────
+    print("=== MAIN CHANNEL WAL (alice + bob + carol) ===")
+    for env in await hub.read_wal(main_ch.channel_id):
+        if env.event_type == EV_TEXT:
+            print(f"  {env.event_data.get('text', '')!r}")
+
+    print("\n=== SIDE-CHANNEL WAL (alice + carol only) ===")
+    for env in await hub.read_wal(side_ch.channel_id):
+        if env.event_type == EV_TEXT:
+            print(f"  {env.event_data.get('text', '')!r}")
+
+    await main_ch.close()
+    await alice_hc.close()
+    await bob_hc.close()
+    await carol_hc.close()
+    await hub.close()
+
+
+asyncio.run(main())
+```
+
+Both WALs are first-class objects on the hub. Bob can replay the main channel from start to finish — carol's private consultation with alice never appears there. From the hub's point of view, two channels ran in parallel, each with its own participant list, its own adapter, and its own set of expectations.
+
+## Deeper TransitionGraph
+
+![Three role cards (drafter / reviewer / specialist) with envelopes flying between them as each turn fires; a "transitions" rules box on the right highlights the matching rule each turn, and on the final turn the ContextEquals("done", True) rule fires and the channel closes with reason "approved". A context_vars panel on the left flips done from False to True.](img/n2-transitions.webp)
+
+`TransitionGraph.sequence([a, b, c])` from the first post is the simplest possible graph — a straight line. For real workflows you'll want two patterns beyond that.
+
+**Dynamic Handoff — routing by return value, not graph edge.** Any `@tool` on a workflow agent can return a `Handoff` instance. The framework extracts the target from the tool's result and overrides the graph rule for that turn. This means the drafter doesn't need a separate `ToolCalled("classify")` edge for every possible specialist — it calls one tool and lets the return value decide:
+
+```python linenums="1"
+from ag2.network import AgentTarget, FromSpeaker, Handoff, Transition, TransitionGraph
+
+drafter_agent = Agent("drafter", prompt="Call classify(topic) for complex topics.", config=config)
+
+@drafter_agent.tool
+async def classify(topic: str) -> Handoff:
+    """Route a complex technical topic to the right specialist."""
+    specialist_id = lookup_specialist(topic)     # your routing logic here
+    return Handoff(target=specialist_id, reason=f"complex topic: {topic}")
+
+graph = TransitionGraph(
+    initial_speaker=user.agent_id,
+    transitions=[
+        Transition(when=FromSpeaker(user.agent_id), then=AgentTarget(drafter.agent_id)),
+        # Fallback path if drafter writes a plain reply instead of calling classify.
+        Transition(when=FromSpeaker(drafter.agent_id), then=AgentTarget(default_agent.agent_id)),
+    ],
+    default_target=TerminateTarget("done"),
+    max_turns=12,
+)
+```
+
+When the `classify()` tool returns `Handoff(target=specialist_id)`, the fold sets the next speaker as the `specialist_id`. The graph edge is never consulted.
+
+**ContextEquals — routing on state, not sender.** `ContextEquals(key, value)` fires when `channel.context_vars[key] == value`. You write context vars from a `@tool` via `set_context(channel, key, value)`. Similar to a tool returning a Handoff, this is evaluated before evaluating transitions, so the same turn that sets a var can immediately route on it:
+
+```python linenums="1"
+from ag2.network import (
+    AgentTarget, ContextEquals, FromSpeaker,
+    TerminateTarget, ToolCalled, Transition, TransitionGraph,
+)
+from ag2.network.workflow_helpers import set_context
+
+reviewer_agent = Agent("reviewer", prompt="Call review_draft(quality, reason) once per turn.", config=config)
+
+@reviewer_agent.tool
+async def review_draft(quality: str, reason: str, channel: ChannelInject) -> str:
+    """Review a draft. quality='approved' ends the workflow; 'needs_work' requests a revision."""
+    if quality == "approved":
+        await set_context(channel, "done", True)
+        return f"approved: {reason}"
+    return f"revision requested: {reason}"
+
+graph = TransitionGraph(
+    initial_speaker=user.agent_id,
+    transitions=[
+        # Terminate as soon as done=True — must be listed before the ToolCalled rule.
+        Transition(when=ContextEquals("done", value=True), then=TerminateTarget("approved")),
+        Transition(when=FromSpeaker(user.agent_id), then=AgentTarget(drafter.agent_id)),
+        Transition(when=FromSpeaker(drafter.agent_id), then=AgentTarget(reviewer.agent_id)),
+        # ToolCalled ensures EV_PACKET is posted even when the reviewer produces no
+        # text body — so the fold and ContextEquals check always happen.
+        Transition(when=ToolCalled("review_draft"), then=AgentTarget(drafter.agent_id)),
+    ],
+    default_target=TerminateTarget("max_iterations"),
+    max_turns=10,
+)
+```
+
+Two things to notice. First, `ContextEquals("done", True)` is listed *before* `ToolCalled("review_draft")` — transitions are walked in list order (with equal `priority`, list position breaks ties), so termination fires before the loop-back. Second, the `ToolCalled("review_draft")` entry does double duty: it makes the adapter post an `EV_PACKET` even when the reviewer calls the tool but writes no text, so the fold always runs and the ContextEquals check always gets evaluated. Without it, an empty-body turn silently disappears and the graph never advances.
+
+## Centerpiece runnable — both dials at once
+
+![A workflow channel with two roles (drafter and specialist). A dynamic Handoff arc jumps from drafter to specialist; specialist calls flag() which sets a context var; a ContextEquals rule fires and the channel closes with reason specialist_done.](img/n2-centerpiece.webp)
+
+The final example combines both dials on a single workflow channel:
+
+1. **Dynamic Handoff** — the drafter calls `classify()` which returns a `Handoff` pointing at the specialist. The graph doesn't need a static edge for every possible specialist.
+2. **ContextEquals routing** — the specialist calls `flag(status='complete')` which writes `status` to the channel's `context_vars`. A `ContextEquals("status", "complete")` transition fires on the specialist's round-end packet and terminates the workflow cleanly.
+
+```python linenums="1"
+import asyncio
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.knowledge import MemoryKnowledgeStore
+from ag2.network import (
+    EV_CHANNEL_CLOSED,
+    AgentTarget, ChannelInject, ContextEquals, FromSpeaker, Handoff,
+    Hub, HubClient, LocalLink, Passport, Resume,
+    TerminateTarget, ToolCalled, Transition, TransitionGraph,
+)
+from ag2.network.workflow_helpers import set_context
+
+
+async def main() -> None:
+    config = AnthropicConfig(model="claude-haiku-4-5-20251001")
+    hub = await Hub.open(MemoryKnowledgeStore(), ttl_sweep_interval=0)
+    link = LocalLink(hub)
+
+    user_hc, drafter_hc, spec_hc = (HubClient(link, hub=hub) for _ in range(3))
+
+    user = await user_hc.register_human(Passport(name="user", kind="human"))
+
+    drafter_agent = Agent(
+        "drafter",
+        prompt="Call classify(topic) to route complex topics to the specialist.",
+        config=config,
+    )
+    specialist_id_holder: list[str] = []
+
+    @drafter_agent.tool
+    async def classify(topic: str) -> Handoff:
+        """Route a complex technical topic to the domain specialist."""
+        return Handoff(target=specialist_id_holder[0], reason=f"complex topic: {topic}")
+
+    drafter = await drafter_hc.register(
+        drafter_agent, Passport(name="drafter"), Resume(), attach_plugin=False,
+    )
+
+    specialist_agent = Agent(
+        "specialist",
+        prompt="Call flag(status='complete') first, then write your 2-sentence analysis.",
+        config=config,
+    )
+
+    @specialist_agent.tool
+    async def flag(status: str, channel: ChannelInject) -> str:
+        """Flag the analysis status for downstream routing."""
+        await set_context(channel, "status", status)
+        return "Status recorded. Write your 2-sentence analysis in this reply."
+
+    specialist = await spec_hc.register(
+        specialist_agent, Passport(name="specialist"), Resume(), attach_plugin=False,
+    )
+    specialist_id_holder.append(specialist.agent_id)
+
+    graph = TransitionGraph(
+        initial_speaker=user.agent_id,
+        transitions=[
+            Transition(when=FromSpeaker(user.agent_id), then=AgentTarget(drafter.agent_id)),
+            Transition(when=FromSpeaker(drafter.agent_id), then=AgentTarget(specialist.agent_id)),
+            # ContextEquals terminates when the specialist flags status='complete'.
+            # ToolCalled("flag") forces EV_PACKET even on text-free tool-only turns,
+            # ensuring the fold always runs and ContextEquals always gets evaluated.
+            Transition(
+                when=ContextEquals("status", "complete"),
+                then=TerminateTarget("specialist_done"),
+                priority=-1,
+            ),
+            Transition(when=ToolCalled("flag"), then=TerminateTarget("specialist_done")),
+            Transition(when=FromSpeaker(specialist.agent_id), then=TerminateTarget("specialist_done")),
+        ],
+        default_target=TerminateTarget("done"),
+        max_turns=12,
+    )
+
+    channel = await user.open(
+        type="workflow",
+        target=[drafter.agent_id, specialist.agent_id],
+        knobs={"graph": graph.to_dict()},
+    )
+    await channel.send(
+        "Brief: explain the security implications of DNS-over-HTTPS for enterprise networks."
+    )
+
+    close_env = await user.next_envelope(
+        predicate=lambda e: e.event_type == EV_CHANNEL_CLOSED and e.channel_id == channel.channel_id,
+        timeout=120.0,
+    )
+    print(f"closed: {close_env.event_data.get('reason')!r}")
+    # → 'specialist_done'
+
+    for hc in (user_hc, drafter_hc, spec_hc):
+        await hc.close()
+    await hub.close()
+
+
+asyncio.run(main())
+```
+
+The WAL from a real run looks like this:
+
+```
+        user  ag2.channel.invite          (× 2 — drafter, specialist)
+     drafter  ag2.channel.invite.ack
+  specialist  ag2.channel.invite.ack
+        user  ag2.channel.opened
+        user  EV_TEXT   : Brief: explain the security implications of DNS-over-HTTPS…
+     drafter  EV_PACKET : routing=handoff  body=Routing to specialist: complex topic…
+  specialist  EV_CONTEXT_SET : {'status': 'complete'}
+  specialist  EV_PACKET : routing=terminate:specialist_done  body=## Security Implications of DoH…
+        user  ag2.channel.closed          reason=specialist_done
+```
+
+Every dial lands exactly once, in the right place, in the right order. The `EV_CONTEXT_SET` is the specialist writing to the channel's state; the `EV_PACKET` that follows is the turn-end envelope whose fold evaluates `ContextEquals("status", "complete")` and terminates the workflow. The `EV_CHANNEL_CLOSED` carries `reason=specialist_done` — clean, deterministic, no stall required.
+
+## Wrapping up
+
+Two dials, one primitive. Audience addressing governs *visibility* — who sees which envelope on which thread. `TransitionGraph` conditions govern *routing* — who speaks next based on what was said or what state was written. The built-in expectations govern *time* automatically: every adapter ships SLAs that fire without any configuration. All three are first-class envelopes on the WAL, which means everything you dial in survives a hub restart exactly as written.
+
+The next post in this series — [**What Survives, Survives Exactly**](/docs/blog/2026/05/16/AG2-Network-What-Survives/) — zooms into that WAL. You'll see how the hub re-derives every channel from scratch on restart, how identity (Passport / Resume / SKILL.md) and the audit log compose with the same fold model, and what "durable" really means for a multi-agent conversation.

--- a/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-audit.webp
+++ b/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-audit.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79a42d06a0b814ebd4b1683c7531b8f5465baf88f067ce3d2155c5bb74f3b2f4
+size 2015022

--- a/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-banner-animated.webp
+++ b/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-banner-animated.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8b86d2f2720bc591afdc54fcd6b424141e12b533ae4f2da7c16968a98910445
+size 229406

--- a/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-identity.webp
+++ b/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-identity.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cea5cb26729ff4ee38429711b7db00c2f14fe071862d59d4df222a9fd07a46c
+size 2984212

--- a/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-wal.webp
+++ b/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/img/n3-wal.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e08ea0107662437d6893d7c28737dbcbf45dd3ac272cc1d0570c1f5a7957c8fd
+size 1172088

--- a/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/index.mdx
+++ b/website/docs/_blogs/2026-05-16-AG2-Network-What-Survives/index.mdx
@@ -1,0 +1,497 @@
+---
+title: "What Survives, Survives Exactly"
+authors: [marklysze]
+tags: [AG2 Beta, Network, Multi-Agent, WAL, Identity, Audit]
+date: 2026-05-16
+slug: ag2-network-what-survives
+---
+
+![What Survives, Survives Exactly](img/n3-banner-animated.webp)
+
+Three agents are mid-conversation. The hub process restarts. When it comes back up, does the conversation survive?
+
+Yes. Exactly as it was, envelope for envelope, in the same order, with the same adapter state. No partial log or replay from an approximation. The write-ahead log is the exact conversation.
+
+The previous posts showed *what* the network lets agents do. This one explains *why you can trust it*.
+
+<!-- more -->
+
+This is the third post in a four-part series on the AG2 Network:
+
+1. [**One Coherent Agent Isn't Enough**](/docs/blog/2026/05/14/AG2-Action-Driven-Network/) — the action-driven network; four conversation shapes.
+2. [**Choreography You Can Dial In**](/docs/blog/2026/05/15/AG2-Network-Choreography-Dial/) — audience addressing, dynamic Handoff routing, and the TransitionGraph.
+3. **What Survives, Survives Exactly** *(this post)* — the trustworthy substrate: WAL + fold + hub restart, three identity records, audit log.
+4. [**Networks You Can Deploy**](/docs/blog/2026/06/16/AG2-Network-Networks-You-Can-Deploy/) — WebSocket transport, authentication, at-least-once delivery, and dynamic membership.
+
+## The Write-Ahead Log
+
+Every channel has one write-ahead log, stored as a `.jsonl` file in the hub's `KnowledgeStore`. Before the hub fans an envelope out to any participant, it appends it to that log. The append comes first. Fan-out second.
+
+That ordering is the whole guarantee.
+
+![The write-ahead log: envelopes append in order, the channel state is a pure fold of the log, and re-folding from disk after a crash yields identical state](img/n3-wal.webp)
+
+If the hub process dies after the append but before the fan-out, the envelope is still in the log. When the hub restarts, it re-derives the channel's state by replaying the log through the adapter — a pure fold with no side effects. Participants reconnect, see their missed envelopes, and pick up exactly where they left off.
+
+> **If it's in the log, it survived. If the process died before the append, it never happened.**
+
+An envelope either made it to the log — and therefore exists, permanently, exactly — or it didn't, and the sender gets an error and can retry.
+
+### The fold
+
+Each channel's adapter maintains a state that's a pure function of the log: a **fold**. The `discussion` adapter's state is "which participant speaks next." The `workflow` adapter's state is "which graph node is active." Neither depends on memory that lives outside the log.
+
+When the hub restarts, it calls `hydrate()`:
+
+```python
+# Hub.hydrate() — called automatically by Hub.open()
+# Channels — load metadata first, then re-fold WALs.
+channel_children = await self._store.list("/channels")
+for channel_id in channel_children:
+    await self._load_channel(channel_id)
+    # ... which re-folds the WAL through the adapter
+```
+
+The adapter state is rebuilt deterministically from disk.
+
+## Hub Restart: A Worked Example
+
+The default `MemoryKnowledgeStore` is in-process — fine for development, but nothing survives a restart. For production, as shown in this example, use a store like `DiskKnowledgeStore`:
+
+```python linenums="1"
+import asyncio
+from pathlib import Path
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.knowledge import DiskKnowledgeStore
+from ag2.network import (
+    EV_TEXT,
+    Hub,
+)
+
+DATA_DIR = Path("./hub-data")  # persisted across restarts
+
+
+async def first_run() -> str:
+    """Alice asks, Bob's LLM replies — then abruptly stop."""
+    hub = await Hub.open(DiskKnowledgeStore(DATA_DIR), ttl_sweep_interval=0)
+
+    alice = await hub.register(
+        Agent("alice", prompt="Ask one short question.", config=AnthropicConfig(model="claude-sonnet-4-6")),
+    )
+    bob = await hub.register(
+        Agent("bob", prompt="Answer in one sentence.", config=AnthropicConfig(model="claude-sonnet-4-6")),
+    )
+
+    channel = await alice.open(type="consulting", target="bob")
+    await channel.send(
+        "What's the most important property of a distributed system?",
+        audience=[bob.agent_id],
+    )
+
+    # Wait for Bob's LLM reply — consulting closes automatically on completion
+    await alice.wait_for_channel_event(
+        channel_id=channel.channel_id,
+        predicate=lambda e: e.event_type == EV_TEXT and e.sender_id == bob.agent_id,
+        timeout=120.0,
+    )
+
+    # ← imagine the process crashes here, after bob has replied
+
+    channel_id = channel.channel_id
+    await hub.close()
+
+    print(f"First run complete. Channel: {channel_id}")
+    return channel_id
+
+
+async def second_run(channel_id: str) -> None:
+    """Re-open the hub from disk. Both messages are exactly as left."""
+    hub = await Hub.open(DiskKnowledgeStore(DATA_DIR), ttl_sweep_interval=0)
+
+    envelopes = await hub.read_wal(channel_id)
+    print(f"Envelopes in WAL after restart: {len(envelopes)}")
+    for env in envelopes:
+        if env.event_type == EV_TEXT:
+            name = hub.name_for(env.sender_id)
+            print(f"  recovered [{name}]: {env.event_data['text']!r}")
+
+    await hub.close()
+
+
+async def main():
+    channel_id = await first_run()
+    await second_run(channel_id)
+
+asyncio.run(main())
+```
+
+Output:
+```text
+First run complete. Channel: ch_abc123
+Envelopes in WAL after restart: 6
+  recovered [alice]: "What's the most important property of a distributed system?"
+  recovered [bob]: 'Fault tolerance — the ability of a distributed system to continue operating correctly even when some of its components fail.'
+```
+
+(The `EV_CHANNEL_INVITE`, `EV_CHANNEL_INVITE_ACK`, `EV_CHANNEL_OPENED`, and `EV_CHANNEL_CLOSED` envelopes are also in the log; only `EV_TEXT` is printed here.)
+
+### Continuing after restart
+
+Reading the WAL is only half the story. The hub restarts fully operational, and open channels are still open — agents can reconnect to the same channel and pick up the conversation exactly where it left off.
+
+A `discussion` channel stays open until explicitly closed, so it's the natural example: Alice and Bob are mid-conversation, the hub process dies, and the channel survives. When the hub comes back up, both agents reconnect to the same `channel_id` and the discussion continues, enabled by the unbroken WAL.
+
+The reconnect pattern is different from re-registration. After a restart, `hydrate()` reloads all agent identities from disk, so calling `register()` again would fail with "already registered." Instead, you retrieve the persisted passport, create a fresh transport binding, and construct the `AgentClient` directly:
+
+```python linenums="1"
+import asyncio
+from pathlib import Path
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.knowledge import DiskKnowledgeStore
+from ag2.network import (
+    EV_TEXT,
+    AgentClient,
+    Channel,
+    Hub,
+    HubClient,
+    LocalLink,
+    NetworkPlugin,
+    Rule,
+)
+
+DATA_DIR = Path("./hub-data-discussion")
+
+PROMPT = "You are in a discussion about distributed systems. Respond in one sentence."
+
+
+async def _noop_handler(_envelope) -> None:
+    pass
+
+
+async def _reconnect(hub, hc, agent, name, *, llm_handler=True):
+    """Rebind a persisted agent to a fresh transport after hub restart."""
+    passport = await hub.get_agent(name)
+    resume = await hub.get_resume(passport.agent_id)
+    client_link = hc._ensure_connected()
+    hub.bind_endpoint(client_link.endpoint_id, passport.agent_id)
+    client = AgentClient(
+        agent=agent,
+        passport=passport,
+        resume=resume,
+        rule=Rule(),
+        hub=hub,
+        hub_client=hc,
+        attach_default_handler=llm_handler,
+    )
+    hc._clients[passport.agent_id] = client
+    if llm_handler:
+        NetworkPlugin(client).register(agent)
+    return client
+
+
+async def first_run() -> str:
+    """Alice and Bob start a discussion — then the process crashes mid-conversation."""
+    hub = await Hub.open(DiskKnowledgeStore(DATA_DIR), ttl_sweep_interval=0)
+
+    # Alice sends manually; bob responds automatically via LLM.
+    alice = await hub.register(
+        Agent("alice", prompt=PROMPT, config=AnthropicConfig(model="claude-sonnet-4-6")),
+        attach_plugin=False,
+    )
+    alice.on_envelope(_noop_handler)
+
+    bob = await hub.register(
+        Agent("bob", prompt=PROMPT, config=AnthropicConfig(model="claude-sonnet-4-6")),
+    )
+
+    channel = await alice.open(type="discussion", target="bob")
+    await channel.send(
+        "What's the single most important guarantee a distributed system must provide?",
+        audience=[bob.agent_id],
+    )
+    await alice.wait_for_channel_event(
+        channel_id=channel.channel_id,
+        predicate=lambda e: e.event_type == EV_TEXT and e.sender_id == bob.agent_id,
+        timeout=120.0,
+    )
+
+    print("=== Process crashes here — channel still open ===")
+    channel_id = channel.channel_id
+    await hub.close()
+    return channel_id
+
+
+async def second_run(channel_id: str) -> None:
+    """Hub restarts — reconnect to the same open channel and continue."""
+    hub = await Hub.open(DiskKnowledgeStore(DATA_DIR), ttl_sweep_interval=0)
+    link = LocalLink(hub)
+    alice_hc = HubClient(link, hub=hub)
+    bob_hc = HubClient(link, hub=hub)
+
+    envelopes = await hub.read_wal(channel_id)
+    print(f"\nEnvelopes in WAL after restart: {len(envelopes)}")
+    for env in envelopes:
+        if env.event_type == EV_TEXT:
+            name = hub.name_for(env.sender_id)
+            print(f"  [{name}]: {env.event_data['text']!r}")
+
+    # Reconnect to existing agent_ids — no re-registration needed.
+    alice = await _reconnect(
+        hub, alice_hc,
+        Agent("alice", prompt=PROMPT, config=AnthropicConfig(model="claude-sonnet-4-6")),
+        "alice", llm_handler=False,
+    )
+    bob = await _reconnect(
+        hub, bob_hc,
+        Agent("bob", prompt=PROMPT, config=AnthropicConfig(model="claude-sonnet-4-6")),
+        "bob",
+    )
+
+    metadata = await alice_hc.get_channel(channel_id)
+    print(f"\nChannel state after restart: {metadata.state.value}")
+    channel = Channel(metadata=metadata, client=alice)
+
+    # Hub replays the WAL on restart, so can_send reflects the true next speaker.
+    if hub.can_send(channel_id, alice.agent_id):
+        print("Next to speak after restart: alice")
+        await channel.send(
+            "Does that guarantee hold under network partitions?",
+            audience=[bob.agent_id],
+        )
+        await alice.wait_for_channel_event(
+            channel_id=channel_id,
+            predicate=lambda e: e.event_type == EV_TEXT and e.sender_id == bob.agent_id,
+            timeout=120.0,
+        )
+    elif hub.can_send(channel_id, bob.agent_id):
+        print("Next to speak after restart: bob")
+        await alice.wait_for_channel_event(
+            channel_id=channel_id,
+            predicate=lambda e: e.event_type == EV_TEXT and e.sender_id == bob.agent_id,
+            timeout=120.0,
+        )
+
+    # One unbroken log spanning the crash.
+    envelopes2 = await hub.read_wal(channel_id)
+    print(f"\nFull conversation ({len(envelopes2)} envelopes total):")
+    for env in envelopes2:
+        if env.event_type == EV_TEXT:
+            name = hub.name_for(env.sender_id)
+            print(f"  [{name}]: {env.event_data['text']!r}")
+
+    await channel.close()
+    await hub.close()
+
+
+async def main():
+    channel_id = await first_run()
+    await second_run(channel_id)
+
+asyncio.run(main())
+```
+
+Output:
+```text
+=== Process crashes here — channel still open ===
+
+Envelopes in WAL after restart: 5
+  [alice]: "What's the single most important guarantee a distributed system must provide?"
+  [bob]: 'Consistency — ensuring all nodes see the same data at the same time.'
+
+Channel state after restart: active
+
+Full conversation (7 envelopes total):
+  [alice]: "What's the single most important guarantee a distributed system must provide?"
+  [bob]: 'Consistency — ensuring all nodes see the same data at the same time.'
+  [alice]: 'Does that guarantee hold under network partitions?'
+  [bob]: 'No — the CAP theorem proves that under a network partition, a system must
+          sacrifice either consistency or availability, so perfect consistency cannot
+          be universally guaranteed.'
+```
+
+The channel was `active` when the hub crashed, and it's still `active` after restart. Alice and Bob reconnect to the same `channel_id` — not a new one — and the WAL grows in place. The crash is invisible in the log.
+
+> In production: use `DiskKnowledgeStore` for local single-node deployments, `RedisKnowledgeStore` for multi-node. The hub's behavior is identical — the store is plugged in at `Hub.open(store=...)`.
+
+## Three Identity Records
+
+Every registered agent is backed by three records, each with a distinct lifecycle:
+
+![Three identity records — Passport (immutable), Resume (mutable), SKILL.md (discovery)](img/n3-identity.webp)
+
+### Passport — immutable, hub-stamped
+
+```python
+Passport(
+    name="alice",            # human-readable address; unique per hub
+    owner="team-search",     # billing / routing scope
+    provider="anthropic",    # optional — the hub uses it for routing hints
+    model="claude-sonnet-4-6",
+    kind="agent",            # "agent" | "human" | "remote_agent"
+)
+```
+
+The hub assigns `agent_id` at registration — a stable, opaque identifier the network routes by. `name` is for humans; `agent_id` is for code.
+
+**Immutable** means: changing `name`, `model`, or any other field requires unregistering and re-registering, which yields a fresh `agent_id`. Existing channels that reference the old `agent_id` remain closed; the new agent starts clean. This is by design — the channel log binds to the identity that spoke, not the name it happened to carry.
+
+Passports are persisted under `/agents/{agent_id}/passport.json`.
+
+### Resume — mutable capability claims + track record
+
+```python
+Resume(
+    claimed_capabilities=["web-search", "code-review"],
+    domains=["research", "engineering"],
+    summary="Searches the web and synthesizes results into structured reports.",
+    examples=[
+        ResumeExample(title="Competitive analysis", outcome="completed"),
+    ],
+)
+```
+
+The `Resume` has two halves:
+
+- **Tenant-provided**: `claimed_capabilities`, `domains`, `summary`, `examples` — you set these at registration and can update them later with `hub.set_resume(agent_id, resume)`. Set these so that other agents can understand your agent's capabilities, helping them to engage your agent for the right tasks.
+- **Hub-observed**: `observed` — a per-capability `ObservedStat` (count, completed, failed, p50 latency) that the hub updates automatically on every terminal task event. You don't write to this; the hub writes it and uses it to prioritize.
+
+When another agent calls `peers(action="find", capability="web-search")`, the hub ranks results using the `observed` track record. An agent with 100 completed web-search tasks and a p50 of 1.2 s ranks above a new agent with zero observations. The signal is real: derived from actual behavior, not self-reported claims.
+
+Resumes are persisted under `/agents/{agent_id}/resume.json`.
+
+### SKILL.md — structured discovery document
+
+A `SKILL.md` is a Markdown file with Anthropic-style YAML frontmatter that describes what an agent can do in a form other agents (and humans) can read:
+
+```markdown
+---
+name: web-search
+description: Search the web and return structured results with titles, snippets, and URLs.
+version: 1.0.0
+capabilities:
+  - web-search
+  - content-fetch
+---
+
+## Usage
+
+Call with a search query. Returns up to 10 ranked results. Use `tinyfish_fetch`
+to retrieve full page content for any result URL.
+
+## Parameters
+
+- `query` — search query string (required)
+- `location` — ISO country code for localized results (optional)
+- `language` — BCP-47 language code for result language (optional)
+```
+
+The hub stores it under `/agents/{agent_id}/SKILL.md` and returns it in `peers(action="inspect", agent_id=...)` responses. When a `SkillsPlugin` pre-loads a skill into an agent's system prompt, it's reading this file. When an agent calls `load_skill()` at runtime, it fetches this file from the hub.
+
+The three records together form a complete, verifiable identity: the passport binds the `agent_id` to a name and provider; the resume carries expected and earned capability evidence; the SKILL.md tells other agents how to use this one.
+
+## The Audit Log
+
+The WAL records what happened *on a channel*. The audit log records what happened *across the hub* — the cross-cutting events that don't belong to any single channel.
+
+![Audit log — hub-wide append-only record of identity and channel lifecycle](img/n3-audit.webp)
+
+One file: `/audit/audit.jsonl`. Each line is a JSON object:
+
+```json
+{"at":"2026-05-16T04:00:01.234Z","kind":"agent_registered","agent_id":"ag_abc","name":"alice"}
+{"at":"2026-05-16T04:00:02.100Z","kind":"channel_created","channel_id":"ch_xyz","manifest_type":"discussion","participants":["ag_abc","ag_def","ag_ghi"]}
+{"at":"2026-05-16T04:00:45.320Z","kind":"resume_set","agent_id":"ag_def","source":"observed","capability":"web-search"}
+{"at":"2026-05-16T04:01:12.000Z","kind":"expectation_violated","channel_id":"ch_xyz","expectation":"reply_within","violators":["ag_ghi"],"on_violation":"notify_channel"}
+{"at":"2026-05-16T04:05:00.000Z","kind":"channel_closed","channel_id":"ch_xyz","reason":"all_participants_left"}
+```
+
+The audit log records:
+
+| Kind | Trigger |
+|---|---|
+| `agent_registered` / `agent_unregistered` | Register / unregister call |
+| `resume_set` | Tenant `set_resume` call (source: `"tenant"`) or hub track-record update (source: `"observed"`) |
+| `skill_set` / `rule_set` | `set_skill` / `set_rule` calls |
+| `channel_created` / `channel_closed` / `channel_expired` | Channel lifecycle transitions |
+| `task_terminated` | Task reaches completed / failed / expired |
+| `expectation_violated` | An expectation fires (per channel, per expectation, per violator) |
+| `turn_failed` | A hub notify-handler raised an exception |
+
+Read it back from any `Hub` instance:
+
+```python
+records = await hub.audit_log.read_all()
+for record in records:
+    print(f"{record['at']}  {record['kind']}")
+```
+
+Or subscribe to a live stream — new records arrive in-process without polling the file:
+
+```python
+async def on_audit(record: dict) -> None:
+    if record["kind"] == "expectation_violated":
+        violators = ", ".join(record["violators"])
+        print(f"⚠  {record['channel_id']}: {record['expectation']} violated by {violators}")
+
+hub.audit_log.subscribe(on_audit)
+```
+
+The audit log is **append-only by design** — nothing is ever overwritten. If you need a different format (structured logging, SIEM export), subclass `AuditLog` and pass it to `Hub.replace_audit_log(...)`.
+
+## What Doesn't Survive
+
+The hub's crash guarantee covers *disk-committed* state. A few things are intentionally not persisted:
+
+| Not persisted | Why |
+|---|---|
+| In-flight transport connections | Reconnect on the next `HubClient` connect |
+| `AgentRuntime` (transport binding, last heartbeat) | Re-established at reconnect; treated as cache |
+| Adapter state cache (`_adapter_states`) | Re-derived by folding the WAL on `hydrate()` |
+| In-progress `asyncio` tasks driving agent turns | Resume is the agent's job, not the hub's |
+
+When a hub restarts, registered agents are loaded from their persisted `passport.json` files but their transport bindings are gone. Each `HubClient` that reconnects re-establishes its binding with a `HelloFrame`. Pending envelopes that were in-flight but not yet WAL-appended at crash time effectively never happened — the sender retries.
+
+> The hub guarantees *what the log contains*. The application is responsible for detecting and retrying sends that never reached the log.
+
+This is the same contract as any WAL-based system (Postgres, Kafka, etcd). The hub doesn't pretend to stronger guarantees than it actually provides.
+
+## The Storage Layout
+
+For completeness — everything the hub persists under a `KnowledgeStore`:
+
+```text
+/agents/
+  {agent_id}/
+    passport.json     ← immutable identity
+    resume.json       ← mutable capability claims + track record
+    SKILL.md          ← discovery document
+    rule.json         ← per-agent policy (access control, rate limits)
+    runtime.json      ← ephemeral; re-written on reconnect
+    inbox.cursor      ← replay offset for missed envelopes
+
+/channels/
+  {channel_id}/
+    metadata.json     ← lifecycle state, adapter manifest, participants
+    wal.jsonl         ← the conversation, exactly as it happened
+
+/registry/
+  by_name.json        ← derived cache: name → agent_id
+  by_capability.json  ← derived cache: capability → [agent_id, ...]
+
+/audit/
+  audit.jsonl         ← hub-wide cross-cutting event record
+```
+
+All of `/registry/` is a derived cache — safe to delete, since `hydrate()` rebuilds it. Everything else is authoritative.
+
+## Where to Next
+
+- [**Networks You Can Deploy**](/docs/blog/2026/06/16/AG2-Network-Networks-You-Can-Deploy/) — WebSocket transport, authentication, at-least-once delivery, and dynamic membership.
+- **The Agent Harness: An Agent Is More Than a Loop**: what's inside each node in the network.
+- Docs: [Hub & Identity](/docs/user-guide/network/hub_and_identity) · [Network Quick Start](/docs/user-guide/network/quick_start) · [Channel Adapters Overview](/docs/user-guide/network/adapters_overview)
+
+Moving to production, you need an agent network that you can trust. The WAL, the identity records, and the audit log are what make the AG2 Network something you can deploy, inspect, and rely on.

--- a/website/docs/_blogs/2026-06-16-AG2-Network-Networks-You-Can-Deploy/img/n4-auth.webp
+++ b/website/docs/_blogs/2026-06-16-AG2-Network-Networks-You-Can-Deploy/img/n4-auth.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66221fbfd606a376d62793a3bb7abbee14a73e9b0762428bfc70b877db44c8d9
+size 903560

--- a/website/docs/_blogs/2026-06-16-AG2-Network-Networks-You-Can-Deploy/img/n4-banner.webp
+++ b/website/docs/_blogs/2026-06-16-AG2-Network-Networks-You-Can-Deploy/img/n4-banner.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f455932afb3a353fe49467fed25845c7c8e5dbf5c680bbdf8f8188beecd12b5c
+size 646916

--- a/website/docs/_blogs/2026-06-16-AG2-Network-Networks-You-Can-Deploy/img/n4-reconnect.webp
+++ b/website/docs/_blogs/2026-06-16-AG2-Network-Networks-You-Can-Deploy/img/n4-reconnect.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab2ace001b171ed947246ff1f060ee1e58714e571e555b859288242b646eb420
+size 616356

--- a/website/docs/_blogs/2026-06-16-AG2-Network-Networks-You-Can-Deploy/index.mdx
+++ b/website/docs/_blogs/2026-06-16-AG2-Network-Networks-You-Can-Deploy/index.mdx
@@ -1,0 +1,278 @@
+---
+title: "Networks You Can Deploy"
+authors: [marklysze]
+tags: [AG2 Beta, Network, Multi-Agent, WebSocket, Authentication, Durability]
+date: 2026-06-16
+slug: ag2-network-networks-you-can-deploy
+---
+
+![Networks You Can Deploy](img/n4-banner.webp)
+
+Moving agents to separate processes usually means rewriting the networking layer. With the AG2 Network, it's a constructor argument.
+
+The Hub absorbs the topology difference. Replace `LocalLink` with `WsLink`, add an auth registry, and your agents are distributed. This post covers the three things you actually wire up to go from a local prototype to a network you can deploy.
+
+<!-- more -->
+
+This is the fourth post in a four-part series on the AG2 Network:
+
+1. [**One Coherent Agent Isn't Enough**](/docs/blog/2026/05/14/AG2-Action-Driven-Network/) — the action-driven network; Hub, HubClient, Channel, Adapter.
+2. [**Choreography You Can Dial In**](/docs/blog/2026/05/15/AG2-Network-Choreography-Dial/) — expectations, audience addressing, TransitionGraph.
+3. [**What Survives, Survives Exactly**](/docs/blog/2026/05/16/AG2-Network-What-Survives/) — write-ahead log, three identity records, audit log.
+4. **Networks You Can Deploy** *(this post)* — WebSocket transport, authentication, at-least-once delivery.
+
+## Crossing the Process Boundary
+
+In the previous posts every example used `LocalLink` — an in-process link that connects a `HubClient` to a `Hub` object in the same Python process. Swapping to WebSocket is a single-line change on the client side:
+
+```python
+# In-process (development)
+from ag2.network import LocalLink
+
+hc = HubClient(LocalLink(hub))  # hub is a Hub object in this process
+
+# Cross-process (production)
+from ag2.network import WsLink
+
+hc = HubClient(WsLink("ws://hub:8765"))  # hub is a running process elsewhere
+```
+
+The hub process itself runs `serve_ws` — an async context manager that binds a WebSocket server to an existing `Hub`:
+
+```python linenums="1"
+import asyncio
+from pathlib import Path
+
+from ag2.knowledge import DiskKnowledgeStore
+from ag2.network import Hub, serve_ws
+
+async def main() -> None:
+    hub = await Hub.open(DiskKnowledgeStore(Path("./hub-data")))
+    async with serve_ws(hub, "0.0.0.0", 8765) as server:
+        host, port = server.sockets[0].getsockname()
+        print(f"hub listening on ws://{host}:{port}")
+        await asyncio.Future()  # run until interrupted
+
+asyncio.run(main())
+```
+
+Agent processes are entirely separate Python programs. Each constructs its own `WsLink` and `HubClient`:
+
+```python linenums="1"
+import asyncio
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.network import (
+    EV_TEXT,
+    HubClient,
+    Passport,
+    Resume,
+    WsLink,
+)
+
+HUB_URL = "ws://hub:8765"
+
+
+async def main() -> None:
+    hc = HubClient(WsLink(HUB_URL))
+    alice = await hc.register(
+        Agent("alice", prompt="You coordinate tasks.", config=AnthropicConfig(model="claude-sonnet-4-6")),
+        Passport(name="alice"),
+        Resume(summary="coordinator"),
+    )
+
+    channel = await alice.open(type="consulting", target=["bob"])
+    await channel.send("What is the current deployment status?")
+
+    await alice.wait_for_channel_event(
+        channel_id=channel.channel_id,
+        predicate=lambda e: e.event_type == EV_TEXT and e.sender_id != alice.agent_id,
+        timeout=60.0,
+    )
+    await hc.close()
+
+asyncio.run(main())
+```
+
+![Three processes — alice, hub, bob — each a separate Python program connected via WebSocket](img/n4-banner.webp)
+
+Everything else — `open`, `send`, `wait_for_channel_event`, `peers`, `read_wal`, `on_envelope` — is identical to the in-process API. The hub's protocol is the same regardless of whether the link goes through in-process queues or a real WebSocket.
+
+> **One topology change, zero agent-code changes.** The agent doesn't know or care whether its `HubClient` speaks to a local object or a remote process.
+
+## Authentication: Knowing Who's Connecting
+
+When agents run in separate processes, the hub needs to verify that a connecting client really is who it claims to be. The default is `NoAuth` — every connection is accepted. For a deployed system, use `ApiKeyAuth`.
+
+### Configuring the hub
+
+Pass an `AuthRegistry` to `Hub.open`. The registry maps scheme names to adapters; `ApiKeyAuth` handles the `"api_key"` scheme:
+
+```python linenums="1"
+from ag2.knowledge import DiskKnowledgeStore
+from ag2.network import ApiKeyAuth, AuthRegistry, Hub, serve_ws
+
+AGENT_KEYS = {
+    "alice": "ak-alice-f3a2b1",
+    "bob":   "ak-bob-9c8d7e",
+    "carol": "ak-carol-5f4e3d",
+}
+
+async def main() -> None:
+    hub = await Hub.open(
+        DiskKnowledgeStore("./hub-data"),
+        auth=AuthRegistry([ApiKeyAuth(keys=AGENT_KEYS)]),
+    )
+    async with serve_ws(hub, "0.0.0.0", 8765):
+        await asyncio.Future()
+```
+
+`ApiKeyAuth` uses constant-time comparison (`hmac.compare_digest`) so token-rejection latency doesn't leak which prefix matched.
+
+### Configuring each agent process
+
+Each agent's `Passport` carries an `AuthBlock` that tells the hub which scheme to validate and what claim to present:
+
+```python linenums="1"
+from ag2.network import AuthBlock, HubClient, Passport, Resume, WsLink
+
+hc = HubClient(WsLink("ws://hub:8765"))
+alice = await hc.register(
+    Agent("alice", ...),
+    Passport(
+        name="alice",
+        auth=AuthBlock(scheme="api_key", claim={"token": "ak-alice-f3a2b1"}),
+    ),
+    Resume(),
+)
+```
+
+![The hub's AuthRegistry validates each connecting agent's token before the HelloFrame handshake completes](img/n4-auth.webp)
+
+If the token is wrong or the name has no registered key, the hub raises `AuthError` at the handshake — before any envelope is accepted or dispatched. Unknown agents get no information beyond rejection.
+
+### Dynamic key resolution
+
+For large deployments where key-per-name static dicts don't scale, pass a `resolver` instead:
+
+```python
+async def resolve_key(name: str) -> str | None:
+    """Return the expected token for `name`, or None if unknown."""
+    return await secrets_manager.get(f"agent/{name}/api_key")
+
+auth = AuthRegistry([ApiKeyAuth(resolver=resolve_key)])
+```
+
+The resolver is tried as fallback when the name is not in `keys`. Return `None` to reject.
+
+## At-Least-Once Delivery
+
+In-process agents don't drop messages — if the hub dispatches to a `LocalLink` client, the client receives it. Over WebSocket, connections close. Processes restart. The network partition you planned around happened anyway.
+
+The AG2 Network solves this with at-least-once delivery: the hub tracks which envelopes each agent has acknowledged. If a connection drops before an `EV_TEXT` is acked, the hub doesn't forget it — the next connection from that agent replays it.
+
+### How replay works
+
+Every `HelloFrame` that opens a WebSocket connection carries an optional `since_envelope_id` — the agent's high-water mark. When set, the hub replays all unacked envelopes addressed to this agent with `envelope_id` strictly greater than that mark, then resumes live traffic.
+
+`HubClient.attach` is the reconnect-aware entry point. It binds the same identity (same `agent_id`, same WAL history) to a fresh connection:
+
+```python linenums="1"
+from ag2.network import HubClient, Passport, Resume, WsLink
+
+# Original node (simulating a process that dropped)
+bob_hc1 = HubClient(WsLink("ws://hub:8765"))
+bob1 = await bob_hc1.register(Agent("bob", ...), Passport(name="bob"), Resume())
+# ... connection drops; alice's message arrived but was never acked
+
+# Fresh process: attach under the same name; hub replays the missed envelope
+bob_hc2 = HubClient(WsLink("ws://hub:8765"))
+bob2 = await bob_hc2.attach(
+    Agent("bob", ...),
+    name="bob",
+    since_envelope_id="",  # "" = replay everything the hub has not seen acked
+)
+# bob2 receives alice's message again and replies normally
+```
+
+`bob2.agent_id == bob1.agent_id` — the identity is the same. The channel WAL grows in place. From the other participants' perspective, `bob` had a brief pause, not a death.
+
+![Bob drops and reconnects. The hub replays e004/e005 to the fresh connection. The DROPPED label fades out as attach() completes.](img/n4-reconnect.webp)
+
+### `since_envelope_id` values
+
+| Value | Effect |
+|---|---|
+| `""` (empty string, default) | Replay everything not acked (hub uses the persisted cursor) |
+| `"env_abc123"` | Replay strictly past that specific envelope |
+| `None` | Skip replay entirely |
+
+### Finishing interrupted turns
+
+Replay re-delivers missed envelopes. But if the agent was already mid-turn — it had received the envelope and started processing — replay won't re-fire. Call `resume_pending_turns()` after `attach()` to re-fire any turn the channel protocol is waiting for:
+
+```python
+bob2 = await bob_hc2.attach(Agent("bob", ...), name="bob", since_envelope_id="")
+replayed = await bob2.resume_pending_turns()
+# replayed = number of pending turns re-fired
+```
+
+`resume_pending_turns` asks the hub for any `PendingTurn` entries, fetches each turn's triggering envelope from the WAL, and feeds it back through the notify handler. It is idempotent: if a prior reply already landed, the handler can short-circuit so the same logical turn is not posted twice.
+
+> **What the hub guarantees:** if an envelope was WAL-appended, it will be delivered to every addressed participant — eventually, exactly once in logical terms. The transport may deliver it more than once; the handler is responsible for idempotency.
+
+## HubBackedCheckpointStore: Durable Task State
+
+Agents that do long-running LLM tasks need to survive a process restart mid-task. `HubBackedCheckpointStore` delegates `checkpoint_task` / `read_task_checkpoint` to the hub's `KnowledgeStore`, so task state is durable wherever the hub persists its own data (`DiskKnowledgeStore`, `RedisKnowledgeStore`, …):
+
+```python linenums="1"
+from ag2.network import HubBackedCheckpointStore, HubClient, WsLink
+
+hc = HubClient(WsLink("ws://hub:8765"))
+checkpoint_store = HubBackedCheckpointStore(hc)
+
+alice = await hc.register(
+    Agent(
+        "alice",
+        prompt="You run long multi-step research tasks.",
+        config=AnthropicConfig(model="claude-sonnet-4-6"),
+        checkpoint_store=checkpoint_store,
+    ),
+    Passport(name="alice"),
+    Resume(claimed_capabilities=["research"]),
+)
+```
+
+The store accepts either a `Hub` (in-process) or a `HubClient` (cross-process) — the API is identical, and the durability tracks wherever the hub stores its data. Agents that don't need cross-process durability can use any other `CheckpointStore` implementation, or omit checkpointing entirely.
+
+## Dynamic Membership
+
+Agents can register and unregister at runtime. The hub handles this without restarting:
+
+```python
+# New agent joins the network
+carol = await hc.register(Agent("carol", ...), Passport(name="carol"), Resume())
+
+# Agent leaves cleanly
+await carol.unregister()
+```
+
+After `unregister`, `carol`'s identity records are removed from disk and the hub's registry caches are updated. Any open channels `carol` was participating in remain open; her `agent_id` is simply absent from future `peers` results.
+
+## The Federation Seam
+
+The `RemoteAgentProxy` Protocol is the hub's seam for cross-org federation. When a participant's passport carries `kind="remote_agent"`, the hub routes envelopes to it through a registered proxy rather than a local endpoint. No proxies ship in the framework — each tenant implements the wire protocol they need (A2A, gRPC, HTTP, message bus) and registers it:
+
+```python
+hub.register_remote_proxy(MyA2AProxy(scheme="a2a", target_url="https://partner.example.com/a2a"))
+```
+
+From the channel's perspective, a `remote_agent` participant is indistinguishable from a local one. It sends envelopes the same way and its messages appear in the same WAL.
+
+## Where to Next
+
+- **The Agent Harness: An Agent Is More Than a Loop** — what's inside each node in the network: Stream, middleware, tools, observers, HITL, memory.
+- Docs: [Hub & Identity](/docs/user-guide/network/hub_and_identity) · [Network Quick Start](/docs/user-guide/network/quick_start) · [Channel Adapters Overview](/docs/user-guide/network/adapters_overview)
+
+The three previous posts described the protocol. This one described the deployment. The two together are the full picture: a network that is durable by construction, authenticated from the handshake, and capable of surviving the failures that always eventually happen.

--- a/website/docs/_blogs/2026-06-17-AG2-Agent-Harness/img/banner.webp
+++ b/website/docs/_blogs/2026-06-17-AG2-Agent-Harness/img/banner.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:600819a13125a3f94d1df14c09635b11b7bfcc7bba63928870ffe84002cdc63d
+size 255124

--- a/website/docs/_blogs/2026-06-17-AG2-Agent-Harness/img/harness.webp
+++ b/website/docs/_blogs/2026-06-17-AG2-Agent-Harness/img/harness.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f271d6eca70adb8a6c611896ca2d0db3ddcb24bb46f95d32a37b2f4f67cba8a
+size 1133796

--- a/website/docs/_blogs/2026-06-17-AG2-Agent-Harness/index.mdx
+++ b/website/docs/_blogs/2026-06-17-AG2-Agent-Harness/index.mdx
@@ -1,0 +1,495 @@
+---
+title: "The Agent Harness: An Agent Is More Than a Loop"
+authors: [marklysze]
+tags: [AG2 Beta, Agent, Middleware, Memory, Observers, HITL, Tools]
+date: 2026-05-17
+slug: ag2-beta-agent-harness
+---
+
+![AG2 Beta — The Agent Harness](img/banner.webp)
+
+Today we're diving into the AG2 agent, it's harness, as this plays a crucial role in having a reliable long-term agent.
+
+An agent has moved on from a simple loop around LLM and tool calls. It has memory that spans thousands of turns. It can run tools in parallel, delegate subtasks, and call back to a human. It keeps producing under context pressure. It can be traced, metered, and gated. This post zooms in on that machinery — what the AG2 beta harness gives you, and how to reach for each part.
+
+<!-- more -->
+
+This is the companion post to the AG2 Network series:
+
+1. [**One Coherent Agent Isn't Enough**](/docs/blog/2026/05/14/AG2-Action-Driven-Network/) — the action-driven multi-agent network.
+2. [**Choreography You Can Dial In**](/docs/blog/2026/05/15/AG2-Network-Choreography-Dial/) — expectations, audience addressing, deeper choreography.
+3. [**What Survives, Survives Exactly**](/docs/blog/2026/05/16/AG2-Network-What-Survives/) — WAL, identity, audit.
+4. **Networks You Can Deploy** — federation, dynamic membership, production incident (coming soon).
+5. **The Agent Harness** *(this post)* — what lives inside each node: stream, assembly, middleware, tools, observers, HITL, and memory.
+
+## The Harness
+
+The `Agent` class in `ag2` is a thin coordinator. It stitches together six independently-pluggable layers:
+
+| Layer | Role |
+|---|---|
+| **MemoryStream** | The append-only backbone. Every event — user messages, model responses, tool calls, results — lands here first. |
+| **AssemblyPolicy** | Rebuilds the context window before each LLM call, applying compaction and aggregation so the agent stays useful under context pressure. |
+| **Middleware** | Four call sites: `on_turn`, `on_llm_call`, `on_tool_execution`, `on_human_input`. The stack wraps each operation — tracing, auth, rate limiting all live here. |
+| **Tools** | Callables decorated with `@tool` (or `Toolkit` instances). Provider-agnostic schema, parallel execution. |
+| **Observers** | Read-only window onto the event stream. `TokenMonitor` and `LoopDetector` ship out of the box; write your own in 10 lines. |
+| **Knowledge** | Persistent key-value storage that survives process restarts. `MemoryKnowledgeStore` for dev and tests, `SqliteKnowledgeStore` for prod. |
+
+Each layer is a Protocol with a sensible default. You only reach for a layer when you need to change its behavior.
+
+## MemoryStream — the event backbone
+
+Every turn starts here. The `MemoryStream` is a typed, append-only log of `BaseEvent` subclasses:
+
+```python
+from ag2 import Agent
+from ag2.config import OpenAIConfig
+
+agent = Agent(
+    "assistant",
+    prompt="You are a helpful assistant.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+)
+
+reply = await agent.ask("What is 2 + 2?")
+print(await reply.content())
+
+# Read the full event history from the reply
+for event in await reply.history.get_events():
+    print(type(event).__name__, getattr(event, "content", "")[:60])
+```
+
+The stream emits events in the order they occurred: `ModelRequest`, `ModelResponse`, `ToolCallEvent`, `ToolResultEvent`, `HumanInputRequest`, `HumanMessage`. **Observers** (covered below) and **assembly** both read from the same stream.
+
+> **Try it live:** open the **Agent Ask** demo in the [AG2 Playground](https://playground.ag2.ai/) — start a turn with `Agent.ask()`, continue it with `AgentReply.ask()`, and watch each event stream in token by token.
+
+## AssemblyPolicy — surviving context pressure
+
+Assembly is what happens before the LLM call. An `AssemblyPolicy` reads the event stream and produces the list of messages the LLM actually sees. The default policy replays every message from the stream. You override it — and add `Compact` and `Aggregate` strategies — when the conversation grows longer than the model's context window.
+
+> **Try it live:** open the **Context Lens** demo in the [AG2 Playground](https://playground.ag2.ai/) — toggle `ConversationPolicy` / `SlidingWindowPolicy` / `TokenBudgetPolicy` and watch the LLM's view diverge from the raw stream in real time.
+
+### Compaction: drop history, keep the gist
+
+Compaction strategies live on the `KnowledgeConfig` and fire when a `CompactTrigger` threshold is crossed. The cheapest strategy, `TailWindowCompact(target=N)`, keeps the last *N* events and drops the rest — zero LLM cost:
+
+```python
+from ag2 import Agent, KnowledgeConfig
+from ag2.compact import CompactTrigger, TailWindowCompact
+from ag2.config import OpenAIConfig
+from ag2.knowledge import MemoryKnowledgeStore
+
+agent = Agent(
+    "assistant",
+    prompt="You are a helpful assistant.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    knowledge=KnowledgeConfig(
+        store=MemoryKnowledgeStore(),
+        compact=TailWindowCompact(target=10),           # keep the last 10 events
+        compact_trigger=CompactTrigger(max_events=40),  # fire once history passes 40 events
+    ),
+)
+```
+
+Once the stream passes 40 events, compaction fires: the history is trimmed to the last 10 events and the dropped span is written to the store's log, so nothing is lost. When you want the gist *kept in context* rather than just archived, swap in `SummarizeCompact(target=10, config=...)` — it spends one LLM call to replace the dropped span with a single `CompactionSummary` event at the head of the history, so the summary is part of the durable record.
+
+> **Try it live:** open the **Compaction Cycle** demo in the [AG2 Playground](https://playground.ag2.ai/) — run `TailWindowCompact` and `SummarizeCompact` over the same conversation side by side; watch the trigger fire, events drop, and the synthesised summary appear.
+
+### Aggregation: accumulate knowledge across turns
+
+Where compaction *discards* history in favour of a gist, aggregation *accumulates* structured knowledge to a persistent store. `ConversationSummaryAggregate` extracts a running summary; `WorkingMemoryAggregate` maintains a key/value memory the agent consults on every turn:
+
+```python
+from ag2 import Agent, KnowledgeConfig
+from ag2.aggregate import AggregateTrigger, WorkingMemoryAggregate
+from ag2.config import OpenAIConfig
+from ag2.knowledge import MemoryKnowledgeStore
+from ag2.policies import WorkingMemoryPolicy
+
+agent = Agent(
+    "assistant",
+    prompt="You are a helpful research assistant. Consult your working memory before answering.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    knowledge=KnowledgeConfig(
+        store=MemoryKnowledgeStore(),
+        aggregate=WorkingMemoryAggregate(config=OpenAIConfig(model="gpt-4o-mini")),
+        aggregate_trigger=AggregateTrigger(every_n_turns=5),
+    ),
+    assembly=[WorkingMemoryPolicy()],
+)
+```
+
+Every 5 turns the aggregator runs, extracts key facts from the conversation, and writes them to `/memory/working.md` in the `KnowledgeStore`. On the next turn the `WorkingMemoryPolicy` in the `assembly=[...]` chain reads that file and prepends the working memory to the context window — so the agent "remembers" facts across compaction boundaries, and across process restarts when the store is persistent.
+
+> **Try it live:** open the **Working Memory** demo in the [AG2 Playground](https://playground.ag2.ai/) — `WorkingMemoryAggregate` writes `/memory/working.md` after every turn; a brand-new Agent in session 2 gets it injected by `WorkingMemoryPolicy` and remembers.
+
+## Middleware — four call sites
+
+The middleware stack wraps every operation with `call_next` semantics, familiar from HTTP middleware (FastAPI, Django, etc.). Override only the hooks you need:
+
+```python
+from collections.abc import Awaitable, Callable, Sequence
+
+from ag2.annotations import Context
+from ag2.events import BaseEvent, ModelResponse, ToolCallEvent, ToolResultEvent, ToolErrorEvent, ClientToolCallEvent
+from ag2.middleware.base import BaseMiddleware, AgentTurn, LLMCall, ToolExecution
+
+ToolResultType = ToolResultEvent | ToolErrorEvent | ClientToolCallEvent
+
+
+class TracingMiddleware(BaseMiddleware):
+    async def on_turn(
+        self,
+        call_next: AgentTurn,
+        event: BaseEvent,
+        context: Context,
+    ) -> ModelResponse:
+        print(f"→ turn start")
+        response = await call_next(event, context)
+        print(f"← turn end ({response.content[:40]}…)")
+        return response
+
+    async def on_llm_call(
+        self,
+        call_next: LLMCall,
+        events: Sequence[BaseEvent],
+        context: Context,
+    ) -> ModelResponse:
+        print(f"  LLM called with {len(events)} events in context")
+        return await call_next(events, context)
+
+    async def on_tool_execution(
+        self,
+        call_next: ToolExecution,
+        event: ToolCallEvent,
+        context: Context,
+    ) -> ToolResultType:
+        print(f"  tool: {event.name}({event.arguments})")
+        result = await call_next(event, context)
+        print(f"  result: {str(result)[:40]}…")
+        return result
+```
+
+Register middleware at construction time:
+
+```python
+from ag2 import Agent, Middleware
+from ag2.config import OpenAIConfig
+
+agent = Agent(
+    "assistant",
+    prompt="You are a helpful assistant.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    middleware=[Middleware(TracingMiddleware)],
+)
+```
+
+The `Middleware(cls, **kwargs)` wrapper is a factory: a new `BaseMiddleware` instance is created per turn so state is naturally turn-scoped. The four hooks are independent — `on_turn` wraps the whole turn, `on_llm_call` wraps only the model call, `on_tool_execution` wraps each tool in isolation, and `on_human_input` wraps the human-input checkpoint.
+
+### Built-in middleware
+
+AG2 ships `TelemetryMiddleware` (OpenTelemetry traces, spans, LLM semantic attributes) and `LoggingMiddleware` out of the box, plus history limiters — `HistoryLimiter` caps the history by event count, and `TokenLimiter` caps it by a token budget, trimming the conversation to fit before each call:
+
+![TokenLimiter middleware keeping the context window within a token budget: the MemoryStream conversation history measured against an 8,192-token budget limit; a TokenLimiter panel (max_tokens 8,192, chars_per_token 4, status nominal); and Assembly reading turns 5–12 into a 6,827-token context window for the LLM call.](img/harness.webp)
+
+See the [middleware docs](/docs/user-guide/middleware) for the full reference.
+
+> **Try it live:** open the **Middleware Stack** demo in the [AG2 Playground](https://playground.ag2.ai/) — watch `LoggingMiddleware`, `RetryMiddleware`, and `HistoryLimiter` wrap a Beta Agent as a retry recovers from a fault and history is trimmed before the model call.
+
+## Tools — @tool, Toolkit, subagent delegation
+
+Tools are the primary way agents extend their capabilities. The `@tool` decorator converts a plain function into a provider-neutral schema that works across LLM provider:
+
+```python
+from ag2 import Agent, tool
+from ag2.config import OpenAIConfig
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Return the current weather for a city (demo: always sunny)."""
+    return f"It is sunny in {city} today."
+
+
+agent = Agent(
+    "weather_bot",
+    prompt="Answer weather questions. Use the provided tool.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    tools=[get_weather],
+)
+
+reply = await agent.ask("What's the weather in Tokyo?")
+```
+
+> **Try it live:** open the **Ask the Web** demo in the [AG2 Playground](https://playground.ag2.ai/) — a single Beta Agent uses Tavily search and fetch to answer with inline citations and live source cards, streamed over the AG-UI protocol.
+
+### Toolkit — group related tools
+
+`Toolkit` bundles related tools into one object. A factory function is the simplest way to build one — the tools share construction-time state (here `user_id`) through a closure, keeping their signatures clean:
+
+```python
+from ag2 import Agent, Toolkit, tool
+from ag2.config import OpenAIConfig
+
+
+def calendar_toolkit(user_id: str) -> Toolkit:
+    @tool
+    def list_events(date: str) -> list[str]:
+        """List calendar events for a date (YYYY-MM-DD)."""
+        return [f"Meeting at 10am on {date}"]
+
+    @tool
+    def add_event(date: str, title: str) -> str:
+        """Add a calendar event."""
+        return f"Added '{title}' on {date} for user {user_id}"
+
+    return Toolkit(list_events, add_event, name="calendar")
+
+
+agent = Agent(
+    "calendar_bot",
+    prompt="Help the user manage their calendar.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    tools=[calendar_toolkit(user_id="u123")],
+)
+```
+
+For richer toolkits you can subclass `Toolkit` and pass the tools to `super().__init__(*tools)` — that's how the built-in `FilesystemToolkit` exposes `read_file`, `write_file`, and friends.
+
+### Subagent delegation
+
+For tasks that need a separate conversation thread — a research pass, a code review, a long-running subtask — wrap a dedicated agent as a tool with `Agent.as_tool()`. The wrapped agent runs on its own stream and returns its result as the tool's output:
+
+```python
+from ag2 import Agent
+from ag2.config import OpenAIConfig
+
+researcher = Agent(
+    "researcher",
+    prompt="You are a thorough research assistant. Synthesise in 3 bullet points.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+)
+
+orchestrator = Agent(
+    "orchestrator",
+    prompt="Answer questions by delegating research to the researcher tool.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    tools=[
+        researcher.as_tool(description="Research a topic and synthesise the findings"),
+    ],
+)
+```
+
+`as_tool` exposes the researcher as a callable named `task_researcher`; when the orchestrator invokes it, the subagent runs in isolation and its reply is injected back as the tool result — no manual `asyncio.gather` or result wiring needed. When you'd rather the framework inject the delegation tools for you, construct the agent with `tasks=TaskConfig(...)` to gain `run_subtask` / `run_subtasks(parallel=True)` automatically.
+
+> **Try it live:** open the **Parallel Research** demo in the [AG2 Playground](https://playground.ag2.ai/) — a lead Beta agent fans out to three specialist subagents running in parallel, with live per-researcher progress lanes and a synthesised cited report.
+
+## Observers — read-only window onto events
+
+Observers see every event on the stream *after* it's committed. They're the right place for monitoring, alerting, and auditing — anything that reads but doesn't change the agent's control flow.
+
+### TokenMonitor
+
+Emit a warning at 50k tokens and a critical alert at 100k:
+
+```python
+from ag2 import Agent
+from ag2.config import OpenAIConfig
+from ag2.observers import TokenMonitor
+
+agent = Agent(
+    "assistant",
+    prompt="You are a helpful assistant.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    observers=[TokenMonitor(warn_threshold=50_000, alert_threshold=100_000)],
+)
+```
+
+When a threshold is crossed the monitor emits an `ObserverAlert` onto the stream. React to it with a tiny `@observer(ObserverAlert)` that runs on each one:
+
+```python
+from ag2 import observer
+from ag2.events import ObserverAlert
+
+
+@observer(ObserverAlert)
+async def report_alerts(event: ObserverAlert) -> None:
+    print(f"[{event.severity}] {event.message}")
+```
+
+### LoopDetector
+
+Fire an alert when the same tool is called with the same arguments three times in a row:
+
+```python
+from ag2 import Agent, tool
+from ag2.config import OpenAIConfig
+from ag2.observers import LoopDetector
+
+
+@tool
+def search(query: str) -> str:
+    """Search the web (demo)."""
+    return "no results"
+
+
+agent = Agent(
+    "tool_agent",
+    prompt="Complete the task using the provided tools.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    tools=[search],
+    observers=[LoopDetector(window_size=10, repeat_threshold=3)],
+)
+```
+
+### Writing your own
+
+The `@observer(EventType)` decorator pairs an event condition with a callback — the function runs once per matching event:
+
+```python
+from ag2 import observer
+from ag2.events import ToolCallEvent
+
+
+@observer(ToolCallEvent)
+async def audit_tools(event: ToolCallEvent) -> None:
+    print(f"audit: tool={event.name} args={event.arguments}")
+```
+
+## Human-in-the-loop (HITL)
+
+Human approval checkpoints interrupt the turn at a predictable point — after the LLM decides to call a tool, before the call executes. The simplest route is the built-in `approval_required()` tool middleware: it pauses the tool and calls `context.input()`, which the agent's `hitl_hook` answers. Approve by returning the human's reply; deny by raising `HumanInputNotProvidedError`:
+
+```python
+from ag2 import Agent, tool
+from ag2.config import OpenAIConfig
+from ag2.middleware import approval_required
+
+
+@tool(middleware=[approval_required()])
+def delete_record(record_id: str) -> str:
+    """Delete a record (requires human approval)."""
+    return f"Record {record_id} deleted."
+
+
+def approve(request) -> str:
+    # `request.content` holds the approval prompt; return the human's answer.
+    return input(f"{request.content} ")
+
+
+agent = Agent(
+    "admin_bot",
+    prompt="You are an admin assistant. Confirm destructive operations.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    tools=[delete_record],
+    hitl_hook=approve,
+)
+```
+
+The `HumanInputRequest` event lands in the stream before the human answer, so the approval decision is part of the durable record — whether the agent runs locally or inside a network node. For full control over routing (a web UI, Slack, a queue), implement the `on_human_input` middleware hook instead and answer the `HumanInputRequest` there.
+
+## KnowledgeStore — persistence across restarts
+
+Agents write to a `KnowledgeStore` for anything that should outlive a process restart: aggregated memory, downloaded files, cached tool results. Four stores ship today:
+
+| Store | When to use |
+|---|---|
+| `MemoryKnowledgeStore` | Tests, single-process demos. Wiped on exit. |
+| `SqliteKnowledgeStore` | Single-host production. Zero dependencies. |
+| `DiskKnowledgeStore` | When you want file-system transparency (and watchdog installed). |
+| `RedisKnowledgeStore` | Multi-process deployments or when you need TTL. |
+
+Swap the store without touching the agent:
+
+```python
+from ag2 import Agent, KnowledgeConfig
+from ag2.aggregate import AggregateTrigger, WorkingMemoryAggregate
+from ag2.config import OpenAIConfig
+from ag2.knowledge import SqliteKnowledgeStore
+
+agent = Agent(
+    "assistant",
+    prompt="You are a helpful assistant with persistent memory.",
+    config=OpenAIConfig(model="gpt-4o-mini"),
+    knowledge=KnowledgeConfig(
+        store=SqliteKnowledgeStore("./agent_memory.db"),
+        aggregate=WorkingMemoryAggregate(config=OpenAIConfig(model="gpt-4o-mini")),
+        aggregate_trigger=AggregateTrigger(every_n_turns=5),
+    ),
+)
+```
+
+Files saved to knowledge via `FilesAPI` (photos, docs, audio) are addressed by path and survive the same store swap — a file uploaded via `MemoryKnowledgeStore` in tests and `SqliteKnowledgeStore` in production is the same API call.
+
+> **Try it live:** the **Working Memory** demo in the [AG2 Playground](https://playground.ag2.ai/) shows the persistence payoff end to end — what one session writes to the store, a brand-new Agent in the next session reads back.
+
+## Putting it together
+
+A minimal production-ready agent with token monitoring, loop detection, compaction, and persistent memory:
+
+```python
+import asyncio
+from ag2 import Agent, KnowledgeConfig, observer, tool
+from ag2.aggregate import AggregateTrigger, WorkingMemoryAggregate
+from ag2.compact import CompactTrigger, TailWindowCompact
+from ag2.config import OpenAIConfig
+from ag2.events import ToolCallEvent
+from ag2.knowledge import SqliteKnowledgeStore
+from ag2.observers import LoopDetector, TokenMonitor
+
+
+@observer(ToolCallEvent)
+async def audit(event: ToolCallEvent) -> None:
+    print(f"AUDIT tool={event.name}")
+
+
+@tool
+def search_docs(query: str) -> str:
+    """Search the documentation."""
+    return f"Results for '{query}': (demo)"
+
+
+async def main():
+    agent = Agent(
+        "prod_assistant",
+        prompt="You are a helpful assistant with long-term memory.",
+        config=OpenAIConfig(model="gpt-4o-mini"),
+        tools=[search_docs],
+        knowledge=KnowledgeConfig(
+            # Persistent store — survives process restarts
+            store=SqliteKnowledgeStore("./memory.db"),
+            # Compaction strategy: keep the last 10 events verbatim
+            compact=TailWindowCompact(target=10),
+            # Run compaction once history passes 40 events
+            compact_trigger=CompactTrigger(max_events=40),
+            # Aggregation strategy: distil the session into working memory
+            aggregate=WorkingMemoryAggregate(config=OpenAIConfig(model="gpt-4o-mini")),
+            # Run aggregation every 5 turns
+            aggregate_trigger=AggregateTrigger(every_n_turns=5),
+        ),
+        observers=[
+            # Warn at 30k tokens in context, alert at 80k
+            TokenMonitor(warn_threshold=30_000, alert_threshold=80_000),
+            # Alert when the same tool call repeats 3 times in a row
+            LoopDetector(repeat_threshold=3),
+            # Custom observer (defined above) — logs every tool call
+            audit,
+        ],
+    )
+
+    while True:
+        user_input = input("You: ")
+        if not user_input:
+            break
+        reply = await agent.ask(user_input)
+        print(f"Agent: {await reply.content()}")
+
+
+asyncio.run(main())
+```
+
+Each component is pluggable and independently testable — the observers don't affect compaction, compaction doesn't affect aggregation, and replacing `SqliteKnowledgeStore` with `MemoryKnowledgeStore` makes any test hermetic.
+
+## What's next?
+
+Start building your own agent - AG2's Agent harness provides the components for you to build robust and long-running agents. Reach out to the friendly community and maintainers on [Discord](https://discord.gg/pAbnFJrkgZ) if you need help.

--- a/website/mkdocs/_website/generate_mkdocs.py
+++ b/website/mkdocs/_website/generate_mkdocs.py
@@ -579,7 +579,9 @@ def generate_mkdocs_navigation(website_dir: Path, mkdocs_root_dir: Path, nav_exc
     mkdocs_docs_dir = mkdocs_root_dir / "docs"
     mkdocs_nav = format_navigation(filtered_nav, mkdocs_docs_dir)
 
-    mkdocs_nav_content = "---\nsearch:\n  exclude: true\n---\n" + mkdocs_nav + "\n"
+    blog_nav = "- Blog\n    - [Blog](docs/blog/index.md)"
+
+    mkdocs_nav_content = "---\nsearch:\n  exclude: true\n---\n" + mkdocs_nav + "\n" + blog_nav + "\n"
     mkdocs_nav_path.write_text(mkdocs_nav_content)
     summary_md_path.write_text(mkdocs_nav_content)
 
@@ -1246,6 +1248,9 @@ def main(force: bool) -> None:
 
     copy_assets(website_dir)
     process_and_copy_files(mint_docs_dir, mkdocs_output_dir, filtered_files)
+
+    authors_yml_path = website_dir / "blogs_and_user_stories_authors.yml"
+    process_blog_files(mkdocs_output_dir, authors_yml_path, website_dir / "snippets")
 
     generate_mkdocs_navigation(website_dir, mkdocs_root_dir, nav_exclusions)
 

--- a/website/mkdocs/mkdocs.yml
+++ b/website/mkdocs/mkdocs.yml
@@ -97,6 +97,9 @@ plugins:
       cache_safe: true
       css_files:
         - stylesheets/extra.css
+  - blog:
+      blog_dir: docs/blog
+      blog_toc: true
 
 markdown_extensions:
   - toc:


### PR DESCRIPTION
## Why are these changes needed?

The classic-framework removal (#3023) deleted the entire `website/docs/_blogs/` tree and stripped the blog wiring out of the mkdocs pipeline, which silently dropped the **Blog** tab from the docs appbar. This PR brings the blog back with the seven posts about the current (former Beta) framework — every post carrying the `AG2 Beta` tag:

- AG2 Beta: Stronger Foundation for Real-World Agents
- Building low-latency voice agents in 3 lines of code with GPT Realtime 2 (LiveAgent)
- One Coherent Agent Isn't Enough — Action-Driven Networking with AG2
- Choreography You Can Dial In
- What Survives, Survives Exactly
- Networks You Can Deploy
- The Agent Harness: An Agent Is More Than a Loop

**Pipeline wiring** (reverts exactly what #3023 removed):
- `website/mkdocs/mkdocs.yml` — re-add the material `blog` plugin (`blog_dir: docs/blog`, `blog_toc: true`)
- `website/mkdocs/_website/generate_mkdocs.py` — re-add the Blog entry in the generated navigation and the `process_blog_files()` call in `main()`

**Content updates** so the restored posts work on today's site:
- Internal links retargeted from the old `/docs/beta/*` paths to `/docs/user-guide/*` (each target page verified to exist). The single reference to the deleted AG2 Compatibility page (the `as_conversable()` adapter was removed in #3023) is unlinked rather than pointed at a 404.
- Code imports actualized from `autogen.beta.*` to `ag2.*` (e.g. `from autogen.beta import Agent` → `from ag2 import Agent`). Import lines map 1:1, so `hl_lines` highlights in code blocks remain accurate.

Classic-era posts (2023–2026, pre-Beta) are intentionally **not** restored — they document the removed framework. The eighth Beta post ("Spending the Context Budget") lives only on the unmerged `docs/agent-harness-steward` branch and stays out of scope here.

**Validation**
- `python docs.py build --force` completes with no errors or new warnings
- The Blog tab renders in the navbar; the blog index and all seven post pages are generated under `/docs/blog/2026/...`
- All 49 unique `from ag2... import ...` statements extracted from the posts were executed against the installed package — all resolve

## Related issue number

Regression introduced by #3023 (no separate issue filed).

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

Prepared with Claude Code (restoration from git history, link/import actualization, and build verification as described above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)