### PR TITLE
fix(docs): repair broken links and migrate to 1.0.0 URL scheme

### DIFF
--- a/ag2/extensions/__init__.py
+++ b/ag2/extensions/__init__.py
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""AG2 Beta Extensions.
+"""AG2 Extensions.
 
 Extensions are first-class components maintained separately to
 the AG2 core classes. See
-https://docs.ag2.ai/docs/beta/contribution_policy for details.
+https://docs.ag2.ai/docs/contributor-guide/contribution_policy/ for details.
 
 During Phase 1 (until v1.0) extensions live here and ship as part of
 ``pip install ag2``. At v1.0 they will move to a dedicated repository.

--- a/ag2/extensions/tools/search/tinyfish.py
+++ b/ag2/extensions/tools/search/tinyfish.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""TinyFish search and fetch extension for AG2 Beta.
+"""TinyFish search and fetch extension for AG2.
 
 Provides a toolkit that lets agents query TinyFish Search for ranked web
 results and use TinyFish Fetch to extract browser-rendered page content.
 
 Maintainer: pranavjana
-Docs: https://docs.ag2.ai/docs/beta/extensions/tools/search/tinyfish
+Docs: https://docs.ag2.ai/docs/user-guide/extensions/tools/search/tinyfish/
 """
 
 import os

--- a/ag2/tools/builtin/google_maps.py
+++ b/ag2/tools/builtin/google_maps.py
@@ -40,7 +40,7 @@ class GoogleMapsTool(Tool):
       :class:`~ag2.exceptions.UnsupportedToolError`.
 
     See:
-    - https://ai.google.dev/gemini-api/docs/google-maps
+    - https://ai.google.dev/gemini-api/docs/maps-grounding
     """
 
     __slots__ = (

--- a/website/docs/contributor-guide/documentation.mdx
+++ b/website/docs/contributor-guide/documentation.mdx
@@ -104,12 +104,6 @@ When switching branches or making major changes to the documentation structure, 
 
 </Note>
 
-## Adding Notebooks to the Website
-
-When you want to add a new Jupyter notebook and have it rendered in the documentation, you need to follow specific guidelines to ensure proper integration with the website.
-
-Please refer to <a href="https://github.com/ag2ai/ag2/blob/main/notebook/contributing.md#how-to-get-a-notebook-displayed-on-the-website" target="_blank">this</a> guideline for more details.
-
 ## Before Making a Pull Request
 
 To maintain code quality and consistency, we use [prek](https://github.com/j178/prek) hooks that automatically run checks like linting, formatting, and other validations before each commit. It’s important to have these properly set up in your development environment before you start committing changes.

--- a/website/docs/contributor-guide/tests.mdx
+++ b/website/docs/contributor-guide/tests.mdx
@@ -4,12 +4,12 @@ title: Tests
 
 Tests are automatically run via GitHub actions. There are two workflows:
 
-1. [core-test.yml](https://github.com/ag2ai/ag2/blob/main/.github/workflows/core-test.yml)
-1. [core-llm-test.yml](https://github.com/ag2ai/ag2/blob/main/.github/workflows/core-llm-test.yml)
+1. [test.yml](https://github.com/ag2ai/ag2/blob/main/.github/workflows/test.yml)
+1. [llm-test.yml](https://github.com/ag2ai/ag2/blob/main/.github/workflows/llm-test.yml)
 
-The first workflow is required to pass for all PRs (and it doesn't do any OpenAI calls). The second workflow is required for changes that affect the OpenAI tests (and does actually call LLM). The second workflow requires approval to run. When writing tests that require OpenAI calls, please use [`pytest.mark.skipif`](https://github.com/ag2ai/ag2/blob/b1adac515931bf236ac59224269eeec683a162ba/test/oai/test_client.py#L19) to make them run in only when `openai` package is installed. If additional dependency for this test is required, install the dependency in the corresponding python version in [core-llm-test.yml](https://github.com/ag2ai/ag2/blob/main/.github/workflows/core-llm-test.yml).
+The first workflow is required to pass for all PRs (and it doesn't do any OpenAI calls). The second workflow is required for changes that affect the OpenAI tests (and does actually call LLM). The second workflow requires approval to run. When writing tests that require OpenAI calls, please use [`pytest.mark.skipif`](https://github.com/ag2ai/ag2/blob/b1adac515931bf236ac59224269eeec683a162ba/test/oai/test_client.py#L19) to make them run in only when `openai` package is installed. If additional dependency for this test is required, install the dependency in the corresponding python version in [llm-test.yml](https://github.com/ag2ai/ag2/blob/main/.github/workflows/llm-test.yml).
 
-Make sure all tests pass, this is required for [core-test.yml](https://github.com/ag2ai/ag2/blob/main/.github/workflows/core-test.yml) checks to pass
+Make sure all tests pass, this is required for [test.yml](https://github.com/ag2ai/ag2/blob/main/.github/workflows/test.yml) checks to pass
 
 ## Running tests locally
 
@@ -28,8 +28,6 @@ bash scripts/test.sh test
 Tests for the `ag2.agentchat.contrib` module may be skipped automatically if the
 required dependencies are not installed. Please consult the documentation for
 each contrib module to see what dependencies are required.
-
-See [here](https://github.com/ag2ai/ag2/blob/main/notebook/contributing.md#testing) for how to run notebook tests.
 
 ## Skip flags for tests
 

--- a/website/docs/user-guide/coding_with_ai.mdx
+++ b/website/docs/user-guide/coding_with_ai.mdx
@@ -55,9 +55,9 @@ cp -r ag2-skills/skills/ag2-quickstart ~/.claude/skills/
 
 Skills teach patterns; the docs keep your assistant honest about the *exact* current signatures. The biggest risk is your assistant falling back on the **classic** `autogen` API it was trained on (`ConversableAgent`, `initiate_chat`, `GroupChat`) — now removed from the package. Give it current ground truth:
 
-- **Live AG2 docs:** [`https://docs.ag2.ai/latest/docs/user-guide/agents/`](https://docs.ag2.ai/latest/docs/user-guide/agents/){.external-link target="_blank"} — point your agent at this section (most assistants can fetch a URL).
+- **Live AG2 docs:** [`https://docs.ag2.ai/docs/user-guide/agents/`](https://docs.ag2.ai/docs/user-guide/agents/){.external-link target="_blank"} — point your agent at this section (most assistants can fetch a URL).
 - **AG2 docs source (Markdown):** [`ag2ai/ag2/website/docs/user-guide`](https://github.com/ag2ai/ag2/tree/main/website/docs/user-guide){.external-link target="_blank"} — the raw `.mdx` your agent can read directly from GitHub.
-- **AG2 `llms.txt`:** [`https://docs.ag2.ai/latest/llms.txt`](https://docs.ag2.ai/latest/llms.txt){.external-link target="_blank"} — a machine-readable index of the AG2 docs following the [llms.txt standard](https://llmstxt.org/){.external-link target="_blank"}, plus [`llms-full.txt`](https://docs.ag2.ai/latest/llms-full.txt){.external-link target="_blank"} for the entire AG2 docs in one file. Both are AG2-scoped, so they never point your agent at the classic API.
+- **AG2 `llms.txt`:** [`https://docs.ag2.ai/llms.txt`](https://docs.ag2.ai/llms.txt){.external-link target="_blank"} — a machine-readable index of the AG2 docs following the [llms.txt standard](https://llmstxt.org/){.external-link target="_blank"}, plus [`llms-full.txt`](https://docs.ag2.ai/llms-full.txt){.external-link target="_blank"} for the entire AG2 docs in one file. Both are AG2-scoped, so they never point your agent at the classic API.
 
 Then anchor your prompt: *"Build with `ag2` only. If a signature is unfamiliar, check the AG2 docs before writing code — do not use the classic `autogen` API."*
 
@@ -86,7 +86,7 @@ This project is built on **AG2** (`ag2`). Follow these rules.
 
 ## Docs & skills
 - Install and use the AG2 skills: `npx skills add ag2ai/ag2-skills`.
-- AG2 docs: https://docs.ag2.ai/latest/docs/user-guide/agents/ (machine-readable index at /latest/llms.txt).
+- AG2 docs: https://docs.ag2.ai/docs/user-guide/agents/ (machine-readable index at /llms.txt).
 - When unsure of a signature, check the AG2 docs before writing code.
 - Do NOT trust generic docs indexers — they surface the retired classic API.
 ```

--- a/website/mkdocs/README.md
+++ b/website/mkdocs/README.md
@@ -1,3 +1,3 @@
 # :warning: DOCUMENTATION CODE SOURCES :warning:
 
-To find a real docs, just visit our website: [http://docs.ag2.ai/latest/](http://docs.ag2.ai/latest/)
+To find a real docs, just visit our website: [https://docs.ag2.ai/](https://docs.ag2.ai/)

--- a/website/mkdocs/_website/llms_txt.py
+++ b/website/mkdocs/_website/llms_txt.py
@@ -28,7 +28,7 @@ with optional_import_block():
     import yaml
     from jinja2 import Template
 
-BASE_URL = "https://docs.ag2.ai/latest"
+BASE_URL = "https://docs.ag2.ai"
 
 PROJECT_TITLE = "AG2"
 
@@ -265,7 +265,7 @@ def generate_llms_txt(website_dir: Path, site_root: Path) -> None:
     Args:
         website_dir: The ``website/`` directory (holds ``mint-json-template.json.jinja``).
         site_root: The MkDocs ``docs_dir`` (``website/mkdocs/docs``); files written here
-            are served at the site root, e.g. ``https://docs.ag2.ai/latest/llms.txt``.
+            are served at the site root, e.g. ``https://docs.ag2.ai/llms.txt``.
     """
     template_path = website_dir / "mint-json-template.json.jinja"
     navigation = json.loads(Template(template_path.read_text(encoding="utf-8")).render())["navigation"]

--- a/website/mkdocs/robots.txt
+++ b/website/mkdocs/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Disallow: /0.
 
-Sitemap: https://docs.ag2.ai/latest/sitemap.xml
+Sitemap: https://docs.ag2.ai/sitemap.xml


### PR DESCRIPTION
## Why are these changes needed?

Documentation had broken and outdated links. Docs versioning was removed
(see `.github/workflows/build-mkdocs.yml`) — the site now publishes at the
gh-pages **root** (`docs.ag2.ai/docs/…`), and the old `/latest/docs/beta/…`
tree is a frozen beta archive. This PR points every reference at the
canonical 1.0.0 URLs and fixes links that were already dead:

- Dead CI-workflow links in `contributor-guide/tests.mdx`:
  `core-test.yml` → `test.yml`, `core-llm-test.yml` → `llm-test.yml` (renamed).
- Removed obsolete `notebook/contributing.md` references (notebooks no longer
  authored; directory gone on main) in `tests.mdx` and `documentation.mdx`.
- Migrated all `docs.ag2.ai` links off `/latest/docs/beta/…` to the root
  1.0.0 scheme (in `ag2/extensions/__init__.py`, `tinyfish.py`,
  `coding_with_ai.mdx`).
- Fixed `BASE_URL` in `llms_txt.py`: page paths already include `docs/…`, so
  the `/latest` prefix generated 404 links in `llms.txt`/`llms-full.txt`.
- Updated `robots.txt` sitemap and mkdocs `README.md` to the root scheme.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
