### PR TITLE
Add cost accounting extension for Usage events

### DIFF
--- a/ag2/extensions/cost_accounting/README.md
+++ b/ag2/extensions/cost_accounting/README.md
@@ -1,0 +1,47 @@
+# Cost Accounting Extension
+
+Estimate model usage cost from AG2 `Usage` data and a maintained pricing catalog.
+
+AG2 core usage accounting remains factual: providers report token usage, AG2
+normalizes it into `Usage`, and this extension derives estimated cost from a
+catalog. The estimate is not an invoice and does not replace provider billing
+systems.
+
+## LiteLLM-style catalog
+
+The catalog loader accepts the model entries used by LiteLLM's
+`model_prices_and_context_window.json`:
+
+```python
+from ag2.extensions.cost_accounting import CostCatalog, UsageCostEstimator
+
+catalog = CostCatalog.from_litellm_mapping({
+    "openai/gpt-4.1-nano": {
+        "litellm_provider": "openai",
+        "input_cost_per_token": 0.0000001,
+        "cache_read_input_token_cost": 0.000000025,
+        "cache_creation_input_token_cost": 0.000000125,
+        "output_cost_per_token": 0.0000004,
+    }
+})
+
+estimator = UsageCostEstimator(catalog)
+estimate = estimator.estimate_usage(usage, model="gpt-4.1-nano", provider="openai")
+```
+
+## Observer
+
+Use `CostAccountingObserver` to emit `ObserverAlert` events when estimated cost
+crosses a threshold. The observer watches `UsageEvent`, AG2's source of truth
+for token accounting, so sub-agent rollups are not double counted.
+
+```python
+from ag2.extensions.cost_accounting import CostAccountingObserver
+
+observer = CostAccountingObserver(
+    estimator,
+    warn_threshold_usd="1.00",
+    alert_threshold_usd="5.00",
+)
+```
+

--- a/ag2/extensions/cost_accounting/__init__.py
+++ b/ag2/extensions/cost_accounting/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Estimated cost accounting for AG2 usage events.
+
+This extension keeps AG2's core ``Usage`` model factual while allowing
+applications to derive estimated USD costs from token usage and a maintained
+pricing catalog.
+"""
+
+from .catalog import CostCatalog, ModelPricing
+from .estimator import CostEstimate, UsageCostEstimator
+from .observer import CostAccountingObserver
+
+__all__ = (
+    "CostAccountingObserver",
+    "CostCatalog",
+    "CostEstimate",
+    "ModelPricing",
+    "UsageCostEstimator",
+)

--- a/ag2/extensions/cost_accounting/catalog.py
+++ b/ag2/extensions/cost_accounting/catalog.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+"""Pricing catalog primitives for estimated usage cost accounting."""
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _field_decimal(raw: Mapping[str, Any], *names: str) -> Decimal | None:
+    for name in names:
+        value = _decimal(raw.get(name))
+        if value is not None:
+            return value
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class ModelPricing:
+    """Per-token model pricing in USD.
+
+    Field names mirror the token classes exposed by ``ag2.events.Usage`` and
+    the most common LiteLLM catalog keys.
+    """
+
+    input_cost_per_token: Decimal | None = None
+    output_cost_per_token: Decimal | None = None
+    cache_read_input_token_cost: Decimal | None = None
+    cache_creation_input_token_cost: Decimal | None = None
+    output_cost_per_reasoning_token: Decimal | None = None
+    provider: str | None = None
+
+    @classmethod
+    def from_litellm_entry(cls, raw: Mapping[str, Any]) -> "ModelPricing | None":
+        """Create pricing from a LiteLLM ``model_prices...`` entry."""
+
+        pricing = cls(
+            input_cost_per_token=_field_decimal(raw, "input_cost_per_token"),
+            output_cost_per_token=_field_decimal(raw, "output_cost_per_token"),
+            cache_read_input_token_cost=_field_decimal(raw, "cache_read_input_token_cost"),
+            cache_creation_input_token_cost=_field_decimal(raw, "cache_creation_input_token_cost"),
+            output_cost_per_reasoning_token=_field_decimal(raw, "output_cost_per_reasoning_token"),
+            provider=str(raw.get("litellm_provider") or raw.get("provider") or "") or None,
+        )
+        if not any((
+            pricing.input_cost_per_token,
+            pricing.output_cost_per_token,
+            pricing.cache_read_input_token_cost,
+            pricing.cache_creation_input_token_cost,
+            pricing.output_cost_per_reasoning_token,
+        )):
+            return None
+        return pricing
+
+
+@dataclass(frozen=True, slots=True)
+class CostCatalog:
+    """Model pricing lookup table.
+
+    The catalog is deliberately immutable and local. Applications may refresh
+    or replace it from any maintained source, including LiteLLM's public JSON
+    file, without coupling AG2 core to mutable provider pricing.
+    """
+
+    prices: Mapping[str, ModelPricing]
+    source: str | None = None
+    version: str | None = None
+
+    @classmethod
+    def from_litellm_mapping(
+        cls,
+        data: Mapping[str, Any],
+        *,
+        source: str | None = None,
+        version: str | None = None,
+    ) -> "CostCatalog":
+        prices: dict[str, ModelPricing] = {}
+        for model, raw in data.items():
+            if not isinstance(raw, Mapping):
+                continue
+            pricing = ModelPricing.from_litellm_entry(raw)
+            if pricing is not None:
+                prices[_model_key(str(model))] = pricing
+        return cls(prices=prices, source=source, version=version)
+
+    @classmethod
+    def from_file(cls, path: str | Path, *, source: str | None = None, version: str | None = None) -> "CostCatalog":
+        catalog_path = Path(path)
+        text = catalog_path.read_text(encoding="utf-8")
+        if catalog_path.suffix.lower() in {".yaml", ".yml"}:
+            payload = yaml.safe_load(text)
+        else:
+            payload = json.loads(text)
+        if not isinstance(payload, Mapping):
+            raise ValueError("cost catalog must be a JSON/YAML object")
+        model_payload = payload.get("models", payload)
+        if not isinstance(model_payload, Mapping):
+            raise ValueError("cost catalog models must be an object")
+        return cls.from_litellm_mapping(model_payload, source=source or str(catalog_path), version=version)
+
+    def pricing_for(self, model: str | None, *, provider: str | None = None) -> ModelPricing | None:
+        if not model:
+            return None
+        keys = _model_lookup_keys(model)
+        if provider:
+            keys = [key for model_key in keys for key in (_model_key(f"{provider}/{model_key}"), model_key)]
+        for key in keys:
+            pricing = self.prices.get(key)
+            if pricing is not None:
+                return pricing
+        return None
+
+
+def _model_key(model: str) -> str:
+    return model.strip().lower()
+
+
+def _model_lookup_keys(model: str) -> list[str]:
+    key = _model_key(model)
+    keys = [key]
+    # Providers may return a dated model revision for an alias configured by the
+    # caller, e.g. ``gpt-4.1-nano`` -> ``gpt-4.1-nano-2025-04-14``.
+    base_key = re.sub(r"-\d{4}-\d{2}-\d{2}$", "", key)
+    if base_key != key:
+        keys.append(base_key)
+    return keys

--- a/ag2/extensions/cost_accounting/estimator.py
+++ b/ag2/extensions/cost_accounting/estimator.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+"""Cost estimation over AG2 ``Usage`` and ``UsageReport`` values."""
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from ag2.events import Usage
+from ag2.usage import UsageRecord, UsageReport
+
+from .catalog import CostCatalog, ModelPricing
+
+
+def _tokens(value: float | int | None) -> Decimal:
+    if value is None:
+        return Decimal("0")
+    return max(Decimal("0"), Decimal(str(value)))
+
+
+def _cost(tokens: Decimal, rate: Decimal | None) -> Decimal:
+    if rate is None:
+        return Decimal("0")
+    return tokens * rate
+
+
+@dataclass(frozen=True, slots=True)
+class CostEstimate:
+    """Estimated USD cost for one usage item or aggregated report."""
+
+    total_cost_usd: Decimal
+    input_cost_usd: Decimal = Decimal("0")
+    output_cost_usd: Decimal = Decimal("0")
+    cache_read_input_cost_usd: Decimal = Decimal("0")
+    cache_creation_input_cost_usd: Decimal = Decimal("0")
+    thinking_cost_usd: Decimal = Decimal("0")
+    model: str | None = None
+    provider: str | None = None
+    currency: str = "USD"
+    pricing_source: str = "catalog"
+    catalog_source: str | None = None
+    catalog_version: str | None = None
+    warnings: tuple[str, ...] = ()
+
+    def __add__(self, other: "CostEstimate") -> "CostEstimate":
+        if not isinstance(other, CostEstimate):
+            return NotImplemented
+        warnings = (*self.warnings, *other.warnings)
+        if self.pricing_source == "catalog" and self.total_cost_usd == 0 and not self.warnings:
+            pricing_source = other.pricing_source
+        elif other.pricing_source == "catalog" and other.total_cost_usd == 0 and not other.warnings:
+            pricing_source = self.pricing_source
+        elif self.pricing_source != other.pricing_source:
+            pricing_source = "mixed"
+        else:
+            pricing_source = self.pricing_source
+        return CostEstimate(
+            total_cost_usd=self.total_cost_usd + other.total_cost_usd,
+            input_cost_usd=self.input_cost_usd + other.input_cost_usd,
+            output_cost_usd=self.output_cost_usd + other.output_cost_usd,
+            cache_read_input_cost_usd=self.cache_read_input_cost_usd + other.cache_read_input_cost_usd,
+            cache_creation_input_cost_usd=self.cache_creation_input_cost_usd + other.cache_creation_input_cost_usd,
+            thinking_cost_usd=self.thinking_cost_usd + other.thinking_cost_usd,
+            currency=self.currency,
+            pricing_source=pricing_source,
+            catalog_source=self.catalog_source or other.catalog_source,
+            catalog_version=self.catalog_version or other.catalog_version,
+            warnings=warnings,
+        )
+
+
+class UsageCostEstimator:
+    """Estimate cost from AG2 usage data and a pricing catalog."""
+
+    def __init__(self, catalog: CostCatalog) -> None:
+        self.catalog = catalog
+
+    def estimate_usage(
+        self,
+        usage: Usage,
+        *,
+        model: str | None = None,
+        provider: str | None = None,
+    ) -> CostEstimate:
+        pricing = self.catalog.pricing_for(model, provider=provider)
+        if pricing is None:
+            return CostEstimate(
+                total_cost_usd=Decimal("0"),
+                model=model,
+                provider=provider,
+                pricing_source="not_configured",
+                catalog_source=self.catalog.source,
+                catalog_version=self.catalog.version,
+                warnings=(f"No pricing configured for model {model!r}.",),
+            )
+
+        return _estimate_with_pricing(
+            usage=usage,
+            pricing=pricing,
+            model=model,
+            provider=provider or pricing.provider,
+            catalog=self.catalog,
+        )
+
+    def estimate_record(self, record: UsageRecord) -> CostEstimate:
+        return self.estimate_usage(record.usage, model=record.model, provider=record.provider)
+
+    def estimate_report(self, report: UsageReport) -> CostEstimate:
+        estimate = CostEstimate(total_cost_usd=Decimal("0"), catalog_source=self.catalog.source)
+        for record in report.records:
+            estimate += self.estimate_record(record)
+        return estimate
+
+
+def _estimate_with_pricing(
+    *,
+    usage: Usage,
+    pricing: ModelPricing,
+    model: str | None,
+    provider: str | None,
+    catalog: CostCatalog,
+) -> CostEstimate:
+    prompt_tokens = _tokens(usage.prompt_tokens)
+    cache_read_tokens = _tokens(usage.cache_read_input_tokens)
+    cache_creation_tokens = _tokens(usage.cache_creation_input_tokens)
+    thinking_tokens = _tokens(usage.thinking_tokens)
+
+    cached_input_tokens = min(prompt_tokens, cache_read_tokens + cache_creation_tokens)
+    regular_input_tokens = prompt_tokens - cached_input_tokens
+
+    completion_tokens = _tokens(usage.completion_tokens)
+    if pricing.output_cost_per_reasoning_token is not None:
+        regular_output_tokens = max(Decimal("0"), completion_tokens - thinking_tokens)
+    else:
+        regular_output_tokens = completion_tokens
+
+    input_cost = _cost(regular_input_tokens, pricing.input_cost_per_token)
+    cache_read_cost = _cost(cache_read_tokens, pricing.cache_read_input_token_cost or pricing.input_cost_per_token)
+    cache_creation_cost = _cost(
+        cache_creation_tokens,
+        pricing.cache_creation_input_token_cost or pricing.input_cost_per_token,
+    )
+    output_cost = _cost(regular_output_tokens, pricing.output_cost_per_token)
+    thinking_cost = _cost(thinking_tokens, pricing.output_cost_per_reasoning_token)
+    total = input_cost + cache_read_cost + cache_creation_cost + output_cost + thinking_cost
+
+    return CostEstimate(
+        total_cost_usd=total,
+        input_cost_usd=input_cost,
+        output_cost_usd=output_cost,
+        cache_read_input_cost_usd=cache_read_cost,
+        cache_creation_input_cost_usd=cache_creation_cost,
+        thinking_cost_usd=thinking_cost,
+        model=model,
+        provider=provider,
+        pricing_source="catalog",
+        catalog_source=catalog.source,
+        catalog_version=catalog.version,
+    )

--- a/ag2/extensions/cost_accounting/observer.py
+++ b/ag2/extensions/cost_accounting/observer.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+"""Observer integration for estimated cost accounting."""
+
+from decimal import Decimal
+from typing import Any
+
+from ag2.annotations import Context
+from ag2.events import BaseEvent, ObserverAlert, Severity, UsageEvent
+from ag2.observers import BaseObserver
+from ag2.watch import EventWatch
+
+from .estimator import CostEstimate, UsageCostEstimator
+
+
+def _decimal(value: Decimal | float | int | str) -> Decimal:
+    return value if isinstance(value, Decimal) else Decimal(str(value))
+
+
+class CostAccountingObserver(BaseObserver):
+    """Tracks estimated cost from ``UsageEvent`` and emits threshold alerts.
+
+    ``UsageEvent`` is AG2's source of truth for token accounting, so this
+    observer avoids double-counting model responses and sub-agent rollups.
+    """
+
+    def __init__(
+        self,
+        estimator: UsageCostEstimator,
+        *,
+        warn_threshold_usd: Decimal | float | int | str = Decimal("1"),
+        alert_threshold_usd: Decimal | float | int | str = Decimal("5"),
+        name: str = "cost-accounting",
+    ) -> None:
+        super().__init__(name, watch=EventWatch(UsageEvent))
+        self._estimator = estimator
+        self._warn_threshold = _decimal(warn_threshold_usd)
+        self._alert_threshold = _decimal(alert_threshold_usd)
+        self._total = CostEstimate(total_cost_usd=Decimal("0"))
+        self._warned = False
+        self._alerted = False
+
+    @property
+    def estimate(self) -> CostEstimate:
+        return self._total
+
+    async def process(self, events: list[BaseEvent], ctx: Context) -> ObserverAlert | None:
+        for event in events:
+            if isinstance(event, UsageEvent) and event.usage:
+                self._total += self._estimator.estimate_usage(
+                    event.usage,
+                    model=event.model,
+                    provider=event.provider,
+                )
+
+        if not self._alerted and self._total.total_cost_usd >= self._alert_threshold:
+            self._alerted = True
+            return ObserverAlert(
+                source=self.name,
+                severity=Severity.CRITICAL,
+                message=(
+                    f"Estimated usage cost critical: ${self._total.total_cost_usd:.6f} "
+                    f"(threshold: ${self._alert_threshold:.6f})."
+                ),
+                data=self._alert_data(),
+            )
+
+        if not self._warned and self._total.total_cost_usd >= self._warn_threshold:
+            self._warned = True
+            return ObserverAlert(
+                source=self.name,
+                severity=Severity.WARNING,
+                message=(
+                    f"Estimated usage cost warning: ${self._total.total_cost_usd:.6f} "
+                    f"(threshold: ${self._warn_threshold:.6f})."
+                ),
+                data=self._alert_data(),
+            )
+
+        return None
+
+    def reset(self) -> None:
+        self._total = CostEstimate(total_cost_usd=Decimal("0"))
+        self._warned = False
+        self._alerted = False
+
+    def _alert_data(self) -> dict[str, Any]:
+        return {
+            "total_cost_usd": str(self._total.total_cost_usd),
+            "input_cost_usd": str(self._total.input_cost_usd),
+            "output_cost_usd": str(self._total.output_cost_usd),
+            "cache_read_input_cost_usd": str(self._total.cache_read_input_cost_usd),
+            "cache_creation_input_cost_usd": str(self._total.cache_creation_input_cost_usd),
+            "thinking_cost_usd": str(self._total.thinking_cost_usd),
+            "pricing_source": self._total.pricing_source,
+            "catalog_source": self._total.catalog_source,
+            "catalog_version": self._total.catalog_version,
+            "warnings": list(self._total.warnings),
+        }

--- a/test/extensions/cost_accounting/__init__.py
+++ b/test/extensions/cost_accounting/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/extensions/cost_accounting/test_cost_accounting.py
+++ b/test/extensions/cost_accounting/test_cost_accounting.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from decimal import Decimal
+
+import pytest
+
+from ag2 import Agent, Context
+from ag2.events import ModelMessage, ModelResponse, ObserverAlert, Severity, Usage, UsageEvent
+from ag2.extensions.cost_accounting import CostAccountingObserver, CostCatalog, UsageCostEstimator
+from ag2.stream import MemoryStream
+from ag2.testing import TestConfig
+from ag2.usage import UsageReport
+
+
+def _catalog() -> CostCatalog:
+    return CostCatalog.from_litellm_mapping(
+        {
+            "openai/gpt-4.1-nano": {
+                "litellm_provider": "openai",
+                "input_cost_per_token": 0.0000001,
+                "output_cost_per_token": 0.0000004,
+                "cache_read_input_token_cost": 0.000000025,
+                "cache_creation_input_token_cost": 0.000000125,
+                "output_cost_per_reasoning_token": 0.0000005,
+            }
+        },
+        source="test-catalog",
+        version="2026-07-10",
+    )
+
+
+class TestCostCatalog:
+    def test_loads_litellm_style_entries(self) -> None:
+        catalog = _catalog()
+
+        pricing = catalog.pricing_for("gpt-4.1-nano", provider="openai")
+
+        assert pricing is not None
+        assert pricing.input_cost_per_token == Decimal("1E-7")
+        assert pricing.output_cost_per_token == Decimal("4E-7")
+        assert pricing.cache_read_input_token_cost == Decimal("2.5E-8")
+        assert pricing.provider == "openai"
+
+    def test_ignores_non_pricing_entries(self) -> None:
+        catalog = CostCatalog.from_litellm_mapping({"sample_spec": {"max_tokens": 1000}})
+
+        assert catalog.pricing_for("sample_spec") is None
+
+    def test_resolves_dated_provider_model_revision_to_base_alias(self) -> None:
+        catalog = _catalog()
+
+        pricing = catalog.pricing_for("gpt-4.1-nano-2025-04-14", provider="openai")
+
+        assert pricing is not None
+        assert pricing.output_cost_per_token == Decimal("4E-7")
+
+
+class TestUsageCostEstimator:
+    def test_estimates_regular_cache_and_reasoning_cost(self) -> None:
+        estimator = UsageCostEstimator(_catalog())
+        usage = Usage(
+            prompt_tokens=100,
+            completion_tokens=50,
+            cache_read_input_tokens=20,
+            cache_creation_input_tokens=10,
+            thinking_tokens=5,
+        )
+
+        estimate = estimator.estimate_usage(usage, model="gpt-4.1-nano", provider="openai")
+
+        # input: 70 * .0000001 = .000007
+        # cache read: 20 * .000000025 = .0000005
+        # cache creation: 10 * .000000125 = .00000125
+        # output: 45 * .0000004 = .000018
+        # thinking: 5 * .0000005 = .0000025
+        assert estimate.total_cost_usd == Decimal("0.00002925")
+        assert estimate.input_cost_usd == Decimal("0.0000070")
+        assert estimate.cache_read_input_cost_usd == Decimal("5.00E-7")
+        assert estimate.cache_creation_input_cost_usd == Decimal("0.000001250")
+        assert estimate.output_cost_usd == Decimal("0.0000180")
+        assert estimate.thinking_cost_usd == Decimal("0.0000025")
+        assert estimate.pricing_source == "catalog"
+        assert estimate.catalog_source == "test-catalog"
+
+    def test_unknown_model_returns_not_configured(self) -> None:
+        estimate = UsageCostEstimator(_catalog()).estimate_usage(
+            Usage(prompt_tokens=10, completion_tokens=5),
+            model="unknown-model",
+        )
+
+        assert estimate.total_cost_usd == Decimal("0")
+        assert estimate.pricing_source == "not_configured"
+        assert estimate.warnings
+
+    def test_estimates_usage_report_from_records(self) -> None:
+        report = UsageReport.from_events([
+            UsageEvent(Usage(prompt_tokens=10, completion_tokens=5), model="gpt-4.1-nano", provider="openai"),
+            UsageEvent(Usage(prompt_tokens=20, completion_tokens=10), model="gpt-4.1-nano", provider="openai"),
+        ])
+
+        estimate = UsageCostEstimator(_catalog()).estimate_report(report)
+
+        assert estimate.total_cost_usd == Decimal("0.000009000")
+
+
+@pytest.mark.asyncio
+class TestCostAccountingObserver:
+    async def test_emits_warning_at_cost_threshold(self) -> None:
+        stream = MemoryStream()
+        ctx = Context(stream=stream)
+        estimator = UsageCostEstimator(_catalog())
+        observer = CostAccountingObserver(
+            estimator,
+            warn_threshold_usd=Decimal("0.00001"),
+            alert_threshold_usd=Decimal("1"),
+        )
+        alerts: list[ObserverAlert] = []
+        stream.where(ObserverAlert).subscribe(lambda event: alerts.append(event))
+        observer.register(ExitStack(), ctx)
+
+        await ctx.send(
+            UsageEvent(
+                Usage(prompt_tokens=10, completion_tokens=50),
+                model="gpt-4.1-nano",
+                provider="openai",
+            )
+        )
+
+        assert len(alerts) == 1
+        assert alerts[0].severity is Severity.WARNING
+        assert alerts[0].source == "cost-accounting"
+        assert alerts[0].data["total_cost_usd"] == "0.000021000"
+        assert observer.estimate.total_cost_usd == Decimal("0.0000210")
+
+    async def test_reset_clears_estimate_and_allows_rewarning(self) -> None:
+        stream = MemoryStream()
+        ctx = Context(stream=stream)
+        observer = CostAccountingObserver(
+            UsageCostEstimator(_catalog()),
+            warn_threshold_usd=Decimal("0.00001"),
+            alert_threshold_usd=Decimal("1"),
+        )
+        alerts: list[ObserverAlert] = []
+        stream.where(ObserverAlert).subscribe(lambda event: alerts.append(event))
+        observer.register(ExitStack(), ctx)
+
+        event = UsageEvent(Usage(prompt_tokens=10, completion_tokens=50), model="gpt-4.1-nano", provider="openai")
+        await ctx.send(event)
+        observer.reset()
+        await ctx.send(event)
+
+        assert len(alerts) == 2
+        assert observer.estimate.total_cost_usd == Decimal("0.0000210")
+
+    async def test_observer_accounts_for_agent_ask_usage_events(self) -> None:
+        stream = MemoryStream()
+        alerts: list[ObserverAlert] = []
+        stream.where(ObserverAlert).subscribe(lambda event: alerts.append(event))
+        observer = CostAccountingObserver(
+            UsageCostEstimator(_catalog()),
+            warn_threshold_usd=Decimal("0.000001"),
+            alert_threshold_usd=Decimal("1"),
+        )
+        agent = Agent(
+            "cost-test",
+            config=TestConfig(
+                ModelResponse(
+                    ModelMessage("ok"),
+                    usage=Usage(prompt_tokens=12, completion_tokens=2, cache_read_input_tokens=3),
+                    model="gpt-4.1-nano",
+                    provider="openai",
+                )
+            ),
+            observers=[observer],
+        )
+
+        reply = await agent.ask("Reply with ok", stream=stream)
+        report = await reply.usage()
+
+        assert report.total.prompt_tokens == 12
+        assert report.total.completion_tokens == 2
+        assert report.total.cache_read_input_tokens == 3
+        assert observer.estimate.total_cost_usd == Decimal("0.000001775")
+        assert len(alerts) == 1
+        assert alerts[0].severity is Severity.WARNING


### PR DESCRIPTION
## Why are these changes needed?

AG2 currently normalizes provider token usage into `Usage` / `UsageEvent`, but there is no optional first-class way to derive estimated cost from that usage. Model prices change frequently and provider billing structures vary, so this PR keeps AG2 core usage accounting factual and adds cost accounting as an extension.

This adds `ag2.extensions.cost_accounting`, which estimates USD cost from `UsageEvent` data and a maintained pricing catalog. The catalog loader supports LiteLLM-style fields such as:

- `input_cost_per_token`
- `output_cost_per_token`
- `cache_read_input_token_cost`
- `cache_creation_input_token_cost`
- `output_cost_per_reasoning_token`

The extension watches `UsageEvent`, AG2's source of truth for usage reporting, so it avoids double counting model responses and sub-agent rollups.

Included APIs:

- `CostCatalog` / `ModelPricing`
- `UsageCostEstimator`
- `CostEstimate`
- `CostAccountingObserver`

Unknown models return `pricing_source="not_configured"` with a warning instead of guessing.

## Related issue number

No existing issue. This PR implements an optional cost accounting extension over AG2 usage telemetry.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
  - Added `ag2/extensions/cost_accounting/README.md` because this repository clone does not include a published docs page for this new extension.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
  - Current reported GitHub status for the latest commit shows the CLA check passing. I do not have the repo's expected `uv` / latest `ruff` toolchain in this local environment, so I also ran focused pytest, compile checks, and a live OpenAI smoke locally.

Validation run locally:

```text
python -m pytest -q test\extensions\cost_accounting\test_cost_accounting.py test\test_usage.py test\observer\test_builtin.py
34 passed

python -m compileall -q ag2\extensions\cost_accounting test\extensions\cost_accounting
passed
```

Live provider smoke with `OpenAIConfig` and `gpt-4.1-nano`:

```text
reply_body 'ok'
prompt_tokens 16
completion_tokens 1
total_tokens 17
cache_read_input_tokens 0
estimated_cost_usd 0.000002000
alerts 1 warning
pricing_source catalog
```

That smoke used a real AG2 `Agent.ask()` call with `OpenAIConfig`, `MemoryStream`, and `CostAccountingObserver` attached.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.