### PR TITLE
feat(search): add Xquik tweet search toolkit

### DIFF
--- a/ag2/extensions/tools/search/__init__.py
+++ b/ag2/extensions/tools/search/__init__.py
@@ -14,7 +14,10 @@ try:
 except ImportError as e:
     TinyFishSearchToolkit = missing_additional_dependency("TinyFishSearchToolkit", "tinyfish>=0.2.3", e)  # type: ignore[misc]
 
+from .xquik import XquikSearchToolkit
+
 __all__ = (
     "ExaToolkit",
     "TinyFishSearchToolkit",
+    "XquikSearchToolkit",
 )

--- a/ag2/extensions/tools/search/xquik.py
+++ b/ag2/extensions/tools/search/xquik.py
@@ -4,7 +4,6 @@
 
 """Xquik tweet search extension for AG2."""
 
-import os
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, TypeAlias
@@ -37,14 +36,14 @@ class XquikSearchToolkit(Toolkit):
     search defaults can be fixed when the toolkit or tool is constructed, or
     supplied through AG2 ``Variable`` values at runtime.
 
-    The API key is read from ``XQUIK_API_KEY`` when ``api_key`` is omitted.
+    An Xquik ``api_key`` is required.
     """
 
     __slots__ = ("_api_key", "_base_url", "_timeout")
 
     def __init__(
         self,
-        api_key: str | None = None,
+        api_key: str,
         *,
         base_url: str = "https://xquik.com",
         timeout: float = 60.0,
@@ -55,6 +54,8 @@ class XquikSearchToolkit(Toolkit):
         limit: int | Variable | None = None,
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
+        if not api_key:
+            raise ValueError("api_key is required")
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
@@ -93,10 +94,6 @@ class XquikSearchToolkit(Toolkit):
             ctx: Context,
         ) -> ToolResult:
             """Search public X posts and return a structured page of results."""
-            resolved_api_key = api_key or os.environ.get("XQUIK_API_KEY")
-            if resolved_api_key is None:
-                raise ValueError("XQUIK_API_KEY is required when api_key is omitted")
-
             params: dict[str, Any] = {
                 "q": query,
                 "queryType": resolve_variable(query_type, ctx, param_name="query_type"),
@@ -109,7 +106,7 @@ class XquikSearchToolkit(Toolkit):
 
             async with httpx.AsyncClient(
                 base_url=base_url,
-                headers={"x-api-key": resolved_api_key},
+                headers={"x-api-key": api_key},
                 timeout=timeout,
             ) as client:
                 response = await client.get("/api/v1/x/tweets/search", params=request_params)

--- a/ag2/extensions/tools/search/xquik.py
+++ b/ag2/extensions/tools/search/xquik.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Xquik tweet search extension for AG2."""
+
+import os
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Annotated, Any, Literal, TypeAlias
+
+import httpx
+from pydantic import Field
+
+from ag2.annotations import Context, Variable
+from ag2.events import ToolResult
+from ag2.middleware import ToolMiddleware
+from ag2.tools.builtin._resolve import resolve_variable
+from ag2.tools.final import Toolkit, tool
+from ag2.tools.final.function_tool import FunctionTool
+
+QueryType: TypeAlias = Literal["Latest", "Top"]
+
+
+@dataclass(slots=True)
+class XquikTweetSearchResponse:
+    query: str
+    tweets: list[dict[str, Any]] = field(default_factory=list)
+    has_next_page: bool = False
+    next_cursor: str = ""
+
+
+class XquikSearchToolkit(Toolkit):
+    """Toolkit that searches public X posts through the Xquik REST API.
+
+    Passing the toolkit to an agent registers ``xquik_tweet_search``. Optional
+    search defaults can be fixed when the toolkit or tool is constructed, or
+    supplied through AG2 ``Variable`` values at runtime.
+
+    The API key is read from ``XQUIK_API_KEY`` when ``api_key`` is omitted.
+    """
+
+    __slots__ = ("_api_key", "_base_url", "_timeout")
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        base_url: str = "https://xquik.com",
+        timeout: float = 60.0,
+        query_type: QueryType | Variable | None = None,
+        cursor: str | Variable | None = None,
+        since_time: str | Variable | None = None,
+        until_time: str | Variable | None = None,
+        limit: int | Variable | None = None,
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+        super().__init__(
+            self.search(
+                query_type=query_type,
+                cursor=cursor,
+                since_time=since_time,
+                until_time=until_time,
+                limit=limit,
+            ),
+            name="xquik_search_toolkit",
+            middleware=middleware,
+        )
+
+    def search(
+        self,
+        *,
+        query_type: QueryType | Variable | None = None,
+        cursor: str | Variable | None = None,
+        since_time: str | Variable | None = None,
+        until_time: str | Variable | None = None,
+        limit: int | Variable | None = None,
+        name: str = "xquik_tweet_search",
+        description: str = ("Search public X posts through Xquik. Returns tweet records and pagination metadata."),
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> FunctionTool:
+        api_key = self._api_key
+        base_url = self._base_url
+        timeout = self._timeout
+
+        @tool(name=name, description=description, middleware=middleware)
+        async def xquik_tweet_search(
+            query: Annotated[str, Field(description="The X search query string.")],
+            ctx: Context,
+        ) -> ToolResult:
+            """Search public X posts and return a structured page of results."""
+            resolved_api_key = api_key or os.environ.get("XQUIK_API_KEY")
+            if resolved_api_key is None:
+                raise ValueError("XQUIK_API_KEY is required when api_key is omitted")
+
+            params: dict[str, Any] = {
+                "q": query,
+                "queryType": resolve_variable(query_type, ctx, param_name="query_type"),
+                "cursor": resolve_variable(cursor, ctx, param_name="cursor"),
+                "sinceTime": resolve_variable(since_time, ctx, param_name="since_time"),
+                "untilTime": resolve_variable(until_time, ctx, param_name="until_time"),
+                "limit": resolve_variable(limit, ctx, param_name="limit"),
+            }
+            request_params = {key: value for key, value in params.items() if value is not None}
+
+            async with httpx.AsyncClient(
+                base_url=base_url,
+                headers={"x-api-key": resolved_api_key},
+                timeout=timeout,
+            ) as client:
+                response = await client.get("/api/v1/x/tweets/search", params=request_params)
+                response.raise_for_status()
+
+            raw: dict[str, Any] = response.json()
+            raw_tweets = raw.get("tweets")
+            tweets = raw_tweets if isinstance(raw_tweets, list) else []
+            raw_cursor = raw.get("next_cursor")
+
+            return ToolResult(
+                XquikTweetSearchResponse(
+                    query=query,
+                    tweets=tweets,
+                    has_next_page=raw.get("has_next_page") is True,
+                    next_cursor=raw_cursor if isinstance(raw_cursor, str) else "",
+                )
+            )
+
+        return xquik_tweet_search

--- a/test/extensions/tools/search/test_xquik.py
+++ b/test/extensions/tools/search/test_xquik.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import httpx
+import pytest
+import respx
+from dirty_equals import IsPartialDict
+
+from ag2 import Agent, Context, DataInput, Variable
+from ag2.events import ModelResponse, ToolCallEvent, ToolCallsEvent, ToolResultsEvent
+from ag2.extensions.tools.search.xquik import XquikSearchToolkit, XquikTweetSearchResponse
+from ag2.testing import TestConfig, TrackingConfig
+from ag2.tools.final.function_tool import FunctionToolSchema
+
+XQUIK_BASE_URL = "https://xquik.com"
+
+
+def _tool_call_config(
+    arguments: dict[str, object],
+    *,
+    tool_name: str = "xquik_tweet_search",
+    final_reply: str = "done",
+) -> TestConfig:
+    return TestConfig(
+        ModelResponse(
+            tool_calls=ToolCallsEvent([
+                ToolCallEvent(arguments=json.dumps(arguments), name=tool_name),
+            ]),
+        ),
+        final_reply,
+    )
+
+
+@pytest.mark.asyncio
+class TestSchema:
+    async def test_default_schema(self, context: Context) -> None:
+        toolkit = XquikSearchToolkit(api_key="test")
+
+        schemas = list(await toolkit.schemas(context))
+        [schema] = schemas
+
+        assert isinstance(schema, FunctionToolSchema)
+        assert schema.function.name == "xquik_tweet_search"
+        assert schema.function.parameters == IsPartialDict({
+            "required": ["query"],
+            "properties": IsPartialDict({"query": IsPartialDict({"type": "string"})}),
+        })
+
+    async def test_custom_name_and_description(self, context: Context) -> None:
+        toolkit = XquikSearchToolkit(api_key="test")
+        custom = toolkit.search(name="search_x", description="Search X posts.")
+
+        [schema] = list(await custom.schemas(context))
+
+        assert schema.function.name == "search_x"
+        assert schema.function.description == "Search X posts."
+
+
+@pytest.mark.asyncio
+class TestSearchExecution:
+    @respx.mock
+    async def test_returns_structured_results(self) -> None:
+        respx.get(f"{XQUIK_BASE_URL}/api/v1/x/tweets/search").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "tweets": [{"id": "123", "text": "AG2 release"}],
+                    "has_next_page": True,
+                    "next_cursor": "cursor-2",
+                },
+            )
+        )
+        toolkit = XquikSearchToolkit(api_key="test")
+        config = TrackingConfig(_tool_call_config({"query": "AG2"}))
+        agent = Agent("a", config=config, tools=[toolkit])
+
+        await agent.ask("search")
+
+        tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            XquikTweetSearchResponse(
+                query="AG2",
+                tweets=[{"id": "123", "text": "AG2 release"}],
+                has_next_page=True,
+                next_cursor="cursor-2",
+            )
+        )
+
+    @respx.mock
+    async def test_forwards_search_defaults_and_auth_header(self) -> None:
+        route = respx.get(f"{XQUIK_BASE_URL}/api/v1/x/tweets/search").mock(
+            return_value=httpx.Response(200, json={"tweets": []})
+        )
+        toolkit = XquikSearchToolkit(
+            api_key="test-key",
+            query_type="Top",
+            cursor="cursor-1",
+            since_time="2026-07-01T00:00:00Z",
+            until_time="2026-07-02T00:00:00Z",
+            limit=25,
+        )
+        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
+
+        await agent.ask("search")
+
+        assert dict(route.calls.last.request.url.params) == {
+            "q": "AG2",
+            "queryType": "Top",
+            "cursor": "cursor-1",
+            "sinceTime": "2026-07-01T00:00:00Z",
+            "untilTime": "2026-07-02T00:00:00Z",
+            "limit": "25",
+        }
+        assert route.calls.last.request.headers["x-api-key"] == "test-key"
+
+    @respx.mock
+    async def test_omits_unset_params(self) -> None:
+        route = respx.get(f"{XQUIK_BASE_URL}/api/v1/x/tweets/search").mock(
+            return_value=httpx.Response(200, json={"tweets": []})
+        )
+        toolkit = XquikSearchToolkit(api_key="test")
+        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
+
+        await agent.ask("search")
+
+        assert dict(route.calls.last.request.url.params) == {"q": "AG2"}
+
+    @respx.mock
+    async def test_reads_api_key_from_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        route = respx.get(f"{XQUIK_BASE_URL}/api/v1/x/tweets/search").mock(
+            return_value=httpx.Response(200, json={"tweets": []})
+        )
+        monkeypatch.setenv("XQUIK_API_KEY", "environment-key")
+        toolkit = XquikSearchToolkit()
+        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
+
+        await agent.ask("search")
+
+        assert route.calls.last.request.headers["x-api-key"] == "environment-key"
+
+    async def test_missing_api_key_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("XQUIK_API_KEY", raising=False)
+        toolkit = XquikSearchToolkit()
+        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
+
+        with pytest.raises(ValueError, match="XQUIK_API_KEY"):
+            await agent.ask("search")
+
+
+@pytest.mark.asyncio
+class TestVariables:
+    @respx.mock
+    async def test_resolves_runtime_values(self) -> None:
+        route = respx.get(f"{XQUIK_BASE_URL}/api/v1/x/tweets/search").mock(
+            return_value=httpx.Response(200, json={"tweets": []})
+        )
+        toolkit = XquikSearchToolkit(api_key="test")
+        search_tool = toolkit.search(query_type=Variable(), limit=Variable("result_limit"))
+        agent = Agent(
+            "a",
+            config=_tool_call_config({"query": "AG2"}),
+            tools=[search_tool],
+            variables={"query_type": "Latest", "result_limit": 10},
+        )
+
+        await agent.ask("search")
+
+        assert dict(route.calls.last.request.url.params) == {
+            "q": "AG2",
+            "queryType": "Latest",
+            "limit": "10",
+        }

--- a/test/extensions/tools/search/test_xquik.py
+++ b/test/extensions/tools/search/test_xquik.py
@@ -128,26 +128,9 @@ class TestSearchExecution:
 
         assert dict(route.calls.last.request.url.params) == {"q": "AG2"}
 
-    @respx.mock
-    async def test_reads_api_key_from_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        route = respx.get(f"{XQUIK_BASE_URL}/api/v1/x/tweets/search").mock(
-            return_value=httpx.Response(200, json={"tweets": []})
-        )
-        monkeypatch.setenv("XQUIK_API_KEY", "environment-key")
-        toolkit = XquikSearchToolkit()
-        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
-
-        await agent.ask("search")
-
-        assert route.calls.last.request.headers["x-api-key"] == "environment-key"
-
-    async def test_missing_api_key_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("XQUIK_API_KEY", raising=False)
-        toolkit = XquikSearchToolkit()
-        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
-
-        with pytest.raises(ValueError, match="XQUIK_API_KEY"):
-            await agent.ask("search")
+    async def test_empty_api_key_raises_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="api_key is required"):
+            XquikSearchToolkit("")
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/extensions/tools/search/xquik.mdx
+++ b/website/docs/user-guide/extensions/tools/search/xquik.mdx
@@ -6,7 +6,7 @@ sidebarTitle: Xquik Tweet Search
 `XquikSearchToolkit` gives an agent a tool for searching public X posts through the [Xquik API](https://docs.xquik.com/api-reference/overview){.external-link target="_blank"}. Use it when an agent needs structured tweet records and pagination metadata.
 
 !!! note
-    Set `XQUIK_API_KEY` or pass an API key to the toolkit. No additional Python package is required.
+    An Xquik `api_key` is required. No additional Python package is required.
 
 ```python linenums="1"
 import os
@@ -21,7 +21,7 @@ agent = Agent(
 )
 ```
 
-If `api_key` is omitted, the toolkit reads `XQUIK_API_KEY` when the tool runs.
+The `api_key` is required and validated when the toolkit is constructed.
 
 ## Tool
 

--- a/website/docs/user-guide/extensions/tools/search/xquik.mdx
+++ b/website/docs/user-guide/extensions/tools/search/xquik.mdx
@@ -1,0 +1,71 @@
+---
+title: Xquik Tweet Search
+sidebarTitle: Xquik Tweet Search
+---
+
+`XquikSearchToolkit` gives an agent a tool for searching public X posts through the [Xquik API](https://docs.xquik.com/api-reference/overview){.external-link target="_blank"}. Use it when an agent needs structured tweet records and pagination metadata.
+
+!!! note
+    Set `XQUIK_API_KEY` or pass an API key to the toolkit. No additional Python package is required.
+
+```python linenums="1"
+import os
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.extensions.tools.search import XquikSearchToolkit
+
+agent = Agent(
+    "social-researcher",
+    config=AnthropicConfig(model="claude-sonnet-4-6"),
+    tools=[XquikSearchToolkit(api_key=os.environ["XQUIK_API_KEY"])],
+)
+```
+
+If `api_key` is omitted, the toolkit reads `XQUIK_API_KEY` when the tool runs.
+
+## Tool
+
+| Tool | Description |
+| :--- | :--- |
+| `xquik_tweet_search` | Search public X posts and return tweet records plus pagination metadata |
+
+## Search configuration
+
+The tool accepts a required `query` at execution time. Configure optional defaults on the toolkit or `toolkit.search()`:
+
+```python linenums="1"
+import os
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.extensions.tools.search import XquikSearchToolkit
+
+toolkit = XquikSearchToolkit(api_key=os.environ["XQUIK_API_KEY"])
+
+search_tool = toolkit.search(
+    query_type="Latest",
+    since_time="2026-07-01T00:00:00Z",
+    until_time="2026-07-02T00:00:00Z",
+    limit=25,
+)
+
+agent = Agent(
+    "social-researcher",
+    config=AnthropicConfig(model="claude-sonnet-4-6"),
+    tools=[search_tool],
+)
+```
+
+Use `cursor` with the `next_cursor` from a previous response to request another page. All search defaults accept a `Variable` for deferred context resolution.
+
+## Result
+
+`xquik_tweet_search` returns an `XquikTweetSearchResponse`:
+
+| Field | Description |
+| :--- | :--- |
+| `query` | The search query sent to Xquik |
+| `tweets` | Structured tweet records returned by the API |
+| `has_next_page` | Whether another result page is available |
+| `next_cursor` | Cursor for the next page, or an empty string |
+
+Check the [Xquik OpenAPI schema](https://xquik.com/openapi.json){.external-link target="_blank"} for current search syntax, limits, and response fields.

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -237,7 +237,8 @@
               "group": "Search",
               "pages": [
                 "docs/user-guide/extensions/tools/search/exa",
-                "docs/user-guide/extensions/tools/search/tinyfish"
+                "docs/user-guide/extensions/tools/search/tinyfish",
+                "docs/user-guide/extensions/tools/search/xquik"
               ]
             }
           ]


### PR DESCRIPTION
## Why are these changes needed?

AG2 has web search extensions, but no typed tool for structured public X post search. This adds an opt-in `XquikSearchToolkit` that:

- reads `XQUIK_API_KEY` at tool execution time or accepts an explicit key
- supports sort order, cursor, date bounds, result limits, and AG2 `Variable` values
- returns tweet records with pagination metadata
- uses AG2's existing `httpx` dependency

The change also adds user documentation and navigation for the toolkit.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/.
- [x] I've added tests corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

Local validation:

- Ruff formatting and lint
- Mypy and Pyright on the new module and tests
- `pytest -q test/extensions/tools/search/test_xquik.py` - 8 passed
- AG2 pre-commit lint and Mypy scripts under Python 3.13
- Codespell, typos, secret detection, and license-header hooks

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
