### PR TITLE
test(openai): support openai>=2.45.0 InputTokensDetails in usage tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ acp = ["agent-client-protocol>=0.10.1,<0.11"]
 ag-ui = ["ag-ui-protocol>=0.1.15,<0.2"]
 
 # === LLM providers (ag2.config) ===
-openai = ["openai>=2.44.0,<3.0"]
+openai = ["openai>=2.45.0,<3.0"]
 anthropic = ["anthropic[vertex]>=0.116.0,<1"]
 gemini = [
     "google-api-core",

--- a/test/config/openai/test_openai_responses_usage.py
+++ b/test/config/openai/test_openai_responses_usage.py
@@ -16,7 +16,7 @@ class TestNormalizeUsage:
             input_tokens=100,
             output_tokens=20,
             total_tokens=120,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails(cached_tokens=0, cache_write_tokens=0),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         )
         result = normalize_responses_usage(usage)
@@ -33,7 +33,7 @@ class TestNormalizeUsage:
             input_tokens=100,
             output_tokens=20,
             total_tokens=120,
-            input_tokens_details=InputTokensDetails(cached_tokens=80),
+            input_tokens_details=InputTokensDetails(cached_tokens=80, cache_write_tokens=0),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         )
         result = normalize_responses_usage(usage)
@@ -50,7 +50,7 @@ class TestNormalizeUsage:
             input_tokens=100,
             output_tokens=20,
             total_tokens=120,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails(cached_tokens=0, cache_write_tokens=0),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=10),
         )
         result = normalize_responses_usage(usage)

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ requires-dist = [
     { name = "jsonschema", marker = "extra == 'gemini'" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.11.0,<2" },
     { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.4.7" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.44.0,<3.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.45.0,<3.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'tracing'", specifier = ">=1.20" },
     { name = "opentelemetry-sdk", marker = "extra == 'tracing'", specifier = ">=1.20" },
     { name = "packaging" },
@@ -4214,7 +4214,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.44.0"
+version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4227,9 +4227,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload-time = "2026-07-09T18:02:44.091Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload-time = "2026-07-09T18:02:42.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why are these changes needed?

openai 2.45.0 made `cache_write_tokens` a **required** field on
`openai.types.responses.response_usage.InputTokensDetails`. The tests in
`test/config/openai/test_openai_responses_usage.py` construct that model as
`InputTokensDetails(cached_tokens=...)` without the new field, so all three
`TestNormalizeUsage` cases fail with a pydantic `ValidationError` on every
platform/Python version once CI resolves openai>=2.45.0 (the dependency pin
`openai>=2.44.0,<3.0` has no upper bound, so CI picks up the new release).

This adds `cache_write_tokens=0` to the test fixtures. Production code in
`ag2/config/openai/mappers.py` only *reads* `cached_tokens`, which still exists,
so no runtime code changes are needed. The fix is backward-compatible with
2.44.0 (the model uses `extra='allow'`).

Verified locally against both openai 2.45.0 (was 3 failed → now 3 passed) and
openai 2.44.0 (still passing).

## Related issue number

<!-- заполни, если есть issue; иначе оставь пустым или: N/A -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
