### PR TITLE
feat(mcp): MCP-UI support

### DIFF
--- a/ag2/mcp/__init__.py
+++ b/ag2/mcp/__init__.py
@@ -11,6 +11,7 @@ try:
     from .resources import Resource, ResourceTemplate
     from .server import MCPServer
     from .sessions import SessionConfig
+    from .tools import MCPUITool, mcp_tool
 except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp] is absent
     MCPServer = missing_optional_dependency("MCPServer", "mcp", e)  # type: ignore[misc]
     build_ask_tool = missing_optional_dependency("build_ask_tool", "mcp", e)  # type: ignore[misc]
@@ -22,11 +23,14 @@ except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp] is a
     Prompt = missing_optional_dependency("Prompt", "mcp", e)  # type: ignore[misc]
     PromptArgument = missing_optional_dependency("PromptArgument", "mcp", e)  # type: ignore[misc]
     PromptMessage = missing_optional_dependency("PromptMessage", "mcp", e)  # type: ignore[misc]
+    MCPUITool = missing_optional_dependency("MCPUITool", "mcp", e)  # type: ignore[misc]
+    mcp_tool = missing_optional_dependency("mcp_tool", "mcp", e)  # type: ignore[misc]
 
 __all__ = (
     "AskContext",
     "ContextProvider",
     "MCPServer",
+    "MCPUITool",
     "Prompt",
     "PromptArgument",
     "PromptMessage",
@@ -34,4 +38,5 @@ __all__ = (
     "ResourceTemplate",
     "SessionConfig",
     "build_ask_tool",
+    "mcp_tool",
 )

--- a/ag2/mcp/__init__.py
+++ b/ag2/mcp/__init__.py
@@ -11,7 +11,7 @@ try:
     from .resources import Resource, ResourceTemplate
     from .server import MCPServer
     from .sessions import SessionConfig
-    from .tools import MCPUITool, mcp_tool
+    from .tools import MCPFunctionTool, mcp_tool
 except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp] is absent
     MCPServer = missing_optional_dependency("MCPServer", "mcp", e)  # type: ignore[misc]
     build_ask_tool = missing_optional_dependency("build_ask_tool", "mcp", e)  # type: ignore[misc]
@@ -23,14 +23,14 @@ except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp] is a
     Prompt = missing_optional_dependency("Prompt", "mcp", e)  # type: ignore[misc]
     PromptArgument = missing_optional_dependency("PromptArgument", "mcp", e)  # type: ignore[misc]
     PromptMessage = missing_optional_dependency("PromptMessage", "mcp", e)  # type: ignore[misc]
-    MCPUITool = missing_optional_dependency("MCPUITool", "mcp", e)  # type: ignore[misc]
+    MCPFunctionTool = missing_optional_dependency("MCPFunctionTool", "mcp", e)  # type: ignore[misc]
     mcp_tool = missing_optional_dependency("mcp_tool", "mcp", e)  # type: ignore[misc]
 
 __all__ = (
     "AskContext",
     "ContextProvider",
+    "MCPFunctionTool",
     "MCPServer",
-    "MCPUITool",
     "Prompt",
     "PromptArgument",
     "PromptMessage",

--- a/ag2/mcp/errors.py
+++ b/ag2/mcp/errors.py
@@ -18,6 +18,16 @@ class MCPAgentConfigError(MCPServerError):
         )
 
 
+class MCPToolNameConflictError(MCPServerError):
+    """Raised when a custom tool's name collides with the agent's ``ask`` tool."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(
+            f"Custom tool {name!r} conflicts with the agent's conversational tool; "
+            "rename the tool or pass a different `tool_name=` to MCPServer."
+        )
+
+
 class MCPResourceNotFoundError(MCPServerError):
     """Raised when a ``resources/read`` targets an unknown URI."""
 

--- a/ag2/mcp/errors.py
+++ b/ag2/mcp/errors.py
@@ -19,13 +19,17 @@ class MCPAgentConfigError(MCPServerError):
 
 
 class MCPToolNameConflictError(MCPServerError):
-    """Raised when a custom tool's name collides with the agent's ``ask`` tool."""
+    """Raised when a custom tool's name collides with the agent's ``ask`` tool or another custom tool."""
 
-    def __init__(self, name: str) -> None:
-        super().__init__(
-            f"Custom tool {name!r} conflicts with the agent's conversational tool; "
-            "rename the tool or pass a different `tool_name=` to MCPServer."
-        )
+    def __init__(self, name: str, *, reserved: bool = True) -> None:
+        if reserved:
+            message = (
+                f"Custom tool {name!r} conflicts with the agent's conversational tool; "
+                "rename the tool or pass a different `tool_name=` to MCPServer."
+            )
+        else:
+            message = f"Duplicate custom tool name {name!r}; tool names must be unique."
+        super().__init__(message)
 
 
 class MCPResourceNotFoundError(MCPServerError):

--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -23,11 +23,13 @@ from starlette.routing import BaseRoute, Mount, Route
 from ag2.agent import Agent
 from ag2.history import MemoryStorage
 
+from .errors import MCPToolNameConflictError
 from .executor import AgentExecutor, ContextProvider
 from .prompts import Prompt, PromptProvider
 from .resources import Resource, ResourceProvider, ResourceTemplate
 from .security import Requirement
 from .sessions import SessionConfig, SessionStore
+from .tools import MCPUITool, ToolProvider
 
 if TYPE_CHECKING:
     from starlette.types import Lifespan, Receive, Scope, Send
@@ -123,6 +125,7 @@ class MCPServer:
         "_session_store",
         "_resource_provider",
         "_prompt_provider",
+        "_tool_provider",
         "_http",
     )
 
@@ -144,6 +147,7 @@ class MCPServer:
         resources: "Sequence[Resource]" = (),
         resource_templates: "Sequence[ResourceTemplate]" = (),
         prompts: "Sequence[Prompt]" = (),
+        tools: "Sequence[MCPUITool]" = (),
         path: str = "/mcp",
         stateless: bool = False,
         json_response: bool = False,
@@ -161,6 +165,11 @@ class MCPServer:
             ResourceProvider(resources, resource_templates) if (resources or resource_templates) else None
         )
         self._prompt_provider = PromptProvider(prompts) if prompts else None
+        if tools:
+            conflict = next((t.name for t in tools if t.name == tool_name), None)
+            if conflict is not None:
+                raise MCPToolNameConflictError(conflict)
+        self._tool_provider = ToolProvider(tools) if tools else None
         self._executor = AgentExecutor(
             agent,
             tool_name=tool_name,
@@ -197,17 +206,25 @@ class MCPServer:
             **kwargs,
         )
         executor = self._executor
+        tool_provider = self._tool_provider
 
         # ``mcp``'s low-level decorators are untyped; ignore the resulting noise.
         @server.list_tools()  # type: ignore[no-untyped-call, misc]
         async def _list_tools() -> list[MCPTool]:
-            return executor.list_tools()
+            tools = executor.list_tools()
+            if tool_provider is not None:
+                tools += tool_provider.list_mcp_tools()
+            return tools
 
         @server.call_tool()  # type: ignore[no-untyped-call, misc]
         async def _call_tool(
             name: str, arguments: dict[str, Any]
         ) -> list[ContentBlock] | tuple[list[ContentBlock], dict[str, Any]] | CallToolResult:
             arguments = arguments or {}
+            # Custom tools run their handler directly; everything else is the
+            # agent's conversational tool (name collisions are rejected at init).
+            if tool_provider is not None and tool_provider.has(name):
+                return await tool_provider.call(name, arguments)
             return await executor.call(
                 name,
                 message=arguments.get("message", ""),

--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -29,7 +29,7 @@ from .prompts import Prompt, PromptProvider
 from .resources import Resource, ResourceProvider, ResourceTemplate
 from .security import Requirement
 from .sessions import SessionConfig, SessionStore
-from .tools import MCPUITool, ToolProvider
+from .tools import MCPFunctionTool, ToolProvider
 
 if TYPE_CHECKING:
     from starlette.types import Lifespan, Receive, Scope, Send
@@ -147,7 +147,7 @@ class MCPServer:
         resources: "Sequence[Resource]" = (),
         resource_templates: "Sequence[ResourceTemplate]" = (),
         prompts: "Sequence[Prompt]" = (),
-        tools: "Sequence[MCPUITool]" = (),
+        tools: "Sequence[MCPFunctionTool]" = (),
         path: str = "/mcp",
         stateless: bool = False,
         json_response: bool = False,
@@ -166,9 +166,13 @@ class MCPServer:
         )
         self._prompt_provider = PromptProvider(prompts) if prompts else None
         if tools:
-            conflict = next((t.name for t in tools if t.name == tool_name), None)
-            if conflict is not None:
-                raise MCPToolNameConflictError(conflict)
+            seen: set[str] = set()
+            for tool in tools:
+                if tool.name == tool_name:
+                    raise MCPToolNameConflictError(tool.name)
+                if tool.name in seen:
+                    raise MCPToolNameConflictError(tool.name, reserved=False)
+                seen.add(tool.name)
         self._tool_provider = ToolProvider(tools) if tools else None
         self._executor = AgentExecutor(
             agent,
@@ -224,7 +228,7 @@ class MCPServer:
             # Custom tools run their handler directly; everything else is the
             # agent's conversational tool (name collisions are rejected at init).
             if tool_provider is not None and tool_provider.has(name):
-                return await tool_provider.call(name, arguments)
+                return await tool_provider.call(name, arguments, server.request_context)
             return await executor.call(
                 name,
                 message=arguments.get("message", ""),

--- a/ag2/mcp/tools.py
+++ b/ag2/mcp/tools.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Awaitable, Callable, Sequence
+from contextlib import AsyncExitStack
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias, overload
+
+from fast_depends import dependency_provider
+from fast_depends.pydantic.schema import get_schema
+from mcp.types import ContentBlock
+from mcp.types import Tool as MCPTool
+
+from ag2.utils import CONTEXT_OPTION_NAME, build_model
+
+from ._async import call_user_fn
+
+# A tool handler receives the call's ``arguments`` and returns the content
+# block(s) to send back. Sync or async; a lone block is accepted for convenience.
+ToolHandler: TypeAlias = Callable[
+    [dict[str, Any]], "Awaitable[ContentBlock | Sequence[ContentBlock]] | ContentBlock | Sequence[ContentBlock]"
+]
+
+
+@dataclass(frozen=True, slots=True)
+class MCPUITool:
+    """A deterministic MCP tool served next to the agent's ``ask`` tool.
+
+    Usually produced by :func:`mcp_tool`. Constructed directly, ``handler`` takes
+    the raw ``tools/call`` ``arguments`` dict and returns the content block(s);
+    ``input_schema`` is the JSON Schema advertised in ``tools/list`` (defaults to
+    an open object).
+    """
+
+    name: str
+    description: str
+    handler: ToolHandler
+    input_schema: dict[str, Any] = field(default_factory=lambda: {"type": "object"})
+
+    def _mcp_tool(self) -> MCPTool:
+        return MCPTool(name=self.name, description=self.description, inputSchema=self.input_schema)
+
+    async def call(self, arguments: dict[str, Any]) -> list[ContentBlock]:
+        result = await call_user_fn(self.handler, arguments)
+        if isinstance(result, ContentBlock):
+            return [result]
+        return list(result)
+
+
+def _bind(call_model: Any) -> ToolHandler:
+    """Wrap a ``fast_depends`` call model as a handler that unpacks ``arguments``.
+
+    Mirrors ``ag2.a2ui.actions.A2UIAction.run``: the call's arguments become the
+    function's keyword arguments (serializer-coerced), and ``Depends``/``Inject``
+    parameters resolve against the process dependency provider.
+    """
+
+    async def handler(arguments: dict[str, Any]) -> Any:
+        async with AsyncExitStack() as stack:
+            return await call_model.asolve(
+                **arguments,
+                stack=stack,
+                cache_dependencies={},
+                dependency_provider=dependency_provider,
+            )
+
+    return handler
+
+
+@overload
+def mcp_tool(
+    function: Callable[..., Any],
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    sync_to_thread: bool = True,
+) -> MCPUITool: ...
+
+
+@overload
+def mcp_tool(
+    function: None = None, *, name: str | None = None, description: str | None = None, sync_to_thread: bool = True
+) -> Callable[[Callable[..., Any]], MCPUITool]: ...
+
+
+def mcp_tool(
+    function: Callable[..., Any] | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    sync_to_thread: bool = True,
+) -> MCPUITool | Callable[[Callable[..., Any]], MCPUITool]:
+    """Turn a function into a :class:`MCPUITool` served alongside the agent's ``ask``.
+
+    The tool ``name`` defaults to the function name, ``description`` to its
+    docstring, and ``input_schema`` is derived from the typed signature. The
+    function returns the MCP content block(s) for the result (e.g. an
+    :mod:`ag2.mcp_ui` resource). Pass the result in ``MCPServer(tools=[...])``.
+
+    Args:
+        function: The function (when used as a bare ``@mcp_tool``).
+        name: Tool name. Defaults to the function name.
+        description: Tool description. Defaults to the function docstring.
+        sync_to_thread: Run a sync function in a worker thread.
+    """
+
+    def make(f: Callable[..., Any]) -> MCPUITool:
+        call_model = build_model(f, sync_to_thread=sync_to_thread, serialize_result=False)
+        schema = get_schema(call_model, exclude=(CONTEXT_OPTION_NAME,))
+        if schema.get("type") != "object":
+            schema = {"type": "object", "properties": {}}
+        return MCPUITool(
+            name=name or f.__name__,
+            description=description or f.__doc__ or "",
+            handler=_bind(call_model),
+            input_schema=schema,
+        )
+
+    if function is not None:
+        return make(function)
+    return make
+
+
+class ToolProvider:
+    """Serves a fixed set of custom :class:`MCPUITool` over MCP.
+
+    Unlike resources/prompts, MCP exposes a single ``tools/call`` handler, so this
+    provider does not self-register decorators; :class:`~ag2.mcp.MCPServer` merges
+    it into the one tool list / dispatcher it already owns.
+    """
+
+    __slots__ = ("_tools", "_by_name")
+
+    def __init__(self, tools: Sequence[MCPUITool]) -> None:
+        self._tools = tuple(tools)
+        self._by_name = {t.name: t for t in self._tools}
+
+    @property
+    def names(self) -> frozenset[str]:
+        return frozenset(self._by_name)
+
+    def list_mcp_tools(self) -> list[MCPTool]:
+        return [t._mcp_tool() for t in self._tools]
+
+    def has(self, name: str) -> bool:
+        return name in self._by_name
+
+    async def call(self, name: str, arguments: dict[str, Any]) -> list[ContentBlock]:
+        return await self._by_name[name].call(arguments)

--- a/ag2/mcp/tools.py
+++ b/ag2/mcp/tools.py
@@ -5,44 +5,75 @@
 from collections.abc import Awaitable, Callable, Sequence
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
-from typing import Any, TypeAlias, overload
+from typing import Annotated, Any, TypeAlias, overload
 
 from fast_depends import dependency_provider
 from fast_depends.pydantic.schema import get_schema
-from mcp.types import ContentBlock
+from mcp.server.session import ServerSession
+from mcp.shared.context import RequestContext
+from mcp.types import ContentBlock, TextContent, ToolAnnotations
 from mcp.types import Tool as MCPTool
 
+from ag2.annotations import ContextField
 from ag2.utils import CONTEXT_OPTION_NAME, build_model
 
 from ._async import call_user_fn
 
-# A tool handler receives the call's ``arguments`` and returns the content
-# block(s) to send back. Sync or async; a lone block is accepted for convenience.
-ToolHandler: TypeAlias = Callable[
-    [dict[str, Any]], "Awaitable[ContentBlock | Sequence[ContentBlock]] | ContentBlock | Sequence[ContentBlock]"
-]
+# The result a handler may produce: the content block(s) to send back, or a
+# plain string (wrapped in a text block for convenience).
+ToolResult: TypeAlias = "ContentBlock | Sequence[ContentBlock] | str"
+
+# The MCP request context handed to a handler (``None`` outside a live request).
+ToolContext: TypeAlias = "RequestContext[ServerSession, Any, Any] | None"
+
+# A tool handler receives the call's ``arguments`` and the live MCP request
+# context. Sync or async.
+ToolHandler: TypeAlias = Callable[[dict[str, Any], ToolContext], "Awaitable[ToolResult] | ToolResult"]
+
+
+# Annotate a ``@mcp_tool`` function parameter (any name) with this to receive
+# the live MCP request context — session, client params, lifespan state:
+#   async def my_tool(x: str, ctx: MCPRequestContext) -> ...
+# Mirrors ``ag2.annotations.Context``; the parameter is excluded from the
+# advertised ``inputSchema``.
+MCPRequestContext = Annotated[RequestContext[ServerSession, Any, Any], ContextField(cast=False)]
 
 
 @dataclass(frozen=True, slots=True)
-class MCPUITool:
+class MCPFunctionTool:
     """A deterministic MCP tool served next to the agent's ``ask`` tool.
 
     Usually produced by :func:`mcp_tool`. Constructed directly, ``handler`` takes
-    the raw ``tools/call`` ``arguments`` dict and returns the content block(s);
-    ``input_schema`` is the JSON Schema advertised in ``tools/list`` (defaults to
-    an open object).
+    the raw ``tools/call`` ``arguments`` dict and the MCP request context, and
+    returns the content block(s) — typically an :mod:`ag2.mcp_ui` resource, but
+    any content block (or plain string) works. ``input_schema`` is the JSON
+    Schema advertised in ``tools/list`` (defaults to an open object).
+
+    ``title`` and ``annotations`` (``mcp.types.ToolAnnotations`` behavior hints
+    such as ``readOnlyHint`` / ``destructiveHint``) are passed through to
+    ``tools/list`` so hosts can decide e.g. whether to ask the user first.
     """
 
     name: str
     description: str
     handler: ToolHandler
     input_schema: dict[str, Any] = field(default_factory=lambda: {"type": "object"})
+    title: str | None = None
+    annotations: ToolAnnotations | None = None
 
     def _mcp_tool(self) -> MCPTool:
-        return MCPTool(name=self.name, description=self.description, inputSchema=self.input_schema)
+        return MCPTool(
+            name=self.name,
+            description=self.description,
+            inputSchema=self.input_schema,
+            title=self.title,
+            annotations=self.annotations,
+        )
 
-    async def call(self, arguments: dict[str, Any]) -> list[ContentBlock]:
-        result = await call_user_fn(self.handler, arguments)
+    async def call(self, arguments: dict[str, Any], request_context: ToolContext = None) -> list[ContentBlock]:
+        result = await call_user_fn(self.handler, arguments, request_context)
+        if isinstance(result, str):
+            return [TextContent(type="text", text=result)]
         if isinstance(result, ContentBlock):
             return [result]
         return list(result)
@@ -52,14 +83,15 @@ def _bind(call_model: Any) -> ToolHandler:
     """Wrap a ``fast_depends`` call model as a handler that unpacks ``arguments``.
 
     Mirrors ``ag2.a2ui.actions.A2UIAction.run``: the call's arguments become the
-    function's keyword arguments (serializer-coerced), and ``Depends``/``Inject``
-    parameters resolve against the process dependency provider.
+    function's keyword arguments (serializer-coerced), ``Depends``/``Inject``
+    parameters resolve against the process dependency provider, and a
+    :data:`MCPRequestContext`-annotated parameter receives the request context.
     """
 
-    async def handler(arguments: dict[str, Any]) -> Any:
+    async def handler(arguments: dict[str, Any], request_context: ToolContext) -> Any:
         async with AsyncExitStack() as stack:
             return await call_model.asolve(
-                **arguments,
+                **(arguments | {CONTEXT_OPTION_NAME: request_context}),
                 stack=stack,
                 cache_dependencies={},
                 dependency_provider=dependency_provider,
@@ -74,14 +106,22 @@ def mcp_tool(
     *,
     name: str | None = None,
     description: str | None = None,
+    title: str | None = None,
+    annotations: ToolAnnotations | None = None,
     sync_to_thread: bool = True,
-) -> MCPUITool: ...
+) -> MCPFunctionTool: ...
 
 
 @overload
 def mcp_tool(
-    function: None = None, *, name: str | None = None, description: str | None = None, sync_to_thread: bool = True
-) -> Callable[[Callable[..., Any]], MCPUITool]: ...
+    function: None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    title: str | None = None,
+    annotations: ToolAnnotations | None = None,
+    sync_to_thread: bool = True,
+) -> Callable[[Callable[..., Any]], MCPFunctionTool]: ...
 
 
 def mcp_tool(
@@ -89,32 +129,41 @@ def mcp_tool(
     *,
     name: str | None = None,
     description: str | None = None,
+    title: str | None = None,
+    annotations: ToolAnnotations | None = None,
     sync_to_thread: bool = True,
-) -> MCPUITool | Callable[[Callable[..., Any]], MCPUITool]:
-    """Turn a function into a :class:`MCPUITool` served alongside the agent's ``ask``.
+) -> MCPFunctionTool | Callable[[Callable[..., Any]], MCPFunctionTool]:
+    """Turn a function into a :class:`MCPFunctionTool` served alongside the agent's ``ask``.
 
     The tool ``name`` defaults to the function name, ``description`` to its
     docstring, and ``input_schema`` is derived from the typed signature. The
     function returns the MCP content block(s) for the result (e.g. an
-    :mod:`ag2.mcp_ui` resource). Pass the result in ``MCPServer(tools=[...])``.
+    :mod:`ag2.mcp_ui` resource) or a plain string. A parameter annotated with
+    :data:`MCPRequestContext` receives the live request context and is excluded
+    from the advertised schema. Pass the result in ``MCPServer(tools=[...])``.
 
     Args:
         function: The function (when used as a bare ``@mcp_tool``).
         name: Tool name. Defaults to the function name.
         description: Tool description. Defaults to the function docstring.
+        title: Human-readable display name for ``tools/list``.
+        annotations: ``mcp.types.ToolAnnotations`` behavior hints
+            (``readOnlyHint``, ``destructiveHint``, …) for the host.
         sync_to_thread: Run a sync function in a worker thread.
     """
 
-    def make(f: Callable[..., Any]) -> MCPUITool:
+    def make(f: Callable[..., Any]) -> MCPFunctionTool:
         call_model = build_model(f, sync_to_thread=sync_to_thread, serialize_result=False)
         schema = get_schema(call_model, exclude=(CONTEXT_OPTION_NAME,))
         if schema.get("type") != "object":
             schema = {"type": "object", "properties": {}}
-        return MCPUITool(
+        return MCPFunctionTool(
             name=name or f.__name__,
             description=description or f.__doc__ or "",
             handler=_bind(call_model),
             input_schema=schema,
+            title=title,
+            annotations=annotations,
         )
 
     if function is not None:
@@ -123,7 +172,7 @@ def mcp_tool(
 
 
 class ToolProvider:
-    """Serves a fixed set of custom :class:`MCPUITool` over MCP.
+    """Serves a fixed set of custom :class:`MCPFunctionTool` over MCP.
 
     Unlike resources/prompts, MCP exposes a single ``tools/call`` handler, so this
     provider does not self-register decorators; :class:`~ag2.mcp.MCPServer` merges
@@ -132,7 +181,7 @@ class ToolProvider:
 
     __slots__ = ("_tools", "_by_name")
 
-    def __init__(self, tools: Sequence[MCPUITool]) -> None:
+    def __init__(self, tools: Sequence[MCPFunctionTool]) -> None:
         self._tools = tuple(tools)
         self._by_name = {t.name: t for t in self._tools}
 
@@ -146,5 +195,7 @@ class ToolProvider:
     def has(self, name: str) -> bool:
         return name in self._by_name
 
-    async def call(self, name: str, arguments: dict[str, Any]) -> list[ContentBlock]:
-        return await self._by_name[name].call(arguments)
+    async def call(
+        self, name: str, arguments: dict[str, Any], request_context: ToolContext = None
+    ) -> list[ContentBlock]:
+        return await self._by_name[name].call(arguments, request_context)

--- a/ag2/mcp_ui/__init__.py
+++ b/ag2/mcp_ui/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from ag2.exceptions import missing_optional_dependency
+
+try:
+    from . import actions
+    from .resources import external_url, raw_html, remote_dom
+except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp-ui] is absent
+    external_url = missing_optional_dependency("external_url", "mcp-ui", e)  # type: ignore[misc]
+    raw_html = missing_optional_dependency("raw_html", "mcp-ui", e)  # type: ignore[misc]
+    remote_dom = missing_optional_dependency("remote_dom", "mcp-ui", e)  # type: ignore[misc]
+    actions = missing_optional_dependency("actions", "mcp-ui", e)  # type: ignore[misc]
+
+__all__ = (
+    "actions",
+    "external_url",
+    "raw_html",
+    "remote_dom",
+)

--- a/ag2/mcp_ui/__init__.py
+++ b/ag2/mcp_ui/__init__.py
@@ -5,17 +5,27 @@
 from ag2.exceptions import missing_optional_dependency
 
 try:
-    from . import actions
+    from .actions import intent, link, notify, post_message, prompt, tool_call
     from .resources import external_url, raw_html, remote_dom
 except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp-ui] is absent
     external_url = missing_optional_dependency("external_url", "mcp-ui", e)  # type: ignore[misc]
     raw_html = missing_optional_dependency("raw_html", "mcp-ui", e)  # type: ignore[misc]
     remote_dom = missing_optional_dependency("remote_dom", "mcp-ui", e)  # type: ignore[misc]
-    actions = missing_optional_dependency("actions", "mcp-ui", e)  # type: ignore[misc]
+    tool_call = missing_optional_dependency("tool_call", "mcp-ui", e)  # type: ignore[misc]
+    prompt = missing_optional_dependency("prompt", "mcp-ui", e)  # type: ignore[misc]
+    link = missing_optional_dependency("link", "mcp-ui", e)  # type: ignore[misc]
+    intent = missing_optional_dependency("intent", "mcp-ui", e)  # type: ignore[misc]
+    notify = missing_optional_dependency("notify", "mcp-ui", e)  # type: ignore[misc]
+    post_message = missing_optional_dependency("post_message", "mcp-ui", e)  # type: ignore[misc]
 
 __all__ = (
-    "actions",
     "external_url",
+    "intent",
+    "link",
+    "notify",
+    "post_message",
+    "prompt",
     "raw_html",
     "remote_dom",
+    "tool_call",
 )

--- a/ag2/mcp_ui/actions.py
+++ b/ag2/mcp_ui/actions.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from mcp_ui_server import (
+    UIActionResultIntent,
+    UIActionResultLink,
+    UIActionResultNotification,
+    UIActionResultPrompt,
+    UIActionResultToolCall,
+    ui_action_result_intent,
+    ui_action_result_link,
+    ui_action_result_notification,
+    ui_action_result_prompt,
+    ui_action_result_tool_call,
+)
+
+__all__ = (
+    "intent",
+    "link",
+    "notify",
+    "prompt",
+    "tool_call",
+)
+
+
+def tool_call(tool_name: str, params: dict[str, Any]) -> UIActionResultToolCall:
+    """A ``tool`` action: ask the host to call the MCP tool ``tool_name(params)``."""
+    return ui_action_result_tool_call(tool_name, params)
+
+
+def prompt(text: str) -> UIActionResultPrompt:
+    """A ``prompt`` action: send ``text`` into the conversation as a follow-up."""
+    return ui_action_result_prompt(text)
+
+
+def link(url: str) -> UIActionResultLink:
+    """A ``link`` action: ask the host to open ``url``."""
+    return ui_action_result_link(url)
+
+
+def intent(name: str, params: dict[str, Any]) -> UIActionResultIntent:
+    """An ``intent`` action: emit a host-defined ``name`` intent with ``params``."""
+    return ui_action_result_intent(name, params)
+
+
+def notify(message: str) -> UIActionResultNotification:
+    """A ``notify`` action: send ``message`` to the host as a notification/log."""
+    return ui_action_result_notification(message)

--- a/ag2/mcp_ui/actions.py
+++ b/ag2/mcp_ui/actions.py
@@ -2,9 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import html
+import json
 from typing import Any
 
 from mcp_ui_server import (
+    UIActionResult,
     UIActionResultIntent,
     UIActionResultLink,
     UIActionResultNotification,
@@ -21,6 +24,7 @@ __all__ = (
     "intent",
     "link",
     "notify",
+    "post_message",
     "prompt",
     "tool_call",
 )
@@ -49,3 +53,16 @@ def intent(name: str, params: dict[str, Any]) -> UIActionResultIntent:
 def notify(message: str) -> UIActionResultNotification:
     """A ``notify`` action: send ``message`` to the host as a notification/log."""
     return ui_action_result_notification(message)
+
+
+def post_message(action: UIActionResult) -> str:
+    """An HTML-attribute-safe ``window.parent.postMessage(...)`` call for ``action``.
+
+    JSON-serializes the action and HTML-escapes the result, so quotes and
+    apostrophes in the payload (e.g. a prompt like ``"What's my order?"``)
+    cannot terminate the surrounding attribute::
+
+        button = f'<button onclick="{post_message(action)}">Add to cart</button>'
+    """
+    payload = json.dumps(action.model_dump(exclude_none=True))
+    return html.escape(f"window.parent.postMessage({payload}, '*')")

--- a/ag2/mcp_ui/resources.py
+++ b/ag2/mcp_ui/resources.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Literal, TypeAlias
+
+from mcp.types import EmbeddedResource
+from mcp_ui_server import create_ui_resource
+
+__all__ = (
+    "external_url",
+    "raw_html",
+    "remote_dom",
+)
+
+# Metadata passed through to the client: ``ui_metadata`` is prefixed by
+# ``mcp-ui-server`` with ``mcpui.dev/ui-`` so the client recognizes it;
+# ``metadata`` is written verbatim into the resource ``_meta``.
+UIMetadata = dict[str, Any]
+Encoding: TypeAlias = Literal["text", "blob"]
+
+
+def _build(options: dict[str, Any]) -> EmbeddedResource:
+    return create_ui_resource(options)
+
+
+def _options(
+    uri: str,
+    content: dict[str, Any],
+    encoding: Encoding,
+    ui_metadata: UIMetadata | None,
+    metadata: UIMetadata | None,
+) -> dict[str, Any]:
+    options: dict[str, Any] = {"uri": uri, "content": content, "encoding": encoding}
+    if ui_metadata:
+        options["uiMetadata"] = ui_metadata
+    if metadata:
+        options["metadata"] = metadata
+    return options
+
+
+def raw_html(
+    uri: str,
+    html: str,
+    *,
+    encoding: Encoding = "text",
+    ui_metadata: UIMetadata | None = None,
+    metadata: UIMetadata | None = None,
+) -> EmbeddedResource:
+    """A UI resource rendering an inline HTML string (``uri`` must start with ``ui://``)."""
+    return _build(_options(uri, {"type": "rawHtml", "htmlString": html}, encoding, ui_metadata, metadata))
+
+
+def external_url(
+    uri: str,
+    url: str,
+    *,
+    encoding: Encoding = "text",
+    ui_metadata: UIMetadata | None = None,
+    metadata: UIMetadata | None = None,
+) -> EmbeddedResource:
+    """A UI resource the client renders by embedding ``url`` in an ``iframe``."""
+    return _build(_options(uri, {"type": "externalUrl", "iframeUrl": url}, encoding, ui_metadata, metadata))
+
+
+def remote_dom(
+    uri: str,
+    script: str,
+    *,
+    framework: Literal["react", "webcomponents"] = "react",
+    encoding: Encoding = "text",
+    ui_metadata: UIMetadata | None = None,
+    metadata: UIMetadata | None = None,
+) -> EmbeddedResource:
+    """A UI resource carrying a Remote-DOM ``script`` the client mounts (``react`` or ``webcomponents``)."""
+    content = {"type": "remoteDom", "script": script, "framework": framework}
+    return _build(_options(uri, content, encoding, ui_metadata, metadata))

--- a/examples/mcp/server_ui.py
+++ b/examples/mcp/server_ui.py
@@ -1,25 +1,22 @@
 import asyncio
-import json
 from typing import Any
 
 from ag2 import Agent
 from ag2.config import AnthropicConfig
 from ag2.mcp import MCPServer, mcp_tool
-from ag2.mcp_ui import actions, external_url, raw_html
+from ag2.mcp_ui import external_url, post_message, raw_html, tool_call
 
 
 @mcp_tool
 async def show_greeting(name: str = "world") -> Any:
     """Return an interactive greeting card with a UI Action button."""
     # A `tool` UI Action: on click the host calls tools/call add_to_cart(...).
-    action = actions.tool_call("add_to_cart", {"good_id": "42"})
-    payload = json.dumps(action.model_dump(exclude_none=True))
+    action = tool_call("add_to_cart", {"good_id": "42"})
     html = (
-        f"<div style='font-family:sans-serif;padding:24px'>"
+        "<div style='font-family:sans-serif;padding:24px'>"
         f"<h1>Hello, {name} 👋</h1>"
-        f"<p>Rendered by an MCP-UI client from an AG2 server.</p>"
-        f"<button onclick='window.parent.postMessage({payload}, \"*\")'>"
-        f"Add to cart</button></div>"
+        "<p>Rendered by an MCP-UI client from an AG2 server.</p>"
+        f'<button onclick="{post_message(action)}">Add to cart</button></div>'
     )
     return raw_html("ui://ag2/greeting", html)
 

--- a/examples/mcp/server_ui.py
+++ b/examples/mcp/server_ui.py
@@ -1,0 +1,49 @@
+import asyncio
+import json
+from typing import Any
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer, mcp_tool
+from ag2.mcp_ui import actions, external_url, raw_html
+
+
+@mcp_tool
+async def show_greeting(name: str = "world") -> Any:
+    """Return an interactive greeting card with a UI Action button."""
+    # A `tool` UI Action: on click the host calls tools/call add_to_cart(...).
+    action = actions.tool_call("add_to_cart", {"good_id": "42"})
+    payload = json.dumps(action.model_dump(exclude_none=True))
+    html = (
+        f"<div style='font-family:sans-serif;padding:24px'>"
+        f"<h1>Hello, {name} 👋</h1>"
+        f"<p>Rendered by an MCP-UI client from an AG2 server.</p>"
+        f"<button onclick='window.parent.postMessage({payload}, \"*\")'>"
+        f"Add to cart</button></div>"
+    )
+    return raw_html("ui://ag2/greeting", html)
+
+
+@mcp_tool
+async def show_docs() -> Any:
+    """Return the AG2 docs embedded in an iframe."""
+    return external_url("ui://ag2/docs", "https://docs.ag2.ai/")
+
+
+@mcp_tool
+async def add_to_cart(good_id: str) -> Any:
+    """Target of the greeting card's UI Action; returns an updated card."""
+    return raw_html("ui://ag2/cart", f"<b>Added item {good_id} to cart ✓</b>")
+
+
+agent = Agent(
+    name="claude",
+    prompt="You are a concise assistant.",
+    config=AnthropicConfig(model="claude-sonnet-4-6"),
+)
+
+server = MCPServer(agent, tools=[show_greeting, show_docs, add_to_cart])
+
+
+if __name__ == "__main__":
+    asyncio.run(server.run_stdio())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,10 @@ mcp = [
     # mcp 1.9.4+ fixes issue #1865 where string parameters are converted to integers
     "mcp>=1.11.0,<2",
 ]
+# MCP-UI resources (ag2.mcp_ui) — return renderable UI blobs from tool results
+mcp-ui = [
+    "mcp-ui-server>=1.0.0",
+]
 
 [dependency-groups]
 # Dev dependency groups (PEP 735). These replace the former dev *extras* and are
@@ -131,6 +135,7 @@ test = [
     { include-group = "test-core" },
     "docker>=6.0.0,<8",
     "ag2[mcp]",
+    "ag2[mcp-ui]", # ag2.mcp_ui — MCP-UI resource & action builders
     "ipykernel==7.3.0",
     "nbconvert==7.17.1",
     "nbformat==5.10.4",
@@ -145,6 +150,7 @@ optionals = [
     "ag2[ag-ui]",
     "ag2[a2ui]", # provides starlette/jsonschema for AG-UI / a2ui serving tests
     "ag2[mcp]", # ag2.mcp — serve an Agent as an MCP server
+    "ag2[mcp-ui]", # ag2.mcp_ui — MCP-UI resource & action builders
     "ag2[tracing]",
     "ag2[metrics]",
     # search tools

--- a/test/mcp/test_custom_tools.py
+++ b/test/mcp/test_custom_tools.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import pytest
+from dirty_equals import IsPartialDict
+from mcp.types import TextContent
+
+from ag2 import Agent
+from ag2.mcp import MCPServer, MCPUITool, mcp_tool
+from ag2.mcp.errors import MCPToolNameConflictError
+from ag2.mcp.testing import connect
+from ag2.testing import TestConfig
+
+
+async def _echo(args: dict[str, Any]) -> TextContent:
+    return TextContent(type="text", text=f"got {args.get('x')}")
+
+
+@pytest.mark.asyncio
+class TestCustomTools:
+    async def test_custom_tools_listed_next_to_ask(self) -> None:
+        server = MCPServer(
+            Agent("g", config=TestConfig("hi")),
+            tools=[MCPUITool("echo", "Echo x", _echo, {"type": "object", "properties": {"x": {"type": "string"}}})],
+        )
+
+        async with connect(server) as session:
+            tools = await session.list_tools()
+
+        assert [t.name for t in tools.tools] == ["ask", "echo"]
+
+    async def test_custom_tool_dispatches_to_handler(self) -> None:
+        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[MCPUITool("echo", "Echo x", _echo)])
+
+        async with connect(server) as session:
+            result = await session.call_tool("echo", {"x": "42"})
+
+        assert result.isError is False
+        assert result.content == [TextContent(type="text", text="got 42")]
+
+    async def test_ask_still_works_alongside_custom_tools(self) -> None:
+        server = MCPServer(Agent("g", config=TestConfig("hello")), tools=[MCPUITool("echo", "Echo x", _echo)])
+
+        async with connect(server) as session:
+            result = await session.call_tool("ask", {"message": "hi"})
+
+        assert result.content == [TextContent(type="text", text="hello")]
+
+    async def test_sync_handler_runs(self) -> None:
+        def sync_handler(args: dict[str, Any]) -> TextContent:
+            return TextContent(type="text", text="sync ok")
+
+        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[MCPUITool("s", "sync", sync_handler)])
+
+        async with connect(server) as session:
+            result = await session.call_tool("s", {})
+
+        assert result.content == [TextContent(type="text", text="sync ok")]
+
+    async def test_name_collision_with_ask_is_rejected(self) -> None:
+        with pytest.raises(MCPToolNameConflictError):
+            MCPServer(Agent("g", config=TestConfig("hi")), tools=[MCPUITool("ask", "clash", _echo)])
+
+    async def test_collision_respects_custom_tool_name(self) -> None:
+        # The reserved name follows ``tool_name``; "ask" is free when renamed.
+        server = MCPServer(
+            Agent("g", config=TestConfig("hi")),
+            tool_name="chat",
+            tools=[MCPUITool("ask", "now free", _echo)],
+        )
+
+        async with connect(server) as session:
+            tools = await session.list_tools()
+
+        assert [t.name for t in tools.tools] == ["chat", "ask"]
+
+
+@pytest.mark.asyncio
+class TestMcpToolDecorator:
+    async def test_derives_name_description_and_schema(self) -> None:
+        @mcp_tool
+        async def greet(name: str = "world") -> TextContent:
+            """Greet someone."""
+            return TextContent(type="text", text=f"hi {name}")
+
+        assert isinstance(greet, MCPUITool)
+        assert greet.name == "greet"
+        assert greet.description == "Greet someone."
+        assert greet.input_schema == IsPartialDict({
+            "type": "object",
+            "properties": {"name": IsPartialDict({"type": "string", "default": "world"})},
+        })
+
+    async def test_dispatches_with_named_arguments(self) -> None:
+        @mcp_tool
+        async def add(good_id: str) -> TextContent:
+            """Add an item."""
+            return TextContent(type="text", text=f"added {good_id}")
+
+        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[add])
+
+        async with connect(server) as session:
+            tools = await session.list_tools()
+            result = await session.call_tool("add", {"good_id": "42"})
+
+        assert tools.tools[1].inputSchema == IsPartialDict({"required": ["good_id"]})
+        assert result.content == [TextContent(type="text", text="added 42")]
+
+    async def test_default_argument_is_optional(self) -> None:
+        @mcp_tool
+        async def greet(name: str = "world") -> TextContent:
+            """Greet."""
+            return TextContent(type="text", text=f"hi {name}")
+
+        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[greet])
+
+        async with connect(server) as session:
+            result = await session.call_tool("greet", {})
+
+        assert result.content == [TextContent(type="text", text="hi world")]
+
+    async def test_explicit_name_override(self) -> None:
+        @mcp_tool(name="custom", description="overridden")
+        async def greet() -> TextContent:
+            """ignored docstring."""
+            return TextContent(type="text", text="ok")
+
+        assert greet.name == "custom"
+        assert greet.description == "overridden"

--- a/test/mcp/test_custom_tools.py
+++ b/test/mcp/test_custom_tools.py
@@ -6,16 +6,17 @@ from typing import Any
 
 import pytest
 from dirty_equals import IsPartialDict
-from mcp.types import TextContent
+from mcp.types import TextContent, ToolAnnotations
 
 from ag2 import Agent
-from ag2.mcp import MCPServer, MCPUITool, mcp_tool
+from ag2.mcp import MCPFunctionTool, MCPServer, mcp_tool
 from ag2.mcp.errors import MCPToolNameConflictError
 from ag2.mcp.testing import connect
+from ag2.mcp.tools import MCPRequestContext, ToolContext
 from ag2.testing import TestConfig
 
 
-async def _echo(args: dict[str, Any]) -> TextContent:
+async def _echo(args: dict[str, Any], _ctx: ToolContext) -> TextContent:
     return TextContent(type="text", text=f"got {args.get('x')}")
 
 
@@ -24,7 +25,9 @@ class TestCustomTools:
     async def test_custom_tools_listed_next_to_ask(self) -> None:
         server = MCPServer(
             Agent("g", config=TestConfig("hi")),
-            tools=[MCPUITool("echo", "Echo x", _echo, {"type": "object", "properties": {"x": {"type": "string"}}})],
+            tools=[
+                MCPFunctionTool("echo", "Echo x", _echo, {"type": "object", "properties": {"x": {"type": "string"}}})
+            ],
         )
 
         async with connect(server) as session:
@@ -33,7 +36,7 @@ class TestCustomTools:
         assert [t.name for t in tools.tools] == ["ask", "echo"]
 
     async def test_custom_tool_dispatches_to_handler(self) -> None:
-        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[MCPUITool("echo", "Echo x", _echo)])
+        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[MCPFunctionTool("echo", "Echo x", _echo)])
 
         async with connect(server) as session:
             result = await session.call_tool("echo", {"x": "42"})
@@ -42,7 +45,7 @@ class TestCustomTools:
         assert result.content == [TextContent(type="text", text="got 42")]
 
     async def test_ask_still_works_alongside_custom_tools(self) -> None:
-        server = MCPServer(Agent("g", config=TestConfig("hello")), tools=[MCPUITool("echo", "Echo x", _echo)])
+        server = MCPServer(Agent("g", config=TestConfig("hello")), tools=[MCPFunctionTool("echo", "Echo x", _echo)])
 
         async with connect(server) as session:
             result = await session.call_tool("ask", {"message": "hi"})
@@ -50,10 +53,10 @@ class TestCustomTools:
         assert result.content == [TextContent(type="text", text="hello")]
 
     async def test_sync_handler_runs(self) -> None:
-        def sync_handler(args: dict[str, Any]) -> TextContent:
+        def sync_handler(args: dict[str, Any], _ctx: ToolContext) -> TextContent:
             return TextContent(type="text", text="sync ok")
 
-        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[MCPUITool("s", "sync", sync_handler)])
+        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[MCPFunctionTool("s", "sync", sync_handler)])
 
         async with connect(server) as session:
             result = await session.call_tool("s", {})
@@ -62,14 +65,50 @@ class TestCustomTools:
 
     async def test_name_collision_with_ask_is_rejected(self) -> None:
         with pytest.raises(MCPToolNameConflictError):
-            MCPServer(Agent("g", config=TestConfig("hi")), tools=[MCPUITool("ask", "clash", _echo)])
+            MCPServer(Agent("g", config=TestConfig("hi")), tools=[MCPFunctionTool("ask", "clash", _echo)])
+
+    async def test_duplicate_tool_names_are_rejected(self) -> None:
+        with pytest.raises(MCPToolNameConflictError):
+            MCPServer(
+                Agent("g", config=TestConfig("hi")),
+                tools=[MCPFunctionTool("echo", "first", _echo), MCPFunctionTool("echo", "second", _echo)],
+            )
+
+    async def test_string_result_from_handler_becomes_a_text_block(self) -> None:
+        # A plain string must not be split into per-character blocks.
+        server = MCPServer(
+            Agent("g", config=TestConfig("hi")),
+            tools=[MCPFunctionTool("hello", "Say hello", lambda args, ctx: "hello world")],
+        )
+
+        async with connect(server) as session:
+            result = await session.call_tool("hello", {})
+
+        assert result.content == [TextContent(type="text", text="hello world")]
+
+    async def test_title_and_annotations_are_advertised(self) -> None:
+        server = MCPServer(
+            Agent("g", config=TestConfig("hi")),
+            tools=[
+                MCPFunctionTool("echo", "Echo x", _echo, title="Echo", annotations=ToolAnnotations(readOnlyHint=True))
+            ],
+        )
+
+        async with connect(server) as session:
+            tools = await session.list_tools()
+
+        assert tools.tools[1].model_dump(exclude_none=True) == IsPartialDict({
+            "name": "echo",
+            "title": "Echo",
+            "annotations": {"readOnlyHint": True},
+        })
 
     async def test_collision_respects_custom_tool_name(self) -> None:
         # The reserved name follows ``tool_name``; "ask" is free when renamed.
         server = MCPServer(
             Agent("g", config=TestConfig("hi")),
             tool_name="chat",
-            tools=[MCPUITool("ask", "now free", _echo)],
+            tools=[MCPFunctionTool("ask", "now free", _echo)],
         )
 
         async with connect(server) as session:
@@ -86,7 +125,7 @@ class TestMcpToolDecorator:
             """Greet someone."""
             return TextContent(type="text", text=f"hi {name}")
 
-        assert isinstance(greet, MCPUITool)
+        assert isinstance(greet, MCPFunctionTool)
         assert greet.name == "greet"
         assert greet.description == "Greet someone."
         assert greet.input_schema == IsPartialDict({
@@ -130,3 +169,40 @@ class TestMcpToolDecorator:
 
         assert greet.name == "custom"
         assert greet.description == "overridden"
+
+    async def test_title_and_annotations_pass_through(self) -> None:
+        @mcp_tool(title="Greet", annotations=ToolAnnotations(readOnlyHint=True))
+        async def greet() -> TextContent:
+            """Greet."""
+            return TextContent(type="text", text="ok")
+
+        assert greet.title == "Greet"
+        assert greet.annotations == ToolAnnotations(readOnlyHint=True)
+
+    async def test_string_result_from_decorated_function_becomes_a_text_block(self) -> None:
+        @mcp_tool
+        async def greet(name: str = "world") -> str:
+            """Greet."""
+            return f"hi {name}"
+
+        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[greet])
+
+        async with connect(server) as session:
+            result = await session.call_tool("greet", {})
+
+        assert result.content == [TextContent(type="text", text="hi world")]
+
+    async def test_request_context_is_injected_and_hidden_from_schema(self) -> None:
+        @mcp_tool
+        async def whoami(ctx: MCPRequestContext) -> str:
+            """Report whether a live session is attached."""
+            return f"live session: {ctx.session is not None}"
+
+        assert "ctx" not in whoami.input_schema.get("properties", {})
+
+        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[whoami])
+
+        async with connect(server) as session:
+            result = await session.call_tool("whoami", {})
+
+        assert result.content == [TextContent(type="text", text="live session: True")]

--- a/test/mcp_ui/__init__.py
+++ b/test/mcp_ui/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+# `mcp` is an optional extra; skip the whole package when it isn't installed
+# (mirrors test/a2a/__init__.py). beta-test.yml runs without ag2[mcp].
+pytest.importorskip("mcp")

--- a/test/mcp_ui/test_actions.py
+++ b/test/mcp_ui/test_actions.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from mcp_ui_server import (
+    UIActionResultIntent,
+    UIActionResultLink,
+    UIActionResultNotification,
+    UIActionResultPrompt,
+    UIActionResultToolCall,
+)
+
+from ag2.mcp_ui import actions
+
+
+class TestUIActions:
+    def test_tool_call(self) -> None:
+        result = actions.tool_call("add_to_cart", {"good_id": "42"})
+
+        assert result == UIActionResultToolCall(
+            type="tool",
+            payload=UIActionResultToolCall.ToolCallPayload(toolName="add_to_cart", params={"good_id": "42"}),
+        )
+
+    def test_prompt(self) -> None:
+        result = actions.prompt("What is the weather?")
+
+        assert result == UIActionResultPrompt(
+            type="prompt",
+            payload=UIActionResultPrompt.PromptPayload(prompt="What is the weather?"),
+        )
+
+    def test_link(self) -> None:
+        result = actions.link("https://docs.ag2.ai/")
+
+        assert result == UIActionResultLink(
+            type="link",
+            payload=UIActionResultLink.LinkPayload(url="https://docs.ag2.ai/"),
+        )
+
+    def test_intent(self) -> None:
+        result = actions.intent("checkout", {"cart_id": "7"})
+
+        assert result == UIActionResultIntent(
+            type="intent",
+            payload=UIActionResultIntent.IntentPayload(intent="checkout", params={"cart_id": "7"}),
+        )
+
+    def test_notify(self) -> None:
+        result = actions.notify("Widget loaded")
+
+        assert result == UIActionResultNotification(
+            type="notify",
+            payload=UIActionResultNotification.NotificationPayload(message="Widget loaded"),
+        )

--- a/test/mcp_ui/test_actions.py
+++ b/test/mcp_ui/test_actions.py
@@ -10,12 +10,12 @@ from mcp_ui_server import (
     UIActionResultToolCall,
 )
 
-from ag2.mcp_ui import actions
+from ag2.mcp_ui import intent, link, notify, post_message, prompt, tool_call
 
 
 class TestUIActions:
     def test_tool_call(self) -> None:
-        result = actions.tool_call("add_to_cart", {"good_id": "42"})
+        result = tool_call("add_to_cart", {"good_id": "42"})
 
         assert result == UIActionResultToolCall(
             type="tool",
@@ -23,7 +23,7 @@ class TestUIActions:
         )
 
     def test_prompt(self) -> None:
-        result = actions.prompt("What is the weather?")
+        result = prompt("What is the weather?")
 
         assert result == UIActionResultPrompt(
             type="prompt",
@@ -31,7 +31,7 @@ class TestUIActions:
         )
 
     def test_link(self) -> None:
-        result = actions.link("https://docs.ag2.ai/")
+        result = link("https://docs.ag2.ai/")
 
         assert result == UIActionResultLink(
             type="link",
@@ -39,7 +39,7 @@ class TestUIActions:
         )
 
     def test_intent(self) -> None:
-        result = actions.intent("checkout", {"cart_id": "7"})
+        result = intent("checkout", {"cart_id": "7"})
 
         assert result == UIActionResultIntent(
             type="intent",
@@ -47,9 +47,28 @@ class TestUIActions:
         )
 
     def test_notify(self) -> None:
-        result = actions.notify("Widget loaded")
+        result = notify("Widget loaded")
 
         assert result == UIActionResultNotification(
             type="notify",
             payload=UIActionResultNotification.NotificationPayload(message="Widget loaded"),
         )
+
+
+class TestPostMessage:
+    def test_builds_post_message_call(self) -> None:
+        result = post_message(tool_call("add_to_cart", {"good_id": "42"}))
+
+        assert result == (
+            "window.parent.postMessage("
+            "{&quot;type&quot;: &quot;tool&quot;, &quot;payload&quot;: "
+            "{&quot;toolName&quot;: &quot;add_to_cart&quot;, &quot;params&quot;: {&quot;good_id&quot;: &quot;42&quot;}}}"
+            ", &#x27;*&#x27;)"
+        )
+
+    def test_quotes_cannot_break_out_of_the_attribute(self) -> None:
+        # An apostrophe in the payload must not terminate a quoted HTML attribute.
+        result = post_message(prompt("What's the status of my order?"))
+
+        assert "'" not in result
+        assert '"' not in result

--- a/test/mcp_ui/test_resources.py
+++ b/test/mcp_ui/test_resources.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+
+from mcp.types import BlobResourceContents, TextResourceContents
+from mcp_ui_server import UIResource
+
+from ag2 import mcp_ui
+
+
+class TestRawHtml:
+    def test_builds_inline_html_resource(self) -> None:
+        block = mcp_ui.raw_html("ui://ag2/greeting", "<h1>Hi</h1>")
+
+        assert block == UIResource(
+            resource=TextResourceContents(uri="ui://ag2/greeting", mimeType="text/html", text="<h1>Hi</h1>"),
+        )
+
+    def test_blob_encoding_base64_encodes_payload(self) -> None:
+        block = mcp_ui.raw_html("ui://ag2/greeting", "<h1>Hi</h1>", encoding="blob")
+
+        assert block == UIResource(
+            resource=BlobResourceContents(
+                uri="ui://ag2/greeting",
+                mimeType="text/html",
+                blob=base64.b64encode(b"<h1>Hi</h1>").decode(),
+            ),
+        )
+
+
+def test_external_url_builds_iframe_resource() -> None:
+    block = mcp_ui.external_url("ui://ag2/docs", "https://docs.ag2.ai/")
+
+    assert block == UIResource(
+        resource=TextResourceContents(uri="ui://ag2/docs", mimeType="text/uri-list", text="https://docs.ag2.ai/"),
+    )
+
+
+class TestRemoteDom:
+    def test_carries_script_and_react_framework(self) -> None:
+        block = mcp_ui.remote_dom("ui://ag2/dom", "root.appendChild(el)", framework="react")
+
+        assert block == UIResource(
+            resource=TextResourceContents(
+                uri="ui://ag2/dom",
+                mimeType="application/vnd.mcp-ui.remote-dom+javascript; framework=react",
+                text="root.appendChild(el)",
+            ),
+        )
+
+    def test_webcomponents_framework(self) -> None:
+        block = mcp_ui.remote_dom("ui://ag2/dom", "root.appendChild(el)", framework="webcomponents")
+
+        assert block == UIResource(
+            resource=TextResourceContents(
+                uri="ui://ag2/dom",
+                mimeType="application/vnd.mcp-ui.remote-dom+javascript; framework=webcomponents",
+                text="root.appendChild(el)",
+            ),
+        )
+
+
+def test_ui_metadata_is_prefixed_and_metadata_is_verbatim() -> None:
+    block = mcp_ui.raw_html(
+        "ui://ag2/greeting",
+        "<h1>Hi</h1>",
+        ui_metadata={"preferred-frame-size": ["800px", "600px"]},
+        metadata={"title": "Greeting"},
+    )
+
+    assert block == UIResource(
+        resource=TextResourceContents(
+            uri="ui://ag2/greeting",
+            mimeType="text/html",
+            text="<h1>Hi</h1>",
+            _meta={
+                "mcpui.dev/ui-preferred-frame-size": ["800px", "600px"],
+                "title": "Greeting",
+            },
+        ),
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -116,6 +116,9 @@ gemini = [
 mcp = [
     { name = "mcp" },
 ]
+mcp-ui = [
+    { name = "mcp-ui-server" },
+]
 metrics = [
     { name = "prometheus-client" },
 ]
@@ -148,7 +151,7 @@ zai = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "ag2", extra = ["a2a", "ag-ui", "anthropic", "dashscope", "ddgs", "gemini", "mcp", "metrics", "ollama", "openai", "perplexity", "redis", "tavily", "tracing", "xai"] },
+    { name = "ag2", extra = ["a2a", "ag-ui", "anthropic", "dashscope", "ddgs", "gemini", "mcp", "mcp-ui", "metrics", "ollama", "openai", "perplexity", "redis", "tavily", "tracing", "xai"] },
     { name = "cairosvg" },
     { name = "codespell" },
     { name = "daytona" },
@@ -224,7 +227,7 @@ lint = [
     { name = "zizmor" },
 ]
 optionals = [
-    { name = "ag2", extra = ["a2ui", "ag-ui", "anthropic", "bedrock", "dashscope", "ddgs", "gemini", "mcp", "metrics", "ollama", "openai", "perplexity", "redis", "tavily", "tracing", "xai", "zai"] },
+    { name = "ag2", extra = ["a2ui", "ag-ui", "anthropic", "bedrock", "dashscope", "ddgs", "gemini", "mcp", "mcp-ui", "metrics", "ollama", "openai", "perplexity", "redis", "tavily", "tracing", "xai", "zai"] },
     { name = "daytona" },
     { name = "docker" },
     { name = "exa-py" },
@@ -233,7 +236,7 @@ optionals = [
     { name = "websockets" },
 ]
 test = [
-    { name = "ag2", extra = ["mcp"] },
+    { name = "ag2", extra = ["mcp", "mcp-ui"] },
     { name = "dirty-equals" },
     { name = "docker" },
     { name = "ipykernel" },
@@ -253,7 +256,7 @@ test-core = [
     { name = "pytest-timeout" },
 ]
 types = [
-    { name = "ag2", extra = ["a2a", "ag-ui", "mcp", "openai"] },
+    { name = "ag2", extra = ["a2a", "ag-ui", "mcp", "mcp-ui", "openai"] },
     { name = "dirty-equals" },
     { name = "docker" },
     { name = "ipykernel" },
@@ -289,6 +292,7 @@ requires-dist = [
     { name = "jsonschema", marker = "extra == 'a2ui'", specifier = ">=4.18.0,<5" },
     { name = "jsonschema", marker = "extra == 'gemini'" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.11.0,<2" },
+    { name = "mcp-ui-server", marker = "extra == 'mcp-ui'", specifier = ">=1.0.0" },
     { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.4.7" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=2.44.0,<3.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'tracing'", specifier = ">=1.20" },
@@ -308,7 +312,7 @@ requires-dist = [
     { name = "xai-sdk", marker = "extra == 'xai'", specifier = ">=1.12.2,<2" },
     { name = "zai-sdk", marker = "extra == 'zai'", specifier = ">=0.2.3,<1" },
 ]
-provides-extras = ["a2a", "a2ui", "acp", "ag-ui", "openai", "anthropic", "gemini", "xai", "zai", "ollama", "bedrock", "dashscope", "redis", "tracing", "metrics", "tavily", "ddgs", "perplexity", "mcp"]
+provides-extras = ["a2a", "a2ui", "acp", "ag-ui", "openai", "anthropic", "gemini", "xai", "zai", "ollama", "bedrock", "dashscope", "redis", "tracing", "metrics", "tavily", "ddgs", "perplexity", "mcp", "mcp-ui"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -318,6 +322,7 @@ dev = [
     { name = "ag2", extras = ["dashscope"] },
     { name = "ag2", extras = ["gemini"] },
     { name = "ag2", extras = ["mcp"] },
+    { name = "ag2", extras = ["mcp-ui"] },
     { name = "ag2", extras = ["metrics"] },
     { name = "ag2", extras = ["ollama"] },
     { name = "ag2", extras = ["openai"] },
@@ -419,6 +424,7 @@ optionals = [
     { name = "ag2", extras = ["dashscope"] },
     { name = "ag2", extras = ["gemini"] },
     { name = "ag2", extras = ["mcp"] },
+    { name = "ag2", extras = ["mcp-ui"] },
     { name = "ag2", extras = ["metrics"] },
     { name = "ag2", extras = ["ollama"] },
     { name = "ag2", extras = ["openai"] },
@@ -436,6 +442,7 @@ optionals = [
 ]
 test = [
     { name = "ag2", extras = ["mcp"] },
+    { name = "ag2", extras = ["mcp-ui"] },
     { name = "dirty-equals", specifier = ">=0.11,<0.12" },
     { name = "docker", specifier = ">=6.0.0,<8" },
     { name = "ipykernel", specifier = "==7.3.0" },
@@ -456,6 +463,7 @@ test-core = [
 ]
 types = [
     { name = "ag2", extras = ["mcp"] },
+    { name = "ag2", extras = ["mcp-ui"] },
     { name = "ag2", extras = ["openai", "a2a", "ag-ui"] },
     { name = "dirty-equals", specifier = ">=0.11,<0.12" },
     { name = "docker", specifier = ">=6.0.0,<8" },
@@ -3613,6 +3621,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+]
+
+[[package]]
+name = "mcp-ui-server"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ed/80b21fb515be72baa7fbb55326ee36bad55aa3080519827431599b003989/mcp_ui_server-1.0.0.tar.gz", hash = "sha256:5ab8f17b93bf794966af7c35e9a575e4f21a9ba2bab3d316cfc107a15f88a3c9", size = 78389, upload-time = "2025-11-04T16:17:01.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8a/4c1b2b5708e2f8bf3f3d2ebc130f5bb2a1805cd648b6eda8e5e4bdc039bc/mcp_ui_server-1.0.0-py3-none-any.whl", hash = "sha256:85f53b2e4300fbd175f1fbb7c40f2566b1f4a4ad03a1f33647867c82a3159dcc", size = 11500, upload-time = "2025-11-04T16:17:00.366Z" },
 ]
 
 [[package]]

--- a/website/docs/user-guide/tools/mcp_ui.mdx
+++ b/website/docs/user-guide/tools/mcp_ui.mdx
@@ -1,0 +1,157 @@
+---
+title: MCP-UI Resources
+sidebarTitle: MCP-UI
+---
+
+# MCP-UI Resources
+
+[MCP-UI](https://mcpui.dev/){.external-link target="_blank"} lets an MCP server return a **renderable UI** — raw HTML, an `iframe` URL, or a Remote-DOM script — from a tool result instead of plain text. A UI-capable client (e.g. the JS [`@mcp-ui/client`](https://mcpui.dev/){.external-link target="_blank"}) renders it inline; a text-only client falls back to the embedded resource.
+
+AG2 builds these resources and the interactive callbacks (**UI Actions**) in `ag2.mcp_ui`. They are returned from the serving side of `ag2.mcp` — an AG2 `Agent` exposed as an MCP server — so this page starts with the minimum you need to serve one, then focuses on the UI helpers.
+
+!!! note "This is the serving side of MCP"
+    `ag2.mcp.MCPServer` exposes an agent **as** an MCP server. This is the inverse of consuming an MCP server as tools with `MCPToolkit` / `MCPServerTool` — see [MCP Servers](/docs/user-guide/tools/mcp_servers) for that.
+
+## Installation
+
+`ag2.mcp_ui` ships as an optional extra (it is **not** pulled in by `ag2[mcp]`):
+
+```bash
+pip install "ag2[mcp-ui]"
+```
+
+Importing `ag2.mcp_ui` without it raises a clear install hint.
+
+## Serving a UI resource
+
+`MCPServer` wraps an agent as a single conversational `ask` tool. To return a UI resource you add a **custom tool** with the `@mcp_tool` decorator: the client sees it in `tools/list`, and a `tools/call` runs your handler directly — the agent is **not** invoked, so the result is deterministic. The handler returns the MCP content block(s) verbatim, which is exactly what `raw_html(...)` produces.
+
+```python linenums="1"
+import asyncio
+from typing import Any
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer, mcp_tool
+from ag2.mcp_ui import raw_html
+
+@mcp_tool
+async def show_greeting(name: str = "world") -> Any:
+    """Return an interactive greeting card."""
+    return raw_html("ui://ag2/greeting", f"<h1>Hello, {name} 👋</h1>")
+
+agent = Agent(name="assistant", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+server = MCPServer(agent, tools=[show_greeting])
+
+if __name__ == "__main__":
+    asyncio.run(server.run_stdio())
+```
+
+`@mcp_tool` (from `ag2.mcp`) derives the tool `name` from the function name, the `description` from its docstring, and the `inputSchema` from the typed signature — the same convention as `ag2.tools.tool`. The handler may be sync or async. Point a UI-capable MCP client (or the MCP Inspector) at this stdio server, call `show_greeting`, and the HTML renders inline.
+
+!!! tip "Why a custom tool and not the `ask` tool"
+    The agent's `ask` tool replies with model-generated text/images, so it cannot emit a deterministic UI blob on its own. Always return UI resources from your own `@mcp_tool`.
+
+## UI resource types
+
+`ag2.mcp_ui` provides three builders, one per MCP-UI content type. Each returns an `mcp.types.EmbeddedResource` — a valid `tools/call` content block — and each `uri` **must** start with `ui://`.
+
+| Builder | Content type | Client renders it as |
+|---|---|---|
+| `raw_html(uri, html)` | `rawHtml` | an inline HTML string |
+| `external_url(uri, url)` | `externalUrl` | `url` embedded in an `iframe` |
+| `remote_dom(uri, script)` | `remoteDom` | a mounted Remote-DOM script |
+
+```python linenums="1"
+from ag2.mcp_ui import external_url, raw_html, remote_dom
+
+# Inline HTML
+raw_html("ui://ag2/greeting", "<h1>Hi</h1>")
+# External site in an iframe
+external_url("ui://ag2/docs", "https://docs.ag2.ai/")
+# Remote-DOM script (framework="react" by default, or "webcomponents")
+remote_dom("ui://ag2/widget", "root.appendChild(el)", framework="react")
+```
+
+Every builder accepts `encoding="blob"` to base64-encode the payload for transports or content that don't survive as inline text (the default is `encoding="text"`):
+
+```python linenums="1"
+raw_html("ui://ag2/report", large_html, encoding="blob")
+```
+
+### Rendering metadata
+
+Two optional keyword arguments attach metadata to the resource:
+
+- `ui_metadata` — client-side rendering hints. Keys are prefixed with `mcpui.dev/ui-` so the client recognizes them.
+- `metadata` — written verbatim into the resource `_meta`.
+
+```python linenums="1"
+raw_html(
+    "ui://ag2/chart",
+    "<div id='chart'>Loading…</div>",
+    ui_metadata={"preferred-frame-size": ["800px", "600px"]},
+    metadata={"title": "Quarterly sales"},
+)
+```
+
+## UI Actions
+
+A rendered UI can carry interactive elements. When the user interacts, the element sends a message to the host with `window.parent.postMessage`, and the host's `onUIAction` handler reacts. `ag2.mcp_ui.actions` builds those message payloads.
+
+!!! warning "UI Actions are dispatched by the host, not your server"
+    Unlike `ag2.a2ui` actions, these are **not** server-side handlers. The [MCP-UI spec](https://mcpui.dev/guide/protocol-details){.external-link target="_blank"} puts the host in control: a UI Action is dispatched client-side (`onUIAction`). A `tool` action just asks the host to call an ordinary MCP tool on your server — expose that tool the normal way; there is no server-side "action handler" to register.
+
+These are **authoring** helpers: serialize the result with `.model_dump(exclude_none=True)` into the UI you build with the resource builders — for example, a button's `postMessage` payload.
+
+```python linenums="1"
+import json
+
+from ag2.mcp_ui import actions, raw_html
+
+# A `tool` action: on click, the host calls tools/call add_to_cart(good_id="42").
+action = actions.tool_call("add_to_cart", {"good_id": "42"})
+payload = json.dumps(action.model_dump(exclude_none=True))
+html = f"<button onclick='window.parent.postMessage({payload}, \"*\")'>Add to cart</button>"
+resource = raw_html("ui://ag2/shop", html)
+```
+
+The five action types map one-to-one to the spec:
+
+| Builder | Action | What the host does |
+|---|---|---|
+| `actions.tool_call(name, params)` | `tool` | call the MCP tool `name(params)` (`tools/call`) |
+| `actions.prompt(text)` | `prompt` | send `text` into the conversation as a follow-up |
+| `actions.link(url)` | `link` | open `url` |
+| `actions.intent(name, params)` | `intent` | emit a host-defined `name` intent with `params` |
+| `actions.notify(message)` | `notify` | receive `message` as a notification / log |
+
+### Closing the loop with a `tool` action
+
+Because a `tool` action asks the host to call `tools/call`, you close the interaction loop by exposing the target as another `@mcp_tool` on the same server:
+
+```python linenums="1"
+import json
+from typing import Any
+
+from ag2.mcp import mcp_tool
+from ag2.mcp_ui import actions, raw_html
+
+@mcp_tool
+async def show_greeting(name: str = "world") -> Any:
+    """Return a greeting card with an 'Add to cart' button."""
+    action = actions.tool_call("add_to_cart", {"good_id": "42"})
+    payload = json.dumps(action.model_dump(exclude_none=True))
+    html = f"<h1>Hello, {name} 👋</h1><button onclick='window.parent.postMessage({payload}, \"*\")'>Add to cart</button>"
+    return raw_html("ui://ag2/greeting", html)
+
+@mcp_tool
+async def add_to_cart(good_id: str) -> Any:
+    """Target of the greeting card's UI Action; returns an updated card."""
+    return raw_html("ui://ag2/cart", f"<b>Added item {good_id} to cart ✓</b>")
+```
+
+Wire both into `MCPServer(agent, tools=[show_greeting, add_to_cart])`. When the user clicks the button, the host turns the `tool` action into a `tools/call add_to_cart` back to your server, and the returned card replaces the UI.
+
+!!! tip "Runnable example"
+    A complete stdio server — greeting card, an iframe of the docs, and the `add_to_cart` loop — lives in `examples/mcp/server_ui.py`.

--- a/website/docs/user-guide/tools/mcp_ui.mdx
+++ b/website/docs/user-guide/tools/mcp_ui.mdx
@@ -47,10 +47,41 @@ if __name__ == "__main__":
     asyncio.run(server.run_stdio())
 ```
 
-`@mcp_tool` (from `ag2.mcp`) derives the tool `name` from the function name, the `description` from its docstring, and the `inputSchema` from the typed signature — the same convention as `ag2.tools.tool`. The handler may be sync or async. Point a UI-capable MCP client (or the MCP Inspector) at this stdio server, call `show_greeting`, and the HTML renders inline.
+`@mcp_tool` (from `ag2.mcp`) derives the tool `name` from the function name, the `description` from its docstring, and the `inputSchema` from the typed signature — the same convention as `ag2.tools.tool`. The handler may be sync or async, and may return a plain string (wrapped in a text block) instead of content blocks. Point a UI-capable MCP client (or the MCP Inspector) at this stdio server, call `show_greeting`, and the HTML renders inline.
+
+Optional `title` and `annotations` keyword arguments are advertised in `tools/list`; `annotations` takes `mcp.types.ToolAnnotations` behavior hints (`readOnlyHint`, `destructiveHint`, …) that hosts use to decide e.g. whether to confirm with the user before calling:
+
+```python linenums="1"
+from typing import Any
+
+from mcp.types import ToolAnnotations
+
+from ag2.mcp import mcp_tool
+from ag2.mcp_ui import external_url
+
+@mcp_tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def show_docs() -> Any:
+    """Return the AG2 docs embedded in an iframe."""
+    return external_url("ui://ag2/docs", "https://docs.ag2.ai/")
+```
 
 !!! tip "Why a custom tool and not the `ask` tool"
     The agent's `ask` tool replies with model-generated text/images, so it cannot emit a deterministic UI blob on its own. Always return UI resources from your own `@mcp_tool`.
+
+### Accessing the request context
+
+Annotate a parameter (any name) with `ag2.mcp.tools.MCPRequestContext` to receive the live MCP request context — the session, client parameters, and lifespan state. The parameter is excluded from the advertised `inputSchema`, so clients never see it:
+
+```python linenums="1"
+from ag2.mcp import mcp_tool
+from ag2.mcp.tools import MCPRequestContext
+
+@mcp_tool
+async def whoami(ctx: MCPRequestContext) -> str:
+    """Report the calling client."""
+    params = ctx.session.client_params
+    return f"client: {params.clientInfo.name if params else 'unknown'}"
+```
 
 ## UI resource types
 
@@ -97,22 +128,19 @@ raw_html(
 
 ## UI Actions
 
-A rendered UI can carry interactive elements. When the user interacts, the element sends a message to the host with `window.parent.postMessage`, and the host's `onUIAction` handler reacts. `ag2.mcp_ui.actions` builds those message payloads.
+A rendered UI can carry interactive elements. When the user interacts, the element sends a message to the host with `window.parent.postMessage`, and the host's `onUIAction` handler reacts. `ag2.mcp_ui` builds those message payloads.
 
 !!! warning "UI Actions are dispatched by the host, not your server"
     Unlike `ag2.a2ui` actions, these are **not** server-side handlers. The [MCP-UI spec](https://mcpui.dev/guide/protocol-details){.external-link target="_blank"} puts the host in control: a UI Action is dispatched client-side (`onUIAction`). A `tool` action just asks the host to call an ordinary MCP tool on your server — expose that tool the normal way; there is no server-side "action handler" to register.
 
-These are **authoring** helpers: serialize the result with `.model_dump(exclude_none=True)` into the UI you build with the resource builders — for example, a button's `postMessage` payload.
+These are **authoring** helpers: embed the built action into the UI with `post_message(action)`, which returns an HTML-attribute-safe `window.parent.postMessage(...)` call (quotes and apostrophes in the payload are escaped, so they cannot break out of the attribute).
 
 ```python linenums="1"
-import json
-
-from ag2.mcp_ui import actions, raw_html
+from ag2.mcp_ui import post_message, raw_html, tool_call
 
 # A `tool` action: on click, the host calls tools/call add_to_cart(good_id="42").
-action = actions.tool_call("add_to_cart", {"good_id": "42"})
-payload = json.dumps(action.model_dump(exclude_none=True))
-html = f"<button onclick='window.parent.postMessage({payload}, \"*\")'>Add to cart</button>"
+action = tool_call("add_to_cart", {"good_id": "42"})
+html = f'<button onclick="{post_message(action)}">Add to cart</button>'
 resource = raw_html("ui://ag2/shop", html)
 ```
 
@@ -120,29 +148,27 @@ The five action types map one-to-one to the spec:
 
 | Builder | Action | What the host does |
 |---|---|---|
-| `actions.tool_call(name, params)` | `tool` | call the MCP tool `name(params)` (`tools/call`) |
-| `actions.prompt(text)` | `prompt` | send `text` into the conversation as a follow-up |
-| `actions.link(url)` | `link` | open `url` |
-| `actions.intent(name, params)` | `intent` | emit a host-defined `name` intent with `params` |
-| `actions.notify(message)` | `notify` | receive `message` as a notification / log |
+| `tool_call(name, params)` | `tool` | call the MCP tool `name(params)` (`tools/call`) |
+| `prompt(text)` | `prompt` | send `text` into the conversation as a follow-up |
+| `link(url)` | `link` | open `url` |
+| `intent(name, params)` | `intent` | emit a host-defined `name` intent with `params` |
+| `notify(message)` | `notify` | receive `message` as a notification / log |
 
 ### Closing the loop with a `tool` action
 
 Because a `tool` action asks the host to call `tools/call`, you close the interaction loop by exposing the target as another `@mcp_tool` on the same server:
 
 ```python linenums="1"
-import json
 from typing import Any
 
 from ag2.mcp import mcp_tool
-from ag2.mcp_ui import actions, raw_html
+from ag2.mcp_ui import post_message, raw_html, tool_call
 
 @mcp_tool
 async def show_greeting(name: str = "world") -> Any:
     """Return a greeting card with an 'Add to cart' button."""
-    action = actions.tool_call("add_to_cart", {"good_id": "42"})
-    payload = json.dumps(action.model_dump(exclude_none=True))
-    html = f"<h1>Hello, {name} 👋</h1><button onclick='window.parent.postMessage({payload}, \"*\")'>Add to cart</button>"
+    action = tool_call("add_to_cart", {"good_id": "42"})
+    html = f'<h1>Hello, {name} 👋</h1><button onclick="{post_message(action)}">Add to cart</button>'
     return raw_html("ui://ag2/greeting", html)
 
 @mcp_tool

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -75,6 +75,7 @@
             "docs/user-guide/tools/toolkits",
             "docs/user-guide/tools/common_toolkits",
             "docs/user-guide/tools/mcp_servers",
+            "docs/user-guide/tools/mcp_ui",
             "docs/user-guide/tools/builtin_tools",
             "docs/user-guide/tools/code_execution",
             "docs/user-guide/tools/local_shell",


### PR DESCRIPTION
## Why are these changes needed?

Adds [MCP-UI](https://mcpui.dev/) support so AG2 MCP servers can return interactive
UI to MCP-UI-capable hosts, not just text:

- `ag2.mcp_ui` — helpers for building UI resources (`raw_html`, `external_url`,
  `remote_dom`) with `text`/`blob` encoding and `ui_metadata`/`metadata`
  pass-through, host action builders (`tool_call`, `prompt`, `link`, `intent`,
  `notify`), and `post_message(action)` producing an HTML-attribute-safe
  `window.parent.postMessage(...)` call for embedding actions into the UI —
  thin wrappers over `mcp-ui-server`.
- `ag2.mcp` — `MCPServer` now accepts extra `tools=[...]` alongside the agent's
  `ask` tool: `MCPFunctionTool` and the `@mcp_tool` decorator (derives name,
  description, and input schema from the function signature; optional `title`
  and `mcp.types.ToolAnnotations` behavior hints are advertised in
  `tools/list`). Handlers may return content blocks or a plain string (wrapped
  in a text block), and a parameter annotated with
  `ag2.mcp.tools.MCPRequestContext` receives the live MCP request context
  (excluded from the advertised schema). Name collisions — with the reserved
  tool name or between custom tools — raise `MCPToolNameConflictError`.
- Docs page (`website/docs/user-guide/tools/mcp_ui.mdx`) and a runnable example
  (`examples/mcp/server_ui.py`).

## Example

```python
from typing import Any

from ag2 import Agent
from ag2.config import AnthropicConfig
from ag2.mcp import MCPServer, mcp_tool
from ag2.mcp_ui import external_url, post_message, raw_html, tool_call


@mcp_tool
async def show_greeting(name: str = "world") -> Any:
    """Return an interactive greeting card with a UI Action button."""
    # A `tool` UI Action: on click the host calls tools/call add_to_cart(...).
    action = tool_call("add_to_cart", {"good_id": "42"})
    html = f'<h1>Hello, {name} 👋</h1><button onclick="{post_message(action)}">Add to cart</button>'
    return raw_html("ui://ag2/greeting", html)


@mcp_tool
async def show_docs() -> Any:
    """Return the AG2 docs embedded in an iframe."""
    return external_url("ui://ag2/docs", "https://docs.ag2.ai/")


@mcp_tool
async def add_to_cart(good_id: str) -> Any:
    """Target of the greeting card's UI Action; returns an updated card."""
    return raw_html("ui://ag2/cart", f"<b>Added item {good_id} to cart ✓</b>")


agent = Agent(name="claude", config=AnthropicConfig(model="claude-sonnet-4-6"))
server = MCPServer(agent, tools=[show_greeting, show_docs, add_to_cart])
```

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. ...
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
