### PR TITLE
fix(openai): request encrypted reasoning content when `store` is false

### DIFF
--- a/ag2/config/openai/openai_responses_client.py
+++ b/ag2/config/openai/openai_responses_client.py
@@ -130,7 +130,13 @@ class OpenAIResponsesClient(LLMClient):
         if r := response_proto_to_text_config(response_schema):
             kwargs["text"] = r
 
-        if includes := responses_api_includes(tools_list):
+        includes = responses_api_includes(tools_list)
+        if self._create_options.get("store") is False:
+            # Stateless mode: the API persists nothing, so replaying a reasoning item
+            # by id on a later turn (a tool loop always does) will fail. Asking
+            # for the encrypted payload makes those items self-contained.
+            includes.append("reasoning.encrypted_content")
+        if includes:
             kwargs["include"] = includes
 
         response = await self._client.responses.create(

--- a/test/config/openai/test_responses_client_store.py
+++ b/test/config/openai/test_responses_client_store.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import httpx
+import pytest
+from fast_depends.use import SerializerCls
+
+from ag2 import Context, MemoryStream
+from ag2.config.openai import OpenAIResponsesConfig
+from ag2.events import ModelRequest, TextInput
+from ag2.tools.builtin.file_search import FileSearchTool
+
+ENCRYPTED_REASONING = "reasoning.encrypted_content"
+
+
+def _capturing_config(captured: dict[str, object], **kwargs: object) -> OpenAIResponsesConfig:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp_1",
+                "object": "response",
+                "created_at": 0,
+                "model": "m",
+                "status": "completed",
+                "output": [],
+                "usage": None,
+                "parallel_tool_calls": True,
+                "tool_choice": "auto",
+                "tools": [],
+                "instructions": None,
+                "metadata": {},
+                "text": {"format": {"type": "text"}},
+            },
+        )
+
+    return OpenAIResponsesConfig(
+        model="m",
+        api_key="test",
+        base_url="http://test/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+async def _request_body(captured: dict[str, object], tools: list, **kwargs: object) -> dict[str, object]:
+    context = Context(stream=MemoryStream())
+    schemas = []
+    for t in tools:
+        schemas.extend(await t.schemas(context))
+    client = _capturing_config(captured, **kwargs).create()
+    await client(
+        messages=[ModelRequest([TextInput("hi")])],
+        context=context,
+        tools=schemas,
+        response_schema=None,
+        serializer=SerializerCls,
+    )
+    return captured["body"]  # type: ignore[return-value]
+
+
+@pytest.mark.asyncio
+async def test_store_false_requests_encrypted_reasoning() -> None:
+    """With store=False nothing is persisted server-side, so a reasoning item replayed
+    by id on the next turn 404s. The encrypted payload makes it self-contained."""
+    captured: dict[str, object] = {}
+
+    body = await _request_body(captured, [], store=False)
+
+    assert body["include"] == [ENCRYPTED_REASONING]
+
+
+@pytest.mark.asyncio
+async def test_store_true_does_not_request_encrypted_reasoning() -> None:
+    """Stored responses resolve reasoning items by id, so the payload is dead weight."""
+    captured: dict[str, object] = {}
+
+    body = await _request_body(captured, [], store=True)
+
+    assert ENCRYPTED_REASONING not in (body.get("include") or [])
+
+
+@pytest.mark.asyncio
+async def test_store_false_appends_to_tool_derived_includes() -> None:
+    """The reasoning include is additive — it must not clobber tool-derived ones."""
+    captured: dict[str, object] = {}
+
+    body = await _request_body(
+        captured,
+        [FileSearchTool(vector_store_ids=["vs_1"], include_results=True)],
+        store=False,
+    )
+
+    assert body["include"] == ["file_search_call.results", ENCRYPTED_REASONING]


### PR DESCRIPTION
## Why are these changes needed?

OpenAI Responses API allows `store=False` which persists nothing server-side, but AG2 replays reasoning items back into `input` by id. This breaks because the API can't resolve them.

This fixes that so that when `store is False`, adds `reasoning.encrypted_content` to `include`. The reasoning items then carry their own encrypted payload, making them self-contained and replayable.

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
