### PR TITLE
feat(perplexity): add X-Pplx-Integration attribution header

### DIFF
--- a/ag2/tools/search/perplexity.py
+++ b/ag2/tools/search/perplexity.py
@@ -4,7 +4,7 @@
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Literal, TypeAlias
+from typing import Annotated, Any, Final, Literal, TypeAlias
 
 import httpx
 from perplexity import AsyncPerplexity
@@ -31,7 +31,7 @@ SearchMode: TypeAlias = Literal["web", "academic", "sec"]
 SearchContextSize: TypeAlias = Literal["low", "medium", "high"]
 RecencyFilter: TypeAlias = Literal["hour", "day", "week", "month", "year"]
 
-_PPLX_INTEGRATION_HEADER = "X-Pplx-Integration"
+_PPLX_INTEGRATION_HEADERS: Final[dict[str, str]] = {"X-Pplx-Integration": f"ag2/{__version__}"}
 
 
 @dataclass(slots=True)
@@ -104,6 +104,10 @@ class PerplexitySearchToolkit(Toolkit):
         self._proxy = proxy
         self._verify = verify
         self._timeout = timeout
+        client_kwargs["default_headers"] = {
+            **(client_kwargs.get("default_headers") or {}),
+            **_PPLX_INTEGRATION_HEADERS,
+        }
         self._client_kwargs = client_kwargs
 
         super().__init__(
@@ -112,11 +116,6 @@ class PerplexitySearchToolkit(Toolkit):
             name="perplexity_toolkit",
             middleware=middleware,
         )
-
-    def _client_kwargs_with_integration_header(self) -> dict[str, Any]:
-        default_headers = dict(self._client_kwargs.get("default_headers") or {})
-        default_headers[_PPLX_INTEGRATION_HEADER] = f"ag2/{__version__}"
-        return {**self._client_kwargs, "default_headers": default_headers}
 
     def search(
         self,
@@ -139,7 +138,7 @@ class PerplexitySearchToolkit(Toolkit):
         proxy = self._proxy
         verify = self._verify
         timeout = self._timeout
-        client_kwargs = self._client_kwargs_with_integration_header()
+        client_kwargs = self._client_kwargs
 
         @tool(name=name, description=description, middleware=middleware)
         async def perplexity_search(
@@ -205,7 +204,7 @@ class PerplexitySearchToolkit(Toolkit):
         proxy = self._proxy
         verify = self._verify
         timeout = self._timeout
-        client_kwargs = self._client_kwargs_with_integration_header()
+        client_kwargs = self._client_kwargs
 
         @tool(name=name, description=description, middleware=middleware)
         async def perplexity_answer(

--- a/ag2/tools/search/perplexity.py
+++ b/ag2/tools/search/perplexity.py
@@ -18,6 +18,7 @@ from ag2.middleware import ToolMiddleware
 from ag2.tools.builtin._resolve import resolve_variable
 from ag2.tools.final import Toolkit, tool
 from ag2.tools.final.function_tool import FunctionTool
+from ag2.version import __version__
 
 SonarModel: TypeAlias = Literal[
     "sonar",
@@ -29,6 +30,12 @@ SonarModel: TypeAlias = Literal[
 SearchMode: TypeAlias = Literal["web", "academic", "sec"]
 SearchContextSize: TypeAlias = Literal["low", "medium", "high"]
 RecencyFilter: TypeAlias = Literal["hour", "day", "week", "month", "year"]
+
+
+def _client_kwargs_with_integration_header(client_kwargs: dict[str, Any]) -> dict[str, Any]:
+    default_headers = dict(client_kwargs.get("default_headers") or {})
+    default_headers["X-Pplx-Integration"] = f"ag2/{__version__}"
+    return {**client_kwargs, "default_headers": default_headers}
 
 
 @dataclass(slots=True)
@@ -156,7 +163,11 @@ class PerplexitySearchToolkit(Toolkit):
             kwargs = {k: v for k, v in params.items() if v is not None}
 
             async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
-                sdk = AsyncPerplexity(api_key=api_key, http_client=http, **client_kwargs)
+                sdk = AsyncPerplexity(
+                    api_key=api_key,
+                    http_client=http,
+                    **_client_kwargs_with_integration_header(client_kwargs),
+                )
                 raw = await sdk.search.create(query=query, **kwargs)
 
             raw_results: list[SearchAPIResult] = getattr(raw, "results", None) or []
@@ -235,7 +246,11 @@ class PerplexitySearchToolkit(Toolkit):
                 **kwargs,
             }
             async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
-                sdk = AsyncPerplexity(api_key=api_key, http_client=http, **client_kwargs)
+                sdk = AsyncPerplexity(
+                    api_key=api_key,
+                    http_client=http,
+                    **_client_kwargs_with_integration_header(client_kwargs),
+                )
                 raw = await sdk.chat.completions.create(**create_kwargs)
 
             content: str | None = None

--- a/ag2/tools/search/perplexity.py
+++ b/ag2/tools/search/perplexity.py
@@ -31,11 +31,7 @@ SearchMode: TypeAlias = Literal["web", "academic", "sec"]
 SearchContextSize: TypeAlias = Literal["low", "medium", "high"]
 RecencyFilter: TypeAlias = Literal["hour", "day", "week", "month", "year"]
 
-
-def _client_kwargs_with_integration_header(client_kwargs: dict[str, Any]) -> dict[str, Any]:
-    default_headers = dict(client_kwargs.get("default_headers") or {})
-    default_headers["X-Pplx-Integration"] = f"ag2/{__version__}"
-    return {**client_kwargs, "default_headers": default_headers}
+_PPLX_INTEGRATION_HEADER = "X-Pplx-Integration"
 
 
 @dataclass(slots=True)
@@ -117,6 +113,11 @@ class PerplexitySearchToolkit(Toolkit):
             middleware=middleware,
         )
 
+    def _client_kwargs_with_integration_header(self) -> dict[str, Any]:
+        default_headers = dict(self._client_kwargs.get("default_headers") or {})
+        default_headers[_PPLX_INTEGRATION_HEADER] = f"ag2/{__version__}"
+        return {**self._client_kwargs, "default_headers": default_headers}
+
     def search(
         self,
         *,
@@ -138,7 +139,7 @@ class PerplexitySearchToolkit(Toolkit):
         proxy = self._proxy
         verify = self._verify
         timeout = self._timeout
-        client_kwargs = self._client_kwargs
+        client_kwargs = self._client_kwargs_with_integration_header()
 
         @tool(name=name, description=description, middleware=middleware)
         async def perplexity_search(
@@ -163,11 +164,7 @@ class PerplexitySearchToolkit(Toolkit):
             kwargs = {k: v for k, v in params.items() if v is not None}
 
             async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
-                sdk = AsyncPerplexity(
-                    api_key=api_key,
-                    http_client=http,
-                    **_client_kwargs_with_integration_header(client_kwargs),
-                )
+                sdk = AsyncPerplexity(api_key=api_key, http_client=http, **client_kwargs)
                 raw = await sdk.search.create(query=query, **kwargs)
 
             raw_results: list[SearchAPIResult] = getattr(raw, "results", None) or []
@@ -208,7 +205,7 @@ class PerplexitySearchToolkit(Toolkit):
         proxy = self._proxy
         verify = self._verify
         timeout = self._timeout
-        client_kwargs = self._client_kwargs
+        client_kwargs = self._client_kwargs_with_integration_header()
 
         @tool(name=name, description=description, middleware=middleware)
         async def perplexity_answer(
@@ -246,11 +243,7 @@ class PerplexitySearchToolkit(Toolkit):
                 **kwargs,
             }
             async with httpx.AsyncClient(proxy=proxy, verify=verify, timeout=timeout) as http:
-                sdk = AsyncPerplexity(
-                    api_key=api_key,
-                    http_client=http,
-                    **_client_kwargs_with_integration_header(client_kwargs),
-                )
+                sdk = AsyncPerplexity(api_key=api_key, http_client=http, **client_kwargs)
                 raw = await sdk.chat.completions.create(**create_kwargs)
 
             content: str | None = None

--- a/test/tools/search/test_perplexity.py
+++ b/test/tools/search/test_perplexity.py
@@ -12,7 +12,7 @@ from dirty_equals import IsPartialDict
 
 pytest.importorskip("perplexity")
 
-from ag2 import Agent, Context, DataInput, ImageInput, Variable
+from ag2 import Agent, Context, DataInput, ImageInput, Variable, __version__
 from ag2.events import ModelResponse, ToolCallEvent, ToolCallsEvent, ToolResultsEvent
 from ag2.testing import TestConfig, TrackingConfig
 from ag2.tools.search.perplexity import (
@@ -238,7 +238,11 @@ class TestSearch:
     async def test_client_kwargs_forwarded_to_sdk(self) -> None:
         custom_url = "https://custom.perplexity.example"
         route = respx.post(f"{custom_url}/search").mock(return_value=httpx.Response(200, json=_search_response()))
-        toolkit = PerplexitySearchToolkit(api_key="test", base_url=custom_url)
+        toolkit = PerplexitySearchToolkit(
+            api_key="test",
+            base_url=custom_url,
+            default_headers={"X-Trace-Id": "abc-123"},
+        )
 
         agent = Agent(
             "a",
@@ -248,6 +252,8 @@ class TestSearch:
         await agent.ask("search")
 
         assert route.called
+        assert route.calls.last.request.headers["X-Pplx-Integration"] == f"ag2/{__version__}"
+        assert route.calls.last.request.headers["X-Trace-Id"] == "abc-123"
 
     @respx.mock
     async def test_custom_tool_name_in_agent(self) -> None:
@@ -393,7 +399,11 @@ class TestAnswer:
         route = respx.post(f"{custom_url}/chat/completions").mock(
             return_value=httpx.Response(200, json=_chat_response())
         )
-        toolkit = PerplexitySearchToolkit(api_key="test", base_url=custom_url)
+        toolkit = PerplexitySearchToolkit(
+            api_key="test",
+            base_url=custom_url,
+            default_headers={"X-Trace-Id": "abc-123"},
+        )
 
         agent = Agent(
             "a",
@@ -403,6 +413,8 @@ class TestAnswer:
         await agent.ask("answer")
 
         assert route.called
+        assert route.calls.last.request.headers["X-Pplx-Integration"] == f"ag2/{__version__}"
+        assert route.calls.last.request.headers["X-Trace-Id"] == "abc-123"
 
     @respx.mock
     async def test_custom_tool_name_in_agent(self) -> None:


### PR DESCRIPTION
## Summary

- Add `X-Pplx-Integration: ag2/<version>` default header to Perplexity SDK client construction in both tools (`perplexity_search`, `perplexity_answer`).
- Merge attribution header with user-supplied `default_headers` — existing client customization intact.
- Tests assert both endpoints propagate the header and preserve user headers.

## Motivation

Header lets Perplexity attribute Search API traffic back to AG2 in api-gateway logs. No-op for users.

Port of #2903 (by @jliounis) to current repo layout — original targeted `autogen/beta/tools/search/`, code now lives in `ag2/tools/search/`.

## Testing

- `uv run pytest test/tools/search/test_perplexity.py` — 26 passed
- `uv run ruff check` + `ruff format --check` — clean
- `uv run mypy ag2/tools/search/perplexity.py` — clean