### PR TITLE
fix(test): run the ACP test suite in CI and fix its Windows failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ optionals = [
     "ag2[a2ui]", # provides starlette/jsonschema for AG-UI / a2ui serving tests
     "ag2[mcp]", # ag2.mcp — serve an Agent as an MCP server
     "ag2[mcp-ui]", # ag2.mcp_ui — MCP-UI resource & action builders
+    "ag2[acp]",
     "ag2[tracing]",
     "ag2[metrics]",
     # search tools

--- a/test/acp/test_bridge.py
+++ b/test/acp/test_bridge.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -172,5 +173,10 @@ async def test_terminal_kill(tmp_path: Path) -> None:
     tid = await st.terminals.create("sleep", ["30"])
     await st.terminals.kill(tid)
     exit_status = await st.terminals.wait(tid)
-    assert exit_status.signal is not None  # terminated by signal
+    if sys.platform == "win32":
+        # Windows has no signals: TerminateProcess surfaces as a non-zero exit
+        # code, so exit_status() reports exit_code instead.
+        assert exit_status.exit_code is not None
+    else:
+        assert exit_status.signal is not None  # terminated by signal
     await st.terminals.release(tid)

--- a/uv.lock
+++ b/uv.lock
@@ -227,7 +227,7 @@ lint = [
     { name = "zizmor" },
 ]
 optionals = [
-    { name = "ag2", extra = ["a2ui", "ag-ui", "anthropic", "bedrock", "dashscope", "ddgs", "gemini", "mcp", "mcp-ui", "metrics", "ollama", "openai", "perplexity", "redis", "tavily", "tracing", "xai", "zai"] },
+    { name = "ag2", extra = ["a2ui", "acp", "ag-ui", "anthropic", "bedrock", "dashscope", "ddgs", "gemini", "mcp", "mcp-ui", "metrics", "ollama", "openai", "perplexity", "redis", "tavily", "tracing", "xai", "zai"] },
     { name = "daytona" },
     { name = "docker" },
     { name = "exa-py" },
@@ -418,6 +418,7 @@ lint = [
 ]
 optionals = [
     { name = "ag2", extras = ["a2ui"] },
+    { name = "ag2", extras = ["acp"] },
     { name = "ag2", extras = ["ag-ui"] },
     { name = "ag2", extras = ["anthropic"] },
     { name = "ag2", extras = ["bedrock"] },


### PR DESCRIPTION
## Why are these changes needed?

`test/acp/__init__.py` guards the package with `pytest.importorskip("acp")`, but `ag2[acp]` is not in the `optionals` dependency group that `.github/workflows/test.yml` installs:

```
uv pip install --system --group=test --group=optionals -e .
```

`acp` appears in `pyproject.toml` only as the extra's own definition — not in `optionals`, `types`, or `docs`, and nowhere in `.github/workflows/`. So **every ACP test has been silently skipped on every CI run**, which is what codecov reports as 0% patch coverage for `ag2/acp`.

This adds `ag2[acp]` to `optionals` so they actually run.

Doing that immediately surfaced a latent Windows failure:

```
assert exit_status.signal is not None  # terminated by signal
E   assert None is not None
test\acp\test_bridge.py: AssertionError
FAILED test/acp/test_bridge.py::test_terminal_kill
```

`test_terminal_kill` assumes POSIX: that killing a process yields a negative returncode carrying a signal. On Windows `kill()` maps to `TerminateProcess`, so the returncode is positive and `Terminal.exit_status()` (`ag2/acp/bridge.py`) correctly returns `exit_code` with `signal=None`.

**The product behaviour is right** — Windows has no signals. The assertion was the POSIX-only part. Asserting per-platform (rather than skipping on Windows) keeps the test meaningful on all three OSes.

### Verification

In a CI-shaped venv (`uv pip install --group=test --group=optionals -e .`):

| | Result |
| :--- | :--- |
| `test/acp/` without `agent-client-protocol` (today's CI) | **8 skipped** |
| `test/acp/` with it (this PR) | **54 passed** |
| Full suite under the CI marker filter | **3323 passed, 6 skipped, 315 deselected, 1 xfailed** |
| `uv lock --check` | passes |

The Windows branch of the assertion can only be verified by CI — local runs were macOS.

### Notes for reviewers

Found while reviewing #3098, which adds a large amount of new code and tests under `ag2/acp`. Split out so that PR stays scoped to its feature; once this lands it can drop its own equivalent commit.

Worth watching whether other long-skipped ACP tests surface further platform issues now that the suite executes — this is the first time these tests will have run on Windows or Linux at all, so `test_terminal_kill` may not be the only POSIX assumption in there.

## Related issue number

No linked issue. Split out of #3098 (discovered while reviewing it); that PR should drop its equivalent commit once this merges.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

This PR was drafted with AI assistance (Claude Code): the diagnosis, the diff, and the verification runs below were produced in an AI-assisted session and reviewed before opening. Flagging it so reviewers can calibrate — per `.github/AI_POLICY.md`.

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
