### PR TITLE
chore: pin mcp<2 in docs group and mcp-ui extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ mcp = [
 # MCP-UI resources (ag2.mcp_ui) — return renderable UI blobs from tool results
 mcp-ui = [
     "mcp-ui-server>=1.0.0",
+    "mcp>=1.11.0,<2",
 ]
 
 [dependency-groups]
@@ -219,7 +220,7 @@ docs = [
     "pyyaml==6.0.3",
     "termcolor==3.3.0",
     "nbclient==0.11.0",
-    "mcp>=1.11.0",
+    "mcp>=1.11.0,<2",
 ]
 
 types = [


### PR DESCRIPTION
## Why are these changes needed?

MCP 2.0 release is breaking, this pins to < 2 until compatibility is implemented.

Two paths could still resolve mcp 2.x:

- the docs dependency group declared an unbounded mcp>=1.11.0
- the mcp-ui extra never declared mcp itself, inheriting it transitively from mcp-ui-server, whose own requirement is an unbounded mcp>=1.0.0, even though ag2/mcp_ui/resources.py imports mcp.types directly

Both now carry the same mcp>=1.11.0,<2 bound as the mcp extra.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
