### PR TITLE
refactor(tools): home the tool abstractions in ag2.tools.types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,8 @@ Cross-cutting and hard-to-reverse design decisions are recorded in `docs/adr/`, 
 | `stream.py` | In-memory event pub/sub | `MemoryStream`, `SubStream` |
 | `events/` | Event types for the agent loop | `BaseEvent`, `ModelRequest`, `ModelResponse`, `ToolCallEvent`, `ToolResultEvent`, `Usage`, … |
 | `config/` | LLM provider clients (see [below](#llm-provider-clients)) | `ModelConfig`, `LLMClient`, `AnthropicConfig`, `OpenAIConfig`, `GeminiConfig`, … |
-| `tools/` | Tool system — builtin + user-defined | `Tool`, `FunctionTool`, `tool`, `Toolkit`, `ToolResult`, `CodeExecutionTool`, `ShellTool`, `WebSearchTool`, … |
+| `tools/` | Ready-to-use tools | `tool`, `Toolkit`, `ToolResult`, `CodeExecutionTool`, `ShellTool`, `WebSearchTool`, … |
+| `tools/types.py` | Tool abstractions & schema types | `Tool`, `FunctionTool`, `ClientTool`, `Toolkit`, `ToolSchema`, … |
 | `tools/subagents/` | Agent-to-agent delegation | `subagent_tool`, `run_task`, `persistent_stream`, `StreamFactory` |
 | `eval/` | Offline evaluation framework | `run`, `scorer`, `EvalTarget`, `Suite`, `Task`, `Trace`, `RunResult`, `Feedback`, `BudgetThresholds`, plus prebuilts under `eval.scorers` |
 | `middleware/` | Request/response interception | `BaseMiddleware`, `Middleware`, `LoggingMiddleware`, `RetryMiddleware`, `TokenLimiter`, `HistoryLimiter`, … |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Cross-cutting and hard-to-reverse design decisions are recorded in `docs/adr/`, 
 | `stream.py` | In-memory event pub/sub | `MemoryStream`, `SubStream` |
 | `events/` | Event types for the agent loop | `BaseEvent`, `ModelRequest`, `ModelResponse`, `ToolCallEvent`, `ToolResultEvent`, `Usage`, … |
 | `config/` | LLM provider clients (see [below](#llm-provider-clients)) | `ModelConfig`, `LLMClient`, `AnthropicConfig`, `OpenAIConfig`, `GeminiConfig`, … |
-| `tools/` | Tool system — builtin + user-defined | `tool`, `Toolkit`, `ToolResult`, `CodeExecutionTool`, `ShellTool`, `WebSearchTool`, … |
+| `tools/` | Tool system — builtin + user-defined | `Tool`, `FunctionTool`, `tool`, `Toolkit`, `ToolResult`, `CodeExecutionTool`, `ShellTool`, `WebSearchTool`, … |
 | `tools/subagents/` | Agent-to-agent delegation | `subagent_tool`, `run_task`, `persistent_stream`, `StreamFactory` |
 | `eval/` | Offline evaluation framework | `run`, `scorer`, `EvalTarget`, `Suite`, `Task`, `Trace`, `RunResult`, `Feedback`, `BudgetThresholds`, plus prebuilts under `eval.scorers` |
 | `middleware/` | Request/response interception | `BaseMiddleware`, `Middleware`, `LoggingMiddleware`, `RetryMiddleware`, `TokenLimiter`, `HistoryLimiter`, … |
@@ -138,7 +138,7 @@ All implementations must be re-exported from their public module's `__init__.py`
 
 ### Design principles
 
-- **Protocols over inheritance**: `LLMClient`, `ModelConfig`, `Stream`, `Storage`, `Tool` are all `Protocol` classes — implementations satisfy them structurally.
+- **Protocols over inheritance**: `LLMClient`, `ModelConfig`, `Stream`, `Storage` are all `Protocol` classes — implementations satisfy them structurally. `Tool` is the exception: it is an `ABC` that tool kinds subclass (see [ADR 0002](docs/adr/0002-tool-composite-hierarchy.md)).
 - **Async throughout**: all major operations (`ask`, tool execution, LLM calls) are async. Sync tool functions run via `sync_to_thread`.
 - **Event-driven**: all agent-loop communication flows through the `Stream` as typed events.
 - **Dependency injection**: all user-provided functions (tools, prompt hooks, HITL, etc.) use `Context`, `Inject`, and `Variable` annotations; resolution is handled by `fast_depends`.

--- a/ag2/tools/__init__.py
+++ b/ag2/tools/__init__.py
@@ -23,35 +23,20 @@ from .builtin import (
     XSearchTool,
 )
 from .code import SandboxCodeTool
-from .final import (
-    ClientTool,
-    FunctionDefinition,
-    FunctionParameters,
-    FunctionTool,
-    FunctionToolSchema,
-    Toolkit,
-    tool,
-)
+from .final import Toolkit, tool
 from .sandbox import LocalEnvironment
-from .schemas import ToolSchema
 from .search import DuckDuckSearchTool, PerplexitySearchToolkit, TavilySearchTool
 from .shell import SandboxShellTool
 from .skills import MemorySkill, SkillPlugin, SkillSearchToolkit, SkillsToolkit
-from .tool import Tool
 from .toolkits import FilesystemToolkit, MCPServerConfig, MCPStdioServerConfig, MCPToolkit
 
 __all__ = (
-    "ClientTool",
     "CodeExecutionTool",
     "ContainerAutoEnvironment",
     "ContainerReferenceEnvironment",
     "DuckDuckSearchTool",
     "FileSearchTool",
     "FilesystemToolkit",
-    "FunctionDefinition",
-    "FunctionParameters",
-    "FunctionTool",
-    "FunctionToolSchema",
     "GoogleMapsTool",
     "ImageGenerationTool",
     "LocalEnvironment",
@@ -72,9 +57,7 @@ __all__ = (
     "SkillsTool",
     "SkillsToolkit",
     "TavilySearchTool",
-    "Tool",
     "ToolResult",
-    "ToolSchema",
     "Toolkit",
     "UserLocation",
     "WebFetchTool",

--- a/ag2/tools/__init__.py
+++ b/ag2/tools/__init__.py
@@ -23,20 +23,35 @@ from .builtin import (
     XSearchTool,
 )
 from .code import SandboxCodeTool
-from .final import Toolkit, tool
+from .final import (
+    ClientTool,
+    FunctionDefinition,
+    FunctionParameters,
+    FunctionTool,
+    FunctionToolSchema,
+    Toolkit,
+    tool,
+)
 from .sandbox import LocalEnvironment
+from .schemas import ToolSchema
 from .search import DuckDuckSearchTool, PerplexitySearchToolkit, TavilySearchTool
 from .shell import SandboxShellTool
 from .skills import MemorySkill, SkillPlugin, SkillSearchToolkit, SkillsToolkit
+from .tool import Tool
 from .toolkits import FilesystemToolkit, MCPServerConfig, MCPStdioServerConfig, MCPToolkit
 
 __all__ = (
+    "ClientTool",
     "CodeExecutionTool",
     "ContainerAutoEnvironment",
     "ContainerReferenceEnvironment",
     "DuckDuckSearchTool",
     "FileSearchTool",
     "FilesystemToolkit",
+    "FunctionDefinition",
+    "FunctionParameters",
+    "FunctionTool",
+    "FunctionToolSchema",
     "GoogleMapsTool",
     "ImageGenerationTool",
     "LocalEnvironment",
@@ -57,7 +72,9 @@ __all__ = (
     "SkillsTool",
     "SkillsToolkit",
     "TavilySearchTool",
+    "Tool",
     "ToolResult",
+    "ToolSchema",
     "Toolkit",
     "UserLocation",
     "WebFetchTool",

--- a/ag2/tools/types.py
+++ b/ag2/tools/types.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tool abstractions and schema types.
+
+The public home for the types you need to *inspect* or *annotate* tools, as
+opposed to the ready-to-use tools exported from :mod:`ag2.tools`.
+
+``Tool`` is the single abstraction every kind of tool implements (ADR 0002);
+``FunctionTool``, ``ClientTool`` and ``Toolkit`` are the kinds. Their schema
+types are here too, since a caller reading a tool's ``schemas()`` needs to be
+able to name what comes back.
+"""
+
+from .final import (
+    ClientTool,
+    FunctionDefinition,
+    FunctionParameters,
+    FunctionTool,
+    FunctionToolSchema,
+    Toolkit,
+)
+from .schemas import ToolSchema
+from .tool import Tool
+
+__all__ = (
+    "ClientTool",
+    "FunctionDefinition",
+    "FunctionParameters",
+    "FunctionTool",
+    "FunctionToolSchema",
+    "Tool",
+    "ToolSchema",
+    "Toolkit",
+)

--- a/test/tools/test_public_exports.py
+++ b/test/tools/test_public_exports.py
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ag2.tools
+import ag2.tools.types
 from ag2 import Agent
-from ag2.tools import (
+from ag2.tools import Toolkit, tool
+from ag2.tools.types import (
     ClientTool,
     FunctionDefinition,
     FunctionParameters,
@@ -12,14 +14,40 @@ from ag2.tools import (
     FunctionToolSchema,
     Tool,
     ToolSchema,
-    Toolkit,
-    tool,
 )
+
+# Ready-to-use tools that must stay importable from `ag2.tools`, so the
+# re-homing of the abstractions cannot quietly take them with it.
+_CONCRETE_TOOLS = ("CodeExecutionTool", "ShellTool", "WebSearchTool", "MCPServerTool")
 
 
 def test_every_public_name_resolves() -> None:
     """``__all__`` must not advertise a name the module does not expose."""
     assert [name for name in ag2.tools.__all__ if not hasattr(ag2.tools, name)] == []
+    assert [name for name in ag2.tools.types.__all__ if not hasattr(ag2.tools.types, name)] == []
+
+
+class TestImportPathsStaySeparate:
+    """`ag2.tools` is ready-to-use tools; `ag2.tools.types` is the abstractions."""
+
+    def test_abstractions_are_importable_from_one_place(self) -> None:
+        assert set(ag2.tools.types.__all__) == {
+            "ClientTool",
+            "FunctionDefinition",
+            "FunctionParameters",
+            "FunctionTool",
+            "FunctionToolSchema",
+            "Tool",
+            "ToolSchema",
+            "Toolkit",
+        }
+
+    def test_abstractions_are_not_mixed_into_ag2_tools(self) -> None:
+        # Toolkit predates this split and stays exported from both.
+        assert [name for name in ag2.tools.types.__all__ if name in ag2.tools.__all__] == ["Toolkit"]
+
+    def test_concrete_tools_are_untouched(self) -> None:
+        assert [name for name in _CONCRETE_TOOLS if name not in ag2.tools.__all__] == []
 
 
 class TestToolAbstraction:

--- a/test/tools/test_public_exports.py
+++ b/test/tools/test_public_exports.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import ag2.tools
+from ag2 import Agent
+from ag2.tools import (
+    ClientTool,
+    FunctionDefinition,
+    FunctionParameters,
+    FunctionTool,
+    FunctionToolSchema,
+    Tool,
+    ToolSchema,
+    Toolkit,
+    tool,
+)
+
+
+def test_every_public_name_resolves() -> None:
+    """``__all__`` must not advertise a name the module does not expose."""
+    assert [name for name in ag2.tools.__all__ if not hasattr(ag2.tools, name)] == []
+
+
+class TestToolAbstraction:
+    """ADR 0002 — one ``Tool`` abstraction; every kind of tool implements it."""
+
+    def test_function_tool_is_a_tool(self) -> None:
+        assert issubclass(FunctionTool, Tool)
+
+    def test_client_tool_is_a_tool(self) -> None:
+        assert issubclass(ClientTool, Tool)
+
+    def test_toolkit_is_a_tool(self) -> None:
+        # The composite: a toolkit *is a* Tool, so an agent accepts it anywhere
+        # it accepts a tool.
+        assert issubclass(Toolkit, Tool)
+
+    def test_function_tool_schema_is_a_tool_schema(self) -> None:
+        assert issubclass(FunctionToolSchema, ToolSchema)
+
+
+class TestPublicReturnTypesAreImportable:
+    """Callables AG2 exports must return types a caller can name."""
+
+    def test_tool_decorator_returns_function_tool(self) -> None:
+        @tool
+        def my_tool(a: str) -> str:
+            """Tool description."""
+            return a
+
+        assert isinstance(my_tool, FunctionTool)
+
+    def test_agent_as_tool_returns_function_tool(self) -> None:
+        child = Agent("child", prompt="You are a child agent.")
+
+        assert isinstance(child.as_tool(description="Delegate to the child."), FunctionTool)
+
+    def test_toolkit_tool_decorator_returns_function_tool(self) -> None:
+        toolkit = Toolkit()
+
+        @toolkit.tool
+        def my_tool(a: str) -> str:
+            """Tool description."""
+            return a
+
+        assert isinstance(my_tool, FunctionTool)
+
+
+def test_function_tool_schema_is_built_from_public_parts() -> None:
+    """``FunctionDefinition`` / ``FunctionParameters`` describe a function tool."""
+    parameters: FunctionParameters = {"type": "object", "properties": {}}
+    schema = FunctionToolSchema(function=FunctionDefinition(name="my_tool", parameters=parameters))
+
+    assert schema.type == "function"
+    assert schema.function.name == "my_tool"

--- a/website/docs/contributor-guide/contribution_policy.mdx
+++ b/website/docs/contributor-guide/contribution_policy.mdx
@@ -132,7 +132,7 @@ Docs: https://docs.ag2.ai/extensions/search-tools/acme
 Examples: https://github.com/ag2ai/build-with-ag2/extensions/acme-search-tool
 """
 
-from ag2.tools import Tool
+from ag2.tools.types import Tool
 
 class AcmeSearch(Tool):
     """Tool that performs web searches via the Acme Search API.


### PR DESCRIPTION
## Why are these changes needed?

The tool abstractions had no discoverable public home. `Tool` lived in `ag2.tools.tool`, `FunctionTool` / `ClientTool` / `Toolkit` in `ag2.tools.final`, and neither reads like a path you would import from — so callers reached for whatever resolved. One project building on AG2 imports `FunctionTool` from `ag2.spec`, which only works because `spec.py` happens to import it and breaks as soon as that changes.

This matters because the types are unavoidable once you inspect rather than just pass tools: `FunctionTool` carries `.name` and not `__name__`, and five exported callables (`tool()`, `Agent.as_tool()`, `subagent_tool()`, `Toolkit.tool()`, `Plugin.tool()`) return it.

### Changes

Adds `ag2/tools/types.py` as the public home for `Tool`, `FunctionTool`, `ClientTool`, `Toolkit` and the schema types.

`ag2.tools` is unchanged from `main` — it stays the ready-to-use tools import path, per review. `Toolkit` remains exported from both, since it was already public there and removing it would be breaking.

Tests assert the split holds in both directions: one fails if abstractions leak back into `ag2.tools`, one fails if the ready-to-use tools disappear from it.

Also updates the contributor guide, whose `Tool` import example targeted `ag2.tools`, and corrects AGENTS.md, which listed `Tool` among the `Protocol` classes — it is an ABC, as ADR 0002 states.

### Open questions

Two things I would still like a call on, since this goes past what the review strictly asked for:

1. **Do we want the new module at all?** The revert alone answers the review — `ag2.tools.final` and `ag2.tools.tool` are already deeper paths. If pointing people at those is preferable, `types.py` can go.
2. **If we keep it, what belongs in it?** `FunctionTool`, `ClientTool` and `Toolkit` all live in `ag2/tools/final/`, so depending on what "final tools" means they may belong with the concrete side, leaving `types.py` as just `Tool` plus the schema types.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
