### PR TITLE
fix(spec): warn on unknown fields in AgentSpec instead of dropping them silently

### DIFF
--- a/ag2/spec.py
+++ b/ag2/spec.py
@@ -3,9 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Callable, Iterable
+from difflib import get_close_matches
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ag2.agent import Agent, Plugin
 from ag2.config.config import ModelConfig
@@ -19,7 +20,36 @@ from ag2.tools.final import FunctionTool, Toolkit
 from ag2.tools.tool import Tool
 
 
-class ResponseSchemaSpec(BaseModel):
+def _unknown_field_message(cls: type[BaseModel], unknown: Iterable[str]) -> str:
+    """Name each unknown key and suggest the closest valid field."""
+
+    known = sorted(cls.model_fields)
+    described: list[str] = []
+    for key in sorted(unknown):
+        closest = get_close_matches(key, known, n=1, cutoff=0.6)
+        described.append(f"{key!r} (did you mean {closest[0]!r}?)" if closest else repr(key))
+
+    return f"Unknown field(s) for {cls.__name__}: {', '.join(described)}. Valid fields: {known}."
+
+
+class _SpecModel(BaseModel):
+    """Base for spec models. Unknown keys are rejected."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_unknown_fields(cls, data: Any) -> Any:
+        """Reject unknown keys. ``extra="forbid"`` alone suggests no correction."""
+
+        if isinstance(data, dict):
+            unknown = [key for key in data if key not in cls.model_fields]
+            if unknown:
+                raise ValueError(_unknown_field_message(cls, unknown))
+        return data
+
+
+class ResponseSchemaSpec(_SpecModel):
     """JSON-serializable description of a response schema."""
 
     name: str
@@ -36,7 +66,7 @@ class ResponseSchemaSpec(BaseModel):
         )
 
 
-class AgentSpec(BaseModel):
+class AgentSpec(_SpecModel):
     """JSON-serializable specification of an Agent.
 
     Captures the declarative, data-only parts of an ``Agent``: name, prompt,
@@ -45,6 +75,8 @@ class AgentSpec(BaseModel):
     Non-serializable parts (middleware, callbacks, dependencies, dynamic prompts)
     are intentionally excluded and must be supplied at reconstruction time via
     :meth:`to_agent`.
+
+    Unrecognised keys are rejected.
     """
 
     name: str

--- a/ag2/spec.py
+++ b/ag2/spec.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from collections.abc import Callable, Iterable
 from difflib import get_close_matches
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from ag2.agent import Agent, Plugin
 from ag2.config.config import ModelConfig
@@ -20,6 +21,16 @@ from ag2.tools.final import FunctionTool, Toolkit
 from ag2.tools.tool import Tool
 
 
+class UnknownSpecFieldWarning(UserWarning):
+    """A spec carried a field this version of AG2 does not recognise.
+
+    Warns rather than raises, so a spec written against a newer AG2 still loads
+    here. To make it fatal, promote it with the standard warning filters::
+
+        warnings.simplefilter("error", UnknownSpecFieldWarning)
+    """
+
+
 def _unknown_field_message(cls: type[BaseModel], unknown: Iterable[str]) -> str:
     """Name each unknown key and suggest the closest valid field."""
 
@@ -29,23 +40,30 @@ def _unknown_field_message(cls: type[BaseModel], unknown: Iterable[str]) -> str:
         closest = get_close_matches(key, known, n=1, cutoff=0.6)
         described.append(f"{key!r} (did you mean {closest[0]!r}?)" if closest else repr(key))
 
-    return f"Unknown field(s) for {cls.__name__}: {', '.join(described)}. Valid fields: {known}."
+    return (
+        f"Unknown field(s) for {cls.__name__}: {', '.join(described)}. "
+        f"Valid fields: {known}. Unknown fields are ignored."
+    )
 
 
 class _SpecModel(BaseModel):
-    """Base for spec models. Unknown keys are rejected."""
-
-    model_config = ConfigDict(extra="forbid")
+    """Base for spec models. Unknown keys are ignored, with a warning."""
 
     @model_validator(mode="before")
     @classmethod
-    def _reject_unknown_fields(cls, data: Any) -> Any:
-        """Reject unknown keys. ``extra="forbid"`` alone suggests no correction."""
+    def _warn_on_unknown_fields(cls, data: Any) -> Any:
+        """Name unknown keys rather than dropping them silently.
+
+        Pydantic ignores them by default, so a misspelled key produces a spec
+        that loads cleanly and builds the wrong agent. Warning keeps that
+        non-breaking while making the mistake visible, and the message suggests
+        the closest valid field so a typo diagnoses itself.
+        """
 
         if isinstance(data, dict):
             unknown = [key for key in data if key not in cls.model_fields]
             if unknown:
-                raise ValueError(_unknown_field_message(cls, unknown))
+                warnings.warn(_unknown_field_message(cls, unknown), UnknownSpecFieldWarning, stacklevel=2)
         return data
 
 
@@ -76,7 +94,7 @@ class AgentSpec(_SpecModel):
     are intentionally excluded and must be supplied at reconstruction time via
     :meth:`to_agent`.
 
-    Unrecognised keys are rejected.
+    Unrecognised keys are ignored, with an :class:`UnknownSpecFieldWarning`.
     """
 
     name: str

--- a/test/spec/test_spec.py
+++ b/test/spec/test_spec.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from dirty_equals import IsPartialDict
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from ag2 import Agent, AgentSpec
 from ag2.exceptions import ToolResolutionError
@@ -196,3 +196,57 @@ class TestToolkit:
         agent = spec.to_agent(available_tools=[add, multiply, ws, fs])
 
         assert [t.name for t in agent.tools] == ["add", "web_search", "read_file"]
+
+
+class TestUnknownFields:
+    def test_unknown_field_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentSpec.model_validate({"name": "x", "tool_nammes": ["add"]})
+
+    def test_error_names_key_and_suggests_nearest_field(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            AgentSpec.model_validate({"name": "x", "tool_nammes": ["add"]})
+
+        message = str(exc_info.value)
+        assert "tool_nammes" in message
+        assert "did you mean 'tool_names'?" in message
+
+    def test_error_reports_every_unknown_key(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            AgentSpec.model_validate({"name": "x", "prompts": [], "tool_nammes": []})
+
+        message = str(exc_info.value)
+        assert "prompts" in message
+        assert "tool_nammes" in message
+
+    def test_unrecognisable_key_reported_without_suggestion(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            AgentSpec.model_validate({"name": "x", "zzzzzz": 1})
+
+        message = str(exc_info.value)
+        assert "zzzzzz" in message
+        assert "did you mean" not in message
+
+    def test_nested_spec_rejects_unknown_field(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            AgentSpec.model_validate({
+                "name": "x",
+                "response_schema": {"name": "Answer", "json_schemaa": {}},
+            })
+
+        assert "json_schemaa" in str(exc_info.value)
+
+    def test_response_schema_spec_rejects_unknown_field_directly(self) -> None:
+        with pytest.raises(ValidationError):
+            ResponseSchemaSpec.model_validate({"name": "A", "json_schema": {}, "extra": 1})
+
+    def test_valid_spec_still_validates(self) -> None:
+        spec = AgentSpec.model_validate({"name": "x", "tool_names": ["add"], "prompt": ["p"]})
+
+        assert spec == AgentSpec(name="x", tool_names=["add"], prompt=["p"])
+
+    def test_round_trip_survives_strict_validation(self) -> None:
+        agent = make_agent()
+        spec = AgentSpec.from_agent(agent)
+
+        assert AgentSpec.model_validate(spec.model_dump()) == spec

--- a/test/spec/test_spec.py
+++ b/test/spec/test_spec.py
@@ -2,16 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from pathlib import Path
 
 import pytest
 from dirty_equals import IsPartialDict
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from ag2 import Agent, AgentSpec
 from ag2.exceptions import ToolResolutionError
 from ag2.response import ResponseSchema
-from ag2.spec import ResponseSchemaSpec
+from ag2.spec import ResponseSchemaSpec, UnknownSpecFieldWarning
 from ag2.tools import FilesystemToolkit, WebSearchTool
 
 from .helpers import add, greet, make_agent, multiply
@@ -199,54 +200,71 @@ class TestToolkit:
 
 
 class TestUnknownFields:
-    def test_unknown_field_raises(self) -> None:
-        with pytest.raises(ValidationError):
+    def test_unknown_field_warns_without_failing(self) -> None:
+        with pytest.warns(UnknownSpecFieldWarning):
+            spec = AgentSpec.model_validate({"name": "x", "tool_nammes": ["add"]})
+
+        # Loading still succeeds; the key is ignored, as Pydantic would anyway.
+        assert spec == AgentSpec(name="x")
+
+    def test_warning_names_key_and_suggests_nearest_field(self) -> None:
+        with pytest.warns(UnknownSpecFieldWarning) as caught:
             AgentSpec.model_validate({"name": "x", "tool_nammes": ["add"]})
 
-    def test_error_names_key_and_suggests_nearest_field(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
-            AgentSpec.model_validate({"name": "x", "tool_nammes": ["add"]})
-
-        message = str(exc_info.value)
+        message = str(caught[0].message)
         assert "tool_nammes" in message
         assert "did you mean 'tool_names'?" in message
 
-    def test_error_reports_every_unknown_key(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
+    def test_warning_reports_every_unknown_key(self) -> None:
+        with pytest.warns(UnknownSpecFieldWarning) as caught:
             AgentSpec.model_validate({"name": "x", "prompts": [], "tool_nammes": []})
 
-        message = str(exc_info.value)
+        message = str(caught[0].message)
         assert "prompts" in message
         assert "tool_nammes" in message
 
     def test_unrecognisable_key_reported_without_suggestion(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.warns(UnknownSpecFieldWarning) as caught:
             AgentSpec.model_validate({"name": "x", "zzzzzz": 1})
 
-        message = str(exc_info.value)
+        message = str(caught[0].message)
         assert "zzzzzz" in message
         assert "did you mean" not in message
 
-    def test_nested_spec_rejects_unknown_field(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
+    def test_nested_spec_warns_on_unknown_field(self) -> None:
+        with pytest.warns(UnknownSpecFieldWarning) as caught:
             AgentSpec.model_validate({
                 "name": "x",
-                "response_schema": {"name": "Answer", "json_schemaa": {}},
+                "response_schema": {"name": "Answer", "json_schema": {}, "json_schemaa": {}},
             })
 
-        assert "json_schemaa" in str(exc_info.value)
+        assert "json_schemaa" in str(caught[0].message)
 
-    def test_response_schema_spec_rejects_unknown_field_directly(self) -> None:
-        with pytest.raises(ValidationError):
+    def test_response_schema_spec_warns_on_unknown_field_directly(self) -> None:
+        with pytest.warns(UnknownSpecFieldWarning):
             ResponseSchemaSpec.model_validate({"name": "A", "json_schema": {}, "extra": 1})
 
-    def test_valid_spec_still_validates(self) -> None:
-        spec = AgentSpec.model_validate({"name": "x", "tool_names": ["add"], "prompt": ["p"]})
+    def test_can_be_promoted_to_an_error(self) -> None:
+        # No new API for strict mode: the standard warning filters do it.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnknownSpecFieldWarning)
+
+            with pytest.raises(UnknownSpecFieldWarning):
+                AgentSpec.model_validate({"name": "x", "tool_nammes": ["add"]})
+
+    def test_valid_spec_does_not_warn(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnknownSpecFieldWarning)
+
+            spec = AgentSpec.model_validate({"name": "x", "tool_names": ["add"], "prompt": ["p"]})
 
         assert spec == AgentSpec(name="x", tool_names=["add"], prompt=["p"])
 
-    def test_round_trip_survives_strict_validation(self) -> None:
+    def test_round_trip_does_not_warn(self) -> None:
         agent = make_agent()
         spec = AgentSpec.from_agent(agent)
 
-        assert AgentSpec.model_validate(spec.model_dump()) == spec
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnknownSpecFieldWarning)
+
+            assert AgentSpec.model_validate(spec.model_dump()) == spec

--- a/website/docs/user-guide/subagents.mdx
+++ b/website/docs/user-guide/subagents.mdx
@@ -209,6 +209,8 @@ The LLM builds an `#!python AgentSpec` on every call. It is JSON-serializable an
 | `tool_names` | `list[str]` | Subset of `available_tools` names to give the child |
 | `response_schema` | `ResponseSchemaSpec | None` | Optional structured output schema |
 
+Unrecognised keys are rejected at validation, and the error names the closest valid field.
+
 ### How the LLM discovers available tool names
 
 The pool's names and descriptions are **rendered into the `#!python create_and_run_agent` tool description automatically** when the factory is built. The calling agent's system prompt does not need to enumerate them — the LLM discovers the valid names from the tool schema.

--- a/website/docs/user-guide/subagents.mdx
+++ b/website/docs/user-guide/subagents.mdx
@@ -209,7 +209,14 @@ The LLM builds an `#!python AgentSpec` on every call. It is JSON-serializable an
 | `tool_names` | `list[str]` | Subset of `available_tools` names to give the child |
 | `response_schema` | `ResponseSchemaSpec | None` | Optional structured output schema |
 
-Unrecognised keys are rejected at validation, and the error names the closest valid field.
+Unrecognised keys are ignored, as Pydantic would anyway, but they raise an `#!python UnknownSpecFieldWarning` naming the key and suggesting the closest valid field — so a misspelled `#!python tool_nammes` no longer silently produces a child with no tools. To make it fatal, promote the warning:
+
+```python linenums="1"
+import warnings
+from ag2.spec import UnknownSpecFieldWarning
+
+warnings.simplefilter("error", UnknownSpecFieldWarning)
+```
 
 ### How the LLM discovers available tool names
 


### PR DESCRIPTION
## Why are these changes needed?

`AgentSpec` sets no `model_config`, so Pydantic's default applies and unknown keys are dropped silently — a spec misspelling `tool_names` validates cleanly and builds an agent with no tools, leaving the user to work backwards from behaviour to a typo.

This isn't only a hand-authoring concern: `AgentSpec` is a tool parameter type in `ag2/tools/dynamic/factory.py`, so an LLM writes one on every `create_and_run_agent` call, making the failure silent and unattended.

### Changes

Adds a shared `_SpecModel` base with a before-validator, inherited by `AgentSpec` and `ResponseSchemaSpec` so nested specs behave the same. Unknown keys now raise an `UnknownSpecFieldWarning` naming every one of them and suggesting the nearest valid field:

```
Unknown field(s) for AgentSpec: 'tool_nammes' (did you mean 'tool_names'?). Valid fields: [...]. Unknown fields are ignored.
```

**Warns rather than rejects**, per review — `AgentSpec` shipped in 1.0 and rejecting would be a breaking change. Keys are still ignored exactly as Pydantic would, so nothing that works today stops working; the difference is that the mistake is now visible.

Strict mode needs no new API surface — the standard warning filters do it:

```python
warnings.simplefilter("error", UnknownSpecFieldWarning)
```

If we later want unknown fields to be fatal by default, this is the deprecation step that gives users notice first.

No extension field, since no cross-version spec exchange exists to justify one.

### Alternative

If an explicit switch is preferred over a warning, the Pydantic-native form is per-call and avoids global state:

```python
AgentSpec.model_validate(data, context={"strict_fields": True})
```

Happy to swap; the warning is the smaller change.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

Tests cover both directions — that a typo warns without failing, that the message names the key and suggests the nearest field, that the warning can be promoted to an error, and that a valid spec and a `from_agent` round-trip do not warn at all.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
