### PR TITLE
fix(perplexity): read SDK response nodes that arrive as dicts

### DIFF
--- a/ag2/tools/search/perplexity.py
+++ b/ag2/tools/search/perplexity.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Final, Literal, TypeAlias
 
@@ -32,6 +32,13 @@ SearchContextSize: TypeAlias = Literal["low", "medium", "high"]
 RecencyFilter: TypeAlias = Literal["hour", "day", "week", "month", "year"]
 
 _PPLX_INTEGRATION_HEADERS: Final[dict[str, str]] = {"X-Pplx-Integration": f"ag2/{__version__}"}
+
+
+def _field(obj: Any, name: str) -> Any:
+    """Read ``name`` off an SDK response node, which may be a model or a raw dict."""
+    if isinstance(obj, Mapping):
+        return obj.get(name)
+    return getattr(obj, name, None)
 
 
 @dataclass(slots=True)
@@ -169,10 +176,10 @@ class PerplexitySearchToolkit(Toolkit):
             raw_results: list[SearchAPIResult] = getattr(raw, "results", None) or []
             results = [
                 PerplexitySearchResult(
-                    title=r.title or "",
-                    url=r.url or "",
-                    snippet=r.snippet,
-                    date=r.date,
+                    title=_field(r, "title") or "",
+                    url=_field(r, "url") or "",
+                    snippet=_field(r, "snippet"),
+                    date=_field(r, "date"),
                 )
                 for r in raw_results
             ]
@@ -248,33 +255,33 @@ class PerplexitySearchToolkit(Toolkit):
             content: str | None = None
             choices = getattr(raw, "choices", None) or []
             if choices:
-                message = getattr(choices[0], "message", None)
-                content = getattr(message, "content", None) if message is not None else None
+                message = _field(choices[0], "message")
+                content = _field(message, "content") if message is not None else None
 
             search_results: list[APIPublicSearchResult] = getattr(raw, "search_results", None) or []
             results = [
                 PerplexitySearchResult(
-                    title=r.title or "",
-                    url=r.url or "",
-                    snippet=r.snippet,
-                    date=r.date,
+                    title=_field(r, "title") or "",
+                    url=_field(r, "url") or "",
+                    snippet=_field(r, "snippet"),
+                    date=_field(r, "date"),
                 )
                 for r in search_results
             ]
 
             citations = list(getattr(raw, "citations", None) or [])
 
-            raw_images: list[dict[str, Any]] = list(getattr(raw, "images", None) or [])
+            raw_images: list[Any] = list(getattr(raw, "images", None) or [])
             images = [
                 PerplexityImageMeta(
                     image_url=url,
-                    origin_url=img.get("origin_url"),
-                    title=img.get("title"),
-                    width=img.get("width"),
-                    height=img.get("height"),
+                    origin_url=_field(img, "origin_url"),
+                    title=_field(img, "title"),
+                    width=_field(img, "width"),
+                    height=_field(img, "height"),
                 )
                 for img in raw_images
-                if (url := img.get("image_url"))
+                if (url := _field(img, "image_url"))
             ]
 
             response = PerplexitySearchResponse(


### PR DESCRIPTION
## Why are these changes needed?

perplexityai 0.43.0 refers to nested response models by string forward reference inside PEP 585 aliases (`list["ChoiceOutput"]`). Python 3.10's `typing._eval_type` does not recurse into `types.GenericAlias` args, so pydantic leaves those annotations unresolved and the SDK hands back raw dicts for `choices` and `search_results` where 3.11+ gets models.

Reading those nodes by attribute therefore dropped `content` and raised `AttributeError: 'dict' object has no attribute 'title'` on 3.10. Read them through a helper that accepts either shape, so parsing no longer depends on the SDK's model construction.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [X] I understand the changes in this PR and can explain them in my own words.
- [X] I have verified that the PR description accurately reflects the actual diff.
- [X] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
