### PR TITLE
feat(middleware): add describe() so middleware can report its configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ Cross-cutting and hard-to-reverse design decisions are recorded in `docs/adr/`, 
 | `tools/` | Tool system — builtin + user-defined | `tool`, `Toolkit`, `ToolResult`, `CodeExecutionTool`, `ShellTool`, `WebSearchTool`, … |
 | `tools/subagents/` | Agent-to-agent delegation | `subagent_tool`, `run_task`, `persistent_stream`, `StreamFactory` |
 | `eval/` | Offline evaluation framework | `run`, `scorer`, `EvalTarget`, `Suite`, `Task`, `Trace`, `RunResult`, `Feedback`, `BudgetThresholds`, plus prebuilts under `eval.scorers` |
-| `middleware/` | Request/response interception | `BaseMiddleware`, `Middleware`, `LoggingMiddleware`, `RetryMiddleware`, `TokenLimiter`, `HistoryLimiter`, `describe_middleware`, … |
+| `middleware/` | Request/response interception | `BaseMiddleware`, `Middleware`, `LoggingMiddleware`, `RetryMiddleware`, `TokenLimiter`, `HistoryLimiter`, `MiddlewareDescription`, … |
 | `response/` | Structured output validation | `ResponseSchema`, `PromptedSchema`, `ResponseProto`, `response_schema` |
 | `history.py` | Conversation history storage | `History`, `Storage`, `MemoryStorage` |
 | `hitl.py` | Human-in-the-loop hooks | — |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ Cross-cutting and hard-to-reverse design decisions are recorded in `docs/adr/`, 
 | `tools/` | Tool system — builtin + user-defined | `tool`, `Toolkit`, `ToolResult`, `CodeExecutionTool`, `ShellTool`, `WebSearchTool`, … |
 | `tools/subagents/` | Agent-to-agent delegation | `subagent_tool`, `run_task`, `persistent_stream`, `StreamFactory` |
 | `eval/` | Offline evaluation framework | `run`, `scorer`, `EvalTarget`, `Suite`, `Task`, `Trace`, `RunResult`, `Feedback`, `BudgetThresholds`, plus prebuilts under `eval.scorers` |
-| `middleware/` | Request/response interception | `BaseMiddleware`, `Middleware`, `LoggingMiddleware`, `RetryMiddleware`, `TokenLimiter`, `HistoryLimiter`, … |
+| `middleware/` | Request/response interception | `BaseMiddleware`, `Middleware`, `LoggingMiddleware`, `RetryMiddleware`, `TokenLimiter`, `HistoryLimiter`, `describe_middleware`, … |
 | `response/` | Structured output validation | `ResponseSchema`, `PromptedSchema`, `ResponseProto`, `response_schema` |
 | `history.py` | Conversation history storage | `History`, `Storage`, `MemoryStorage` |
 | `hitl.py` | Human-in-the-loop hooks | — |

--- a/ag2/middleware/__init__.py
+++ b/ag2/middleware/__init__.py
@@ -23,7 +23,7 @@ from .builtin import (
     TokenLimiter,
     approval_required,
 )
-from .describe import DescribableMiddleware, MiddlewareDescription, describe_middleware
+from .describe import DescribableMiddleware, MiddlewareDescription
 
 __all__ = (
     "AgentTurn",
@@ -45,5 +45,4 @@ __all__ = (
     "ToolMiddleware",
     "ToolResultType",
     "approval_required",
-    "describe_middleware",
 )

--- a/ag2/middleware/__init__.py
+++ b/ag2/middleware/__init__.py
@@ -14,6 +14,7 @@ from .base import (
     ToolResultType,
 )
 from .builtin import (
+    ApprovalRequired,
     HistoryLimiter,
     LoggingMiddleware,
     MetricsMiddleware,
@@ -22,17 +23,21 @@ from .builtin import (
     TokenLimiter,
     approval_required,
 )
+from .describe import DescribableMiddleware, MiddlewareDescription, describe_middleware
 
 __all__ = (
     "AgentTurn",
+    "ApprovalRequired",
     "BaseMiddleware",
     "ConditionalMiddleware",
+    "DescribableMiddleware",
     "HistoryLimiter",
     "HumanInputHook",
     "LLMCall",
     "LoggingMiddleware",
     "MetricsMiddleware",
     "Middleware",
+    "MiddlewareDescription",
     "RetryMiddleware",
     "TelemetryMiddleware",
     "TokenLimiter",
@@ -40,4 +45,5 @@ __all__ = (
     "ToolMiddleware",
     "ToolResultType",
     "approval_required",
+    "describe_middleware",
 )

--- a/ag2/middleware/base.py
+++ b/ag2/middleware/base.py
@@ -18,6 +18,7 @@ from ag2.events import (
     ToolResultEvent,
 )
 from ag2.events.conditions import TypeCondition
+from ag2.middleware.describe import MiddlewareDescription, describe_middleware
 
 
 class MiddlewareFactory(Protocol):
@@ -34,6 +35,19 @@ class Middleware(MiddlewareFactory):
     ) -> None:
         self._cls = middleware_cls
         self._options = kwargs
+
+    def describe(self) -> "MiddlewareDescription":
+        """Report the wrapped class and option names, but not option values.
+
+        Always incomplete: option values are caller-supplied and may hold
+        credentials, and the wrapped class is only instantiated per turn.
+        """
+
+        return MiddlewareDescription(
+            kind=self._cls.__qualname__,
+            config={"options": tuple(sorted(self._options))},
+            complete=False,
+        )
 
     def __call__(
         self,
@@ -158,6 +172,13 @@ class ConditionalMiddleware:
     ) -> None:
         self._middleware = middleware
         self._condition = condition if isinstance(condition, Condition) else TypeCondition(condition)
+
+    def describe(self) -> "MiddlewareDescription":
+        return MiddlewareDescription(
+            kind=type(self).__qualname__,
+            config={"condition": type(self._condition).__qualname__},
+            inner=(describe_middleware(self._middleware),),
+        )
 
     def __call__(
         self,

--- a/ag2/middleware/base.py
+++ b/ag2/middleware/base.py
@@ -18,7 +18,7 @@ from ag2.events import (
     ToolResultEvent,
 )
 from ag2.events.conditions import TypeCondition
-from ag2.middleware.describe import MiddlewareDescription, describe_middleware
+from ag2.middleware.describe import MiddlewareDescription, _describe
 
 
 class MiddlewareFactory(Protocol):
@@ -177,7 +177,7 @@ class ConditionalMiddleware:
         return MiddlewareDescription(
             kind=type(self).__qualname__,
             config={"condition": type(self._condition).__qualname__},
-            inner=(describe_middleware(self._middleware),),
+            inner=(_describe(self._middleware),),
         )
 
     def __call__(

--- a/ag2/middleware/builtin/__init__.py
+++ b/ag2/middleware/builtin/__init__.py
@@ -8,7 +8,7 @@ from .history_limiter import HistoryLimiter
 from .llm_retry import RetryMiddleware
 from .logging import LoggingMiddleware
 from .token_limiter import TokenLimiter
-from .tools import approval_required
+from .tools import ApprovalRequired, approval_required
 
 try:
     from .telemetry import TelemetryMiddleware
@@ -21,6 +21,7 @@ except ImportError as e:
     MetricsMiddleware = missing_optional_dependency("MetricsMiddleware", "metrics", e)
 
 __all__ = (
+    "ApprovalRequired",
     "HistoryLimiter",
     "LoggingMiddleware",
     "MetricsMiddleware",

--- a/ag2/middleware/builtin/history_limiter.py
+++ b/ag2/middleware/builtin/history_limiter.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from ag2.annotations import Context
 from ag2.events import BaseEvent, ModelRequest, ModelResponse, ToolResultsEvent
 from ag2.middleware.base import BaseMiddleware, LLMCall, MiddlewareFactory
+from ag2.middleware.describe import MiddlewareDescription
 
 
 class HistoryLimiter(MiddlewareFactory):
@@ -14,6 +15,12 @@ class HistoryLimiter(MiddlewareFactory):
         if max_events < 1:
             raise ValueError("max_events must be greater than 0")
         self._max_events = max_events
+
+    def describe(self) -> MiddlewareDescription:
+        return MiddlewareDescription(
+            kind=type(self).__qualname__,
+            config={"max_events": self._max_events},
+        )
 
     def __call__(self, event: "BaseEvent", context: "Context") -> "BaseMiddleware":
         return _HistoryLimiter(event, context, self._max_events)

--- a/ag2/middleware/builtin/llm_retry.py
+++ b/ag2/middleware/builtin/llm_retry.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from ag2.annotations import Context
 from ag2.events import BaseEvent, ModelResponse
 from ag2.middleware.base import BaseMiddleware, LLMCall, MiddlewareFactory
+from ag2.middleware.describe import MiddlewareDescription
 
 
 class RetryMiddleware(MiddlewareFactory):
@@ -17,6 +18,15 @@ class RetryMiddleware(MiddlewareFactory):
     ):
         self._max_retries = max_retries
         self._retry_on = retry_on
+
+    def describe(self) -> MiddlewareDescription:
+        return MiddlewareDescription(
+            kind=type(self).__qualname__,
+            config={
+                "max_retries": self._max_retries,
+                "retry_on": tuple(exc.__qualname__ for exc in self._retry_on),
+            },
+        )
 
     def __call__(self, event: "BaseEvent", context: "Context") -> "BaseMiddleware":
         return _RetryMiddleware(

--- a/ag2/middleware/builtin/logging.py
+++ b/ag2/middleware/builtin/logging.py
@@ -16,11 +16,19 @@ from ag2.middleware.base import (
     ToolExecution,
     ToolResultType,
 )
+from ag2.middleware.describe import MiddlewareDescription
 
 
 class LoggingMiddleware(MiddlewareFactory):
     def __init__(self, logger: logging.Logger | None = None) -> None:
         self._logger = logger or logging.getLogger("ag2")
+
+    def describe(self) -> MiddlewareDescription:
+        # Logger name, not the object.
+        return MiddlewareDescription(
+            kind=type(self).__qualname__,
+            config={"logger": self._logger.name},
+        )
 
     def __call__(self, event: "BaseEvent", context: "Context") -> BaseMiddleware:
         return _LoggingMiddleware(event, context, self._logger)

--- a/ag2/middleware/builtin/metrics.py
+++ b/ag2/middleware/builtin/metrics.py
@@ -34,6 +34,7 @@ from ag2.middleware.base import (
     ToolExecution,
     ToolResultType,
 )
+from ag2.middleware.describe import MiddlewareDescription
 from ag2.utils import AGENT_CONTEXT_DEPENDENCY_KEY, MODEL_CONFIG_CONTEXT_DEPENDENCY_KEY
 
 try:
@@ -130,6 +131,10 @@ class MetricsMiddleware(MiddlewareFactory):
                 "MetricsMiddleware cannot be created more than once for the same CollectorRegistry. "
                 "Create one MetricsMiddleware per CollectorRegistry and reuse that middleware instance across agents."
             ) from exc
+
+    def describe(self) -> MiddlewareDescription:
+        # Registry is a live collector; report presence only.
+        return MiddlewareDescription(kind=type(self).__qualname__, config={"registry": self._metrics is not None})
 
     def __call__(self, event: "BaseEvent", context: "Context") -> BaseMiddleware:
         return _MetricsMiddleware(event, context, self._metrics)

--- a/ag2/middleware/builtin/telemetry.py
+++ b/ag2/middleware/builtin/telemetry.py
@@ -38,6 +38,7 @@ from ag2.middleware.base import (
     ToolExecution,
     ToolResultType,
 )
+from ag2.middleware.describe import MiddlewareDescription
 
 try:
     from opentelemetry import trace
@@ -85,6 +86,19 @@ class TelemetryMiddleware(MiddlewareFactory):
         self._provider_name = provider_name
         self._model_name = model_name
         self._span_attributes: dict[str, str] = span_attributes or {}
+
+    def describe(self) -> MiddlewareDescription:
+        # span_attributes may carry secrets; report keys only.
+        return MiddlewareDescription(
+            kind=type(self).__qualname__,
+            config={
+                "capture_content": self._capture_content,
+                "agent_name": self._agent_name,
+                "provider_name": self._provider_name,
+                "model_name": self._model_name,
+                "span_attributes": tuple(sorted(self._span_attributes)),
+            },
+        )
 
     def __call__(self, event: BaseEvent, context: Context) -> BaseMiddleware:
         return _TelemetryMiddlewareInstance(

--- a/ag2/middleware/builtin/token_limiter.py
+++ b/ag2/middleware/builtin/token_limiter.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from ag2.annotations import Context
 from ag2.events import BaseEvent, ModelRequest, ModelResponse, ToolResultsEvent, estimated_tokens
 from ag2.middleware.base import BaseMiddleware, LLMCall, MiddlewareFactory
+from ag2.middleware.describe import MiddlewareDescription
 
 
 class TokenLimiter(MiddlewareFactory):
@@ -24,6 +25,12 @@ class TokenLimiter(MiddlewareFactory):
             raise ValueError("chars_per_token must be greater than 0")
         self._max_tokens = max_tokens
         self._chars_per_token = chars_per_token
+
+    def describe(self) -> MiddlewareDescription:
+        return MiddlewareDescription(
+            kind=type(self).__qualname__,
+            config={"max_tokens": self._max_tokens, "chars_per_token": self._chars_per_token},
+        )
 
     def __call__(self, event: "BaseEvent", context: "Context") -> "BaseMiddleware":
         return _TokenLimiter(event, context, self._max_tokens, self._chars_per_token)

--- a/ag2/middleware/builtin/tools/__init__.py
+++ b/ag2/middleware/builtin/tools/__init__.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .approval import approval_required
+from .approval import ApprovalRequired, approval_required
 
-__all__ = ("approval_required",)
+__all__ = (
+    "ApprovalRequired",
+    "approval_required",
+)

--- a/ag2/middleware/builtin/tools/approval.py
+++ b/ag2/middleware/builtin/tools/approval.py
@@ -5,12 +5,76 @@
 from ag2.annotations import Context
 from ag2.events import ToolCallEvent, ToolResultEvent
 from ag2.middleware.base import ToolExecution, ToolMiddleware, ToolResultType
+from ag2.middleware.describe import MiddlewareDescription
 
 _DEFAULT_MESSAGE = (
     "Agent wants to call the tool:\n`{tool_name}`, {tool_arguments}\nPlease approve or deny this request.\nY/N?\n"
 )
 _DEFAULT_MESSAGE_ALWAYS = "Agent wants to call the tool:\n`{tool_name}`, {tool_arguments}\nPlease approve or deny this request.\nY/N/Always?\n"
 BYPASS_KEY = "ag:approval_required:always"
+
+
+class ApprovalRequired:
+    """Tool middleware that requests human approval before executing a tool call.
+
+    Callable, so it satisfies :data:`~ag2.middleware.ToolMiddleware` wherever a
+    hook is accepted. Approval state lives in ``context.variables``, not here.
+    """
+
+    def __init__(
+        self,
+        message: str | None = None,
+        denied_message: str = "User denied the tool call request",
+        *,
+        timeout: int = 30,
+        allow_always: bool = True,
+    ) -> None:
+        self._prompt = (
+            message if message is not None else (_DEFAULT_MESSAGE_ALWAYS if allow_always else _DEFAULT_MESSAGE)
+        )
+        self._denied_message = denied_message
+        self._timeout = timeout
+        self._allow_always = allow_always
+
+    def describe(self) -> MiddlewareDescription:
+        return MiddlewareDescription(
+            kind=type(self).__qualname__,
+            config={
+                "message": self._prompt,
+                "denied_message": self._denied_message,
+                "timeout": self._timeout,
+                "allow_always": self._allow_always,
+            },
+        )
+
+    async def __call__(
+        self,
+        call_next: ToolExecution,
+        event: ToolCallEvent,
+        context: Context,
+    ) -> ToolResultType:
+        if self._allow_always:
+            bypass_dict = context.variables.get(BYPASS_KEY, {})
+            if bypass_dict.get(event.name):
+                return await call_next(event, context)
+
+        user_result = (
+            await context.input(
+                self._prompt.format(tool_name=event.name, tool_arguments=event.arguments),
+                timeout=self._timeout,
+            )
+        ).lower()
+
+        if self._allow_always and user_result == "always":
+            bypass_dict = context.variables.get(BYPASS_KEY, {})
+            bypass_dict[event.name] = True
+            context.variables[BYPASS_KEY] = bypass_dict
+            return await call_next(event, context)
+
+        elif user_result in ("y", "yes", "1"):
+            return await call_next(event, context)
+
+        return ToolResultEvent.from_call(event, result=self._denied_message)
 
 
 def approval_required(
@@ -33,38 +97,13 @@ def approval_required(
             same context.
 
     Returns:
-        A tool middleware hook that can be passed to the ``middleware``
-        parameter of :func:`~ag2.tool`.
+        An :class:`ApprovalRequired` hook that can be passed to the
+        ``middleware`` parameter of :func:`~ag2.tool`.
     """
 
-    prompt = message if message is not None else (_DEFAULT_MESSAGE_ALWAYS if allow_always else _DEFAULT_MESSAGE)
-
-    async def hitl_hook(
-        call_next: ToolExecution,
-        event: ToolCallEvent,
-        context: Context,
-    ) -> ToolResultType:
-        if allow_always:
-            bypass_dict = context.variables.get(BYPASS_KEY, {})
-            if bypass_dict.get(event.name):
-                return await call_next(event, context)
-
-        user_result = (
-            await context.input(
-                prompt.format(tool_name=event.name, tool_arguments=event.arguments),
-                timeout=timeout,
-            )
-        ).lower()
-
-        if allow_always and user_result == "always":
-            bypass_dict = context.variables.get(BYPASS_KEY, {})
-            bypass_dict[event.name] = True
-            context.variables[BYPASS_KEY] = bypass_dict
-            return await call_next(event, context)
-
-        elif user_result in ("y", "yes", "1"):
-            return await call_next(event, context)
-
-        return ToolResultEvent.from_call(event, result=denied_message)
-
-    return hitl_hook
+    return ApprovalRequired(
+        message,
+        denied_message,
+        timeout=timeout,
+        allow_always=allow_always,
+    )

--- a/ag2/middleware/describe.py
+++ b/ag2/middleware/describe.py
@@ -9,7 +9,6 @@ from typing import Any, Protocol, runtime_checkable
 __all__ = (
     "DescribableMiddleware",
     "MiddlewareDescription",
-    "describe_middleware",
 )
 
 
@@ -57,8 +56,13 @@ def _kind_of(middleware: Any) -> str:
     return type(middleware).__qualname__
 
 
-def describe_middleware(middleware: Any) -> MiddlewareDescription:
+def _describe(middleware: Any) -> MiddlewareDescription:
     """Describe ``middleware``, whether or not it implements ``describe()``.
+
+    Internal. Middleware that opts in is asked directly; this exists so the
+    library can describe anything uniformly, including middleware that did not
+    opt in. It is not public API: callers reach descriptions through the
+    surfaces that expose middleware.
 
     Never raises. Middleware without ``describe()``, or whose ``describe()``
     raises or returns a non-``MiddlewareDescription``, yields ``complete=False``

--- a/ag2/middleware/describe.py
+++ b/ag2/middleware/describe.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass, field
+from inspect import isroutine
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = (
+    "DescribableMiddleware",
+    "MiddlewareDescription",
+    "describe_middleware",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MiddlewareDescription:
+    """A middleware's type and configuration.
+
+    Supports equality but not hashing, since ``config`` may hold arbitrary
+    values. Does not express which instances are shared between tools.
+
+    Attributes:
+        kind: Qualified name of the middleware type, without module path.
+        config: Flat settings mapping. Excludes state that changes during a run.
+        complete: ``False`` when the configuration was not fully captured.
+            Forced to ``False`` if any entry in ``inner`` is incomplete.
+        inner: Descriptions of wrapped middleware, for composites.
+
+    See ADR 0013 for the rationale behind these choices.
+    """
+
+    kind: str
+    config: dict[str, Any] = field(default_factory=dict)
+    complete: bool = True
+    inner: tuple["MiddlewareDescription", ...] = ()
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.complete and not all(described.complete for described in self.inner):
+            object.__setattr__(self, "complete", False)
+
+
+@runtime_checkable
+class DescribableMiddleware(Protocol):
+    """Middleware that can report its own type and configuration."""
+
+    def describe(self) -> MiddlewareDescription: ...
+
+
+def _kind_of(middleware: Any) -> str:
+    """Qualified name of the middleware, without its module path."""
+
+    if isinstance(middleware, type) or isroutine(middleware):
+        return str(middleware.__qualname__)
+    return type(middleware).__qualname__
+
+
+def describe_middleware(middleware: Any) -> MiddlewareDescription:
+    """Describe ``middleware``, whether or not it implements ``describe()``.
+
+    Never raises. Middleware without ``describe()``, or whose ``describe()``
+    raises or returns a non-``MiddlewareDescription``, yields ``complete=False``
+    with an empty ``config``. Closure cells are not inspected.
+    """
+
+    describe = getattr(middleware, "describe", None)
+    if callable(describe):
+        try:
+            described = describe()
+        except Exception:
+            described = None
+        if isinstance(described, MiddlewareDescription):
+            return described
+
+    return MiddlewareDescription(kind=_kind_of(middleware), config={}, complete=False)

--- a/docs/adr/0013-middleware-describes-itself-or-reports-unknown.md
+++ b/docs/adr/0013-middleware-describes-itself-or-reports-unknown.md
@@ -1,0 +1,70 @@
+---
+status: accepted
+date: 2026-07-31
+---
+
+# Middleware describes itself, or is reported as unknown — never guessed
+
+## Context
+
+Nothing could ask a middleware instance what it was or how it was configured. Consumers
+that needed to log, compare, or snapshot middleware read `__code__.co_freevars` and
+`__closure__` for tool-scoped hooks, or private `_`-prefixed attributes for agent-level
+factories.
+
+The two families differ:
+
+- **Agent-level** (`TokenLimiter`, `RetryMiddleware`, `LoggingMiddleware`, …) were already
+  classes holding configuration in named attributes — introspectable, but with no contract
+  and no public accessor.
+- **Tool-scoped** (`ToolMiddleware`, a bare `Callable` alias) is the closure case. The one
+  built-in, `approval_required`, kept its settings in closure cells.
+
+Cell names and ordering are an implementation detail of the producing function, so any
+refactor breaks consumers silently. A consumer reading only some cells gets a partial
+result indistinguishable from a complete one.
+
+## Decision
+
+`describe_middleware(mw)` returns `MiddlewareDescription(kind, config, complete, inner)`.
+Middleware opts in via `describe()` (the `DescribableMiddleware` protocol); everything else
+is reported as unknown. All seven built-ins opt in.
+
+Non-obvious choices:
+
+- **`__closure__` is never inspected**, though the configuration is reachable there. An
+  honest `complete=False` is preferred over a partial answer that cannot be distinguished
+  from a complete one.
+- **`describe_middleware()` never raises.** A `describe()` that throws or returns the wrong
+  type degrades to `complete=False`. The primary uses are logging and observability, so
+  introspection must not break its caller.
+- **`MiddlewareDescription` is unhashable** (`__hash__ = None`), despite being a frozen
+  dataclass. `config` holds arbitrary values including nested descriptions, so hashing
+  cannot work in general. Equality is supported; set and dict-key use is not.
+- **`__post_init__` overrides an explicit `complete=True`** when any entry in `inner` is
+  incomplete. Because every description normalises at its own construction, an inner is
+  already `False` when a parent inspects it, so completeness propagates at any depth without
+  the parent walking the tree. A helper would have to recurse and could be bypassed by
+  direct construction.
+- **`Middleware(...)` always reports `complete=False`** and only option names, not values.
+  It cannot know whether an option is a credential, and `_cls` is only instantiated per
+  turn, so there is no instance to delegate to at description time.
+- **`kind` excludes the module path**, so an internal file move does not break a snapshot.
+- **`approval_required` became a callable class** (`ApprovalRequired`, factory kept for
+  compatibility). Attaching metadata to the closure would state the configuration twice and
+  let behaviour and description drift.
+
+## Consequences
+
+- `config` is for settings only. Counters and caches belong in `context.variables` or the
+  per-turn `BaseMiddleware` instance; a description carrying a moving number produces flaky
+  snapshots. The built-ins already comply.
+- Middleware wrapping other middleware reports it in `inner`, keeping `config` a flat
+  settings mapping.
+- `describe()` must not expose credentials. Built-ins summarise live objects: `LoggingMiddleware`
+  reports its logger's name, `TelemetryMiddleware` only the keys of `span_attributes`,
+  `MetricsMiddleware` registry presence as a bool.
+- **Sharing structure is out of scope.** A description reports one instance; grouping by
+  object identity belongs to whatever walks the agent.
+- User-written closures keep working and are reported as unknown. A complete description
+  requires a class with `describe()`.

--- a/test/middleware/test_describe.py
+++ b/test/middleware/test_describe.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+import ag2.middleware as middleware_pkg
 from ag2 import Context
 from ag2.events import ToolCallEvent
 from ag2.middleware import (
@@ -19,8 +20,10 @@ from ag2.middleware import (
     ToolExecution,
     ToolResultType,
     approval_required,
-    describe_middleware,
 )
+
+# Internal: describes middleware that did not opt in. Not public API.
+from ag2.middleware.describe import _describe
 
 
 async def undescribed_guard(
@@ -55,19 +58,19 @@ class WrongTypeGuard:
 
 class TestBuiltinsDescribeThemselves:
     def test_token_limiter(self) -> None:
-        assert describe_middleware(TokenLimiter(max_tokens=100)) == MiddlewareDescription(
+        assert TokenLimiter(max_tokens=100).describe() == MiddlewareDescription(
             kind="TokenLimiter",
             config={"max_tokens": 100, "chars_per_token": 4},
         )
 
     def test_history_limiter(self) -> None:
-        assert describe_middleware(HistoryLimiter(max_events=5)) == MiddlewareDescription(
+        assert HistoryLimiter(max_events=5).describe() == MiddlewareDescription(
             kind="HistoryLimiter",
             config={"max_events": 5},
         )
 
     def test_retry_middleware_names_exception_types(self) -> None:
-        described = describe_middleware(RetryMiddleware(max_retries=2, retry_on=(ValueError,)))
+        described = RetryMiddleware(max_retries=2, retry_on=(ValueError,)).describe()
 
         assert described == MiddlewareDescription(
             kind="RetryMiddleware",
@@ -75,12 +78,10 @@ class TestBuiltinsDescribeThemselves:
         )
 
     def test_logging_middleware_reports_logger_name_not_object(self) -> None:
-        described = describe_middleware(LoggingMiddleware())
-
-        assert described.config == {"logger": "ag2"}
+        assert LoggingMiddleware().describe().config == {"logger": "ag2"}
 
     def test_approval_required(self) -> None:
-        described = describe_middleware(approval_required(timeout=5, allow_always=False))
+        described = approval_required(timeout=5, allow_always=False).describe()
 
         assert described.kind == "ApprovalRequired"
         assert described.complete is True
@@ -90,7 +91,7 @@ class TestBuiltinsDescribeThemselves:
 
 class TestUndescribedMiddleware:
     def test_reports_incomplete_rather_than_guessing(self) -> None:
-        assert describe_middleware(undescribed_guard) == MiddlewareDescription(
+        assert _describe(undescribed_guard) == MiddlewareDescription(
             kind="undescribed_guard",
             config={},
             complete=False,
@@ -103,13 +104,13 @@ class TestUndescribedMiddleware:
 
             return guard
 
-        described = describe_middleware(make_guard(limit=7))
+        described = _describe(make_guard(limit=7))
 
         assert described.config == {}
         assert described.complete is False
 
     def test_class_based_middleware_without_describe(self) -> None:
-        assert describe_middleware(UndescribedGuard(limit=3)) == MiddlewareDescription(
+        assert _describe(UndescribedGuard(limit=3)) == MiddlewareDescription(
             kind="UndescribedGuard",
             config={},
             complete=False,
@@ -118,7 +119,7 @@ class TestUndescribedMiddleware:
 
 class TestWrappers:
     def test_middleware_wrapper_reports_wrapped_class_and_option_names(self) -> None:
-        assert describe_middleware(Middleware(LoggingMiddleware, level=10)) == MiddlewareDescription(
+        assert Middleware(LoggingMiddleware, level=10).describe() == MiddlewareDescription(
             kind="LoggingMiddleware",
             config={"options": ("level",)},
             complete=False,
@@ -126,14 +127,14 @@ class TestWrappers:
 
     def test_middleware_wrapper_never_reports_option_values(self) -> None:
         # The wrapper cannot know whether a caller-supplied option is a secret.
-        described = describe_middleware(Middleware(LoggingMiddleware, api_key="sk-SECRET-123"))
+        described = Middleware(LoggingMiddleware, api_key="sk-SECRET-123").describe()
 
         assert "sk-SECRET-123" not in repr(described)
         assert described.config == {"options": ("api_key",)}
         assert described.complete is False
 
     def test_conditional_middleware_reports_inner_separately_from_config(self) -> None:
-        described = describe_middleware(ConditionalMiddleware(TokenLimiter(max_tokens=10), ToolCallEvent))
+        described = ConditionalMiddleware(TokenLimiter(max_tokens=10), ToolCallEvent).describe()
 
         assert described.kind == "ConditionalMiddleware"
         assert described.config == {"condition": "TypeCondition"}
@@ -142,21 +143,19 @@ class TestWrappers:
         )
 
     def test_conditional_middleware_propagates_incompleteness(self) -> None:
-        described = describe_middleware(ConditionalMiddleware(undescribed_guard, ToolCallEvent))
-
-        assert described.complete is False
+        assert ConditionalMiddleware(undescribed_guard, ToolCallEvent).describe().complete is False
 
 
 class TestBrokenDescribe:
     def test_raising_describe_does_not_take_down_the_caller(self) -> None:
-        assert describe_middleware(RaisingGuard()) == MiddlewareDescription(
+        assert _describe(RaisingGuard()) == MiddlewareDescription(
             kind="RaisingGuard",
             config={},
             complete=False,
         )
 
     def test_describe_returning_the_wrong_type_degrades_to_incomplete(self) -> None:
-        assert describe_middleware(WrongTypeGuard()) == MiddlewareDescription(
+        assert _describe(WrongTypeGuard()) == MiddlewareDescription(
             kind="WrongTypeGuard",
             config={},
             complete=False,
@@ -197,7 +196,7 @@ class TestHashing:
     def test_description_is_deliberately_unhashable(self) -> None:
         # config holds arbitrary values, so equality is supported but hashing is not.
         with pytest.raises(TypeError, match="unhashable type: 'MiddlewareDescription'"):
-            hash(describe_middleware(TokenLimiter(max_tokens=100)))
+            hash(TokenLimiter(max_tokens=100).describe())
 
 
 class TestProtocol:
@@ -210,10 +209,10 @@ class TestProtocol:
 
 class TestComparison:
     def test_identical_configuration_compares_equal(self) -> None:
-        assert describe_middleware(TokenLimiter(max_tokens=50)) == describe_middleware(TokenLimiter(max_tokens=50))
+        assert TokenLimiter(max_tokens=50).describe() == TokenLimiter(max_tokens=50).describe()
 
     def test_differing_configuration_compares_unequal(self) -> None:
-        assert describe_middleware(TokenLimiter(max_tokens=50)) != describe_middleware(TokenLimiter(max_tokens=99))
+        assert TokenLimiter(max_tokens=50).describe() != TokenLimiter(max_tokens=99).describe()
 
 
 class TestApprovalRequiredRemainsUsable:
@@ -223,3 +222,14 @@ class TestApprovalRequiredRemainsUsable:
     def test_is_still_callable_as_tool_middleware(self) -> None:
         # ToolMiddleware is a Callable alias, so an instance must satisfy it.
         assert callable(approval_required())
+
+
+class TestPublicSurface:
+    def test_no_free_describe_function_is_exported(self) -> None:
+        # Middleware reports itself; there is no public module-level describe().
+        assert not hasattr(middleware_pkg, "describe_middleware")
+        assert "describe_middleware" not in middleware_pkg.__all__
+
+    def test_description_types_are_exported(self) -> None:
+        assert "MiddlewareDescription" in middleware_pkg.__all__
+        assert "DescribableMiddleware" in middleware_pkg.__all__

--- a/test/middleware/test_describe.py
+++ b/test/middleware/test_describe.py
@@ -22,8 +22,16 @@ from ag2.middleware import (
     approval_required,
 )
 
-# Internal: describes middleware that did not opt in. Not public API.
-from ag2.middleware.describe import _describe
+
+def described(middleware: object) -> MiddlewareDescription:
+    """Describe ``middleware`` through a public surface.
+
+    ``ConditionalMiddleware`` reports whatever it wraps, so this exercises how
+    the library describes middleware that has not opted in, without the test
+    reaching for internals of its own.
+    """
+
+    return ConditionalMiddleware(middleware, ToolCallEvent).describe().inner[0]  # type: ignore[arg-type]
 
 
 async def undescribed_guard(
@@ -70,9 +78,9 @@ class TestBuiltinsDescribeThemselves:
         )
 
     def test_retry_middleware_names_exception_types(self) -> None:
-        described = RetryMiddleware(max_retries=2, retry_on=(ValueError,)).describe()
+        description = RetryMiddleware(max_retries=2, retry_on=(ValueError,)).describe()
 
-        assert described == MiddlewareDescription(
+        assert description == MiddlewareDescription(
             kind="RetryMiddleware",
             config={"max_retries": 2, "retry_on": ("ValueError",)},
         )
@@ -81,17 +89,17 @@ class TestBuiltinsDescribeThemselves:
         assert LoggingMiddleware().describe().config == {"logger": "ag2"}
 
     def test_approval_required(self) -> None:
-        described = approval_required(timeout=5, allow_always=False).describe()
+        description = approval_required(timeout=5, allow_always=False).describe()
 
-        assert described.kind == "ApprovalRequired"
-        assert described.complete is True
-        assert described.config["timeout"] == 5
-        assert described.config["allow_always"] is False
+        assert description.kind == "ApprovalRequired"
+        assert description.complete is True
+        assert description.config["timeout"] == 5
+        assert description.config["allow_always"] is False
 
 
 class TestUndescribedMiddleware:
     def test_reports_incomplete_rather_than_guessing(self) -> None:
-        assert _describe(undescribed_guard) == MiddlewareDescription(
+        assert described(undescribed_guard) == MiddlewareDescription(
             kind="undescribed_guard",
             config={},
             complete=False,
@@ -104,13 +112,13 @@ class TestUndescribedMiddleware:
 
             return guard
 
-        described = _describe(make_guard(limit=7))
+        description = described(make_guard(limit=7))
 
-        assert described.config == {}
-        assert described.complete is False
+        assert description.config == {}
+        assert description.complete is False
 
     def test_class_based_middleware_without_describe(self) -> None:
-        assert _describe(UndescribedGuard(limit=3)) == MiddlewareDescription(
+        assert described(UndescribedGuard(limit=3)) == MiddlewareDescription(
             kind="UndescribedGuard",
             config={},
             complete=False,
@@ -127,18 +135,18 @@ class TestWrappers:
 
     def test_middleware_wrapper_never_reports_option_values(self) -> None:
         # The wrapper cannot know whether a caller-supplied option is a secret.
-        described = Middleware(LoggingMiddleware, api_key="sk-SECRET-123").describe()
+        description = Middleware(LoggingMiddleware, api_key="sk-SECRET-123").describe()
 
-        assert "sk-SECRET-123" not in repr(described)
-        assert described.config == {"options": ("api_key",)}
-        assert described.complete is False
+        assert "sk-SECRET-123" not in repr(description)
+        assert description.config == {"options": ("api_key",)}
+        assert description.complete is False
 
     def test_conditional_middleware_reports_inner_separately_from_config(self) -> None:
-        described = ConditionalMiddleware(TokenLimiter(max_tokens=10), ToolCallEvent).describe()
+        description = ConditionalMiddleware(TokenLimiter(max_tokens=10), ToolCallEvent).describe()
 
-        assert described.kind == "ConditionalMiddleware"
-        assert described.config == {"condition": "TypeCondition"}
-        assert described.inner == (
+        assert description.kind == "ConditionalMiddleware"
+        assert description.config == {"condition": "TypeCondition"}
+        assert description.inner == (
             MiddlewareDescription(kind="TokenLimiter", config={"max_tokens": 10, "chars_per_token": 4}),
         )
 
@@ -148,14 +156,14 @@ class TestWrappers:
 
 class TestBrokenDescribe:
     def test_raising_describe_does_not_take_down_the_caller(self) -> None:
-        assert _describe(RaisingGuard()) == MiddlewareDescription(
+        assert described(RaisingGuard()) == MiddlewareDescription(
             kind="RaisingGuard",
             config={},
             complete=False,
         )
 
     def test_describe_returning_the_wrong_type_degrades_to_incomplete(self) -> None:
-        assert _describe(WrongTypeGuard()) == MiddlewareDescription(
+        assert described(WrongTypeGuard()) == MiddlewareDescription(
             kind="WrongTypeGuard",
             config={},
             complete=False,

--- a/test/middleware/test_describe.py
+++ b/test/middleware/test_describe.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from ag2 import Context
+from ag2.events import ToolCallEvent
+from ag2.middleware import (
+    ApprovalRequired,
+    ConditionalMiddleware,
+    DescribableMiddleware,
+    HistoryLimiter,
+    LoggingMiddleware,
+    Middleware,
+    MiddlewareDescription,
+    RetryMiddleware,
+    TokenLimiter,
+    ToolExecution,
+    ToolResultType,
+    approval_required,
+    describe_middleware,
+)
+
+
+async def undescribed_guard(
+    call_next: ToolExecution,
+    event: ToolCallEvent,
+    context: Context,
+) -> ToolResultType:
+    """A user-written closure-style hook that has not opted in."""
+    return await call_next(event, context)
+
+
+class UndescribedGuard:
+    """A user-written class-based hook that has not opted in."""
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+
+
+class RaisingGuard:
+    """Middleware whose describe() is broken."""
+
+    def describe(self) -> MiddlewareDescription:
+        raise RuntimeError("kaboom")
+
+
+class WrongTypeGuard:
+    """Middleware whose describe() returns something that is not a description."""
+
+    def describe(self) -> MiddlewareDescription:
+        return {"kind": "WrongTypeGuard"}  # type: ignore[return-value]
+
+
+class TestBuiltinsDescribeThemselves:
+    def test_token_limiter(self) -> None:
+        assert describe_middleware(TokenLimiter(max_tokens=100)) == MiddlewareDescription(
+            kind="TokenLimiter",
+            config={"max_tokens": 100, "chars_per_token": 4},
+        )
+
+    def test_history_limiter(self) -> None:
+        assert describe_middleware(HistoryLimiter(max_events=5)) == MiddlewareDescription(
+            kind="HistoryLimiter",
+            config={"max_events": 5},
+        )
+
+    def test_retry_middleware_names_exception_types(self) -> None:
+        described = describe_middleware(RetryMiddleware(max_retries=2, retry_on=(ValueError,)))
+
+        assert described == MiddlewareDescription(
+            kind="RetryMiddleware",
+            config={"max_retries": 2, "retry_on": ("ValueError",)},
+        )
+
+    def test_logging_middleware_reports_logger_name_not_object(self) -> None:
+        described = describe_middleware(LoggingMiddleware())
+
+        assert described.config == {"logger": "ag2"}
+
+    def test_approval_required(self) -> None:
+        described = describe_middleware(approval_required(timeout=5, allow_always=False))
+
+        assert described.kind == "ApprovalRequired"
+        assert described.complete is True
+        assert described.config["timeout"] == 5
+        assert described.config["allow_always"] is False
+
+
+class TestUndescribedMiddleware:
+    def test_reports_incomplete_rather_than_guessing(self) -> None:
+        assert describe_middleware(undescribed_guard) == MiddlewareDescription(
+            kind="undescribed_guard",
+            config={},
+            complete=False,
+        )
+
+    def test_never_reads_closure_cells(self) -> None:
+        def make_guard(limit: int):  # type: ignore[no-untyped-def]
+            async def guard(call_next, event, context):  # type: ignore[no-untyped-def]
+                return await call_next(event, context)
+
+            return guard
+
+        described = describe_middleware(make_guard(limit=7))
+
+        assert described.config == {}
+        assert described.complete is False
+
+    def test_class_based_middleware_without_describe(self) -> None:
+        assert describe_middleware(UndescribedGuard(limit=3)) == MiddlewareDescription(
+            kind="UndescribedGuard",
+            config={},
+            complete=False,
+        )
+
+
+class TestWrappers:
+    def test_middleware_wrapper_reports_wrapped_class_and_option_names(self) -> None:
+        assert describe_middleware(Middleware(LoggingMiddleware, level=10)) == MiddlewareDescription(
+            kind="LoggingMiddleware",
+            config={"options": ("level",)},
+            complete=False,
+        )
+
+    def test_middleware_wrapper_never_reports_option_values(self) -> None:
+        # The wrapper cannot know whether a caller-supplied option is a secret.
+        described = describe_middleware(Middleware(LoggingMiddleware, api_key="sk-SECRET-123"))
+
+        assert "sk-SECRET-123" not in repr(described)
+        assert described.config == {"options": ("api_key",)}
+        assert described.complete is False
+
+    def test_conditional_middleware_reports_inner_separately_from_config(self) -> None:
+        described = describe_middleware(ConditionalMiddleware(TokenLimiter(max_tokens=10), ToolCallEvent))
+
+        assert described.kind == "ConditionalMiddleware"
+        assert described.config == {"condition": "TypeCondition"}
+        assert described.inner == (
+            MiddlewareDescription(kind="TokenLimiter", config={"max_tokens": 10, "chars_per_token": 4}),
+        )
+
+    def test_conditional_middleware_propagates_incompleteness(self) -> None:
+        described = describe_middleware(ConditionalMiddleware(undescribed_guard, ToolCallEvent))
+
+        assert described.complete is False
+
+
+class TestBrokenDescribe:
+    def test_raising_describe_does_not_take_down_the_caller(self) -> None:
+        assert describe_middleware(RaisingGuard()) == MiddlewareDescription(
+            kind="RaisingGuard",
+            config={},
+            complete=False,
+        )
+
+    def test_describe_returning_the_wrong_type_degrades_to_incomplete(self) -> None:
+        assert describe_middleware(WrongTypeGuard()) == MiddlewareDescription(
+            kind="WrongTypeGuard",
+            config={},
+            complete=False,
+        )
+
+
+class TestCompletenessPropagation:
+    def test_any_incomplete_inner_makes_the_composite_incomplete(self) -> None:
+        composite = MiddlewareDescription(
+            kind="Composite",
+            inner=(
+                MiddlewareDescription(kind="A"),
+                MiddlewareDescription(kind="B", complete=False),
+            ),
+        )
+
+        assert composite.complete is False
+
+    def test_all_complete_inners_leave_the_composite_complete(self) -> None:
+        composite = MiddlewareDescription(
+            kind="Composite",
+            inner=(MiddlewareDescription(kind="A"), MiddlewareDescription(kind="B")),
+        )
+
+        assert composite.complete is True
+
+    def test_explicit_incompleteness_is_never_overridden(self) -> None:
+        composite = MiddlewareDescription(
+            kind="Composite",
+            complete=False,
+            inner=(MiddlewareDescription(kind="A"),),
+        )
+
+        assert composite.complete is False
+
+
+class TestHashing:
+    def test_description_is_deliberately_unhashable(self) -> None:
+        # config holds arbitrary values, so equality is supported but hashing is not.
+        with pytest.raises(TypeError, match="unhashable type: 'MiddlewareDescription'"):
+            hash(describe_middleware(TokenLimiter(max_tokens=100)))
+
+
+class TestProtocol:
+    def test_builtin_satisfies_protocol(self) -> None:
+        assert isinstance(TokenLimiter(max_tokens=1), DescribableMiddleware)
+
+    def test_plain_callable_does_not(self) -> None:
+        assert not isinstance(undescribed_guard, DescribableMiddleware)
+
+
+class TestComparison:
+    def test_identical_configuration_compares_equal(self) -> None:
+        assert describe_middleware(TokenLimiter(max_tokens=50)) == describe_middleware(TokenLimiter(max_tokens=50))
+
+    def test_differing_configuration_compares_unequal(self) -> None:
+        assert describe_middleware(TokenLimiter(max_tokens=50)) != describe_middleware(TokenLimiter(max_tokens=99))
+
+
+class TestApprovalRequiredRemainsUsable:
+    def test_factory_returns_the_class(self) -> None:
+        assert isinstance(approval_required(), ApprovalRequired)
+
+    def test_is_still_callable_as_tool_middleware(self) -> None:
+        # ToolMiddleware is a Callable alias, so an instance must satisfy it.
+        assert callable(approval_required())

--- a/website/docs/user-guide/middleware.mdx
+++ b/website/docs/user-guide/middleware.mdx
@@ -456,19 +456,19 @@ conditional = ConditionalMiddleware(
 
 ## Describing Middleware
 
-`#!python describe_middleware()` reports what a middleware is and how it was configured, so you can log it, compare two instances, or assert on an agent's composition in a test.
+A middleware can report what it is and how it was configured, so it can be logged, compared against another instance, or asserted on in a test. Every built-in does:
 
 ```python linenums="1" hl_lines="3 6"
-from ag2.middleware import TokenLimiter, describe_middleware
+from ag2.middleware import TokenLimiter
 
-describe_middleware(TokenLimiter(max_tokens=100))
+TokenLimiter(max_tokens=100).describe()
 # MiddlewareDescription(kind='TokenLimiter', config={'max_tokens': 100, 'chars_per_token': 4}, complete=True)
 
-describe_middleware(TokenLimiter(max_tokens=100)) == describe_middleware(TokenLimiter(max_tokens=100))
+TokenLimiter(max_tokens=100).describe() == TokenLimiter(max_tokens=100).describe()
 # True
 ```
 
-Every built-in describes itself. Your own middleware opts in by implementing `#!python describe()`:
+Your own middleware opts in the same way, by implementing `#!python describe()`:
 
 ```python linenums="1" hl_lines="9-13"
 from ag2.middleware import MiddlewareDescription
@@ -487,7 +487,7 @@ class RateLimit:
         )
 ```
 
-Middleware that has not opted in is reported honestly rather than guessed at — `#!python config` is empty and `#!python complete` is `#!python False`. AG2 never inspects `#!python __closure__` to recover configuration, because cell names and ordering are an implementation detail of whatever function produced the closure. `#!python describe_middleware()` never raises: a `#!python describe()` that fails or returns the wrong type degrades to the same honest unknown, so introspection cannot break the code doing the logging.
+Opting in is optional. Where AG2 surfaces middleware, anything that has not opted in is reported honestly rather than guessed at — `#!python config` is empty and `#!python complete` is `#!python False`. AG2 never inspects `#!python __closure__` to recover configuration, because cell names and ordering are an implementation detail of whatever function produced the closure. A `#!python describe()` that fails or returns the wrong type degrades to that same honest unknown, so introspection cannot break the code doing the logging.
 
 Middleware that wraps other middleware reports them in `#!python inner`, keeping `#!python config` a flat settings mapping:
 
@@ -495,7 +495,7 @@ Middleware that wraps other middleware reports them in `#!python inner`, keeping
 from ag2.middleware import ConditionalMiddleware, TokenLimiter
 from ag2.events import ToolCallEvent
 
-describe_middleware(ConditionalMiddleware(TokenLimiter(max_tokens=10), ToolCallEvent))
+ConditionalMiddleware(TokenLimiter(max_tokens=10), ToolCallEvent).describe()
 # MiddlewareDescription(
 #     kind='ConditionalMiddleware', config={'condition': 'TypeCondition'}, complete=True,
 #     inner=(MiddlewareDescription(kind='TokenLimiter', config={'max_tokens': 10, ...}),),

--- a/website/docs/user-guide/middleware.mdx
+++ b/website/docs/user-guide/middleware.mdx
@@ -454,6 +454,67 @@ conditional = ConditionalMiddleware(
 
 `ConditionalMiddleware` wraps any `MiddlewareFactory` — including `Middleware(...)` instances, bare `BaseMiddleware` subclasses, and other `ConditionalMiddleware` wrappers.
 
+## Describing Middleware
+
+`#!python describe_middleware()` reports what a middleware is and how it was configured, so you can log it, compare two instances, or assert on an agent's composition in a test.
+
+```python linenums="1" hl_lines="3 6"
+from ag2.middleware import TokenLimiter, describe_middleware
+
+describe_middleware(TokenLimiter(max_tokens=100))
+# MiddlewareDescription(kind='TokenLimiter', config={'max_tokens': 100, 'chars_per_token': 4}, complete=True)
+
+describe_middleware(TokenLimiter(max_tokens=100)) == describe_middleware(TokenLimiter(max_tokens=100))
+# True
+```
+
+Every built-in describes itself. Your own middleware opts in by implementing `#!python describe()`:
+
+```python linenums="1" hl_lines="9-13"
+from ag2.middleware import MiddlewareDescription
+
+class RateLimit:
+    def __init__(self, per_minute: int) -> None:
+        self._per_minute = per_minute
+
+    async def __call__(self, call_next, event, context):
+        return await call_next(event, context)
+
+    def describe(self) -> MiddlewareDescription:
+        return MiddlewareDescription(
+            kind=type(self).__qualname__,
+            config={"per_minute": self._per_minute},
+        )
+```
+
+Middleware that has not opted in is reported honestly rather than guessed at — `#!python config` is empty and `#!python complete` is `#!python False`. AG2 never inspects `#!python __closure__` to recover configuration, because cell names and ordering are an implementation detail of whatever function produced the closure. `#!python describe_middleware()` never raises: a `#!python describe()` that fails or returns the wrong type degrades to the same honest unknown, so introspection cannot break the code doing the logging.
+
+Middleware that wraps other middleware reports them in `#!python inner`, keeping `#!python config` a flat settings mapping:
+
+```python linenums="1" hl_lines="6-7"
+from ag2.middleware import ConditionalMiddleware, TokenLimiter
+from ag2.events import ToolCallEvent
+
+describe_middleware(ConditionalMiddleware(TokenLimiter(max_tokens=10), ToolCallEvent))
+# MiddlewareDescription(
+#     kind='ConditionalMiddleware', config={'condition': 'TypeCondition'}, complete=True,
+#     inner=(MiddlewareDescription(kind='TokenLimiter', config={'max_tokens': 10, ...}),),
+# )
+```
+
+A composite is only as describable as its parts: `#!python complete` is forced to `#!python False` when any entry in `#!python inner` is incomplete, so composing middleware cannot claim completeness its parts do not support. Because each description applies the rule as it is constructed, it holds at any depth without a parent walking the tree.
+
+Descriptions support equality but are deliberately **not hashable** — `#!python config` may hold arbitrary values, so they cannot go in a `#!python set` or be used as dict keys.
+
+!!! note
+    `#!python Middleware(...)` reports the wrapped class and which options were set, but never their values, and always `#!python complete=False`. The options are caller-supplied and the wrapper cannot know whether one is a credential. Write a `#!python MiddlewareFactory` with its own `#!python describe()` when you want a complete description.
+
+!!! note
+    `#!python config` is for settings only. Counters, caches, and anything else that changes during a run belong in `#!python context.variables` or the per-turn `#!python BaseMiddleware` instance — a description that carries a moving number produces flaky snapshots.
+
+!!! warning
+    Descriptions are meant to be logged and committed as test fixtures, so `#!python describe()` must not expose credentials. The built-ins report live objects by name or presence — `#!python LoggingMiddleware` reports its logger's name, and `#!python TelemetryMiddleware` reports only the *keys* of its `#!python span_attributes`.
+
 ## Choosing the Right Hook
 
 If you are unsure where a behavior belongs, use this rule of thumb:

--- a/website/docs/user-guide/tools/approval_required.mdx
+++ b/website/docs/user-guide/tools/approval_required.mdx
@@ -53,6 +53,19 @@ Typing **y** lets the tool run. Any other input denies it — the agent receives
 !!! note
     `approval_required()` relies on the agent's `#!python hitl_hook` to collect user input. If no `hitl_hook` is configured, `#!python context.input()` will raise an error at runtime. Read more about [Human in the Loop](/docs/user-guide/context/human_in_the_loop) to learn how to configure a HITL hook.
 
+## Inspecting the configuration
+
+`#!python approval_required()` returns an `#!python ApprovalRequired` instance, also exported from `ag2.middleware`. It reports its settings, so you can log or assert on how a tool was gated:
+
+```python linenums="1"
+from ag2.middleware import approval_required, describe_middleware
+
+describe_middleware(approval_required(timeout=5, allow_always=False)).config
+# {'message': '...', 'denied_message': 'User denied...', 'timeout': 5, 'allow_always': False}
+```
+
+Approval state (which tools the user answered "always" for) lives in `#!python context.variables`, not on the instance, so it never appears in the description. See [Describing middleware](/docs/user-guide/middleware#describing-middleware).
+
 ## Customizing the prompt
 
 Override the `message` parameter to tailor the approval prompt:

--- a/website/docs/user-guide/tools/approval_required.mdx
+++ b/website/docs/user-guide/tools/approval_required.mdx
@@ -58,9 +58,9 @@ Typing **y** lets the tool run. Any other input denies it — the agent receives
 `#!python approval_required()` returns an `#!python ApprovalRequired` instance, also exported from `ag2.middleware`. It reports its settings, so you can log or assert on how a tool was gated:
 
 ```python linenums="1"
-from ag2.middleware import approval_required, describe_middleware
+from ag2.middleware import approval_required
 
-describe_middleware(approval_required(timeout=5, allow_always=False)).config
+approval_required(timeout=5, allow_always=False).describe().config
 # {'message': '...', 'denied_message': 'User denied...', 'timeout': 5, 'allow_always': False}
 ```
 

--- a/website/docs/user-guide/tools/tool_middleware.mdx
+++ b/website/docs/user-guide/tools/tool_middleware.mdx
@@ -67,7 +67,7 @@ agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"))
 
 ## Making a hook describable
 
-A plain function like `#!python add_request_id` above works, but cannot report its configuration: [`describe_middleware()`](/docs/user-guide/middleware#describing-middleware) returns `#!python complete=False` for it, because its settings live in closure cells that AG2 does not inspect.
+A plain function like `#!python add_request_id` above works, but cannot report its configuration: it has no [`describe()`](/docs/user-guide/middleware#describing-middleware), so AG2 reports it as `#!python complete=False` rather than guessing, because its settings live in closure cells that AG2 does not inspect.
 
 For a describable hook, write a class with `#!python async def __call__` and a `#!python describe()` method. It is still a plain callable, so how you pass it does not change:
 

--- a/website/docs/user-guide/tools/tool_middleware.mdx
+++ b/website/docs/user-guide/tools/tool_middleware.mdx
@@ -65,6 +65,44 @@ agent = Agent("assistant", config=OpenAIConfig("gpt-4o-mini"))
 !!! note
     Tool-scoped hooks are plain callables. They do **not** use the `Middleware(...)` factory or `BaseMiddleware`.
 
+## Making a hook describable
+
+A plain function like `#!python add_request_id` above works, but cannot report its configuration: [`describe_middleware()`](/docs/user-guide/middleware#describing-middleware) returns `#!python complete=False` for it, because its settings live in closure cells that AG2 does not inspect.
+
+For a describable hook, write a class with `#!python async def __call__` and a `#!python describe()` method. It is still a plain callable, so how you pass it does not change:
+
+```python linenums="1" hl_lines="18-22"
+from ag2 import Context, tool
+from ag2.events import ToolCallEvent
+from ag2.middleware import MiddlewareDescription, ToolExecution, ToolResultType
+
+class AddRequestId:
+    def __init__(self, default: str = "unknown") -> None:
+        self._default = default
+
+    async def __call__(
+        self,
+        call_next: ToolExecution,
+        event: ToolCallEvent,
+        context: Context,
+    ) -> ToolResultType:
+        context.variables.setdefault("request_id", self._default)
+        return await call_next(event, context)
+
+    def describe(self) -> MiddlewareDescription:
+        return MiddlewareDescription(
+            kind=type(self).__qualname__,
+            config={"default": self._default},
+        )
+
+@tool(middleware=[AddRequestId()])
+def search(query: str) -> str:
+    """Runs a search."""
+    return f"results-for-{query}"
+```
+
+`#!python approval_required()` is the built-in example: it returns an `#!python ApprovalRequired` instance that describes its prompt, timeout, and `#!python allow_always` settings. Keep run-time state such as counters in `#!python context.variables` — `#!python config` is for settings only.
+
 ## Adding middleware to an existing tool
 
 Use `#!python tool.with_middleware()` to wrap a tool with additional hooks **without modifying** the original. The returned tool is an independent copy with the new middleware as the outermost layer:


### PR DESCRIPTION
## Why are these changes needed?

Middleware cannot report what it is or how it was configured. `ToolMiddleware` is a bare `Callable` alias and `MiddlewareFactory` is a `Protocol` with only `__call__`, so a configured middleware is an opaque closure:

```python
guard = rate_limit(max_calls=3, denied_message="capped")
```

You can reach the object, but not `max_calls=3`, unless you read `__closure__` — where cell names and ordering are an implementation detail of whatever function produced the closure, so any refactor breaks the reader silently.

This matters for comparing two agents, asserting on composition in a test, and logging what an agent is actually made of.

### What this adds

An opt-in `describe()` protocol. Middleware reports itself; nothing guesses.

```python
TokenLimiter(max_tokens=100).describe()
# MiddlewareDescription(kind='TokenLimiter', config={'max_tokens': 100, 'chars_per_token': 4}, complete=True)
```

- **`MiddlewareDescription(kind, config, complete, inner)`** — what a middleware is and how it was configured
- **`DescribableMiddleware`** — the protocol, for annotating your own middleware
- **Every built-in implements `describe()`**
- **No module-level function.** Middleware describes itself; the fallback for middleware that has not opted in is internal, used where the library surfaces middleware

Nothing here restores middleware from a description. This is for comparing and logging.

### Design notes

- **`config` is settings only.** Counters, caches and anything that moves during a run belong in the context or the per-turn instance — a description carrying a moving number produces flaky snapshots.
- **Honest unknown, never a guess.** Middleware that has not opted in reports `complete=False` with an empty `config`. A `describe()` that raises or returns the wrong type degrades the same way, so introspection cannot take down the code doing the logging.
- **Composition is explicit.** Middleware that wraps other middleware reports them in `inner`, keeping `config` a flat settings mapping. A composite cannot claim completeness its parts do not support: `complete` is forced to `False` when any entry in `inner` is incomplete, enforced in `__post_init__` so it holds at any depth.
- **Secrets stay out.** Descriptions are meant to be logged and committed as fixtures, so the built-ins report live objects by name or presence. `Middleware(...)` reports which options were set but never their values, since it cannot know whether one is a credential.
- **`approval_required` is now an `ApprovalRequired` class** with the factory function kept, so every call site is unchanged. It is the worked example of converting a closure factory to something describable without breaking callers.
- **Deliberately unhashable.** `config` may hold arbitrary values, so descriptions support equality but cannot go in a `set` or be used as dict keys. `__hash__ = None` is explicit rather than relying on dataclass defaults, so the error names the type instead of the field it tripped over.

### Reading middleware off an agent

This PR is the author-facing half: how a middleware declares its configuration. The reader-facing half — `agent.middleware`, `tool.middleware` and the rest of the composition surface — is in #3134, stacked on this branch.

## Related issue number

None.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

CI is currently red on `test/extensions/tools/search/test_tinyfish.py` (respx rejecting unmocked TinyFish API calls). `main`'s own Tests workflow fails on the same file, so it is not from this branch.

Local: 24 tests in `test/middleware/test_describe.py` covering the built-ins, the honest-unknown fallback, broken `describe()` implementations, wrapper delegation, completeness propagation, hashing, protocol conformance, and that `approval_required` remains usable as tool middleware. Full suite green apart from 5 sandbox/shell tests that fail identically on `main` and pass in isolation.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
