### PR TITLE
fix(subagents): make persistent_stream() reuse a live stream object

### DIFF
--- a/ag2/tools/subagents/persistent_stream.py
+++ b/ag2/tools/subagents/persistent_stream.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 from ag2.annotations import Context
 from ag2.stream import MemoryStream
@@ -16,13 +15,13 @@ if TYPE_CHECKING:
 
 def persistent_stream() -> StreamFactory:
     def stream_factory(agent: "Agent", ctx: "Context") -> MemoryStream:
+        # Cache the stream instance, not just its id: the turn lock is keyed
+        # by object identity, so a fresh object per call would silently get
+        # its own independent lock.
         key = f"ag:{agent.name}:stream"
-        if not (stream_id := ctx.dependencies.get(key)):
-            stream_id = ctx.dependencies[key] = uuid4()
+        if (stream := ctx.dependencies.get(key)) is None:
+            stream = ctx.dependencies[key] = MemoryStream(storage=ctx.stream.history.storage)
 
-        return MemoryStream(
-            storage=ctx.stream.history.storage,
-            id=stream_id,
-        )
+        return stream
 
     return stream_factory

--- a/test/tools/test_persistent_stream.py
+++ b/test/tools/test_persistent_stream.py
@@ -61,13 +61,23 @@ class TestPersistentStream:
 
         assert stream_a.id != stream_b.id
 
-    def test_stores_stream_id_in_dependencies(self, ctx: Context) -> None:
+    def test_stores_stream_in_dependencies(self, ctx: Context) -> None:
         factory = persistent_stream()
         agent = _make_agent("helper")
 
         stream = factory(agent, ctx)
 
-        assert ctx.dependencies["ag:helper:stream"] == stream.id
+        assert ctx.dependencies["ag:helper:stream"] is stream
+
+    def test_reuses_same_stream_object_on_second_call(self, ctx: Context) -> None:
+        # agent.py's turn lock is keyed by stream object identity, not id.
+        factory = persistent_stream()
+        agent = _make_agent()
+
+        first = factory(agent, ctx)
+        second = factory(agent, ctx)
+
+        assert first is second
 
     def test_uses_parent_storage_backend(self, ctx: Context, storage: MemoryStorage) -> None:
         factory = persistent_stream()


### PR DESCRIPTION
### Root cause

`agent.py`'s `_get_stream_turn_lock` attaches the per-turn serialization lock to a stream object via `setattr(stream, "_ag2_turn_lock", lock)`, keyed by that object's identity. `persistent_stream()`'s factory built a brand-new `MemoryStream` on every call, reusing only `.id` and `.storage`, never the object itself. Two concurrent delegations into the same persistent sub-agent (the concurrent-`asyncio.gather` case `run_task()`'s own docstring anticipates) therefore got two different `MemoryStream` instances that share an `id` but not an identity, and consequently two independent locks: the serialization the lock exists for silently did not apply to the one case it was written for.

### Fix

Cache the constructed `MemoryStream` instance in `ctx.dependencies` and return it on subsequent calls, instead of caching just its `id` and rebuilding the object. Same object identity, same lock.

The one existing test that encoded the old contract (`ctx.dependencies[key] == stream.id`) is updated to assert the new one (`ctx.dependencies[key] is stream`), and a new test asserts two calls with the same `agent`/`ctx` return the same object.

### Verification

- New/updated tests fail on unmodified `main` (`AssertionError: assert UUID(...) is <MemoryStream ...>`) and pass on this branch; full `test/tools/` + `test/agent/` (633 tests) and the repo's non-LLM suite (3474 tests) stay green.
- `ruff check`/`ruff format --check` clean on both changed files; `mypy`'s scope (`pyproject.toml`'s `[tool.mypy] files`) does not currently include this module.
- Not verified: behavior under real network/timing contention (e.g. an actual overlapping-tool-call race against a live model), only the object-identity/lock-identity mechanism itself, via direct unit-level calls into the real `persistent_stream()` and `_get_stream_turn_lock`.

Fixes #3123

AI assistance: I used an AI coding assistant to help investigate this and draft the fix and tests; I reviewed the diff and reasoning myself before submitting.
