### PR TITLE
docs(contributing): document the optionals dependency group for Extensions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,8 @@ All implementations must be re-exported from their public module's `__init__.py`
 - **Core modules** use **optional dependencies** shipped as pyproject extras — fall back via `missing_optional_dependency`, which hints `pip install "ag2[<extra>]"`.
 - **Extensions** (`ag2/extensions/`) are **not** shipped as extras — declare their third-party packages as **additional dependencies** and fall back via `missing_additional_dependency`, which hints the upstream package directly (e.g. `pip install "daytona>=0.171.0,<1"`).
 
+Either way, add the third-party package to the `optionals` **dependency group** in `pyproject.toml` (PEP 735 — CI-only, never part of `pip install ag2`) so the test workflow installs it. Tests guarded by `pytest.importorskip("<package>")` are silently skipped otherwise, and CI still passes.
+
 ### Design principles
 
 - **Protocols over inheritance**: `LLMClient`, `ModelConfig`, `Stream`, `Storage`, `Tool` are all `Protocol` classes — implementations satisfy them structurally.

--- a/website/docs/contributor-guide/contribution_policy.mdx
+++ b/website/docs/contributor-guide/contribution_policy.mdx
@@ -65,11 +65,15 @@ Extensions are held to the same quality bar as Core; the difference is that the 
 - Include **documentation** that lets a new user understand and use it — at minimum a module-level docstring summarising the Extension, docstrings on public classes and functions, and a page under the **Extensions** section of the docs. Following standards as noted in [Code Documentation example](#code-documentation-example).
 - Include **tests** covering the Extension's behaviour.
 - Declare third-party packages as **additional dependencies**, not as `pip install ag2[...]` extras — Extensions are not shipped as pyproject extras. Guard the optional imports with a `try/except ImportError` block in the Extension's `__init__.py` and fall back via `missing_additional_dependency`, so the install hint points at the upstream package directly (for example `pip install "daytona>=0.171.0,<1"`). Use `missing_optional_dependency` (the `ag2[...]` extra form) only for Core modules.
+- Add those same packages to the **`optionals` dependency group** in `pyproject.toml`, so CI installs them and your tests actually run. This is a [PEP 735](https://peps.python.org/pep-0735/){.external-link target="_blank"} dependency group, *not* a published extra — it is never part of `pip install ag2`; it exists so the test workflow can collect and run the full non-LLM suite. Skipping this step is easy to miss: a test module guarded by `pytest.importorskip("<package>")` is silently skipped on every CI run, so the Extension ships with no test coverage and CI still passes.
 - Pass **code review by AG2** so we can confirm it is safe to ship alongside Core.
 - Have a **named maintainer** (you, your team, or a designated successor) who agrees to:
     - respond to issues and PRs,
     - keep the Extension working with current Core releases, and
     - **let us know if you can no longer maintain it**, so we can find a new maintainer or move it to the archive.
+
+!!! note "Keep an eye on the dependency footprint"
+    The `optionals` group is resolved as a single environment alongside every other optional dependency AG2 tests against. A package with heavy or loosely-bounded transitive dependencies can downgrade shared packages (`protobuf`, `httpx`, `pydantic`, provider SDKs) for *unrelated* tests, so prefer upper bounds and a slim dependency list. If your package pulls in large optional subsystems, consider moving them behind its own extras before adding it here.
 
 AG2 facilitates Extension PR reviews, but ongoing bug fixes and evolution are the maintainer's role.
 


### PR DESCRIPTION
## Why are these changes needed?

The Extension contribution policy explains how to declare an Extension's third-party packages — additional dependencies, guarded by `missing_additional_dependency`, explicitly *not* as pyproject extras. What it never mentions is that the package also has to go into the `optionals` **dependency group** in `pyproject.toml`, which is what the test workflow actually installs:

```
uv pip install --system --group=test --group=optionals -e .
```

Read alongside "not as `pip install ag2[...]` extras", the current wording reasonably parses as "don't touch `pyproject.toml` at all". The failure mode is quiet: the Extension's tests are guarded by `pytest.importorskip("<package>")`, the package is never installed in CI, every test is skipped, and CI stays green. The Extension ships with no effective test coverage and nothing surfaces it.

This came up while reviewing #2968, where the contributor followed the documented guard pattern correctly and still ended up with a fully skipped suite:

```console
$ pytest test/extensions/tealtiger/ -q
1 skipped in 0.01s
```

Right now the only explanation of the `optionals` group lives in a comment inside `pyproject.toml` — not somewhere a contributor would think to look. `daytona` works only because someone knew to add it (`pyproject.toml:193`).

This PR adds the missing step to the policy page and mirrors it in `AGENTS.md`.

It also adds a short note on dependency footprint. `optionals` resolves as a single environment alongside every other optional dependency AG2 tests against, so a package with heavy or loosely-bounded transitive dependencies can downgrade shared packages for unrelated tests. A concrete example from the same review: adding one Extension package pulled in the deprecated `google-generativeai` SDK and would have downgraded `protobuf` from 6.33.6 to 5.29.6 underneath the Gemini and OTLP-gRPC tracing tests.

Docs-only — no code or dependency changes.

## Related issue number

None. Follow-up from the review of #2968.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
