### PR TITLE
feat(agent): expose composition as public read-only properties

### DIFF
--- a/ag2/agent.py
+++ b/ag2/agent.py
@@ -19,7 +19,7 @@ import asyncio
 import json
 import logging
 import types
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping, Sequence
 from contextlib import AsyncExitStack, ExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass
 from functools import partial
@@ -74,6 +74,7 @@ from .middleware.base import (
     MiddlewareFactory,
     ToolMiddleware,
 )
+from .middleware.describe import DescribedMiddleware
 from .observers import Observer
 from .plugin import Plugin, PluginTarget, PromptType
 from .response import ResponseProto, ResponseSchema
@@ -758,6 +759,69 @@ class Agent(PluginTarget, Generic[TResult]):
 
             self.add_middleware(_AssemblerMiddlewareFactory(self._policies))
             self.add_middleware(_HaltCheckMiddlewareFactory())
+
+    # --- Composition -----------------------------------------------------
+    # Read-only views of what this agent is made of, for comparing two agents,
+    # asserting on composition in a test, or logging it. Each returns a copy or
+    # a read-only view, so callers cannot mutate the agent through them.
+
+    @property
+    def system_prompt(self) -> tuple[str, ...]:
+        """Static system prompt fragments, in order."""
+
+        return tuple(self._system_prompt)
+
+    @property
+    def dynamic_prompt(self) -> tuple[PromptType, ...]:
+        """Dynamic prompt hooks, in registration order."""
+
+        return tuple(self._dynamic_prompt)
+
+    @property
+    def middleware(self) -> tuple[DescribedMiddleware, ...]:
+        """Agent-level middleware, in registration order.
+
+        Each entry pairs the middleware object with its description. Entries are
+        built on access, so compare ``entry.middleware`` rather than the entry.
+        """
+
+        return tuple(DescribedMiddleware(m) for m in self._middleware)
+
+    @property
+    def dependencies(self) -> Mapping[Any, Any]:
+        """Dependencies injected into tool calls, keyed as they were supplied."""
+
+        return types.MappingProxyType(self._agent_dependencies)
+
+    @property
+    def variables(self) -> Mapping[Any, Any]:
+        """Variables available to this agent."""
+
+        return types.MappingProxyType(self._agent_variables)
+
+    @property
+    def response_schema(self) -> ResponseProto[TResult] | None:
+        """The response schema, or ``None`` when replies are free text."""
+
+        return self._response_schema
+
+    @property
+    def observers(self) -> tuple[Observer, ...]:
+        """Observers attached to this agent, in registration order."""
+
+        return tuple(self._observers)
+
+    @property
+    def tasks(self) -> TaskConfig | None:
+        """Sub-task configuration, or ``None`` when sub-tasks are not enabled."""
+
+        return self._task_config
+
+    @property
+    def assembly(self) -> tuple[AssemblyPolicy, ...]:
+        """Assembly policies, in the order they are applied."""
+
+        return tuple(self._policies)
 
     def task(
         self,

--- a/ag2/middleware/__init__.py
+++ b/ag2/middleware/__init__.py
@@ -23,7 +23,7 @@ from .builtin import (
     TokenLimiter,
     approval_required,
 )
-from .describe import DescribableMiddleware, MiddlewareDescription
+from .describe import DescribableMiddleware, DescribedMiddleware, MiddlewareDescription
 
 __all__ = (
     "AgentTurn",
@@ -31,6 +31,7 @@ __all__ = (
     "BaseMiddleware",
     "ConditionalMiddleware",
     "DescribableMiddleware",
+    "DescribedMiddleware",
     "HistoryLimiter",
     "HumanInputHook",
     "LLMCall",

--- a/ag2/middleware/base.py
+++ b/ag2/middleware/base.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from types import MappingProxyType
 from typing import Any, Protocol, TypeAlias
 
 from ag2.annotations import Context
@@ -35,6 +36,23 @@ class Middleware(MiddlewareFactory):
     ) -> None:
         self._cls = middleware_cls
         self._options = kwargs
+
+    @property
+    def cls(self) -> type["BaseMiddleware"]:
+        """The middleware class this factory instantiates per turn."""
+
+        return self._cls
+
+    @property
+    def options(self) -> Mapping[str, Any]:
+        """The options this factory was constructed with.
+
+        Unlike :meth:`describe`, this exposes the values. A description is meant
+        to be logged or committed as a fixture, so it reports option names only;
+        reading an option off a factory you already hold is a deliberate act.
+        """
+
+        return MappingProxyType(self._options)
 
     def describe(self) -> "MiddlewareDescription":
         """Report the wrapped class and option names, but not option values.

--- a/ag2/middleware/describe.py
+++ b/ag2/middleware/describe.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol, runtime_checkable
 
 __all__ = (
     "DescribableMiddleware",
+    "DescribedMiddleware",
     "MiddlewareDescription",
 )
 
@@ -79,3 +80,29 @@ def _describe(middleware: Any) -> MiddlewareDescription:
             return described
 
     return MiddlewareDescription(kind=_kind_of(middleware), config={}, complete=False)
+
+
+@dataclass(frozen=True, slots=True)
+class DescribedMiddleware:
+    """A middleware paired with its description.
+
+    Yielded wherever AG2 exposes attached middleware, so every entry reports
+    itself whether or not that middleware opted in to :class:`DescribableMiddleware`.
+
+    ``middleware`` is the object itself, not a copy. Two entries holding the
+    same instance are the same object, which is how shared state is told apart
+    from independent copies: one rate limiter across ten tools and ten separate
+    ones configured identically produce equal descriptions, so identity is the
+    only thing that distinguishes them.
+
+    Entries are built on access, so ``agent.middleware[0] is agent.middleware[0]``
+    is ``False``. Compare :attr:`middleware` rather than the entry.
+    """
+
+    middleware: Any
+
+    @property
+    def description(self) -> MiddlewareDescription:
+        """What this middleware is and how it was configured."""
+
+        return _describe(self.middleware)

--- a/ag2/plugin.py
+++ b/ag2/plugin.py
@@ -5,6 +5,7 @@
 import warnings
 from collections.abc import Awaitable, Callable, Iterable
 from contextlib import AsyncExitStack
+from functools import wraps
 from typing import Any, TypeAlias, overload
 
 from fast_depends import Provider
@@ -357,6 +358,9 @@ def _wrap_prompt_hook(
 ) -> Callable[[ModelRequest, Context], Awaitable[str]]:
     call_model = build_model(func)
 
+    # Carry the hook's identity onto the wrapper, so `Agent.dynamic_prompt`
+    # yields something nameable rather than a row of anonymous `wrapper`s.
+    @wraps(func)
     async def wrapper(event: ModelRequest, context: Context) -> str:
         async with AsyncExitStack() as stack:
             r = await call_model.asolve(

--- a/ag2/tools/final/function_tool.py
+++ b/ag2/tools/final/function_tool.py
@@ -13,7 +13,13 @@ from fast_depends.pydantic.schema import get_schema
 
 from ag2.annotations import Context
 from ag2.events import ToolCallEvent, ToolErrorEvent, ToolResultEvent
-from ag2.middleware import BaseMiddleware, ToolExecution, ToolMiddleware, ToolResultType
+from ag2.middleware import (
+    BaseMiddleware,
+    DescribedMiddleware,
+    ToolExecution,
+    ToolMiddleware,
+    ToolResultType,
+)
 from ag2.tools.schemas import ToolSchema
 from ag2.tools.tool import Tool
 from ag2.utils import CONTEXT_OPTION_NAME, build_model
@@ -72,6 +78,18 @@ class FunctionTool(Tool):
         )
 
         self.name = name
+
+    @property
+    def middleware(self) -> tuple[DescribedMiddleware, ...]:
+        """Tool-scoped middleware, in execution order.
+
+        Each entry pairs the middleware object with its description. Entries are
+        built on access, so compare ``entry.middleware`` rather than the entry:
+        two tools sharing one middleware instance share its state, which is what
+        distinguishes a combined budget from independent ones.
+        """
+
+        return tuple(DescribedMiddleware(hook) for hook in self._middleware)
 
     def with_middleware(self, *middleware: ToolMiddleware) -> "FunctionTool":
         """Return a new FunctionTool with additional middleware appended.

--- a/test/test_agent_composition.py
+++ b/test/test_agent_composition.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from pydantic import BaseModel
+
+from ag2 import Agent, TaskConfig, tool
+from ag2.middleware import (
+    ApprovalRequired,
+    LoggingMiddleware,
+    Middleware,
+    TokenLimiter,
+)
+from ag2.observers import observer
+
+
+def alpha(x: int) -> int:
+    """Alpha."""
+    return x
+
+
+def beta(x: int) -> int:
+    """Beta."""
+    return x
+
+
+def make_hook():  # type: ignore[no-untyped-def]
+    async def hook(call_next, event, context):  # type: ignore[no-untyped-def]
+        return await call_next(event, context)
+
+    return hook
+
+
+class Out(BaseModel):
+    value: int
+
+
+class TestAgentComposition:
+    def test_reports_what_the_agent_is_made_of(self) -> None:
+        agent = Agent(
+            "bot",
+            prompt="hello",
+            tools=[alpha],
+            dependencies={"db": object()},
+            variables={"k": 1},
+        )
+
+        assert agent.system_prompt == ("hello",)
+        assert [t.name for t in agent.tools] == ["alpha"]
+        assert list(agent.dependencies) == ["db"]
+        assert list(agent.variables) == ["k"]
+
+    def test_unset_slots_read_as_defaults(self) -> None:
+        agent = Agent("bot", prompt="p")
+
+        assert agent.dynamic_prompt == ()
+        assert agent.observers == ()
+        assert agent.assembly == ()
+        assert agent.tasks is None
+        assert agent.response_schema is None
+
+    def test_set_slots_are_reported(self) -> None:
+        @observer
+        def watcher(event, context) -> None:  # type: ignore[no-untyped-def]
+            return None
+
+        agent = Agent("bot", prompt="p", observers=[watcher], tasks=TaskConfig(), response_schema=Out)
+
+        assert len(agent.observers) == 1
+        assert isinstance(agent.tasks, TaskConfig)
+        assert agent.response_schema is not None
+
+    def test_dynamic_prompt_hooks_are_nameable(self) -> None:
+        agent = Agent("bot", prompt="p")
+
+        @agent.prompt
+        async def greeting() -> str:
+            return "hi"
+
+        assert [hook.__name__ for hook in agent.dynamic_prompt] == ["greeting"]
+
+
+class TestViewsAreReadOnly:
+    def test_sequences_are_immutable_snapshots(self) -> None:
+        agent = Agent("bot", prompt="p", tools=[alpha])
+
+        assert isinstance(agent.system_prompt, tuple)
+        assert isinstance(agent.dynamic_prompt, tuple)
+        assert isinstance(agent.middleware, tuple)
+        assert isinstance(agent.observers, tuple)
+        assert isinstance(agent.assembly, tuple)
+
+    def test_mappings_cannot_be_mutated_through_the_view(self) -> None:
+        agent = Agent("bot", prompt="p", dependencies={"db": object()}, variables={"k": 1})
+
+        with pytest.raises(TypeError):
+            agent.dependencies["db"] = object()  # type: ignore[index]
+
+        with pytest.raises(TypeError):
+            agent.variables["k"] = 2  # type: ignore[index]
+
+    def test_dependency_values_are_the_injected_objects(self) -> None:
+        db = object()
+        agent = Agent("bot", prompt="p", dependencies={"db": db})
+
+        assert agent.dependencies["db"] is db
+
+
+class TestMiddlewareEntries:
+    def test_agent_middleware_pairs_object_with_description(self) -> None:
+        limiter = TokenLimiter(max_tokens=10)
+        agent = Agent("bot", prompt="p", middleware=[limiter])
+
+        entry = agent.middleware[0]
+
+        assert entry.middleware is limiter
+        assert entry.description.kind == "TokenLimiter"
+        assert entry.description.config == {"max_tokens": 10, "chars_per_token": 4}
+
+    def test_tool_middleware_pairs_object_with_description(self) -> None:
+        guard = ApprovalRequired(timeout=5)
+        built = tool(alpha, middleware=[guard])
+
+        entry = built.middleware[0]
+
+        assert entry.middleware is guard
+        assert entry.description.kind == "ApprovalRequired"
+
+    def test_middleware_without_describe_reports_incomplete(self) -> None:
+        agent = Agent("bot", prompt="p", middleware=[make_hook()])
+
+        description = agent.middleware[0].description
+
+        assert description.complete is False
+        assert description.config == {}
+
+    def test_entries_are_built_on_access(self) -> None:
+        limiter = TokenLimiter(max_tokens=10)
+        agent = Agent("bot", prompt="p", middleware=[limiter])
+
+        # The entry is a fresh view each time; the middleware inside is not.
+        assert agent.middleware[0] is not agent.middleware[0]
+        assert agent.middleware[0].middleware is agent.middleware[0].middleware
+
+
+class TestSharingIsObservable:
+    def test_one_instance_across_two_tools_reads_as_the_same_object(self) -> None:
+        shared = make_hook()
+        agent = Agent(
+            "bot",
+            prompt="p",
+            tools=[tool(alpha, middleware=[shared]), tool(beta, middleware=[shared])],
+        )
+        first, second = agent.tools
+
+        assert first.middleware[0].middleware is second.middleware[0].middleware
+
+    def test_separate_instances_with_equal_config_are_not_the_same_object(self) -> None:
+        agent = Agent(
+            "bot",
+            prompt="p",
+            tools=[tool(alpha, middleware=[make_hook()]), tool(beta, middleware=[make_hook()])],
+        )
+        first, second = agent.tools
+
+        # Descriptions cannot tell these apart, which is why identity is exposed.
+        assert first.middleware[0].description == second.middleware[0].description
+        assert first.middleware[0].middleware is not second.middleware[0].middleware
+
+
+class TestMiddlewareFactoryFields:
+    def test_reports_the_wrapped_class_and_its_options(self) -> None:
+        factory = Middleware(LoggingMiddleware, level=10)
+
+        assert factory.cls is LoggingMiddleware
+        assert dict(factory.options) == {"level": 10}
+
+    def test_options_expose_values_that_the_description_withholds(self) -> None:
+        factory = Middleware(LoggingMiddleware, api_key="sk-SECRET-123")
+
+        # A description may be logged or committed as a fixture, so it reports
+        # names only. Reading the factory you already hold is a deliberate act.
+        assert factory.options["api_key"] == "sk-SECRET-123"
+        assert "sk-SECRET-123" not in repr(factory.describe())
+
+    def test_options_cannot_be_mutated_through_the_view(self) -> None:
+        factory = Middleware(LoggingMiddleware, level=10)
+
+        with pytest.raises(TypeError):
+            factory.options["level"] = 20  # type: ignore[index]
+
+
+class TestComparingTwoAgents:
+    def test_independently_built_identical_agents_compare_equal(self) -> None:
+        def build() -> Agent:
+            return Agent(
+                "bot",
+                prompt="hello",
+                tools=[alpha],
+                middleware=[TokenLimiter(max_tokens=10)],
+                dependencies={"db": "shared"},
+            )
+
+        def fingerprint(agent: Agent) -> object:
+            return (
+                agent.name,
+                agent.system_prompt,
+                tuple(t.name for t in agent.tools),
+                tuple(m.description for m in agent.middleware),
+                tuple(sorted(map(str, agent.dependencies))),
+            )
+
+        assert fingerprint(build()) == fingerprint(build())
+
+    def test_a_changed_middleware_setting_is_caught(self) -> None:
+        loose = Agent("bot", prompt="p", middleware=[TokenLimiter(max_tokens=10)])
+        tight = Agent("bot", prompt="p", middleware=[TokenLimiter(max_tokens=99)])
+
+        assert loose.middleware[0].description != tight.middleware[0].description

--- a/website/docs/user-guide/agent_harness.mdx
+++ b/website/docs/user-guide/agent_harness.mdx
@@ -202,6 +202,58 @@ reply = await parent.ask("Find out where Melbourne is.")
 
 `as_tool()` returns a `FunctionTool` named `task_{child.name}` that accepts an `objective` parameter and forwards it into the child's stream. See [Subagents](/docs/user-guide/subagents) for sub-task streams, depth limiting, and stream factories.
 
+## Reading an agent's composition
+
+An Agent reports what it is made of, so you can compare two agents, assert on composition in a test, or log it. Each constructor argument has a matching read-only property:
+
+| Property | Reports |
+|---|---|
+| `#!python name` | agent name |
+| `#!python system_prompt` | static prompt fragments, in order |
+| `#!python dynamic_prompt` | dynamic prompt hooks, in registration order |
+| `#!python tools` | attached tools |
+| `#!python middleware` | agent-level middleware, in registration order |
+| `#!python dependencies` / `#!python variables` | injected values, keyed as supplied |
+| `#!python config` / `#!python response_schema` / `#!python hitl_hook` | model config, schema, human-input hook |
+| `#!python observers` / `#!python assembly` / `#!python tasks` | observers, assembly policies, `#!python TaskConfig` |
+
+Sequences come back as tuples and mappings as read-only views, so an agent cannot be changed through them.
+
+```python linenums="1" hl_lines="6-8"
+def fingerprint(agent: Agent) -> tuple:
+    return (
+        agent.name,
+        agent.system_prompt,
+        tuple(t.name for t in agent.tools),
+        tuple(m.description for m in agent.middleware),
+        tuple(sorted(map(str, agent.dependencies))),
+    )
+
+assert fingerprint(built_one_way) == fingerprint(built_another_way)
+```
+
+### Middleware entries
+
+`#!python agent.middleware` and `#!python tool.middleware` yield entries pairing each middleware with its [description](/docs/user-guide/middleware#describing-middleware):
+
+```python linenums="1" hl_lines="2-3"
+for entry in agent.middleware:
+    entry.description   # what it is and how it was configured
+    entry.middleware    # the object itself
+```
+
+Both are needed. A description says what a middleware *is*; identity says whether two tools *share* one. A single rate limiter across ten tools and ten separate ones configured identically produce equal descriptions, so `#!python is` on `#!python entry.middleware` is the only thing that tells them apart:
+
+```python linenums="1" hl_lines="3"
+first, second = agent.tools
+
+first.middleware[0].middleware is second.middleware[0].middleware
+# True when both tools hold one instance, so they share its state
+```
+
+!!! note
+    Entries are built when you read the property, so `#!python agent.middleware[0] is agent.middleware[0]` is `#!python False`. Compare `#!python entry.middleware`, never the entry itself.
+
 ## Turn lifecycle
 
 Each `await agent.ask(...)` runs through the middleware chain in this order (outermost → innermost):

--- a/website/docs/user-guide/middleware.mdx
+++ b/website/docs/user-guide/middleware.mdx
@@ -506,8 +506,10 @@ A composite is only as describable as its parts: `#!python complete` is forced t
 
 Descriptions support equality but are deliberately **not hashable** — `#!python config` may hold arbitrary values, so they cannot go in a `#!python set` or be used as dict keys.
 
+To read the middleware attached to an agent or a tool, use `#!python agent.middleware` and `#!python tool.middleware`. Each entry pairs the middleware object with its description, so an entry always has one whether or not that middleware opted in. See [Reading an agent's composition](/docs/user-guide/agent_harness#reading-an-agents-composition).
+
 !!! note
-    `#!python Middleware(...)` reports the wrapped class and which options were set, but never their values, and always `#!python complete=False`. The options are caller-supplied and the wrapper cannot know whether one is a credential. Write a `#!python MiddlewareFactory` with its own `#!python describe()` when you want a complete description.
+    `#!python Middleware(...)` reports the wrapped class and which options were set, but never their values, and always `#!python complete=False`. The options are caller-supplied and the wrapper cannot know whether one is a credential. Write a `#!python MiddlewareFactory` with its own `#!python describe()` when you want a complete description. Its `#!python .cls` and `#!python .options` expose the class and the option values directly, for when you are inspecting a factory you already hold rather than producing something to log.
 
 !!! note
     `#!python config` is for settings only. Counters, caches, and anything else that changes during a run belong in `#!python context.variables` or the per-turn `#!python BaseMiddleware` instance — a description that carries a moving number produces flaky snapshots.


### PR DESCRIPTION
Stacked on #3120 — review that one first, this PR targets its branch.

## Why are these changes needed?

Building a custom dumper, comparing two agents, or asserting on composition in a test all require reading private attributes today:

```python
agent._system_prompt      agent._middleware        agent._agent_dependencies
agent._dynamic_prompt     agent._agent_variables   agent._task_config
tool._middleware          mw._cls                  mw._options
```

`AgentSpec.from_agent()` covers the serializable subset and deliberately drops the rest, so anything needing middleware, dependencies or dynamic prompts has nowhere supported to go.

### What this adds

Read-only properties for what those callers actually need.

| Type | Properties |
|---|---|
| `Agent` | `system_prompt`, `dynamic_prompt`, `middleware`, `dependencies`, `variables`, `response_schema`, `observers`, `tasks`, `assembly` |
| `FunctionTool` | `middleware` |
| `Middleware` | `cls`, `options` |

Sequences return tuples and mappings return read-only views, so an agent cannot be mutated through them. No new module-level functions, and no opinionated description format: what you build from these is yours.

```python
def fingerprint(agent: Agent) -> tuple:
    return (
        agent.name,
        agent.system_prompt,
        tuple(t.name for t in agent.tools),
        tuple(m.description for m in agent.middleware),
        tuple(sorted(map(str, agent.dependencies))),
    )

assert fingerprint(built_one_way) == fingerprint(built_another_way)
```

### Middleware entries

`agent.middleware` and `tool.middleware` yield `DescribedMiddleware` entries, so every entry has a description whether or not that middleware opted in to `describe()`:

```python
for entry in agent.middleware:
    entry.description   # what it is and how it was configured
    entry.middleware    # the object itself
```

Both are needed. A description says what a middleware **is**; identity says whether two tools **share** one. Ten tools holding a single rate limiter and ten holding separate ones with identical settings produce equal descriptions, so `is` on `entry.middleware` is the only thing that distinguishes them — and the difference is real, because sharing an instance means sharing its state.

**Entries are built on access**, not stored. That keeps the execution path untouched (no extra frame per call), leaves `_middleware` holding the real objects, and means the object inside an entry is the one that was attached rather than a copy. The trade-off is that `agent.middleware[0] is agent.middleware[0]` is `False`; compare `entry.middleware`, never the entry. Documented and tested.

### `Middleware.cls` / `.options`

`Middleware(...).describe()` reports option *names* only, because a description may be logged or committed as a fixture and the wrapper cannot know whether an option is a credential. `.options` exposes the values, for the different act of inspecting a factory you already hold.

### Also here

Prompt hooks now carry their identity through the wrapper (`functools.wraps`), so `agent.dynamic_prompt` yields nameable hooks instead of a row of anonymous `wrapper`s. One line, and it is what makes that property useful.

## Related issue number

None. Follows the review discussion on #3120.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

CI is currently red on `test/extensions/tools/search/test_tinyfish.py` (respx rejecting unmocked TinyFish API calls). `main`'s own Tests workflow fails on the same file, so it is not from this branch.

Local results:

- 18 new tests in `test/test_agent_composition.py` covering each property, read-only enforcement, entry structure, observable sharing, factory fields, and the two-agents-compare-equal case
- Full suite **3495 passed**, with the same 5 pre-existing sandbox/shell failures as `main` (they pass in isolation on both branches; ordering, not this change)
- `ruff` clean; `mypy` unchanged at the same 58 pre-existing errors as `main`

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
