### PR TITLE
fix(tinyfish): adapt to tinyfish 0.5 per-product hosts and pin >=0.5,<0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ optionals = [
     "websockets>=14.0,<17",  # WsLink (ag2.network)
     "docker>=6.0.0,<8",  # code execution (ag2.extensions.docker)
     "daytona>=0.171.0,<1",
-    "tinyfish>=0.2.3; python_version>='3.11'",
+    "tinyfish>=0.5,<0.6; python_version>='3.11'",
     "exa-py>=2.12.1,<3",
     # providers
     "ag2[openai]",
@@ -192,7 +192,7 @@ docs = [
     "ag2[metrics]", # Metrics is exposed in the public API by the optional `ag2.middleware` module
     "ag2[ag-ui]",   # AG-UI is exposed in the public API by the optional `ag2.ag_ui` module
     # Extensions are not shipped as extras; install their packages directly so docs can import the modules
-    "tinyfish>=0.2.3; python_version>='3.11'",
+    "tinyfish>=0.5,<0.6; python_version>='3.11'",
     "daytona>=0.171.0,<1",
     "exa-py>=2.12.1,<3",
     "docker>=6.0.0,<8",                # Code execution tools are exposed in the public API by the optional `ag2.tools` module

--- a/test/extensions/tools/search/test_tinyfish.py
+++ b/test/extensions/tools/search/test_tinyfish.py
@@ -29,7 +29,10 @@ from ag2.extensions.tools.search.tinyfish import (
 )
 from ag2.testing import TestConfig, TrackingConfig
 
-TINYFISH_BASE_URL = "https://agent.tinyfish.ai"
+# tinyfish >= 0.5 sends Search and Fetch to per-product hosts serving at the root path,
+# unless an explicit base_url is configured on the client (then it's {base_url}/v1/{product}).
+TINYFISH_SEARCH_URL = "https://api.search.tinyfish.ai/"
+TINYFISH_FETCH_URL = "https://api.fetch.tinyfish.ai/"
 
 SAMPLE_SEARCH_RAW: dict[str, Any] = {
     "query": "AG2 framework",
@@ -181,7 +184,7 @@ class TestSchema:
 class TestSearchExecution:
     @respx.mock
     async def test_returns_structured_results(self) -> None:
-        respx.get(f"{TINYFISH_BASE_URL}/v1/search").mock(return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW))
+        respx.get(TINYFISH_SEARCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test")
 
         config = TrackingConfig(_tool_call_config({"query": "AG2 framework"}, tool_name="tinyfish_search"))
@@ -215,9 +218,7 @@ class TestSearchExecution:
 
     @respx.mock
     async def test_search_params_forwarded(self) -> None:
-        route = respx.get(f"{TINYFISH_BASE_URL}/v1/search").mock(
-            return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW)
-        )
+        route = respx.get(TINYFISH_SEARCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test")
 
         agent = Agent(
@@ -233,15 +234,25 @@ class TestSearchExecution:
 
     @respx.mock
     async def test_none_search_params_omitted(self) -> None:
-        route = respx.get(f"{TINYFISH_BASE_URL}/v1/search").mock(
-            return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW)
-        )
+        route = respx.get(TINYFISH_SEARCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test")
 
         agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="tinyfish_search"), tools=[toolkit])
         await agent.ask("search")
 
         assert set(route.calls.last.request.url.params.keys()) == {"query"}
+
+    @respx.mock
+    async def test_explicit_base_url_routes_via_v1_path(self) -> None:
+        route = respx.get("https://example.test/v1/search").mock(
+            return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW)
+        )
+        toolkit = TinyFishSearchToolkit(api_key="test", base_url="https://example.test")
+
+        agent = Agent("a", config=_tool_call_config({"query": "q"}, tool_name="tinyfish_search"), tools=[toolkit])
+        await agent.ask("search")
+
+        assert route.called
 
 
 @pytest.mark.asyncio
@@ -255,9 +266,7 @@ class TestFetchExecution:
 
     @respx.mock
     async def test_returns_structured_results_and_errors(self) -> None:
-        route = respx.post(f"{TINYFISH_BASE_URL}/v1/fetch").mock(
-            return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW)
-        )
+        route = respx.post(TINYFISH_FETCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test")
 
         config = TrackingConfig(
@@ -330,9 +339,7 @@ class TestFetchExecution:
 
     @respx.mock
     async def test_fetch_rejects_unsafe_url_scheme_before_client_call(self) -> None:
-        route = respx.post(f"{TINYFISH_BASE_URL}/v1/fetch").mock(
-            return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW)
-        )
+        route = respx.post(TINYFISH_FETCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test")
 
         config = TrackingConfig(_tool_call_config({"urls": ["file:///etc/passwd"]}, tool_name="tinyfish_fetch"))
@@ -347,9 +354,7 @@ class TestFetchExecution:
 
     @respx.mock
     async def test_fetch_params_forwarded(self) -> None:
-        route = respx.post(f"{TINYFISH_BASE_URL}/v1/fetch").mock(
-            return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW)
-        )
+        route = respx.post(TINYFISH_FETCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test")
 
         agent = Agent(
@@ -370,9 +375,7 @@ class TestFetchExecution:
 
     @respx.mock
     async def test_toolkit_level_fetch_params_applied_to_default_fetch(self) -> None:
-        route = respx.post(f"{TINYFISH_BASE_URL}/v1/fetch").mock(
-            return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW)
-        )
+        route = respx.post(TINYFISH_FETCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test", format="markdown", links=True)
 
         agent = Agent(
@@ -393,9 +396,7 @@ class TestFetchExecution:
 class TestTinyFishToolkitVariable:
     @respx.mock
     async def test_search_resolved(self) -> None:
-        route = respx.get(f"{TINYFISH_BASE_URL}/v1/search").mock(
-            return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW)
-        )
+        route = respx.get(TINYFISH_SEARCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test")
         search_tool = toolkit.search(location=Variable("user_location"), language=Variable())
 
@@ -412,9 +413,7 @@ class TestTinyFishToolkitVariable:
 
     @respx.mock
     async def test_fetch_resolved(self) -> None:
-        route = respx.post(f"{TINYFISH_BASE_URL}/v1/fetch").mock(
-            return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW)
-        )
+        route = respx.post(TINYFISH_FETCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test")
         fetch_tool = toolkit.fetch(format=Variable("fetch_format"), links=Variable())
 
@@ -436,7 +435,7 @@ class TestTinyFishToolkitVariable:
 
     @respx.mock
     async def test_missing_raises(self) -> None:
-        respx.get(f"{TINYFISH_BASE_URL}/v1/search").mock(return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW))
+        respx.get(TINYFISH_SEARCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test")
         search_tool = toolkit.search(location=Variable())
 
@@ -454,9 +453,7 @@ class TestTinyFishToolkitVariable:
 class TestIndividualTools:
     @respx.mock
     async def test_search_tool_passed_alone(self) -> None:
-        route = respx.get(f"{TINYFISH_BASE_URL}/v1/search").mock(
-            return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW)
-        )
+        route = respx.get(TINYFISH_SEARCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_SEARCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test")
 
         agent = Agent(
@@ -470,9 +467,7 @@ class TestIndividualTools:
 
     @respx.mock
     async def test_fetch_tool_passed_alone(self) -> None:
-        route = respx.post(f"{TINYFISH_BASE_URL}/v1/fetch").mock(
-            return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW)
-        )
+        route = respx.post(TINYFISH_FETCH_URL).mock(return_value=httpx.Response(200, json=SAMPLE_FETCH_RAW))
         toolkit = TinyFishSearchToolkit(api_key="test")
 
         agent = Agent(


### PR DESCRIPTION
## Why are these changes needed?

CI has been red on every branch (and main's nightly Tests run) since Aug 5. Root cause: [tinyfish 0.5.0](https://pypi.org/project/tinyfish/0.5.0/) shipped 2026-08-04 and changed its endpoint routing — Search and Fetch now go to dedicated hosts (`api.search.tinyfish.ai` / `api.fetch.tinyfish.ai`, serving at the root path) when no `base_url` is configured, instead of `{base}/v1/{product}` on `agent.tinyfish.ai`. With the dependency unpinned as `tinyfish>=0.2.3`, every CI run installs 0.5.0, all respx mocks in `test_tinyfish.py` miss, and its 10 tests fail with `AllMockedAssertionError`. (Python 3.10 jobs stayed green because tinyfish is only installed on `python_version>='3.11'`.)

This PR:

- points the test mocks at the new per-product hosts (`TINYFISH_SEARCH_URL` / `TINYFISH_FETCH_URL` constants),
- adds `test_explicit_base_url_routes_via_v1_path` to pin the other half of the 0.5 routing contract (an explicit `base_url` on the toolkit routes requests to `{base_url}/v1/search`),
- pins `tinyfish>=0.5,<0.6` (both occurrences in `pyproject.toml`) so a future minor release can't silently break CI again.

The toolkit itself (`ag2/extensions/tools/search/tinyfish.py`) needed no changes: `search.query`, `fetch.get_contents`, `close()`, and every response field it reads are unchanged in 0.5.0. Verified locally against tinyfish 0.5.0: `test/extensions/` passes (106 tests, 21 in `test_tinyfish.py` including the new one), and the toolkit was exercised end-to-end against the live TinyFish API.

## Related issue number

None — CI breakage observed directly on `main` nightly runs and open PRs (e.g. run 31060199898).

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally. *(No doc changes needed — test-only change plus a dependency pin.)*
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

This PR was produced with significant AI assistance (Claude Code). The diagnosis, the diff, and this description were AI-drafted; the change was tested locally against tinyfish 0.5.0 (unit tests plus a live end-to-end run of the toolkit).

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
