### PR TITLE
feat(a2a): add gRPC TLS support for secure agent communication

### DIFF
--- a/ag2/a2a/__init__.py
+++ b/ag2/a2a/__init__.py
@@ -16,8 +16,16 @@ try:
 except ImportError as e:
     A2AServer = missing_additional_dependency("A2AServer", "a2a-sdk[http-server]", e)  # type: ignore[misc]
 
+try:
+    from .transports.grpc import secure_grpc_channel_factory
+except ImportError as e:
+    secure_grpc_channel_factory = missing_additional_dependency(  # type: ignore[misc]
+        "secure_grpc_channel_factory", "a2a-sdk[grpc]", e
+    )
+
 __all__ = (
     "A2AConfig",
     "A2AServer",
     "build_card",
+    "secure_grpc_channel_factory",
 )

--- a/ag2/a2a/server.py
+++ b/ag2/a2a/server.py
@@ -30,6 +30,7 @@ from .transports.jsonrpc import build_jsonrpc_asgi
 from .transports.rest import build_rest_asgi
 
 if TYPE_CHECKING:
+    import grpc
     from grpc.aio import Server
     from starlette.applications import Starlette
 
@@ -193,13 +194,16 @@ class A2AServer:
         grpc_url: str,
         card: AgentCard | None = None,
         options: Sequence[tuple[str, Any]] = (),
+        server_credentials: "grpc.ServerCredentials | None" = None,
     ) -> "Server":
         """``grpc.aio.Server`` bound to ``bind``; caller starts/awaits it.
 
         ``bind`` is the listener address (e.g. ``"0.0.0.0:50051"``).
         ``grpc_url`` is the public URL clients will connect to (used in
         the AgentCard interface entry — usually identical to ``bind``,
-        but not when behind a load balancer). Insecure binding only.
+        but not when behind a load balancer). Binding is insecure by default;
+        pass ``server_credentials`` (for example, from
+        ``grpc.ssl_server_credentials(...)``) to enable TLS.
 
         ``card_modifier`` does not apply: A2A v1.x has no ``GetAgentCard``
         gRPC method — the public card is served over HTTP only.
@@ -216,5 +220,6 @@ class A2AServer:
             agent_card=resolved_card,
             bind=bind,
             options=options,
+            server_credentials=server_credentials,
             **self._shared_kwargs(include_card_modifier=False),
         )

--- a/ag2/a2a/transports/grpc.py
+++ b/ag2/a2a/transports/grpc.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import grpc
@@ -30,13 +30,50 @@ from ._common import (
 # import, not a defect here — drop them once stubs are available.
 
 
-def default_grpc_channel_factory(url: str) -> grpc.aio.Channel:  # type: ignore[no-any-unimported]
-    """Insecure ``grpc.aio.Channel`` factory; strips ``grpc(+insecure)://`` prefix."""
-    for prefix in ("grpc+insecure://", "grpc://"):
+_TLS_PREFIXES = ("grpcs://", "grpc+tls://")
+_INSECURE_PREFIXES = ("grpc+insecure://", "grpc://")
+
+
+def _strip_scheme(url: str, prefixes: Sequence[str]) -> str:
+    for prefix in prefixes:
         if url.startswith(prefix):
-            url = url[len(prefix) :]
-            break
-    return grpc.aio.insecure_channel(url)
+            return url[len(prefix) :]
+    return url
+
+
+def default_grpc_channel_factory(url: str) -> grpc.aio.Channel:  # type: ignore[no-any-unimported]
+    """Build a gRPC channel whose security is selected by the URL scheme.
+
+    ``grpcs://`` and ``grpc+tls://`` use TLS with system CA roots. Existing
+    ``grpc://``, ``grpc+insecure://``, and bare ``host:port`` targets remain
+    insecure. Use :func:`secure_grpc_channel_factory` for private CAs or mTLS.
+    """
+    for prefix in _TLS_PREFIXES:
+        if url.startswith(prefix):
+            return grpc.aio.secure_channel(url[len(prefix) :], grpc.ssl_channel_credentials())
+    return grpc.aio.insecure_channel(_strip_scheme(url, _INSECURE_PREFIXES))
+
+
+def secure_grpc_channel_factory(  # type: ignore[no-any-unimported]
+    credentials: grpc.ChannelCredentials | None = None,
+    options: Sequence[tuple[str, Any]] = (),
+) -> Callable[[str], grpc.aio.Channel]:
+    """Create a TLS channel factory with optional custom credentials.
+
+    When ``credentials`` is omitted, system CA roots are used. The returned
+    factory accepts every supported gRPC URL spelling but always dials TLS.
+    """
+    resolved_credentials = credentials if credentials is not None else grpc.ssl_channel_credentials()
+
+    def factory(url: str) -> grpc.aio.Channel:  # type: ignore[no-any-unimported]
+        target = _strip_scheme(url, (*_TLS_PREFIXES, *_INSECURE_PREFIXES))
+        return grpc.aio.secure_channel(
+            target,
+            resolved_credentials,
+            options=list(options) if options else None,
+        )
+
+    return factory
 
 
 def build_grpc_server(  # type: ignore[no-any-unimported]
@@ -51,8 +88,13 @@ def build_grpc_server(  # type: ignore[no-any-unimported]
     push_config_store: PushNotificationConfigStore | None = None,
     push_sender: PushNotificationSender | None = None,
     options: Sequence[tuple[str, Any]] = (),
+    server_credentials: grpc.ServerCredentials | None = None,
 ) -> grpc.aio.Server:
-    """``grpc.aio.Server`` exposing A2A service; caller starts/awaits it."""
+    """``grpc.aio.Server`` exposing A2A service; caller starts/awaits it.
+
+    The server binds insecurely by default for backwards compatibility. Pass
+    ``server_credentials`` to bind the port with TLS instead.
+    """
     agent_card = prepare_public_card(
         agent_card,
         extended=extended_agent_card is not None,
@@ -73,5 +115,8 @@ def build_grpc_server(  # type: ignore[no-any-unimported]
     )
     server = grpc.aio.server(options=list(options) if options else None)
     a2a_pb2_grpc.add_A2AServiceServicer_to_server(GrpcHandler(handler), server)  # type: ignore[no-untyped-call]
-    server.add_insecure_port(bind)
+    if server_credentials is not None:
+        server.add_secure_port(bind, server_credentials)
+    else:
+        server.add_insecure_port(bind)
     return server

--- a/test/a2a/test_grpc_tls.py
+++ b/test/a2a/test_grpc_tls.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime, timedelta, timezone
+from ipaddress import ip_address
+
+import grpc
+import grpc.aio
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from ag2 import Agent
+from ag2.a2a import A2AConfig, A2AServer, build_card, secure_grpc_channel_factory
+from ag2.a2a.testing import pick_free_port
+from ag2.a2a.transports import default_grpc_channel_factory
+from ag2.testing import TestConfig
+
+HOST = "127.0.0.1"
+
+
+@pytest.fixture(scope="module")
+def self_signed() -> tuple[bytes, bytes]:
+    """Return a private key and certificate PEM pair for 127.0.0.1."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, HOST)])
+    cert = (
+        x509
+        .CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(minutes=5))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(hours=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.IPAddress(ip_address(HOST))]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    return key_pem, cert.public_bytes(serialization.Encoding.PEM)
+
+
+@pytest.mark.asyncio
+async def test_default_factory_accepts_tls_prefixes() -> None:
+    for url in (f"grpcs://{HOST}:50051", f"grpc+tls://{HOST}:50051"):
+        channel = default_grpc_channel_factory(url)
+        assert isinstance(channel, grpc.aio.Channel)
+        await channel.close()
+
+
+@pytest.mark.asyncio
+async def test_default_factory_keeps_insecure_prefixes() -> None:
+    for url in (f"grpc://{HOST}:50051", f"grpc+insecure://{HOST}:50051", f"{HOST}:50051"):
+        channel = default_grpc_channel_factory(url)
+        assert isinstance(channel, grpc.aio.Channel)
+        await channel.close()
+
+
+@pytest.mark.asyncio
+async def test_secure_factory_builds_channels(self_signed: tuple[bytes, bytes]) -> None:
+    _, cert_pem = self_signed
+    factory = secure_grpc_channel_factory(
+        grpc.ssl_channel_credentials(root_certificates=cert_pem),
+    )
+    channel = factory(f"{HOST}:50051")
+    assert isinstance(channel, grpc.aio.Channel)
+    await channel.close()
+
+
+@pytest.mark.asyncio
+async def test_grpc_tls_round_trip(self_signed: tuple[bytes, bytes]) -> None:
+    key_pem, cert_pem = self_signed
+    server_agent = Agent("tls-server", config=TestConfig("secure pong"))
+    server = A2AServer(server_agent)
+
+    grpc_url = f"{HOST}:{pick_free_port(HOST)}"
+    card = build_card(server_agent, url=grpc_url, transports=("grpc",), grpc_url=grpc_url)
+    grpc_server = server.build_grpc(
+        bind=grpc_url,
+        grpc_url=grpc_url,
+        card=card,
+        server_credentials=grpc.ssl_server_credentials([(key_pem, cert_pem)]),
+    )
+    await grpc_server.start()
+    try:
+        client = Agent(
+            "tls-client",
+            config=A2AConfig(
+                card_url=grpc_url,
+                preset_card=card,
+                prefer="grpc",
+                streaming=False,
+                grpc_channel_factory=secure_grpc_channel_factory(
+                    grpc.ssl_channel_credentials(root_certificates=cert_pem),
+                ),
+            ),
+        )
+        reply = await client.ask("ping")
+        assert reply.body == "secure pong"
+    finally:
+        await grpc_server.stop(grace=None)

--- a/website/docs/user-guide/a2a/client.mdx
+++ b/website/docs/user-guide/a2a/client.mdx
@@ -39,6 +39,54 @@ config = A2AConfig(
 !!! tip
     `#!python card_url` is always an HTTP URL — even when the resolved transport is gRPC. The card is served over HTTP per spec; only the actual message exchange uses the resolved binding.
 
+## gRPC TLS
+
+The default gRPC channel factory selects security from the interface URL published in the agent card. `#!python grpcs://` and `#!python grpc+tls://` create a TLS channel using the system CA roots; `#!python grpc://`, `#!python grpc+insecure://` and a bare `#!python host:port` keep the backwards-compatible insecure channel.
+
+For a server certificate issued by a public CA, the client needs no TLS-specific configuration. It fetches the card over HTTPS and follows the secure gRPC interface declared there:
+
+```python linenums="1" hl_lines="7"
+from ag2 import Agent
+from ag2.a2a import A2AConfig
+
+remote = Agent(
+    "remote",
+    config=A2AConfig(
+        card_url="https://agents.example.com",
+        prefer="grpc",
+    ),
+)
+reply = await remote.ask("Summarize the latest report.")
+```
+
+Private CAs, self-signed certificates and mTLS need custom `#!python grpc.ChannelCredentials`. Wrap those credentials with `#!python secure_grpc_channel_factory(...)` and pass the returned callable through the existing `#!python grpc_channel_factory` escape hatch:
+
+```python linenums="1" hl_lines="7-8 11-16"
+from pathlib import Path
+
+import grpc
+
+from ag2 import Agent
+from ag2.a2a import A2AConfig, secure_grpc_channel_factory
+
+ca_certificate = Path("certs/ca.pem").read_bytes()
+credentials = grpc.ssl_channel_credentials(root_certificates=ca_certificate)
+remote = Agent(
+    "remote",
+    config=A2AConfig(
+        card_url="https://agents.internal.example",
+        prefer="grpc",
+        grpc_channel_factory=secure_grpc_channel_factory(credentials),
+    ),
+)
+reply = await remote.ask("Run the internal health check.")
+```
+
+The secure factory always creates a TLS channel, regardless of whether the card uses a secure, insecure or bare gRPC URL spelling. It also accepts gRPC channel options via `#!python options=`. For mTLS, construct the credentials with `#!python root_certificates=`, `#!python private_key=` and `#!python certificate_chain=`; AG2 passes the resulting object to gRPC unchanged.
+
+!!! warning
+    TLS protects the gRPC connection only. Card discovery is a separate HTTP request, so publish the card over HTTPS as well and keep `#!python card_url` on that HTTPS origin.
+
 ## Multi-turn — `reply.ask`
 
 A2A servers are stateless from AG2's perspective: every call ships the full conversation history as a `#!python application/vnd.ag2.history+json` `#!python DataPart` attached to the outgoing message. The continuation API is the regular `#!python reply.ask(...)`:
@@ -162,7 +210,7 @@ See [Declaring Extensions](/docs/user-guide/a2a/server#declaring-extensions) for
 | `input_required_timeout` | `#!python Optional[float]` | `#!python None` | Cap how long the client waits on a HITL hook |
 | `httpx_client_factory` | `#!python Optional[Callable[[], AsyncClient]]` | `#!python None` | Custom `#!python httpx.AsyncClient` (proxies, custom TLS, etc.) |
 | `interceptors` | `#!python Sequence[ClientCallInterceptor]` | `#!python ()` | A2A SDK call interceptors |
-| `grpc_channel_factory` | `#!python Optional[Callable[[str], Channel]]` | `#!python None` | Custom gRPC channel builder (defaults to insecure) |
+| `grpc_channel_factory` | `#!python Optional[Callable[[str], Channel]]` | `#!python None` | Custom gRPC channel builder. The default follows the card URL scheme: `#!python grpcs://` / `#!python grpc+tls://` use system CA roots; other gRPC URL forms stay insecure. See [gRPC TLS](/docs/user-guide/a2a/client#grpc-tls) |
 | `preset_card` | `#!python Optional[AgentCard]` | `#!python None` | Skip the discovery round-trip when the card is already known |
 | `card_signature_verifier` | `#!python Optional[Callable[[AgentCard], None]]` | `#!python None` | Verify the JWS signature on every card consumed — fetched, preset and extended (see [Card Signing](/docs/user-guide/a2a/card_signing)) |
 | `tenant` | `#!python Optional[str]` | `#!python None` | Multi-tenancy scope on a shared backend |

--- a/website/docs/user-guide/a2a/server.mdx
+++ b/website/docs/user-guide/a2a/server.mdx
@@ -124,6 +124,35 @@ await grpc_server.wait_for_termination()
 !!! note
     A2A v1.x has no `#!python GetAgentCard` gRPC method — the public card is always served over HTTP at `#!python /.well-known/agent-card.json`. So even for a gRPC-only server clients fetch the card via HTTP first, then switch to gRPC for the actual exchange. Plan your card URL accordingly.
 
+#### TLS
+
+`#!python build_grpc` binds an insecure port by default for backwards compatibility. Pass a `#!python grpc.ServerCredentials` object as `#!python server_credentials=` to bind a secure port, and publish the interface with a `#!python grpcs://` or `#!python grpc+tls://` URL:
+
+```python linenums="1" hl_lines="7-9 11-18"
+from pathlib import Path
+
+import grpc
+
+from ag2.a2a import build_card
+
+private_key = Path("certs/server-key.pem").read_bytes()
+certificate = Path("certs/server.pem").read_bytes()
+credentials = grpc.ssl_server_credentials([(private_key, certificate)])
+
+grpc_url = "grpcs://agents.example.com:50051"
+card = build_card(agent, url="https://agents.example.com", transports=("grpc",), grpc_url=grpc_url)
+grpc_server = server.build_grpc(
+    bind="0.0.0.0:50051",
+    grpc_url=grpc_url,
+    card=card,
+    server_credentials=credentials,
+)
+await grpc_server.start()
+await grpc_server.wait_for_termination()
+```
+
+AG2 does not read certificate files or alter the credentials; certificate loading, rotation and mTLS policy remain under application control. To require client certificates, create the server credentials with `#!python root_certificates=<client CA>` and `#!python require_client_auth=True`. See [gRPC TLS on the client](/docs/user-guide/a2a/client#grpc-tls) for public-CA, private-CA and mTLS channels.
+
 ### One Server, Three Transports
 
 The same `#!python A2AServer` instance can back any combination of transports. Build a single multi-transport `#!python AgentCard` and call each `#!python build_*` against it — they share one task store.


### PR DESCRIPTION
## Why are these changes needed?

The A2A gRPC transport previously supported only insecure client channels and server ports. This prevented applications from protecting agent-to-agent traffic with TLS and made the transport unsuitable for production environments that require public certificates, private certificate authorities, or mutual TLS.

This PR adds opt-in TLS support to both sides of the A2A gRPC transport while preserving the existing insecure behavior.

### What changed

Client side:

- `default_grpc_channel_factory` now recognizes secure URL schemes:
  - `grpcs://`
  - `grpc+tls://`
- Secure URLs use `grpc.aio.secure_channel` with system CA roots.
- Existing `grpc://`, `grpc+insecure://`, and bare `host:port` targets remain insecure.
- A new public `secure_grpc_channel_factory` helper supports custom `grpc.ChannelCredentials`, including private CAs and mTLS.
- The helper is exported from `ag2.a2a`.

Server side:

- `A2AServer.build_grpc(...)` and the lower-level `build_grpc_server(...)` now accept optional `server_credentials`.
- When credentials are provided, the server binds with `add_secure_port`.
- Without credentials, the server continues to use `add_insecure_port`.

Documentation and tests:

- Added client and server documentation for system CA roots, private CAs, self-signed certificates, and mTLS.
- Added tests for secure and insecure URL handling.
- Added an end-to-end TLS round-trip using a generated self-signed certificate.
- The tests exercise the public `A2AServer`, `A2AConfig`, and `secure_grpc_channel_factory` APIs without patching internals.

### Public API

A server enables TLS by passing native gRPC server credentials:

```python
import grpc

from ag2.a2a import A2AServer

server = A2AServer(agent)

grpc_server = server.build_grpc(
    bind="0.0.0.0:50051",
    grpc_url="grpcs://agents.example.com:50051",
    server_credentials=grpc.ssl_server_credentials(
        [(private_key_pem, certificate_pem)]
    ),
)

await grpc_server.start()
```

For certificates issued by a public CA, clients only need the server card to advertise a `grpcs://` or `grpc+tls://` interface. The default channel factory uses system CA roots automatically:

```python
from ag2 import Agent
from ag2.a2a import A2AConfig

remote = Agent(
    "remote",
    config=A2AConfig(
        card_url="https://agents.example.com",
        prefer="grpc",
    ),
)
```

Private CAs, self-signed certificates, and mTLS use the new public factory:

```python
import grpc

from ag2.a2a import A2AConfig, secure_grpc_channel_factory

config = A2AConfig(
    card_url="https://agents.internal.example",
    prefer="grpc",
    grpc_channel_factory=secure_grpc_channel_factory(
        grpc.ssl_channel_credentials(
            root_certificates=ca_certificate_pem,
        ),
    ),
)
```

The factory also accepts gRPC channel options:

```python
factory = secure_grpc_channel_factory(
    credentials,
    options=(("grpc.keepalive_time_ms", 30_000),),
)
```

### Compatibility and review notes

- This is backwards compatible: insecure URLs and calls without `server_credentials` retain their previous behavior.
- The secure factory always creates a TLS channel, regardless of the URL scheme passed to it.
- AG2 does not read certificate files or manage certificate rotation. It wires user-provided native gRPC credential objects into the transport.
- TLS handshake and certificate errors remain native gRPC errors.
- Agent card discovery is still performed over HTTP(S), separately from the gRPC connection. Deployments should publish the card over HTTPS as well.
- No runtime dependency was added. `cryptography` is used only by the test suite to generate a self-signed certificate.

### Validation

- `test/a2a/test_grpc_tls.py`: 4 passed.
- Full A2A suite: 183 passed.
- Ruff checks and formatting passed.
- Mypy passed for the modified A2A source modules.
- Documentation built successfully with the project documentation environment.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

AI assistance was used to implement the change, add tests and documentation, and draft this PR description. The implementation was validated with the checks listed above.

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
