### PR TITLE
feat(acp): serve an AG2 Agent over ACP

### DIFF
--- a/ag2/acp/__init__.py
+++ b/ag2/acp/__init__.py
@@ -1,24 +1,52 @@
 # Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-"""Drive external CLI coding agents (Claude Code, Codex, …) via the Agent Client Protocol.
+"""Both halves of AG2's Agent Client Protocol support.
 
-AG2 plays the ACP *Client* role; each CLI agent runs as an ACP *Agent* subprocess.
-The integration is a :class:`ModelConfig` + :class:`LLMClient` pair — no changes
-to the :class:`~ag2.Agent` class.
+**Consume** — drive external CLI coding agents (Claude Code, Codex, …) from an
+AG2 agent. AG2 plays the ACP *Client* role; each CLI agent runs as an ACP *Agent*
+subprocess. The integration is a :class:`ModelConfig` + :class:`LLMClient` pair —
+no changes to the :class:`~ag2.Agent` class.
+
+**Serve** — expose an AG2 agent *as* an ACP Agent, so any ACP Client can drive
+it. That is :class:`ACPAgent`: the same job :class:`ag2.mcp.MCPServer` and
+:class:`ag2.a2a.A2AServer` do for their protocols, named the way ACP names the
+role (there is no "server" in ACP — its two roles are Client and Agent).
 """
 
 from ag2.exceptions import missing_optional_dependency
 
 try:
+    from .agent import ACPAgent, PromptContent
+    from .auth import AuthProvider, AuthenticationFailedError, StaticTokenAuth
     from .config import ACPConfig, ClaudeCodeConfig, CodexConfig, KiloCodeConfig, OpenCodeConfig
+    from .sessions import SessionConfig
     from .tool_gateway import MCPCapabilityError
 except ImportError as e:  # pragma: no cover - exercised only when ag2[acp] is absent
     ACPConfig = missing_optional_dependency("ACPConfig", "acp", e)  # type: ignore[misc]
+    ACPAgent = missing_optional_dependency("ACPAgent", "acp", e)  # type: ignore[misc]
+    PromptContent = missing_optional_dependency("PromptContent", "acp", e)  # type: ignore[misc]
+    AuthProvider = missing_optional_dependency("AuthProvider", "acp", e)  # type: ignore[misc]
+    AuthenticationFailedError = missing_optional_dependency("AuthenticationFailedError", "acp", e)  # type: ignore[misc]
     ClaudeCodeConfig = missing_optional_dependency("ClaudeCodeConfig", "acp", e)  # type: ignore[misc]
     CodexConfig = missing_optional_dependency("CodexConfig", "acp", e)  # type: ignore[misc]
     KiloCodeConfig = missing_optional_dependency("KiloCodeConfig", "acp", e)  # type: ignore[misc]
     OpenCodeConfig = missing_optional_dependency("OpenCodeConfig", "acp", e)  # type: ignore[misc]
     MCPCapabilityError = missing_optional_dependency("MCPCapabilityError", "acp", e)  # type: ignore[misc]
+    SessionConfig = missing_optional_dependency("SessionConfig", "acp", e)  # type: ignore[misc]
+    StaticTokenAuth = missing_optional_dependency("StaticTokenAuth", "acp", e)  # type: ignore[misc]
 
-__all__ = ["ACPConfig", "ClaudeCodeConfig", "CodexConfig", "KiloCodeConfig", "MCPCapabilityError", "OpenCodeConfig"]
+__all__ = [
+    "ACPAgent",
+    "ACPConfig",
+    "AuthProvider",
+    "AuthenticationFailedError",
+    "ClaudeCodeConfig",
+    "CodexConfig",
+    "KiloCodeConfig",
+    "MCPCapabilityError",
+    "OpenCodeConfig",
+    "PromptContent",
+    "SessionConfig",
+    "StaticTokenAuth",
+]

--- a/ag2/acp/agent.py
+++ b/ag2/acp/agent.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING, Any
 
 import acp
 from acp import schema
+from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
+from acp.stdio import stdio_streams
 
 from ag2.agent import Agent
 
@@ -41,7 +43,7 @@ from .sessions import (
 )
 
 if TYPE_CHECKING:
-    from .types import ContentBlock
+    from .types import ContentBlock, McpServer
 
 logger = logging.getLogger(__name__)
 
@@ -214,9 +216,6 @@ class ACPAgent:
         drops the connection, while this agent advertises image and embedded
         content as supported.
         """
-        from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
-        from acp.stdio import stdio_streams
-
         limit = DEFAULT_STDIO_BUFFER_LIMIT_BYTES if buffer_limit_bytes is None else buffer_limit_bytes
         reader, writer = await stdio_streams(limit=limit)
         await serve(self.bind, reader, writer)
@@ -320,7 +319,7 @@ class _ConnectionScope:
         self,
         cwd: str,
         additional_directories: "list[str] | None" = None,
-        mcp_servers: "list[Any] | None" = None,
+        mcp_servers: "list[McpServer] | None" = None,
         **kwargs: Any,
     ) -> schema.NewSessionResponse:
         """Create an isolated session and return its id.

--- a/ag2/acp/agent.py
+++ b/ag2/acp/agent.py
@@ -1,0 +1,494 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Expose an AG2 :class:`~ag2.Agent` through the Agent Client Protocol.
+
+This is the *serving* half of AG2's ACP support: AG2 plays the ACP **Agent** role
+so any ACP Client (Zed, an SDK client, an application acting on a user's behalf)
+can drive an AG2 agent. The consume side — AG2 driving an external CLI agent —
+lives in :mod:`ag2.acp.config` and :mod:`ag2.acp.client`.
+
+The class is named for the role ACP itself defines. AG2 names each protocol
+adapter after that protocol's own word for the serving side — MCP and A2A both
+call it a *Server* (:class:`ag2.mcp.MCPServer`, :class:`ag2.a2a.A2AServer`), and
+ACP calls it an *Agent*, so this is ``ACPAgent``. It is a wrapper around an AG2
+:class:`~ag2.Agent`, not a subclass of one.
+"""
+
+import asyncio
+import importlib.metadata
+import logging
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import acp
+from acp import schema
+
+from ag2.agent import Agent
+
+from .auth import AuthProvider
+from .executor import STOP_CANCELLED, AgentExecutor, heal_cancelled_turn, isolate_variables
+from .guard import serve
+from .sessions import (
+    AgentSession,
+    ConnectionOverloadedError,
+    SessionBusyError,
+    SessionConfig,
+    SessionLimitError,
+    SessionStore,
+    UnknownSessionError,
+)
+
+if TYPE_CHECKING:
+    from .types import ContentBlock
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_VERSION = "0.0.0"
+
+
+@dataclass(frozen=True, slots=True)
+class PromptContent:
+    """Which non-text prompt content this deployment can actually handle.
+
+    Advertised verbatim in the ``initialize`` handshake, where a Client reads it
+    to decide what it may send. Whether a given block *works* depends on the
+    model behind the agent, and AG2 has no registry of provider modalities to
+    consult — the mapper converting ACP blocks into AG2 inputs will happily build
+    an ``AudioInput`` that, say, the Anthropic mapper then rejects.
+
+    So this is a declaration by whoever deploys the agent, not a guess. The
+    defaults cover what every provider AG2 ships supports; ``audio`` is off
+    because most do not. Turn on what your model actually accepts::
+
+        ACPAgent(agent, prompt_content=PromptContent(audio=True))
+    """
+
+    image: bool = True
+    audio: bool = False
+    embedded_context: bool = True
+
+
+def _request_meta(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """The request's ACP ``_meta`` map, as delivered to a handler.
+
+    The SDK router *spreads* a request's ``_meta`` entries into the handler's
+    keyword arguments rather than passing the map itself (``acp/router.py``:
+    ``params.update(meta)``). Every declared parameter is bound by name, so
+    whatever is left in ``**kwargs`` is exactly the metadata the Client sent.
+
+    Kept verbatim. ``_meta`` is where applications put their own namespaced data
+    — AG2 Space provenance, say — and AG2 has no business interpreting it.
+    """
+    return dict(kwargs)
+
+
+def _package_version() -> str:
+    try:
+        return importlib.metadata.version("ag2")
+    except importlib.metadata.PackageNotFoundError:  # pragma: no cover - ag2 always installed in practice
+        return _DEFAULT_VERSION
+
+
+class ACPAgent:
+    """Serve an AG2 :class:`Agent` as an ACP Agent.
+
+    The simplest form serves over stdio, which is how ACP Clients normally launch
+    an Agent::
+
+        from ag2 import Agent
+        from ag2.acp import ACPAgent
+
+        await ACPAgent(Agent("workie", ...)).run_stdio()
+
+    The instance implements the :class:`acp.Agent` protocol, so it can also be
+    handed to :func:`acp.run_agent` directly with your own streams.
+
+    Each ``session/new`` gets an isolated conversation with its own history;
+    sessions never see each other's messages. Concurrent prompts on *one* session
+    queue rather than interleave (bounded by ``sessions.max_queued``), matching
+    how :class:`ag2.mcp.MCPServer` already treats one session's overlapping calls.
+
+    ``session/cancel`` names a session, so it cancels that session's running turn
+    *and* everything queued behind it, leaving other sessions untouched. Events
+    already streamed stay in the session's history.
+
+    Args:
+        agent: The AG2 agent to expose.
+        name: Advertised agent name (defaults to ``agent.name``).
+        version: Advertised version (defaults to the installed ``ag2`` version).
+        title: Optional human-readable title for the ``initialize`` handshake.
+        sessions: Session registry bounds — ``True`` for defaults, or a
+            :class:`SessionConfig` to tune the LRU cap, idle TTL, history backend
+            and per-session prompt queue depth.
+        auth: Authentication provider. ``None`` (the default) advertises no auth
+            methods and rejects ``authenticate`` — appropriate for local stdio,
+            where the Client already launched the process. A provider decides
+            whether a Client may connect, not which Client it is: no principal
+            reaches the turn, so serve one tenant per instance. See
+            :mod:`ag2.acp.auth` for the full limitation.
+        stream_thoughts: Whether to project the agent's reasoning as ACP
+            ``agent_thought_chunk`` updates. Off by default: reasoning is
+            internal, and an ACP Client may be an external audience. Even when
+            on, thoughts are only sent to a Client that advertised support.
+        prompt_content: Which non-text prompt content to advertise as supported.
+            See :class:`PromptContent` — it depends on the model behind the
+            agent, so it is declared rather than guessed.
+    """
+
+    __slots__ = (
+        "_agent",
+        "_executor",
+        "_name",
+        "_title",
+        "_version",
+        "_auth",
+        "_stream_thoughts",
+        "_prompt_content",
+        "_session_config",
+        "_scope",
+    )
+
+    def __init__(
+        self,
+        agent: Agent,
+        *,
+        name: str | None = None,
+        version: str | None = None,
+        title: str | None = None,
+        sessions: "bool | SessionConfig" = True,
+        auth: AuthProvider | None = None,
+        stream_thoughts: bool = False,
+        prompt_content: PromptContent | None = None,
+    ) -> None:
+        self._agent = agent
+        self._name = name or agent.name
+        self._version = version or _package_version()
+        self._title = title
+        self._auth = auth
+        self._stream_thoughts = stream_thoughts
+        self._prompt_content = prompt_content or PromptContent()
+        config = sessions if isinstance(sessions, SessionConfig) else SessionConfig()
+        self._executor = AgentExecutor(agent, stream_thoughts=stream_thoughts)
+        self._session_config = config
+        # The most recently opened connection, so ``sessions`` has something to
+        # point at. Authorization and sessions live on the scope, never here.
+        self._scope: _ConnectionScope | None = None
+
+    @property
+    def agent(self) -> Agent:
+        return self._agent
+
+    @property
+    def sessions(self) -> SessionStore:
+        """The current connection's session registry (for advanced wiring and tests).
+
+        Sessions belong to a connection, so this is the newest one's store. Before
+        any Client has connected it is an empty store belonging to nothing.
+        """
+        if self._scope is None:
+            self._scope = self.bind(None)
+        return self._scope.sessions
+
+    def bind(self, client: "acp.Client | None") -> "_ConnectionScope":
+        """Open a fresh authorization and session scope for one Client.
+
+        Handed to the SDK as a factory so that *every* connection gets its own
+        state. Sharing one mutable set of flags across connections cannot be made
+        safe: a request carries no connection identity, so a handler reading
+        shared flags is reading whichever connection touched them last.
+        """
+        scope = _ConnectionScope(self, client)
+        self._scope = scope
+        return scope
+
+    async def run_stdio(self, *, buffer_limit_bytes: int | None = None) -> None:
+        """Serve over stdin/stdout until the Client disconnects.
+
+        ``buffer_limit_bytes`` caps a single incoming ACP frame. The default is
+        the SDK's own (50 MiB), not asyncio's 64 KiB: ACP frames are one line of
+        JSON, so a prompt carrying an inline image or embedded document is one
+        very long line. At asyncio's default an image of about 48 KiB — well
+        under anything a user would think twice about — overruns the reader and
+        drops the connection, while this agent advertises image and embedded
+        content as supported.
+        """
+        from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
+        from acp.stdio import stdio_streams
+
+        limit = DEFAULT_STDIO_BUFFER_LIMIT_BYTES if buffer_limit_bytes is None else buffer_limit_bytes
+        reader, writer = await stdio_streams(limit=limit)
+        await serve(self.bind, reader, writer)
+
+
+class _ConnectionScope:
+    """One Client's slice of an :class:`ACPAgent`: its authorization and sessions.
+
+    A request reaching a handler carries no hint of which connection sent it, so
+    authorization state cannot live on an object shared between connections —
+    whichever connection wrote the flags last would be speaking for all of them.
+    Giving each connection its own scope is what makes "authenticated" mean
+    "*this* Client authenticated".
+
+    Created through :meth:`ACPAgent.bind`, which the SDK calls once per
+    connection.
+    """
+
+    __slots__ = ("_owner", "_client", "_sessions", "_initialized", "_authenticated", "_client_capabilities")
+
+    def __init__(self, owner: "ACPAgent", client: "acp.Client | None") -> None:
+        self._owner = owner
+        self._client = client
+        self._sessions = SessionStore.from_config(owner._session_config)
+        self._initialized = False
+        self._authenticated = owner._auth is None
+        self._client_capabilities: schema.ClientCapabilities | None = None
+
+    @property
+    def sessions(self) -> SessionStore:
+        return self._sessions
+
+    async def aclose(self) -> None:
+        """Drop this connection's sessions — its scope is over."""
+        await self._sessions.aclose()
+
+    def on_connect(self, conn: acp.Client) -> None:
+        """Record the Client handle this scope pushes ``session/update`` through."""
+        self._client = conn
+
+    async def initialize(
+        self,
+        protocol_version: int,
+        client_capabilities: "schema.ClientCapabilities | None" = None,
+        client_info: "schema.Implementation | None" = None,
+        **kwargs: Any,
+    ) -> schema.InitializeResponse:
+        """Negotiate the protocol version and advertise implemented capabilities.
+
+        Capabilities are derived from what is actually wired, never aspirational:
+        a Client must be able to trust that anything advertised here works.
+
+        Marks this connection as having completed its handshake; every session
+        method below refuses to run before that. ACP requires initialize first
+        but the SDK router does not enforce it, so this class does.
+        """
+        self._initialized = True
+        self._client_capabilities = client_capabilities
+        return schema.InitializeResponse(
+            protocol_version=min(protocol_version, acp.PROTOCOL_VERSION),
+            agent_capabilities=self._capabilities(),
+            auth_methods=self._owner._auth.methods() if self._owner._auth is not None else [],
+            agent_info=schema.Implementation(
+                name=self._owner._name, title=self._owner._title, version=self._owner._version
+            ),
+        )
+
+    def _capabilities(self) -> schema.AgentCapabilities:
+        return schema.AgentCapabilities(
+            # session/load is not implemented, so it must not be advertised.
+            load_session=False,
+            prompt_capabilities=schema.PromptCapabilities(
+                image=self._owner._prompt_content.image,
+                audio=self._owner._prompt_content.audio,
+                embedded_context=self._owner._prompt_content.embedded_context,
+            ),
+            # Client-declared MCP servers are captured but never connected, so
+            # every transport stays off.
+            mcp_capabilities=schema.McpCapabilities(http=False, sse=False, acp=False),
+            # Session operations are advertised by *presence*: an absent field
+            # means unsupported. Everything past new / prompt / cancel —
+            # list, delete, fork, resume, close — is unimplemented. (``session/close``
+            # is also still an unstable ACP method, so a stable v1 Client could not
+            # call it even if it were wired.)
+            session_capabilities=schema.SessionCapabilities(),
+        )
+
+    async def authenticate(self, method_id: str, **kwargs: Any) -> schema.AuthenticateResponse:
+        """Delegate to the configured provider; reject when none is configured."""
+        if not self._initialized:
+            raise acp.RequestError.invalid_request({"reason": "Call initialize before authenticate."})
+        if self._owner._auth is None:
+            raise acp.RequestError.invalid_request({
+                "reason": "This ACP agent does not require or support authentication."
+            })
+        await self._owner._auth.authenticate(method_id, **kwargs)
+        self._authenticated = True
+        return schema.AuthenticateResponse()
+
+    async def new_session(
+        self,
+        cwd: str,
+        additional_directories: "list[str] | None" = None,
+        mcp_servers: "list[Any] | None" = None,
+        **kwargs: Any,
+    ) -> schema.NewSessionResponse:
+        """Create an isolated session and return its id.
+
+        ``cwd``, ``additional_directories`` and ``mcp_servers`` are recorded as
+        session context. They are *not* acted on: a path or MCP server named by a
+        Client is context, not authorization for the agent to reach it. An
+        embedding application decides what to honour.
+        """
+        self._require_session_scope()
+        try:
+            session = await self._sessions.create(
+                cwd=cwd,
+                additional_directories=list(additional_directories or []),
+                mcp_servers=list(mcp_servers or []),
+                meta=_request_meta(kwargs),
+                # Seeded by value: this conversation owns its variables from here on.
+                variables=isolate_variables(self._owner._agent._agent_variables),
+            )
+        except SessionLimitError as exc:
+            raise acp.RequestError.invalid_request({"reason": str(exc)}) from exc
+        return schema.NewSessionResponse(session_id=session.session_id)
+
+    async def prompt(
+        self,
+        session_id: str,
+        prompt: "list[ContentBlock]",
+        **kwargs: Any,
+    ) -> schema.PromptResponse:
+        """Run one agent turn on ``session_id`` and report how it ended.
+
+        A prompt arriving while the session is busy waits its turn. If the
+        session is cancelled — before or during the turn — the response is
+        ``stop_reason="cancelled"`` and the agent is never reached.
+
+        A turn that fails for any other reason becomes a JSON-RPC internal error
+        carrying the cause. The Client is in a different process, so an error
+        without its reason leaves whoever is debugging with nothing at all.
+        """
+        self._require_session_scope()
+        session = await self._get_session(session_id)
+        client = self._require_client()
+        meta = _request_meta(kwargs) or dict(session.meta)
+
+        abandoned = False
+        try:
+            # Connection-wide admission first: a prompt waiting its turn on a busy
+            # session still occupies a request handler, so it has to count.
+            async with self._sessions.admit(), session.turn(), self._sessions.running_turn():
+                task = asyncio.create_task(
+                    self._owner._executor.run_turn(
+                        session=session,
+                        store=self._sessions,
+                        client=client,
+                        blocks=prompt,
+                        meta=meta,
+                    )
+                )
+                session.turn_task = task
+                try:
+                    # ``asyncio.wait`` reports the turn's own cancellation instead
+                    # of re-raising it, which is what separates the two very
+                    # different cancellations that reach the handler below: this
+                    # one can only be *the request* being cancelled.
+                    await asyncio.wait([task])
+                except asyncio.CancelledError:
+                    abandoned = True
+                    # Nothing else is going to stop the turn now, and its history
+                    # writes have to be finished before the store is torn down.
+                    task.cancel()
+                    with suppress(asyncio.CancelledError, Exception):
+                        await task
+                    raise
+                stop_reason = task.result()
+        except asyncio.CancelledError:
+            if abandoned:
+                # The request itself was cancelled, which happens when the
+                # connection is being closed underneath it. There is no Client
+                # left to answer, and the SDK stops its sender before it unwinds
+                # handlers — so replying here would park on a closed sender
+                # forever, and the close it is unwinding for would never finish.
+                raise
+            # Cancellation is a normal ACP outcome, not a failure: report it as a
+            # stop reason rather than tearing down the JSON-RPC request. Repair
+            # the transcript first — a cancel can land between a tool call and
+            # its result, and the session has to stay usable afterwards.
+            await self._heal(session)
+            return schema.PromptResponse(stop_reason=STOP_CANCELLED)
+        except (SessionBusyError, ConnectionOverloadedError) as exc:
+            raise acp.RequestError.invalid_request({"reason": str(exc)}) from exc
+        except acp.RequestError:
+            raise  # already a protocol error with its own payload
+        except Exception as exc:
+            logger.exception("ACP prompt turn failed for session %s", session_id)
+            raise acp.RequestError.internal_error({
+                "reason": str(exc) or exc.__class__.__name__,
+                "type": exc.__class__.__name__,
+            }) from exc
+
+        return schema.PromptResponse(stop_reason=stop_reason)
+
+    async def cancel(self, session_id: str, **kwargs: Any) -> None:
+        """Cancel ``session_id``'s running turn and everything queued behind it.
+
+        A notification, not a request: there is no response channel, so an
+        unknown session id — or a caller with no right to touch it — is logged
+        and ignored rather than raised.
+
+        Cancelling is a mutation of someone's conversation, so it needs the same
+        connection scope as prompting. Without that check a reconnect could stop
+        work belonging to the connection it replaced, just by remembering an id.
+        """
+        try:
+            self._require_session_scope()
+        except acp.RequestError:
+            logger.debug("session/cancel outside an authorized connection scope; ignored")
+            return
+        try:
+            session = await self._sessions.get(session_id)
+        except UnknownSessionError:
+            logger.debug("session/cancel for unknown session %s; ignored", session_id)
+            return
+        await session.cancel()
+
+    async def _heal(self, session: AgentSession) -> None:
+        """Make a cancelled session's history valid to send to a provider again.
+
+        Runs under the session's turn lock so the next prompt cannot start
+        mid-repair — the repair rewrites the whole transcript, and a turn racing
+        it would either read an unanswered tool call or have its own events
+        overwritten by a stale snapshot. Several cancelled prompts may each land
+        here; the lock serializes them and the repair is idempotent, so the ones
+        after the first find nothing left to close.
+
+        Best-effort: if it fails the session is still cancelled, and reporting
+        that matters more than the repair.
+        """
+        try:
+            async with session.recovery():
+                closed = await heal_cancelled_turn(self._sessions.stream(session))
+        except Exception:  # pragma: no cover - defensive; storage failures only
+            logger.warning("could not repair history for cancelled session %s", session.session_id, exc_info=True)
+            return
+        if closed:
+            logger.debug("closed %d unanswered tool call(s) after cancelling %s", closed, session.session_id)
+
+    async def _get_session(self, session_id: str) -> AgentSession:
+        try:
+            return await self._sessions.get(session_id)
+        except UnknownSessionError as exc:
+            raise acp.RequestError.resource_not_found(f"acp-session:{session_id}") from exc
+
+    def _require_client(self) -> acp.Client:
+        if self._client is None:  # pragma: no cover - set by the SDK before any request
+            raise acp.RequestError.internal_error({"reason": "ACP connection is not established."})
+        return self._client
+
+    def _require_session_scope(self) -> None:
+        """Gate every session operation on an initialized, authenticated connection.
+
+        ACP requires ``initialize`` before anything else, but the SDK router does
+        not enforce that — so we do. Without it, a reconnecting Client could skip
+        the handshake and, with it, the scope reset that revokes the previous
+        connection's authentication.
+        """
+        if not self._initialized:
+            raise acp.RequestError.invalid_request({
+                "reason": "Call initialize before any session method.",
+            })
+        if not self._authenticated:
+            raise acp.RequestError.auth_required({"reason": "Call authenticate first."})

--- a/ag2/acp/auth.py
+++ b/ag2/acp/auth.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Authentication seam for :class:`~ag2.acp.agent.ACPAgent`.
+
+AG2 owns the protocol hook — advertising methods at ``initialize`` and gating
+session operations until ``authenticate`` succeeds. The embedding application
+owns everything behind it: credentials, user identity, authorization scope,
+token storage and revocation.
+
+Local stdio needs none of this: the Client launched the process, so the default
+is no provider, no advertised methods, and ``authenticate`` rejected. A remote
+transport, or the ACP Registry (which requires registered Agents to advertise
+valid authentication methods), is where a provider becomes necessary.
+
+.. warning::
+
+   This seam authenticates a connection. It does not identify a tenant.
+
+   :meth:`AuthProvider.authenticate` returns ``None``, so no principal or claims
+   reach the turn. Every authenticated Client drives the same agent, the same
+   tools and the same :class:`~ag2.knowledge.KnowledgeStore`, and downstream code
+   has no trusted identity to authorize against.
+
+   The ACP ``_meta`` map is the only caller-supplied identity that reaches a
+   turn. It is client-controlled: suitable as provenance, not as the basis of an
+   authorization decision.
+
+   Serve one tenant per :class:`~ag2.acp.agent.ACPAgent`. This matches the stdio
+   deployment, where the Client launches the process. Multi-tenant deployments
+   require one process and one agent per tenant.
+
+   Carrying a principal and claims into the turn is deferred until a downstream
+   consumer defines the requirement, rather than fixing an authentication
+   contract that would be costly to change afterwards.
+"""
+
+from typing import Any, Protocol, TypeAlias, runtime_checkable
+
+from acp import schema
+
+# The ``InitializeResponse.auth_methods`` union. The SDK exports no named alias
+# for it, so — as with the aliases in :mod:`ag2.acp.types` — mirror it once here.
+AuthMethod: TypeAlias = schema.EnvVarAuthMethod | schema.TerminalAuthMethod | schema.AuthMethodAgent
+
+__all__ = (
+    "AuthMethod",
+    "AuthProvider",
+    "AuthenticationFailedError",
+    "StaticTokenAuth",
+)
+
+
+class AuthenticationFailedError(Exception):
+    """Raised by an :class:`AuthProvider` when a credential is rejected."""
+
+
+@runtime_checkable
+class AuthProvider(Protocol):
+    """Advertises authentication methods and validates them.
+
+    Implement this to plug an application's identity system into ACP. The
+    provider makes the admission decision only; any identity it resolves stays
+    within the provider. See the single-tenant warning in this module's
+    docstring before serving more than one tenant from one agent.
+    """
+
+    def methods(self) -> "list[AuthMethod]":
+        """The methods advertised in the ``initialize`` response."""
+        ...
+
+    async def authenticate(self, method_id: str, **kwargs: Any) -> None:
+        """Validate an ``authenticate`` call.
+
+        Return normally to accept. Raise :class:`AuthenticationFailedError` (or any
+        exception) to reject; the adapter surfaces it as a protocol error.
+
+        The ``None`` return type is intentional: this is an admission gate, not
+        an identity lookup. No value from here is carried into the turn, so a
+        tool cannot determine which Client authenticated.
+        """
+        ...
+
+
+class StaticTokenAuth:
+    """Minimal :class:`AuthProvider` checking a shared secret.
+
+    Intended for tests and single-tenant deployments where the Client and Agent
+    are configured together. It is *not* a substitute for an identity system:
+    there is one credential, it never expires, and it identifies no user.
+    """
+
+    __slots__ = ("_token", "_method_id", "_description")
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        method_id: str = "token",
+        description: str = "Shared token configured on both the Client and the Agent.",
+    ) -> None:
+        if not token:
+            raise ValueError("token must be a non-empty string.")
+        self._token = token
+        self._method_id = method_id
+        self._description = description
+
+    def methods(self) -> "list[AuthMethod]":
+        return [
+            schema.AuthMethodAgent(
+                id=self._method_id,
+                name="Shared token",
+                description=self._description,
+            )
+        ]
+
+    async def authenticate(self, method_id: str, **kwargs: Any) -> None:
+        if method_id != self._method_id:
+            raise AuthenticationFailedError(f"Unknown authentication method: {method_id!r}")
+        supplied = kwargs.get("token") or (kwargs.get("meta") or {}).get("token")
+        if supplied != self._token:
+            raise AuthenticationFailedError("Invalid token.")

--- a/ag2/acp/executor.py
+++ b/ag2/acp/executor.py
@@ -1,0 +1,404 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Run one ACP ``session/prompt`` as one AG2 agent turn.
+
+The executor owns the bridge in both directions: ACP content blocks in, AG2
+events projected back out as ``session/update`` notifications. It deliberately
+runs an ordinary AG2 turn — no simplified execution path — so tool events, human
+input, observers and middleware all behave exactly as they do off-protocol.
+
+Modelled on :class:`ag2.a2a.executor.AgentExecutor`, which solves the same
+problem for A2A.
+"""
+
+import asyncio
+import logging
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
+
+import acp
+
+from ag2.agent import Agent
+from ag2.context import ConversationContext
+from ag2.events import (
+    BaseEvent,
+    ModelMessageChunk,
+    ModelRequest,
+    ModelResponse,
+    TextInput,
+    ToolCallsEvent,
+    ToolResultEvent,
+    ToolResultsEvent,
+)
+from ag2.events.tool_events import ToolResult
+from ag2.utils import AGENT_CONTEXT_DEPENDENCY_KEY
+
+from .mappers import event_to_session_update, prompt_to_inputs
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ag2.context import SubId
+    from ag2.stream import MemoryStream
+
+    from .sessions import AgentSession, SessionStore
+    from .types import ContentBlock
+
+logger = logging.getLogger(__name__)
+
+# ACP stop reasons AG2 can report truthfully. The protocol also defines
+# ``max_tokens`` / ``max_turn_requests`` / ``refusal``, but an AG2 ``ModelResponse``
+# carries no unambiguous signal for those, and guessing one would tell the Client
+# something we do not know.
+STOP_END_TURN = "end_turn"
+STOP_CANCELLED = "cancelled"
+
+# Namespaced context variable carrying the Client's ``_meta`` into the turn.
+# AG2 OSS never interprets what is inside; a downstream agent that cares (e.g.
+# reading AG2 Space provenance) reads this key, and a generic agent ignores it.
+META_VARIABLE = "acp.meta"
+
+# Stands in for a tool result the Client will never get, because the turn was
+# cancelled while the tool was still running. See :func:`heal_cancelled_turn`.
+CANCELLED_TOOL_RESULT = "The turn was cancelled before this tool finished."
+
+
+class UpdateDeliveryError(RuntimeError):
+    """Raised when a ``session/update`` could not be pushed to the Client.
+
+    Fails the turn rather than letting it report success for output nobody
+    received.
+    """
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__(f"Could not deliver a session/update to the Client for session {session_id!r}.")
+        self.session_id = session_id
+
+
+class HumanInputUnsupportedError(RuntimeError):
+    """Raised when an agent asks for human input over a transport that has none.
+
+    ACP elicitation is not wired in this version. Failing loudly beats hanging
+    forever on a prompt the Client will never be asked to answer.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "The agent requested human input, but ACPAgent does not implement ACP "
+            "elicitation yet, so there is nobody to ask. Remove the human-input step "
+            "or serve this agent over a transport that supports it."
+        )
+
+
+class AgentExecutor:
+    """Bridge one ACP prompt turn onto :meth:`Agent._execute`.
+
+    ``Agent._execute`` is private API, used here for the same reason
+    :class:`ag2.a2a.executor.AgentExecutor` uses it: it is the only entry point
+    that takes a pre-built :class:`~ag2.context.Context`, which is how a session's
+    accumulated history reaches the turn. The context is handed to
+    ``Agent._prepare_turn`` first, so an ACP turn resolves its prompts and
+    dependencies through the same path every off-protocol turn uses.
+    """
+
+    __slots__ = ("_agent", "_stream_thoughts")
+
+    def __init__(self, agent: Agent, *, stream_thoughts: bool = False) -> None:
+        self._agent = agent
+        self._stream_thoughts = stream_thoughts
+
+    @property
+    def agent(self) -> Agent:
+        return self._agent
+
+    async def run_turn(
+        self,
+        *,
+        session: "AgentSession",
+        store: "SessionStore",
+        client: acp.Client,
+        blocks: "Sequence[ContentBlock]",
+        meta: dict[str, Any] | None = None,
+    ) -> str:
+        """Run one prompt to completion and return its ACP stop reason.
+
+        Raises :class:`asyncio.CancelledError` if ``session/cancel`` arrives
+        mid-turn; the caller turns that into ``stop_reason="cancelled"``. Events
+        already streamed stay in the session's history either way.
+        """
+        stream = store.stream(session)
+        delivered, subscription = self._forward_updates(stream, client=client, session_id=session.session_id)
+
+        inputs = prompt_to_inputs(blocks)
+        if not inputs:
+            # A prompt of blocks we could not map at all. Send an empty text
+            # input rather than nothing, so the turn is still well-formed.
+            inputs = [TextInput("")]
+
+        try:
+            reply = await self._dispatch(ModelRequest(inputs), stream=stream, session=session, meta=meta)
+            await self._send_final_text(reply, delivered, client=client, session_id=session.session_id)
+        finally:
+            # The stream belongs to the session, not to this turn, so the
+            # subscriber has to come off explicitly — otherwise every prompt
+            # would leave another forwarder behind, and a later turn would send
+            # each update once per prompt the session had ever run.
+            stream.unsubscribe(subscription)
+        return STOP_END_TURN
+
+    def _forward_updates(
+        self, stream: "MemoryStream", *, client: acp.Client, session_id: str
+    ) -> "tuple[list[str], SubId]":
+        """Project this turn's AG2 events onto ``session/update`` notifications.
+
+        A single subscriber handles every event, so notifications reach the
+        Client in stream order.
+
+        Returns the text delivered during the turn's *final* model call — what
+        the final response is compared against, see :meth:`_send_final_text` —
+        along with the subscription id the caller must release when the turn
+        ends.
+        """
+        stream_thoughts = self._stream_thoughts
+        current: list[str] = []
+        final_call: list[str] = []
+
+        # ``subscribe`` returns the id this binding is released by, so the name
+        # holds a ``SubId`` rather than the function.
+        @stream.subscribe
+        async def subscription(event: BaseEvent) -> None:
+            if isinstance(event, ModelResponse):
+                # One model call just ended. A turn can contain several — a
+                # tool-selection call, then the answering call — and each may
+                # stream its own text. Keep only the most recent call's, because
+                # ``reply.response`` describes that call and nothing earlier.
+                final_call[:] = current
+                current.clear()
+                return
+
+            update = event_to_session_update(event, stream_thoughts=stream_thoughts)
+            if update is None:
+                return
+            await self._deliver(update, client=client, session_id=session_id)
+            # Recorded only *after* the notification is on the wire. Counting a
+            # chunk we failed to send would make the de-dup below suppress the
+            # final text too, and the Client would end the turn having received
+            # nothing at all.
+            if isinstance(event, ModelMessageChunk):
+                current.append(event.content)
+
+        return final_call, subscription
+
+    async def _send_final_text(
+        self,
+        reply: Any,
+        delivered: list[str],
+        *,
+        client: acp.Client,
+        session_id: str,
+    ) -> None:
+        """Deliver the final reply text the Client has not already been sent.
+
+        A streaming provider emits the answer as ``ModelMessageChunk``s, which are
+        already on the wire — re-sending the assembled text would show the reply
+        twice. A non-streaming provider emits no chunks at all, so without this
+        the Client would receive an empty turn.
+
+        ``delivered`` is scoped to the turn's *final* model call. Comparing
+        against every chunk of the whole turn would break the moment an earlier
+        call streamed anything of its own: the totals would differ, and the
+        answer would go out a second time.
+        """
+        message = getattr(reply.response, "message", None)
+        final = getattr(message, "content", "") or ""
+        if not final or final == "".join(delivered):
+            return
+        await self._deliver(acp.update_agent_message_text(final), client=client, session_id=session_id)
+
+    async def _deliver(self, update: Any, *, client: acp.Client, session_id: str) -> None:
+        """Push one ``session/update``, letting a delivery failure fail the turn.
+
+        Swallowing this would let a turn answer ``stop_reason="end_turn"`` to a
+        Client that never received the answer — a success report for work it
+        cannot see. The turn's events are already on the session's stream by the
+        time this runs, so history survives regardless; what fails is only the
+        claim that the Client was told.
+        """
+        try:
+            await client.session_update(session_id=session_id, update=update)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("failed to deliver ACP session/update for session %s", session_id, exc_info=True)
+            raise UpdateDeliveryError(session_id) from exc
+
+    async def _dispatch(
+        self,
+        initial_event: BaseEvent,
+        *,
+        stream: "MemoryStream",
+        session: "AgentSession",
+        meta: dict[str, Any] | None,
+    ) -> Any:
+        agent = self._agent
+        if agent.config is None:
+            raise RuntimeError(f"Agent {agent.name!r} has no config; cannot serve it over ACP.")
+
+        # The session's own variables, handed over as-is: this is the same dict
+        # every turn of this conversation sees, so what a tool writes is still
+        # there next prompt. It was seeded by value at ``session/new``, so no
+        # other conversation shares it.
+        variables = session.variables
+        if meta:
+            variables[META_VARIABLE] = meta
+        else:
+            # Metadata belongs to the request that carried it; leaving the
+            # previous one in place would misattribute this turn.
+            variables.pop(META_VARIABLE, None)
+
+        context = ConversationContext(
+            stream,
+            dependencies=dict(agent._agent_dependencies),
+            variables=variables,
+            dependency_provider=agent.dependency_provider,
+        )
+        # Off-protocol turns get this from ``Agent.ask``, which builds its own
+        # context; without it, metrics cannot attribute the turn to its agent.
+        context.dependencies[AGENT_CONTEXT_DEPENDENCY_KEY] = agent
+
+        # ``_prepare_turn`` is private, but it is the only entry point that runs the
+        # standard preparation an off-protocol turn gets: it fills an *empty*
+        # ``context.prompt`` from the static prompt **and** every ``@agent.prompt``
+        # hook, and records the resolved config as a context dependency. Seeding the
+        # prompt here instead would leave it non-empty and silently skip the hooks —
+        # so a served agent would drop the per-request policy those hooks carry,
+        # which the same agent applies under ``ask``.
+        client = await agent._prepare_turn(initial_event, context, None)
+
+        return await agent._execute(
+            initial_event,
+            context=context,
+            client=client,
+            hitl_hook=_reject_human_input,
+        )
+
+
+def _tool_call_batches(events: "Sequence[BaseEvent]") -> "list[ToolCallsEvent]":
+    """Every batch of tool calls in ``events``, from either place they appear.
+
+    A turn persists the model's :class:`ModelResponse` — which already carries
+    ``tool_calls`` — *before* the agent emits the matching
+    :class:`ToolCallsEvent`. Cancelling in that window leaves history holding
+    calls that no ``ToolCallsEvent`` describes, so reading only the latter would
+    find nothing to repair and leave the transcript with an unanswered call.
+
+    Batches are deduplicated by call id, because the usual case is both records
+    present and describing the same calls.
+    """
+    batches: list[ToolCallsEvent] = []
+    seen: set[str] = set()
+    for event in events:
+        calls = (
+            event.tool_calls.calls
+            if isinstance(event, ModelResponse) and event.tool_calls
+            else event.calls
+            if isinstance(event, ToolCallsEvent)
+            else []
+        )
+        fresh = [call for call in calls if call.id not in seen]
+        if not fresh:
+            continue
+        seen.update(call.id for call in fresh)
+        batches.append(ToolCallsEvent(fresh))
+    return batches
+
+
+def isolate_variables(defaults: dict[Any, Any]) -> dict[Any, Any]:
+    """Seed one session's variables from the agent's defaults, by value.
+
+    A shallow copy is not enough. It stops one session *rebinding* a key another
+    session reads, but every nested list, dict or object stays a shared
+    reference — so one conversation appending to a list is immediately visible in
+    all the others. Sessions are supposed to be independent conversations, and a
+    budget, an approval list or a workflow accumulator is exactly the kind of
+    value that gets stored nested.
+
+    A value that cannot be deep-copied (an open handle, a lock, a client) is kept
+    as a shared reference and named in a warning, because silently degrading to
+    sharing is how the original bug looked from the outside.
+    """
+    isolated: dict[Any, Any] = {}
+    for key, value in defaults.items():
+        try:
+            isolated[key] = deepcopy(value)
+        except Exception:
+            logger.warning(
+                "ACP session variable %r could not be copied and is shared across sessions; "
+                "mutating it in one conversation will affect the others.",
+                key,
+            )
+            isolated[key] = value
+    return isolated
+
+
+async def heal_cancelled_turn(stream: "MemoryStream") -> int:
+    """Close off tool calls a cancelled turn left unanswered. Returns how many.
+
+    Cancelling stops the turn wherever it happened to be, which can be *between*
+    a tool call and its result. That leaves history holding an assistant
+    tool-call with nothing answering it — and providers reject that shape, so the
+    session would fail on its next prompt even though cancelling is supposed to
+    be a normal, recoverable thing to do.
+
+    Appending a synthetic result per unanswered call keeps the transcript valid
+    and tells the model plainly what happened, rather than rewriting history to
+    pretend the call was never made.
+    """
+    events = list(await stream.history.get_events())
+
+    # A batch counts as settled only once a ``ToolResultsEvent`` covers it —
+    # that wrapper is what providers serialize. A loose ``ToolResultEvent`` left
+    # behind by a tool that *did* finish is not enough on its own: a partially
+    # completed batch would otherwise be rebuilt with the finished call missing,
+    # and the transcript would carry more tool calls than tool results.
+    settled = {r.parent_id for e in events if isinstance(e, ToolResultsEvent) for r in e.results}
+    completed = {e.parent_id: e for e in events if isinstance(e, ToolResultEvent) and e.parent_id not in settled}
+
+    repaired: list[ToolResultsEvent] = []
+    closed = 0
+    for event in _tool_call_batches(events):
+        pending = [call for call in event.calls if call.id not in settled]
+        if not pending:
+            continue
+        # Rebuild the *whole* outstanding batch: results that did land, plus a
+        # stand-in for each call the cancellation cut short.
+        results = []
+        for call in pending:
+            done = completed.get(call.id)
+            results.append(
+                done
+                if done is not None
+                else ToolResultEvent(
+                    parent_id=call.id,
+                    name=call.name,
+                    result=ToolResult(CANCELLED_TOOL_RESULT),
+                )
+            )
+            closed += int(done is None)
+        repaired.append(ToolResultsEvent(results))
+
+    if not repaired:
+        return 0
+
+    await stream.history.replace([*events, *repaired])
+    return closed
+
+
+async def _reject_human_input(event: BaseEvent, context: Any) -> str:
+    """``hitl_hook`` that fails the turn instead of waiting forever.
+
+    Declared as returning ``str`` to satisfy the hook signature; it never
+    returns. See :class:`HumanInputUnsupportedError`.
+    """
+    raise HumanInputUnsupportedError

--- a/ag2/acp/guard.py
+++ b/ag2/acp/guard.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Reject ACP requests whose ``_meta`` would overwrite a validated parameter.
+
+The SDK's router expands a request into keyword arguments and then merges the
+request's ``_meta`` on top (``acp/router.py``: ``params.update(meta)``). Metadata
+therefore *wins* over the protocol's own fields: a request carrying
+``_meta: {"session_id": "..."}`` reaches the handler with its ``session_id``
+silently replaced, and with no trace of the substitution left in ``**kwargs``.
+
+That matters because ``_meta`` is the one part of a request an application is
+encouraged to fill with data from elsewhere — AG2 Space provenance, say. Data
+that came from a chat room must not be able to name the session a prompt runs
+against.
+
+By the time a handler runs the original value is gone, so the check has to
+happen earlier: this module wraps the router and refuses any request whose
+metadata collides with a field of that request, before the merge takes place.
+"""
+
+import asyncio
+import logging
+from typing import Any
+
+from acp import schema
+from acp.exceptions import RequestError
+
+logger = logging.getLogger(__name__)
+
+# ``_meta`` as it appears on the wire; the request models call it ``field_meta``.
+META_KEY = "_meta"
+
+
+def _reserved_names(model: type) -> frozenset[str]:
+    """Every name a request's fields answer to — field name and JSON alias."""
+    names: set[str] = set()
+    for name, field in getattr(model, "model_fields", {}).items():
+        names.add(name)
+        if field.alias:
+            names.add(field.alias)
+    names.discard("field_meta")
+    return frozenset(names)
+
+
+# Built once from the SDK's own models, so a protocol addition is covered
+# automatically rather than needing this list to be maintained by hand.
+_RESERVED: dict[str, frozenset[str]] = {
+    "initialize": _reserved_names(schema.InitializeRequest),
+    "authenticate": _reserved_names(schema.AuthenticateRequest),
+    "session/new": _reserved_names(schema.NewSessionRequest),
+    "session/load": _reserved_names(schema.LoadSessionRequest),
+    "session/prompt": _reserved_names(schema.PromptRequest),
+    "session/cancel": _reserved_names(schema.CancelNotification),
+}
+
+
+def colliding_meta_keys(method: str, params: Any) -> frozenset[str]:
+    """Metadata keys in ``params`` that would displace one of ``method``'s fields."""
+    reserved = _RESERVED.get(method)
+    if not reserved or not isinstance(params, dict):
+        return frozenset()
+    meta = params.get(META_KEY)
+    if not isinstance(meta, dict):
+        return frozenset()
+    return frozenset(reserved.intersection(meta))
+
+
+def guard_router(handler: Any) -> Any:
+    """Wrap an ACP message handler so colliding ``_meta`` is refused, not merged.
+
+    Rejecting is the only honest option: the substitution is indistinguishable
+    from a legitimate request once the merge has happened, so there is nothing
+    left to sanitize downstream.
+    """
+
+    async def guarded(method: str, params: Any = None, is_notification: bool = False) -> Any:
+        collisions = colliding_meta_keys(method, params)
+        if collisions:
+            listed = ", ".join(sorted(collisions))
+            logger.warning("rejected %s: _meta would overwrite the request field(s) %s", method, listed)
+            if is_notification:
+                # No response channel on a notification — dropping it is the
+                # whole remedy, and acting on it is what we must not do.
+                return None
+            raise RequestError.invalid_params({
+                "reason": f"_meta may not contain the reserved request field(s): {listed}",
+            })
+        return await handler(method, params, is_notification)
+
+    return guarded
+
+
+async def serve(agent: Any, reader: Any, writer: Any) -> None:
+    """Run ``agent`` over the given streams with the ``_meta`` guard installed.
+
+    Equivalent to :func:`acp.run_agent`, plus :func:`guard_router`. The guard has
+    to sit between the transport and the router, which is one layer below what
+    ``run_agent`` exposes — hence assembling the connection here instead.
+
+    ``agent`` may be a callable taking the Client, in which case it is invoked
+    once for this connection. That is how :class:`~ag2.acp.agent.ACPAgent` gives
+    each connection its own authorization and sessions — and since that scope is
+    created here, releasing it is this function's job too: nothing else ever sees
+    it, so nobody else could.
+    """
+    from acp.agent.connection import AgentSideConnection
+
+    # ``AgentSideConnection`` invokes the factory and keeps the result to itself,
+    # so intercept it on the way past. Only what the factory produced is closed
+    # below: a caller who passes a ready-made agent object still owns it.
+    scope: Any = None
+
+    def bind(client: Any) -> Any:
+        nonlocal scope
+        scope = agent(client)
+        return scope
+
+    # ``AgentSideConnection`` takes (input=writer, output=reader).
+    conn = AgentSideConnection(bind if callable(agent) else agent, writer, reader, listening=False)
+    # The router is built inside ``AgentSideConnection`` and is not exposed, so
+    # the guard is installed by wrapping it here — before anything is read off
+    # the wire, and before any handler can be reached.
+    conn._conn._handler = guard_router(conn._conn._handler)
+    try:
+        await conn.listen()
+    finally:
+        try:
+            # Shielded like ``acp.run_agent`` does: teardown must finish even when
+            # the surrounding task is being cancelled.
+            await asyncio.shield(conn.close())
+        finally:
+            # Strictly after the connection, which is what stops the in-flight
+            # handlers: closing the scope cancels live turns and deletes their
+            # histories, so a handler still running would be writing into a store
+            # that had just been purged. In its own ``finally`` because a failed
+            # ``conn.close()`` is no reason to strand a Client's sessions.
+            await asyncio.shield(_release(scope))
+
+
+async def _release(scope: Any) -> None:
+    """Close the per-connection scope, if the factory produced a closable one.
+
+    ``serve`` is usable with any object implementing the SDK's Agent protocol, and
+    that protocol says nothing about teardown — so this is opt-in rather than
+    required, and an agent with no per-connection state to drop simply has no
+    ``aclose``.
+    """
+    aclose = getattr(scope, "aclose", None)
+    if aclose is None:
+        return
+    await aclose()

--- a/ag2/acp/mappers.py
+++ b/ag2/acp/mappers.py
@@ -6,16 +6,39 @@
 Functions here take the ``acp.schema`` model objects directly (no ``model_dump``
 indirection) and dispatch with :func:`isinstance`, so the mapping is checked
 against the real SDK types rather than stringly-typed dicts.
+
+Both directions live here:
+
+* **ACP -> AG2** (:func:`map_session_update`, :func:`content_blocks_to_text`, …)
+  serves the *client* side — AG2 driving an external CLI agent.
+* **AG2 -> ACP** (:func:`prompt_to_inputs`, :func:`event_to_session_update`)
+  serves the *serving* side — :class:`~ag2.acp.agent.ACPAgent` exposing an AG2
+  agent to an ACP Client.
 """
 
 import base64
 import json
 import logging
 from collections.abc import Sequence
+from typing import Any, cast
 
+import acp
 from acp import schema
 
-from ag2.events import BaseEvent, ModelMessageChunk, ModelReasoning
+from ag2.events import (
+    AudioInput,
+    BaseEvent,
+    DataInput,
+    DocumentInput,
+    ImageInput,
+    Input,
+    ModelMessageChunk,
+    ModelReasoning,
+    TextInput,
+    ToolCallEvent,
+    ToolErrorEvent,
+    ToolResultEvent,
+)
 from ag2.events.tool_events import BuiltinToolCallEvent, BuiltinToolResultEvent, ToolResult
 from ag2.events.types import BinaryResult, Usage
 
@@ -23,6 +46,10 @@ from .events import ACPAvailableCommands, ACPModeChange, ACPPlan, ACPPlanEntry
 from .types import ContentBlock, SessionUpdate, ToolCallContent
 
 logger = logging.getLogger(__name__)
+
+# AG2 tool events carry no ACP ``kind`` (read / edit / execute / …), and guessing
+# one from a tool's name would be wrong more often than useful.
+DEFAULT_TOOL_KIND: "schema.ToolKind" = "other"
 
 
 def block_text(block: ContentBlock | None) -> str:
@@ -125,3 +152,137 @@ def map_session_update(update: SessionUpdate) -> BaseEvent | None:
 
 def _plan(entries: "Sequence[schema.PlanEntry]") -> ACPPlan:
     return ACPPlan(entries=[ACPPlanEntry(content=e.content, status=e.status, priority=e.priority) for e in entries])
+
+
+def block_to_input(block: ContentBlock) -> Input | None:
+    """Translate one ACP prompt content block into an AG2 input.
+
+    Returns ``None`` for a block this version has no AG2 representation for —
+    the caller decides whether to drop it or fail.
+
+    Resource *links* are deliberately not fetched: a URI named by a Client is
+    context, not authorization to dereference it. The link is passed through as
+    text so the model can see it was referenced.
+    """
+    if isinstance(block, schema.TextContentBlock):
+        return TextInput(block.text)
+
+    if isinstance(block, schema.ImageContentBlock):
+        if block.data:
+            return ImageInput(data=base64.b64decode(block.data), media_type=cast(Any, block.mime_type))
+        return ImageInput(block.uri) if block.uri else None
+
+    if isinstance(block, schema.AudioContentBlock):
+        return AudioInput(data=base64.b64decode(block.data), media_type=cast(Any, block.mime_type))
+
+    if isinstance(block, schema.EmbeddedResourceContentBlock):
+        resource = block.resource
+        if isinstance(resource, schema.TextResourceContents):
+            return TextInput(resource.text)
+        # A blob the Client inlined — its bytes travelled with the prompt, so
+        # using them reads nothing from the host filesystem.
+        return DocumentInput(
+            data=base64.b64decode(resource.blob),
+            media_type=cast(Any, resource.mime_type or "application/octet-stream"),
+        )
+
+    if isinstance(block, schema.ResourceContentBlock):
+        label = block.name or block.title or block.uri
+        return TextInput(f"[resource] {label} ({block.uri})")
+
+    return None
+
+
+def prompt_to_inputs(blocks: "Sequence[ContentBlock]") -> list[Input]:
+    """Translate an ACP ``session/prompt`` payload into AG2 inputs, in order.
+
+    Blocks with no AG2 equivalent are logged and skipped rather than failing the
+    turn — a Client sending one richer block should not lose the rest of its
+    prompt.
+    """
+    inputs: list[Input] = []
+    for block in blocks:
+        mapped = block_to_input(block)
+        if mapped is None:
+            logger.debug("no AG2 input for ACP content block %r; skipped", getattr(block, "type", block))
+            continue
+        inputs.append(mapped)
+    return inputs
+
+
+def event_to_session_update(event: BaseEvent, *, stream_thoughts: bool = False) -> SessionUpdate | None:
+    """Translate one AG2 event into an ACP ``session/update``.
+
+    Returns ``None`` for events with no ACP equivalent, so the caller can drop
+    them without a branch per event type.
+
+    ``stream_thoughts`` gates :class:`ModelReasoning`. Reasoning is internal by
+    default and an ACP Client may be an external audience, so exposing it is an
+    explicit opt-in rather than a side effect of connecting.
+
+    The final :class:`~ag2.events.ModelResponse` is intentionally *not* mapped:
+    its text was already delivered chunk by chunk, and re-sending it would show
+    the reply twice.
+    """
+    if isinstance(event, ModelMessageChunk):
+        return acp.update_agent_message_text(event.content)
+
+    if isinstance(event, ModelReasoning):
+        return acp.update_agent_thought_text(event.content) if stream_thoughts else None
+
+    # ToolErrorEvent subclasses ToolResultEvent, so it must be tested first.
+    if isinstance(event, ToolErrorEvent):
+        return acp.update_tool_call(
+            event.parent_id,
+            title=event.name,
+            status="failed",
+            content=[acp.tool_content(acp.text_block(str(event.error)))],
+        )
+
+    if isinstance(event, ToolResultEvent):
+        return acp.update_tool_call(
+            event.parent_id,
+            title=event.name,
+            status="completed",
+            content=[acp.tool_content(acp.text_block(tool_result_text(event.result)))],
+        )
+
+    if isinstance(event, ToolCallEvent):
+        return acp.start_tool_call(
+            event.id,
+            title=event.name,
+            kind=DEFAULT_TOOL_KIND,
+            status="in_progress",
+            raw_input=event.serialized_arguments,
+        )
+
+    return None
+
+
+def tool_result_text(result: ToolResult) -> str:
+    """Flatten a tool result's parts into the text ACP carries in ``content``.
+
+    A tool returning a non-string (an ``int``, a ``dict``) is coerced by AG2 into
+    a :class:`DataInput`, so rendering only :class:`TextInput` would show every
+    such result as a placeholder. Binary parts *are* placeheld — their bytes have
+    no faithful text form and must not be smuggled into a text block.
+    """
+    pieces: list[str] = []
+    for part in result.parts:
+        if isinstance(part, TextInput):
+            pieces.append(part.content)
+        elif isinstance(part, DataInput):
+            pieces.append(_render_data(part.data))
+        else:
+            pieces.append(f"[{getattr(part, 'kind', 'binary')}]")
+    return "".join(pieces)
+
+
+def _render_data(data: Any) -> str:
+    """Render a ``DataInput`` payload as text, preferring JSON for structures."""
+    if isinstance(data, str):
+        return data
+    try:
+        return json.dumps(data)
+    except (TypeError, ValueError):
+        return str(data)

--- a/ag2/acp/mappers.py
+++ b/ag2/acp/mappers.py
@@ -263,9 +263,9 @@ def tool_result_text(result: ToolResult) -> str:
     """Flatten a tool result's parts into the text ACP carries in ``content``.
 
     A tool returning a non-string (an ``int``, a ``dict``) is coerced by AG2 into
-    a :class:`DataInput`, so rendering only :class:`TextInput` would show every
-    such result as a placeholder. Binary parts *are* placeheld — their bytes have
-    no faithful text form and must not be smuggled into a text block.
+    a :class:`DataInput`, so rendering only :class:`TextInput` would reduce every
+    such result to a placeholder. Binary parts *do* get a placeholder — their
+    bytes have no faithful text form and must not be smuggled into a text block.
     """
     pieces: list[str] = []
     for part in result.parts:

--- a/ag2/acp/sessions.py
+++ b/ag2/acp/sessions.py
@@ -29,6 +29,8 @@ from uuid import UUID, uuid4
 from ag2.history import MemoryStorage, Storage
 from ag2.stream import MemoryStream
 
+from .types import McpServer
+
 logger = logging.getLogger(__name__)
 
 __all__ = (
@@ -169,7 +171,7 @@ class AgentSession:
     stream_id: UUID
     cwd: str = "."
     additional_directories: list[str] = field(default_factory=list)
-    mcp_servers: list[Any] = field(default_factory=list)
+    mcp_servers: list[McpServer] = field(default_factory=list)
     meta: dict[str, Any] = field(default_factory=dict)
     max_queued: int = 8
 

--- a/ag2/acp/sessions.py
+++ b/ag2/acp/sessions.py
@@ -1,0 +1,575 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Agent-side ACP session state.
+
+An ACP session is one independent conversation. Unlike MCP — where the session id
+is supplied by the transport — ACP mints the id explicitly at ``session/new``, so
+:class:`SessionStore` generates it and hands it back to the Client.
+
+Each session owns a slice of history over a shared :class:`~ag2.history.Storage`,
+keyed by its own stream id, plus the run-scoped state a turn needs: the task
+currently executing (what ``session/cancel`` kills) and the queue of prompts
+waiting behind it.
+
+Not to be confused with the *client*-side :class:`~ag2.acp.session.ACPSession`,
+which owns a subprocess connection to an external CLI agent.
+"""
+
+import asyncio
+import logging
+import time
+from collections import OrderedDict
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+from ag2.history import MemoryStorage, Storage
+from ag2.stream import MemoryStream
+
+logger = logging.getLogger(__name__)
+
+__all__ = (
+    "AgentSession",
+    "SessionConfig",
+    "SessionLimitError",
+    "SessionStore",
+    "UnknownSessionError",
+)
+
+
+class UnknownSessionError(KeyError):
+    """Raised when a Client names a session id the store has never issued.
+
+    The ACP agent turns this into a protocol error rather than letting it
+    surface as an unhandled exception.
+    """
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__(session_id)
+        self.session_id = session_id
+
+    def __str__(self) -> str:
+        return f"Unknown ACP session id: {self.session_id!r}"
+
+
+class SessionLimitError(RuntimeError):
+    """Raised when a new session cannot be admitted without breaking the cap.
+
+    Only fires when the registry is full *and* every session in it is busy, so
+    there is nothing safe to evict. Refusing admission is what keeps
+    ``max_sessions`` a real bound: the alternative — letting the registry grow
+    while turns are in flight — is no bound at all, because a Client can hold
+    every session busy indefinitely.
+    """
+
+    def __init__(self, max_sessions: int) -> None:
+        super().__init__(max_sessions)
+        self.max_sessions = max_sessions
+
+    def __str__(self) -> str:
+        return (
+            f"At the {self.max_sessions}-session limit and every session is busy. "
+            "Retry once a turn finishes, or close a session."
+        )
+
+
+class ConnectionOverloadedError(RuntimeError):
+    """Raised when a connection already has ``max_active_prompts`` in flight.
+
+    The per-session bounds cannot see each other, so this is what stops one
+    Client spreading its load across many sessions and leaving the connection
+    itself unbounded.
+    """
+
+    def __init__(self, max_active_prompts: int) -> None:
+        super().__init__(max_active_prompts)
+        self.max_active_prompts = max_active_prompts
+
+    def __str__(self) -> str:
+        return f"This connection already has {self.max_active_prompts} prompts in flight. Retry once one finishes."
+
+
+class SessionBusyError(RuntimeError):
+    """Raised when a session's prompt queue is already at ``max_queued``.
+
+    Prompts on a busy session normally *wait* (see :meth:`AgentSession.turn`);
+    this fires only on overflow, so a chatty Client cannot grow memory without
+    bound.
+    """
+
+    def __init__(self, session_id: str, max_queued: int) -> None:
+        super().__init__(session_id, max_queued)
+        self.session_id = session_id
+        self.max_queued = max_queued
+
+    def __str__(self) -> str:
+        return f"ACP session {self.session_id!r} already has {self.max_queued} prompts queued."
+
+
+@dataclass(frozen=True, slots=True)
+class SessionConfig:
+    """Tunables for :class:`SessionStore`.
+
+    Mirrors :class:`ag2.mcp.sessions.SessionConfig` — the two AG2 protocol
+    adapters should bound their session registries the same way — plus
+    ``max_queued``, which ACP needs because it lets a Client fire a second
+    ``session/prompt`` while the first is still running.
+
+    * ``max_sessions`` — LRU cap; the least-recently-used session is dropped
+      (and its history deleted) once the cap is exceeded.
+    * ``ttl`` — optional idle expiry in seconds; a session untouched for longer
+      is dropped on the next access (``None`` = no expiry).
+    * ``storage`` — pluggable history backend shared across sessions, each keyed
+      by its own stream id. Defaults to an in-memory :class:`MemoryStorage`.
+    * ``max_queued`` — how many prompts may wait behind the running turn on one
+      session before further prompts are rejected.
+
+    The two bounds above are *per session*, which on their own leave the whole
+    connection unbounded: a Client may hold ``max_sessions`` conversations and
+    start a paid turn in every one of them at once. These cap the connection as a
+    whole:
+
+    * ``max_concurrent_turns`` — how many turns may run at the same time across
+      all sessions. Prompts past this wait for a slot rather than being refused,
+      since a burst across separate conversations is normal traffic, not abuse.
+      This is the knob that bounds spend and provider rate-limit pressure.
+    * ``max_active_prompts`` — how many prompts may be admitted at once across
+      all sessions, running and waiting together. Past this, prompts are refused,
+      so an unbounded queue of parked request handlers cannot build up.
+    """
+
+    max_sessions: int = 1024
+    ttl: float | None = None
+    storage: Storage | None = None
+    max_queued: int = 8
+    max_concurrent_turns: int = 8
+    max_active_prompts: int = 64
+
+
+@dataclass(slots=True)
+class AgentSession:
+    """One ACP session: its identity, its history slice, and its live turn state.
+
+    ``stream_id`` names this session's slice of the shared
+    :class:`~ag2.history.Storage`; :attr:`stream` is the one stream object built
+    against it and kept for the session's lifetime, so an inbox message or a
+    background task outliving its turn is still reachable from the next one (see
+    :meth:`SessionStore.stream`).
+
+    ``cwd``, ``additional_directories``, ``mcp_servers`` and ``meta`` are
+    Client-provided *context*, captured verbatim and acted on by nothing here.
+    Per the ACP integration design, a path named by a Client is not authority to
+    reach it; an embedding application decides what, if anything, to honour.
+    """
+
+    session_id: str
+    stream_id: UUID
+    cwd: str = "."
+    additional_directories: list[str] = field(default_factory=list)
+    mcp_servers: list[Any] = field(default_factory=list)
+    meta: dict[str, Any] = field(default_factory=dict)
+    max_queued: int = 8
+
+    # This conversation's context variables. Seeded from the agent's defaults at
+    # ``session/new`` and then owned by the session: the same dict is handed to
+    # every turn, so a tool's writes survive into the next prompt the way they do
+    # across ``AgentReply.ask``. Seeded by *value*, so one conversation's writes
+    # are invisible to another — see :func:`ag2.acp.executor.isolate_variables`.
+    variables: dict[Any, Any] = field(default_factory=dict)
+
+    # Clock the session stamps ``last_active`` from; injected so tests can drive
+    # expiry deterministically.
+    clock: Callable[[], float] = field(default=time.monotonic, compare=False, repr=False)
+    # When this session was last *used* — set on every access and, crucially,
+    # again when a turn finishes. Idle expiry measures from here, so a turn that
+    # runs longer than the TTL cannot expire the session it is running in.
+    last_active: float = field(default=0.0, compare=False, repr=False)
+
+    # This session's stream, created on first use and kept for the session's
+    # lifetime so its inbox and background tasks survive between turns. Run
+    # state, not identity.
+    stream: "MemoryStream | None" = field(default=None, compare=False, repr=False)
+
+    # Run-scoped, not identity. The task currently driving a turn — the handle
+    # ``session/cancel`` acts on. AG2 has no turn-level cancel API, so cancelling
+    # the task is the mechanism (the same one ``ag2/a2a/executor.py`` relies on).
+    turn_task: "asyncio.Task[Any] | None" = field(default=None, compare=False, repr=False)
+
+    # Serializes turns on this session so their histories cannot interleave.
+    _turn_lock: asyncio.Lock = field(default_factory=asyncio.Lock, compare=False, repr=False)
+    # Prompts admitted but not yet running — the bound ``max_queued`` applies to.
+    # Counted, not stored: the waiters are coroutines parked on ``_turn_lock``.
+    _queued: int = field(default=0, compare=False, repr=False)
+    # Prompts admitted and not yet finished (waiting *plus* the one running).
+    # Drives the cancel latch: it clears only once the whole batch has drained.
+    _inflight: int = field(default=0, compare=False, repr=False)
+    # Set while a cancel is in force, so prompts already queued behind the
+    # cancelled turn abort instead of running. Cleared once the queue drains.
+    _cancelled: bool = field(default=False, compare=False, repr=False)
+
+    @property
+    def queued(self) -> int:
+        """Prompts currently waiting behind the running turn."""
+        return self._queued
+
+    @property
+    def inflight(self) -> int:
+        """Prompts admitted and not yet finished, including the running one."""
+        return self._inflight
+
+    @property
+    def is_idle(self) -> bool:
+        """Whether this session has no work running or waiting.
+
+        Only an idle session may be evicted; see
+        :meth:`SessionStore._evict_overflow`.
+        """
+        task = self.turn_task
+        return self._inflight == 0 and (task is None or task.done())
+
+    @property
+    def cancelled(self) -> bool:
+        """Whether a ``session/cancel`` is still draining this session's queue."""
+        return self._cancelled
+
+    async def cancel(self) -> None:
+        """Cancel the running turn and every prompt queued behind it.
+
+        ``session/cancel`` names a *session*, so its blast radius is this whole
+        session and nothing else — other sessions are untouched. Cancelling the
+        running turn only, and letting the queue roll on, would make a stop
+        button start the next thing the user typed.
+
+        Events already emitted are left alone: cancelling the task does not
+        touch the stream, so completed work stays in history.
+        """
+        self._cancelled = self._inflight > 0 or self.turn_task is not None
+        task = self.turn_task
+        if task is not None and not task.done():
+            task.cancel()
+
+    @asynccontextmanager
+    async def recovery(self) -> AsyncIterator[None]:
+        """Hold the turn lock for post-cancellation repair.
+
+        Repairing a cancelled turn is a read-modify-write over the session's
+        whole history, so it has to exclude the next prompt: otherwise a new turn
+        can start on a transcript that still has an unanswered tool call, or
+        append events that the repair then overwrites with its stale snapshot.
+
+        Unlike :meth:`turn` this ignores the queue bound and the cancel latch —
+        recovery is not a prompt, and it is precisely what has to happen *while*
+        the latch is still set.
+        """
+        async with self._turn_lock:
+            yield
+
+    @asynccontextmanager
+    async def turn(self) -> AsyncIterator[None]:
+        """Hold this session's turn lock for the duration of one prompt.
+
+        Concurrent prompts on one session queue rather than interleave —
+        matching :meth:`ag2.mcp.sessions.SessionStore.session`. ``max_queued``
+        bounds the prompts *waiting*, not counting the one running, so a session
+        admits ``max_queued + 1`` at a time; past that,
+        :class:`SessionBusyError`. A prompt that was still waiting when
+        :meth:`cancel` ran raises :class:`asyncio.CancelledError` without ever
+        reaching the agent.
+        """
+        if self._queued >= self.max_queued:
+            raise SessionBusyError(self.session_id, self.max_queued)
+        # Only count as queued while actually waiting: once this prompt holds the
+        # lock it is the running turn, and the queue behind it is free again.
+        waiting = self._turn_lock.locked()
+        self._queued += int(waiting)
+        self._inflight += 1
+        try:
+            async with self._turn_lock:
+                if waiting:
+                    self._queued -= 1
+                    waiting = False
+                if self._cancelled:
+                    raise asyncio.CancelledError
+                yield
+        finally:
+            self._queued -= int(waiting)
+            self._inflight -= 1
+            # Restamp on the way out. Idle expiry is measured from the last time
+            # the session was *used*, and a turn only just finished — without
+            # this, a turn that outlives the TTL would leave behind a session
+            # already stale enough for the next sweep to delete.
+            self.last_active = self.clock()
+            # Last one out clears the cancel latch, so the session is usable
+            # again for prompts that arrive after the cancelled batch drained.
+            if self._inflight == 0:
+                self._cancelled = False
+                self.turn_task = None
+
+
+async def _stop_background(session: AgentSession) -> None:
+    """Cancel the background work a session's stream is still carrying.
+
+    ``spawn_background`` hands a tool or subagent a task that deliberately
+    outlives the turn that started it. That is fine while the session is alive;
+    once it is being torn down, the Client that asked for the work is gone and
+    anything the task still does reaches the outside world unattributed.
+    """
+    stream = session.stream
+    if stream is None:
+        return
+    tasks = [task for task in getattr(stream, "_background_tasks", ()) if not task.done()]
+    for task in tasks:
+        task.cancel()
+    for task in tasks:
+        with suppress(asyncio.CancelledError, Exception):
+            await task
+
+
+class SessionStore:
+    """Bounded LRU registry of :class:`AgentSession`, keyed by ACP session id.
+
+    Adapted from :class:`ag2.mcp.sessions.SessionStore`: same LRU-plus-TTL
+    bounding and the same "fresh :class:`MemoryStream` per turn over a stable
+    stream id" arrangement, with the id minted here (ACP's ``session/new``
+    returns it) instead of arriving from the transport.
+    """
+
+    __slots__ = (
+        "_storage",
+        "_max",
+        "_ttl",
+        "_max_queued",
+        "_sessions",
+        "_lock",
+        "_clock",
+        "_turn_slots",
+        "_max_active_prompts",
+        "_active_prompts",
+    )
+
+    def __init__(
+        self,
+        *,
+        max_sessions: int = 1024,
+        ttl: float | None = None,
+        storage: Storage | None = None,
+        max_queued: int = 8,
+        max_concurrent_turns: int = 8,
+        max_active_prompts: int = 64,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if max_sessions < 1:
+            raise ValueError(f"max_sessions must be >= 1, got {max_sessions}.")
+        if ttl is not None and ttl <= 0:
+            raise ValueError(f"ttl must be > 0 when set, got {ttl}.")
+        if max_queued < 1:
+            raise ValueError(f"max_queued must be >= 1, got {max_queued}.")
+        if max_concurrent_turns < 1:
+            raise ValueError(f"max_concurrent_turns must be >= 1, got {max_concurrent_turns}.")
+        if max_active_prompts < max_concurrent_turns:
+            raise ValueError(
+                f"max_active_prompts ({max_active_prompts}) must be >= max_concurrent_turns "
+                f"({max_concurrent_turns}); otherwise no turn could ever reach a slot."
+            )
+        self._storage = storage or MemoryStorage()
+        self._max = max_sessions
+        self._ttl = ttl
+        self._max_queued = max_queued
+        # OrderedDict order is the LRU order; each session carries its own
+        # ``last_active`` stamp, which is what idle expiry measures.
+        self._sessions: OrderedDict[str, AgentSession] = OrderedDict()
+        self._lock = asyncio.Lock()
+        self._clock = clock
+        self._turn_slots = asyncio.Semaphore(max_concurrent_turns)
+        self._max_active_prompts = max_active_prompts
+        self._active_prompts = 0
+
+    @classmethod
+    def from_config(cls, config: SessionConfig) -> "SessionStore":
+        return cls(
+            max_sessions=config.max_sessions,
+            ttl=config.ttl,
+            storage=config.storage,
+            max_queued=config.max_queued,
+            max_concurrent_turns=config.max_concurrent_turns,
+            max_active_prompts=config.max_active_prompts,
+        )
+
+    @property
+    def max_queued(self) -> int:
+        return self._max_queued
+
+    @property
+    def active_prompts(self) -> int:
+        """Prompts admitted across all this connection's sessions, running or waiting."""
+        return self._active_prompts
+
+    @asynccontextmanager
+    async def admit(self) -> AsyncIterator[None]:
+        """Admit one prompt against the connection-wide bounds.
+
+        Wraps the whole prompt, *outside* the session's own turn lock, so a
+        prompt queued behind its session still counts against
+        ``max_active_prompts``. That is the point: the cost being bounded here is
+        a parked request handler, which exists whether or not its turn has
+        started.
+        """
+        if self._active_prompts >= self._max_active_prompts:
+            raise ConnectionOverloadedError(self._max_active_prompts)
+        self._active_prompts += 1
+        try:
+            yield
+        finally:
+            self._active_prompts -= 1
+
+    @asynccontextmanager
+    async def running_turn(self) -> AsyncIterator[None]:
+        """Hold one of the connection's concurrent-turn slots.
+
+        Taken *inside* the session's turn lock, so a prompt waiting its turn on a
+        busy session does not sit on a slot another session could be using.
+        """
+        async with self._turn_slots:
+            yield
+
+    @property
+    def storage(self) -> Storage:
+        return self._storage
+
+    def __len__(self) -> int:
+        return len(self._sessions)
+
+    async def create(self, **context: Any) -> AgentSession:
+        """Mint a new session id and register it. ``context`` seeds ``AgentSession``.
+
+        Raises :class:`SessionLimitError` when the registry is full and every
+        session in it is busy — see that class for why admission is refused
+        rather than the cap being stretched.
+        """
+        async with self._lock:
+            now = self._clock()
+            await self._evict_expired(now)
+            await self._make_room()
+            session = AgentSession(
+                session_id=uuid4().hex,
+                stream_id=uuid4(),
+                max_queued=self._max_queued,
+                clock=self._clock,
+                last_active=now,
+                **context,
+            )
+            self._sessions[session.session_id] = session
+            return session
+
+    async def get(self, session_id: str) -> AgentSession:
+        """Return a live session, refreshing its LRU position.
+
+        Raises :class:`UnknownSessionError` for an id this store never issued or
+        has since evicted.
+        """
+        async with self._lock:
+            now = self._clock()
+            await self._evict_expired(now)
+            session = self._sessions.get(session_id)
+            if session is None:
+                raise UnknownSessionError(session_id)
+            session.last_active = now
+            self._sessions.move_to_end(session_id)
+            return session
+
+    def stream(self, session: AgentSession) -> MemoryStream:
+        """``session``'s stream, created once and kept for its lifetime.
+
+        A fresh object per turn — the shape :class:`ag2.mcp.sessions.SessionStore`
+        uses — keeps per-turn subscribers from piling up, but a stream carries
+        more than history. Its inbox (``pending_messages``) and its background
+        tasks live on the object, so a background task finishing after the turn
+        that spawned it would deliver onto a stream nobody reads again, and
+        nothing on the session could see that work was still running at teardown.
+
+        Keeping one stream fixes both. Per-turn subscribers are dealt with where
+        they are added, by unsubscribing when the turn ends.
+        """
+        if session.stream is None:
+            session.stream = MemoryStream(storage=self._storage, id=session.stream_id)
+        return session.stream
+
+    async def close(self, session_id: str) -> None:
+        """Cancel a session's live work and drop it, deleting its history.
+
+        Explicit teardown, so unlike eviction it *does* stop work in progress.
+        Durable state belongs to an injected :class:`Storage`; the default
+        in-memory one has none to keep.
+        """
+        async with self._lock:
+            session = self._sessions.pop(session_id, None)
+        if session is None:
+            raise UnknownSessionError(session_id)
+        await self._discard(session)
+
+    async def aclose(self) -> None:
+        """Cancel and drop every session — the shutdown path."""
+        async with self._lock:
+            sessions = list(self._sessions.values())
+            self._sessions.clear()
+        for session in sessions:
+            await self._discard(session)
+
+    async def _discard(self, session: AgentSession) -> None:
+        """Stop a session's work, wait for it to unwind, then delete its history.
+
+        Awaiting the cancelled task matters: dropping history while the turn is
+        still winding down races the agent's own last writes, which would leave
+        the store holding events for a session that no longer exists.
+
+        Background work spawned by a tool or a subagent outlives the turn that
+        started it, so it is stopped here too. Otherwise a closed session could
+        keep calling out to the world long after the Client that asked for it
+        disconnected.
+        """
+        await session.cancel()
+        task = session.turn_task
+        if task is not None and not task.done():
+            with suppress(asyncio.CancelledError, Exception):
+                await task
+        await _stop_background(session)
+        await self._storage.drop_history(session.stream_id)
+
+    async def _evict_expired(self, now: float) -> None:
+        """Drop idle sessions past the TTL.
+
+        A session running or queueing a turn is never expired out from under
+        itself — an eviction policy is a memory bound, not a reason to kill work
+        somebody is waiting on. Its clock restarts when the turn finishes.
+        """
+        if self._ttl is None:
+            return
+        expired = [
+            sid for sid, session in self._sessions.items() if session.is_idle and now - session.last_active > self._ttl
+        ]
+        for sid in expired:
+            session = self._sessions.pop(sid)
+            await self._storage.drop_history(session.stream_id)
+
+    async def _make_room(self) -> None:
+        """Free a slot for one new session, or refuse to admit it.
+
+        Called *before* the new session exists, so there is no risk of choosing
+        it as the victim and handing back an id that is already dead.
+
+        Eviction never takes a session with work running or queued — an eviction
+        policy is a memory bound, not a reason to kill something a Client is
+        waiting on. When nothing idle is left to take, admission fails instead.
+        Stretching the cap "just while turns are in flight" sounds bounded but is
+        not: a Client can keep every session busy indefinitely and grow the
+        registry without limit.
+        """
+        while len(self._sessions) >= self._max:
+            victim = next((sid for sid, session in self._sessions.items() if session.is_idle), None)
+            if victim is None:
+                raise SessionLimitError(self._max)
+            session = self._sessions.pop(victim)
+            await self._storage.drop_history(session.stream_id)

--- a/ag2/acp/testing.py
+++ b/ag2/acp/testing.py
@@ -252,10 +252,10 @@ async def connect(
 ) -> "AsyncGenerator[tuple[ClientSideConnection, RecordingClient]]":
     """Yield a real ACP ``ClientSideConnection`` driving ``server`` in-process.
 
-    Both sides are the genuine SDK connection classes, wired over an in-memory
-    duplex pipe — no subprocess, no sockets — so tests exercise real JSON-RPC
-    framing, dispatch and error mapping. The ACP analogue of
-    :func:`ag2.mcp.testing.connect`.
+    Both sides are the genuine SDK connection classes, wired over a connected
+    socket pair inside this process — no subprocess to spawn and no port to
+    bind — so tests exercise real JSON-RPC framing, dispatch and error mapping.
+    The ACP analogue of :func:`ag2.mcp.testing.connect`.
 
     Yields the connection (call ``new_session``, ``prompt``, … on it) and the
     :class:`RecordingClient` that captured the notifications.

--- a/ag2/acp/testing.py
+++ b/ag2/acp/testing.py
@@ -13,10 +13,11 @@ keep it out of the extra-free :mod:`ag2.testing`.
 """
 
 import asyncio
+import os
 from collections.abc import Awaitable, Callable, Iterator, Sequence
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import acp
 from acp import schema
@@ -27,14 +28,19 @@ from .types import SessionUpdate
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
+    from acp.core import ClientSideConnection
+
     from ag2.context import StreamId
 
+    from .agent import ACPAgent
     from .config import ConnectHook
     from .session import ACPSession
 
 __all__ = (
     "ACPTurn",
     "FakeACPConfig",
+    "RecordingClient",
+    "connect",
     "fake_acp_config",
 )
 
@@ -193,3 +199,101 @@ def fake_acp_config(
 
     config._connect = connect
     return config
+
+
+class RecordingClient:
+    """An :class:`acp.Client` that records every ``session/update`` it receives.
+
+    The server side of the harness: pair it with :func:`connect` to assert on the
+    notifications an :class:`~ag2.acp.agent.ACPAgent` actually emitted, in the
+    order it emitted them.
+
+    Client capabilities are all off — this client implements no filesystem,
+    terminal or permission behaviour, so advertising any would let a test pass
+    against a capability nothing here provides.
+    """
+
+    def __init__(self) -> None:
+        self.updates: list[tuple[str, SessionUpdate]] = []
+
+    def updates_for(self, session_id: str) -> "list[SessionUpdate]":
+        """Only the updates belonging to ``session_id``, in arrival order."""
+        return [u for sid, u in self.updates if sid == session_id]
+
+    async def session_update(self, *, session_id: str, update: Any, **kwargs: Any) -> None:
+        self.updates.append((session_id, update))
+
+    async def request_permission(self, **kwargs: Any) -> Any:
+        raise NotImplementedError("RecordingClient does not implement permissions.")
+
+    async def write_text_file(self, **kwargs: Any) -> Any:
+        raise NotImplementedError("RecordingClient does not implement fs/write_text_file.")
+
+    async def read_text_file(self, **kwargs: Any) -> Any:
+        raise NotImplementedError("RecordingClient does not implement fs/read_text_file.")
+
+    async def create_terminal(self, **kwargs: Any) -> Any:
+        raise NotImplementedError("RecordingClient does not implement terminals.")
+
+    async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        raise NotImplementedError(f"RecordingClient does not implement ext method {method!r}.")
+
+    async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
+        return None
+
+
+@asynccontextmanager
+async def connect(
+    server: "ACPAgent",
+    *,
+    client: "RecordingClient | None" = None,
+    initialize: bool = True,
+) -> "AsyncGenerator[tuple[ClientSideConnection, RecordingClient]]":
+    """Yield a real ACP ``ClientSideConnection`` driving ``server`` in-process.
+
+    Both sides are the genuine SDK connection classes, wired over an in-memory
+    duplex pipe — no subprocess, no sockets — so tests exercise real JSON-RPC
+    framing, dispatch and error mapping. The ACP analogue of
+    :func:`ag2.mcp.testing.connect`.
+
+    Yields the connection (call ``new_session``, ``prompt``, … on it) and the
+    :class:`RecordingClient` that captured the notifications.
+    """
+    from acp.core import ClientSideConnection
+
+    recorder = client or RecordingClient()
+
+    # Two one-directional pipes: client writes -> agent reads, agent writes ->
+    # client reads. `acp` speaks newline-delimited JSON over asyncio streams.
+    to_agent_r, to_agent_w = await _pipe()
+    to_client_r, to_client_w = await _pipe()
+
+    # ``ACPAgent`` / ``RecordingClient`` implement the SDK's Agent / Client
+    # Protocols structurally; mypy cannot see that through the ``**kwargs``
+    # signatures the Protocols declare.
+    from .guard import serve
+
+    agent_task = asyncio.create_task(serve(server.bind, to_agent_r, to_client_w))
+    conn = ClientSideConnection(cast("Any", lambda _agent: recorder), to_agent_w, to_client_r)
+    try:
+        if initialize:
+            await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+        yield conn, recorder
+    finally:
+        for writer in (to_agent_w, to_client_w):
+            writer.close()
+        agent_task.cancel()
+        with suppress(asyncio.CancelledError, Exception):
+            await agent_task
+
+
+async def _pipe() -> "tuple[asyncio.StreamReader, asyncio.StreamWriter]":
+    """An in-memory duplex byte pipe as an asyncio reader/writer pair."""
+    read_fd, write_fd = os.pipe()
+    loop = asyncio.get_running_loop()
+
+    reader = asyncio.StreamReader()
+    await loop.connect_read_pipe(lambda: asyncio.StreamReaderProtocol(reader), os.fdopen(read_fd, "rb", 0))
+    transport, protocol = await loop.connect_write_pipe(asyncio.streams.FlowControlMixin, os.fdopen(write_fd, "wb", 0))
+    writer = asyncio.StreamWriter(transport, protocol, None, loop)
+    return reader, writer

--- a/ag2/acp/testing.py
+++ b/ag2/acp/testing.py
@@ -13,7 +13,7 @@ keep it out of the extra-free :mod:`ag2.testing`.
 """
 
 import asyncio
-import os
+import socket
 from collections.abc import Awaitable, Callable, Iterator, Sequence
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
@@ -41,6 +41,7 @@ __all__ = (
     "FakeACPConfig",
     "RecordingClient",
     "connect",
+    "duplex",
     "fake_acp_config",
 )
 
@@ -263,37 +264,42 @@ async def connect(
 
     recorder = client or RecordingClient()
 
-    # Two one-directional pipes: client writes -> agent reads, agent writes ->
-    # client reads. `acp` speaks newline-delimited JSON over asyncio streams.
-    to_agent_r, to_agent_w = await _pipe()
-    to_client_r, to_client_w = await _pipe()
+    # One socket pair carries both directions. `acp` speaks newline-delimited
+    # JSON over asyncio streams, and a connected socket gives each side a real
+    # ``StreamReader``/``StreamWriter`` on every platform.
+    agent_end, client_end = socket.socketpair()
+    agent_reader, agent_writer = await asyncio.open_connection(sock=agent_end)
+    client_reader, client_writer = await asyncio.open_connection(sock=client_end)
 
     # ``ACPAgent`` / ``RecordingClient`` implement the SDK's Agent / Client
     # Protocols structurally; mypy cannot see that through the ``**kwargs``
     # signatures the Protocols declare.
     from .guard import serve
 
-    agent_task = asyncio.create_task(serve(server.bind, to_agent_r, to_client_w))
-    conn = ClientSideConnection(cast("Any", lambda _agent: recorder), to_agent_w, to_client_r)
+    agent_task = asyncio.create_task(serve(server.bind, agent_reader, agent_writer))
+    conn = ClientSideConnection(cast("Any", lambda _agent: recorder), client_writer, client_reader)
     try:
         if initialize:
             await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
         yield conn, recorder
     finally:
-        for writer in (to_agent_w, to_client_w):
+        for writer in (client_writer, agent_writer):
             writer.close()
         agent_task.cancel()
         with suppress(asyncio.CancelledError, Exception):
             await agent_task
 
 
-async def _pipe() -> "tuple[asyncio.StreamReader, asyncio.StreamWriter]":
-    """An in-memory duplex byte pipe as an asyncio reader/writer pair."""
-    read_fd, write_fd = os.pipe()
-    loop = asyncio.get_running_loop()
+async def duplex() -> (
+    "tuple[tuple[asyncio.StreamReader, asyncio.StreamWriter], tuple[asyncio.StreamReader, asyncio.StreamWriter]]"
+):
+    """A connected pair of asyncio stream endpoints, one per side.
 
-    reader = asyncio.StreamReader()
-    await loop.connect_read_pipe(lambda: asyncio.StreamReaderProtocol(reader), os.fdopen(read_fd, "rb", 0))
-    transport, protocol = await loop.connect_write_pipe(asyncio.streams.FlowControlMixin, os.fdopen(write_fd, "wb", 0))
-    writer = asyncio.StreamWriter(transport, protocol, None, loop)
-    return reader, writer
+    Backed by :func:`socket.socketpair` rather than :func:`os.pipe`. An anonymous
+    pipe cannot be registered with Windows' IOCP, so the proactor event loop
+    rejects it — ``connect_read_pipe`` there raises
+    ``OSError: [WinError 6] The handle is invalid``. A socket works on every
+    platform asyncio supports.
+    """
+    left, right = socket.socketpair()
+    return await asyncio.open_connection(sock=left), await asyncio.open_connection(sock=right)

--- a/ag2/acp/types.py
+++ b/ag2/acp/types.py
@@ -42,3 +42,9 @@ ContentBlock: TypeAlias = (
 ToolCallContent: TypeAlias = (
     schema.ContentToolCallContent | schema.FileEditToolCallContent | schema.TerminalToolCallContent
 )
+
+# Every MCP server shape a Client may declare in ``session/new``, mirroring
+# ``NewSessionRequest.mcp_servers``. The ``acp`` SDK parses the request; naming
+# the result here is what keeps a recorded server readable as its own model
+# rather than as ``Any`` at every point it is passed along.
+McpServer: TypeAlias = schema.HttpMcpServer | schema.SseMcpServer | schema.AcpMcpServer | schema.McpServerStdio

--- a/examples/acp/server_stdio.py
+++ b/examples/acp/server_stdio.py
@@ -1,0 +1,50 @@
+"""Serve an AG2 agent to an ACP Client over stdio.
+
+Nothing here is started by you: the Client launches this file as a subprocess and
+speaks ACP over the pipe between you. Point an ACP Client at it with a launch
+entry of the shape every Client uses:
+
+.. code-block:: json
+
+    {
+      "command": "/abs/path/to/.venv/bin/python",
+      "args": ["/abs/path/to/examples/acp/server_stdio.py"],
+      "env": {"ANTHROPIC_API_KEY": "<your key>"}
+    }
+
+Both paths are absolute on purpose. Your virtualenv is not activated for that
+process, so a bare ``python`` resolves to an interpreter that does not have
+``ag2`` installed.
+
+**stdout is the protocol wire.** A stray ``print()`` anywhere in this process —
+yours or a library's — corrupts the JSON-RPC framing and drops the connection.
+Write to stderr instead.
+"""
+
+import asyncio
+
+from ag2 import Agent
+from ag2.acp import ACPAgent
+from ag2.config import AnthropicConfig
+from ag2.tools import tool
+
+
+@tool(description="Add two integers.")
+async def calc_add(a: int, b: int) -> str:
+    return str(a + b)
+
+
+agent = Agent(
+    name="workie",
+    prompt="You are a concise assistant. Use tools when they help.",
+    config=AnthropicConfig(model="claude-sonnet-4-6", streaming=True),
+    tools=[calc_add],
+)
+
+
+async def main() -> None:
+    await ACPAgent(agent).run_stdio()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test/acp/_stdio_agent.py
+++ b/test/acp/_stdio_agent.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""A standalone ACP agent process, for the stdio end-to-end test.
+
+Run as ``python -m test.acp._stdio_agent``. An ACP Client launches this the same
+way it launches Claude Code or Codex: as a subprocess speaking ACP on stdio.
+
+Nothing may be written to stdout except the protocol itself — stdout *is* the
+transport.
+"""
+
+import asyncio
+
+from ag2 import Agent
+from ag2.acp import ACPAgent
+from ag2.events import ToolCallEvent
+from ag2.testing import TestConfig
+
+
+def build_server() -> ACPAgent:
+    agent = Agent(
+        "workie",
+        config=TestConfig(ToolCallEvent(name="add", arguments='{"a": 100, "b": 100}'), "200"),
+    )
+
+    @agent.tool
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    return ACPAgent(agent, name="workie", version="test")
+
+
+if __name__ == "__main__":
+    asyncio.run(build_server().run_stdio())

--- a/test/acp/test_agent_cancel.py
+++ b/test/acp/test_agent_cancel.py
@@ -1,0 +1,627 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from collections.abc import Sequence
+from typing import Any
+
+import acp
+import pytest
+from acp import schema
+from typing_extensions import Self
+
+from ag2 import Agent, Context
+from ag2.acp import ACPAgent, SessionConfig, StaticTokenAuth
+from ag2.acp.executor import CANCELLED_TOOL_RESULT
+from ag2.acp.testing import connect
+from ag2.config import LLMClient, ModelConfig
+from ag2.config.openai.mappers import convert_messages
+from ag2.events import BaseEvent, ModelResponse, ToolCallEvent, ToolCallsEvent, ToolResultsEvent
+from ag2.testing import TestConfig
+
+
+class _GatedClient(LLMClient):
+    """Blocks inside the LLM call until released, so a turn can be held mid-flight."""
+
+    def __init__(self, client: LLMClient, entered: asyncio.Event, release: asyncio.Event) -> None:
+        self.client = client
+        self.entered = entered
+        self.release = release
+
+    async def __call__(self, messages: Sequence[BaseEvent], context: Context, **kwargs: Any) -> ModelResponse:
+        self.entered.set()
+        await self.release.wait()
+        return await self.client(messages, context=context, **kwargs)
+
+
+class _GatedConfig(ModelConfig):
+    """A config whose turns park until :attr:`release` is set."""
+
+    def __init__(self, *turns: object) -> None:
+        self.config = TestConfig(*(turns or ("ok",)))
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> _GatedClient:
+        return _GatedClient(self.config.create(), self.entered, self.release)
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+class _NullSerializer:
+    """Stand-in for the provider serializer; tool schemas are not exercised here."""
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def response(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+def _texts(updates: list[Any]) -> list[str]:
+    return [u.content.text for u in updates if isinstance(u, schema.AgentMessageChunk)]
+
+
+@pytest.mark.asyncio
+class TestCancel:
+    async def test_a_cancelled_turn_reports_the_cancelled_stop_reason(self) -> None:
+        config = _GatedConfig("never delivered")
+
+        async with connect(ACPAgent(Agent("workie", config=config))) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            turn = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("slow")]))
+            await config.entered.wait()
+
+            await conn.cancel(session_id=session.session_id)
+            response = await turn
+
+        assert response.stop_reason == "cancelled"
+
+    async def test_the_agent_never_completes_a_cancelled_turn(self) -> None:
+        config = _GatedConfig("never delivered")
+
+        async with connect(ACPAgent(Agent("workie", config=config))) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            turn = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("slow")]))
+            await config.entered.wait()
+
+            await conn.cancel(session_id=session.session_id)
+            await turn
+
+        assert "never delivered" not in _texts(recorder.updates_for(session.session_id))
+
+    async def test_updates_already_sent_are_not_retracted(self) -> None:
+        """Cancelling stops the turn; it does not undo what the Client already saw."""
+        config = _GatedConfig("second turn text")
+
+        async with connect(ACPAgent(Agent("workie", config=config))) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+
+            # A completed turn first, so there is delivered history to preserve.
+            config.release.set()
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("first")])
+            delivered = list(recorder.updates_for(session.session_id))
+
+            config.release.clear()
+            config.entered.clear()
+            turn = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("second")]))
+            await config.entered.wait()
+            await conn.cancel(session_id=session.session_id)
+            await turn
+
+        assert recorder.updates_for(session.session_id)[: len(delivered)] == delivered
+
+    async def test_cancelling_one_session_leaves_another_running(self) -> None:
+        config = _GatedConfig("reply", "reply")
+
+        async with connect(ACPAgent(Agent("workie", config=config))) as (conn, _):
+            cancelled = await conn.new_session(cwd="/tmp")
+            other = await conn.new_session(cwd="/tmp")
+
+            held = asyncio.create_task(conn.prompt(session_id=cancelled.session_id, prompt=[acp.text_block("slow")]))
+            await config.entered.wait()
+            await conn.cancel(session_id=cancelled.session_id)
+            assert (await held).stop_reason == "cancelled"
+
+            config.release.set()
+            survivor = await conn.prompt(session_id=other.session_id, prompt=[acp.text_block("fine")])
+
+        assert survivor.stop_reason == "end_turn"
+
+    async def test_cancelling_an_unknown_session_is_ignored(self) -> None:
+        """``session/cancel`` is a notification — there is no channel for an error."""
+        async with connect(ACPAgent(Agent("workie", config=TestConfig("ok")))) as (conn, _):
+            await conn.cancel(session_id="never-issued")
+
+            session = await conn.new_session(cwd="/tmp")
+            response = await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("hi")])
+
+        assert response.stop_reason == "end_turn"
+
+    async def test_a_session_is_usable_again_after_a_cancel(self) -> None:
+        config = _GatedConfig("first", "after cancel")
+
+        async with connect(ACPAgent(Agent("workie", config=config))) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            held = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("slow")]))
+            await config.entered.wait()
+            await conn.cancel(session_id=session.session_id)
+            await held
+
+            config.release.set()
+            response = await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("again")])
+
+        assert response.stop_reason == "end_turn"
+
+
+@pytest.mark.asyncio
+class TestBusySession:
+    async def test_a_second_prompt_waits_rather_than_interleaving(self) -> None:
+        config = _GatedConfig("first", "second")
+
+        async with connect(ACPAgent(Agent("workie", config=config))) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            first = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("one")]))
+            await config.entered.wait()
+            second = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("two")]))
+            await asyncio.sleep(0.01)
+
+            assert not second.done()  # queued behind the running turn
+
+            config.release.set()
+            assert (await first).stop_reason == "end_turn"
+            assert (await second).stop_reason == "end_turn"
+
+    async def test_a_cancel_drops_prompts_queued_behind_the_running_turn(self) -> None:
+        config = _GatedConfig("first", "second")
+
+        async with connect(ACPAgent(Agent("workie", config=config))) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            first = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("one")]))
+            await config.entered.wait()
+            second = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("two")]))
+            await asyncio.sleep(0.01)
+
+            await conn.cancel(session_id=session.session_id)
+
+            assert (await first).stop_reason == "cancelled"
+            assert (await second).stop_reason == "cancelled"
+
+    async def test_the_queue_is_bounded(self) -> None:
+        config = _GatedConfig(*["reply"] * 6)
+        server = ACPAgent(Agent("workie", config=config), sessions=SessionConfig(max_queued=2))
+
+        async with connect(server) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            running = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("one")]))
+            await config.entered.wait()
+
+            queued = [
+                asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("more")]))
+                for _ in range(2)
+            ]
+            await asyncio.sleep(0.01)
+
+            with pytest.raises(acp.RequestError):
+                await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("overflow")])
+
+            config.release.set()
+            await running
+            await asyncio.gather(*queued)
+
+
+@pytest.mark.asyncio
+class TestCancelLeavesAUsableSession:
+    """Cancelling is meant to be recoverable, so it must not corrupt history.
+
+    A cancel can land between a tool call and its result. Providers reject an
+    assistant tool-call with nothing answering it, so a session left in that
+    shape would fail on its *next* prompt — turning a normal stop into a broken
+    conversation.
+    """
+
+    @staticmethod
+    def _agent_with_a_hanging_tool(entered: asyncio.Event) -> Agent:
+        agent = Agent(
+            "workie",
+            config=TestConfig(ToolCallEvent(name="slow", arguments="{}"), "done"),
+        )
+
+        @agent.tool
+        async def slow() -> str:
+            """Never finishes on its own."""
+            entered.set()
+            await asyncio.Event().wait()
+            return "unreachable"  # pragma: no cover - the turn is cancelled first
+
+        return agent
+
+    async def _cancel_mid_tool(self, server: ACPAgent, conn: Any) -> str:
+        session = await conn.new_session(cwd="/tmp")
+        turn = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")]))
+        await self.entered.wait()
+        await conn.cancel(session_id=session.session_id)
+        assert (await turn).stop_reason == "cancelled"
+        return session.session_id
+
+    async def test_every_tool_call_is_answered_after_a_cancel(self) -> None:
+        self.entered = asyncio.Event()
+        server = ACPAgent(self._agent_with_a_hanging_tool(self.entered))
+
+        async with connect(server) as (conn, _):
+            session_id = await self._cancel_mid_tool(server, conn)
+            session = await server.sessions.get(session_id)
+            events = list(await server.sessions.stream(session).history.get_events())
+
+        calls = {c.id for e in events if isinstance(e, ToolCallsEvent) for c in e.calls}
+        answered = {r.parent_id for e in events if isinstance(e, ToolResultsEvent) for r in e.results}
+        assert calls and calls <= answered
+
+    async def test_the_synthetic_result_says_what_happened(self) -> None:
+        self.entered = asyncio.Event()
+        server = ACPAgent(self._agent_with_a_hanging_tool(self.entered))
+
+        async with connect(server) as (conn, _):
+            session_id = await self._cancel_mid_tool(server, conn)
+            session = await server.sessions.get(session_id)
+            events = list(await server.sessions.stream(session).history.get_events())
+
+        [results] = [e for e in events if isinstance(e, ToolResultsEvent)]
+        assert CANCELLED_TOOL_RESULT in str(results.results[0].result)
+
+    async def test_the_repaired_history_converts_for_a_strict_provider(self) -> None:
+        """The failure this prevents: OpenAI rejects an unanswered tool call."""
+        self.entered = asyncio.Event()
+        server = ACPAgent(self._agent_with_a_hanging_tool(self.entered))
+
+        async with connect(server) as (conn, _):
+            session_id = await self._cancel_mid_tool(server, conn)
+            session = await server.sessions.get(session_id)
+            events = list(await server.sessions.stream(session).history.get_events())
+
+        messages = convert_messages([], events, _NullSerializer())
+        orphans = [
+            message
+            for index, message in enumerate(messages)
+            if message.get("role") == "assistant"
+            and message.get("tool_calls")
+            and (index + 1 >= len(messages) or messages[index + 1].get("role") != "tool")
+        ]
+        assert orphans == []
+
+    async def test_nothing_is_appended_when_no_tool_was_pending(self) -> None:
+        """A cancel between turns must not invent results for calls already answered."""
+        config = _GatedConfig("never delivered")
+        server = ACPAgent(Agent("workie", config=config))
+
+        async with connect(server) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            turn = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("hi")]))
+            await config.entered.wait()
+            await conn.cancel(session_id=session.session_id)
+            await turn
+
+            live = await server.sessions.get(session.session_id)
+            events = list(await server.sessions.stream(live).history.get_events())
+
+        assert [e for e in events if isinstance(e, ToolResultsEvent)] == []
+
+
+@pytest.mark.asyncio
+class TestCancelIsScoped:
+    """Cancelling mutates someone's conversation, so it needs the same authority."""
+
+    @staticmethod
+    async def _hold(server: ACPAgent, session_id: str) -> "asyncio.Task[None]":
+        session = await server.sessions.get(session_id)
+        started = asyncio.Event()
+
+        async def hold() -> None:
+            async with session.turn():
+                started.set()
+                await asyncio.Event().wait()
+
+        task = asyncio.create_task(hold())
+        session.turn_task = task
+        await started.wait()
+        return task
+
+    async def test_an_uninitialized_reconnect_cannot_cancel(self) -> None:
+        server = ACPAgent(Agent("workie", config=TestConfig("ok")), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server) as (conn, _):
+            await conn.authenticate(method_id="token", token="s3cret")
+            session = await conn.new_session(cwd="/tmp")
+            task = await self._hold(server, session.session_id)
+
+            async with connect(server, initialize=False) as (intruder, _):
+                await intruder.cancel(session_id=session.session_id)
+                await asyncio.sleep(0.05)
+
+            assert not task.done()
+            task.cancel()
+
+    async def test_an_unauthenticated_connection_cannot_cancel(self) -> None:
+        """Initialized is not enough — cancelling needs the credential too.
+
+        The session is created through the store rather than the protocol,
+        because a connection that has not authenticated cannot create one; the
+        point here is only that a *cancel* from it is refused.
+        """
+        server = ACPAgent(Agent("workie", config=TestConfig("ok")), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server) as (conn, _):
+            session = await server.sessions.create()
+            task = await self._hold(server, session.session_id)
+
+            await conn.cancel(session_id=session.session_id)
+            await asyncio.sleep(0.05)
+
+            assert not task.done()
+            task.cancel()
+
+    async def test_an_authenticated_connection_can_still_cancel(self) -> None:
+        server = ACPAgent(Agent("workie", config=TestConfig("ok")), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server) as (conn, _):
+            await conn.authenticate(method_id="token", token="s3cret")
+            session = await conn.new_session(cwd="/tmp")
+            task = await self._hold(server, session.session_id)
+
+            await conn.cancel(session_id=session.session_id)
+            await asyncio.sleep(0.05)
+
+            assert task.cancelled()
+
+
+@pytest.mark.asyncio
+class TestRepairIsSerialised:
+    """The repair rewrites the whole transcript, so no turn may run alongside it."""
+
+    async def test_a_prompt_racing_the_repair_still_sees_valid_history(self) -> None:
+        agent = Agent(
+            "workie",
+            config=TestConfig(ToolCallEvent(name="slow", arguments="{}"), "done", "second"),
+        )
+        entered = asyncio.Event()
+
+        @agent.tool
+        async def slow() -> str:
+            """Never finishes on its own."""
+            entered.set()
+            await asyncio.Event().wait()
+            return "unreachable"  # pragma: no cover - cancelled first
+
+        server = ACPAgent(agent)
+
+        async with connect(server) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            first = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")]))
+            await entered.wait()
+
+            # Fire the follow-up prompt without waiting for the repair to finish.
+            cancelling = asyncio.create_task(conn.cancel(session_id=session.session_id))
+            second = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("again")]))
+            await first
+            await cancelling
+            await second
+
+            live = await server.sessions.get(session.session_id)
+            events = list(await server.sessions.stream(live).history.get_events())
+
+        calls = {c.id for e in events if isinstance(e, ToolCallsEvent) for c in e.calls}
+        answered = {r.parent_id for e in events if isinstance(e, ToolResultsEvent) for r in e.results}
+        assert calls and calls <= answered
+
+
+@pytest.mark.asyncio
+class TestParallelToolCancellation:
+    """A half-finished parallel batch must still serialize to valid history.
+
+    Providers pair every tool call with a tool result. If one tool of a batch
+    completed and another was cancelled, the repair has to emit results for the
+    *whole* batch — the completed one included — or the transcript ends up with
+    more calls than results and the next prompt is rejected.
+    """
+
+    @staticmethod
+    def _agent(entered: asyncio.Event) -> Agent:
+        agent = Agent(
+            "workie",
+            config=TestConfig(
+                [ToolCallEvent(name="fast", arguments="{}"), ToolCallEvent(name="slow", arguments="{}")],
+                "done",
+            ),
+        )
+
+        @agent.tool
+        async def fast() -> str:
+            """Returns straight away."""
+            return "quick result"
+
+        @agent.tool
+        async def slow() -> str:
+            """Never finishes on its own."""
+            entered.set()
+            await asyncio.Event().wait()
+            return "unreachable"  # pragma: no cover - cancelled first
+
+        return agent
+
+    async def test_every_call_in_the_batch_is_answered(self) -> None:
+        entered = asyncio.Event()
+        server = ACPAgent(self._agent(entered))
+
+        async with connect(server) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            turn = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")]))
+            await entered.wait()
+            await asyncio.sleep(0.05)
+            await conn.cancel(session_id=session.session_id)
+            await turn
+            live = await server.sessions.get(session.session_id)
+            events = list(await server.sessions.stream(live).history.get_events())
+
+        calls = {c.id for e in events if isinstance(e, ToolCallsEvent) for c in e.calls}
+        answered = {r.parent_id for e in events if isinstance(e, ToolResultsEvent) for r in e.results}
+        assert len(calls) == 2
+        assert calls == answered
+
+    async def test_the_completed_result_is_kept_not_overwritten(self) -> None:
+        entered = asyncio.Event()
+        server = ACPAgent(self._agent(entered))
+
+        async with connect(server) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            turn = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")]))
+            await entered.wait()
+            await asyncio.sleep(0.05)
+            await conn.cancel(session_id=session.session_id)
+            await turn
+            live = await server.sessions.get(session.session_id)
+            events = list(await server.sessions.stream(live).history.get_events())
+
+        rendered = str([r.result for e in events if isinstance(e, ToolResultsEvent) for r in e.results])
+        assert "quick result" in rendered
+        assert CANCELLED_TOOL_RESULT in rendered
+
+    async def test_calls_and_results_balance_for_a_strict_provider(self) -> None:
+        entered = asyncio.Event()
+        server = ACPAgent(self._agent(entered))
+
+        async with connect(server) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            turn = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")]))
+            await entered.wait()
+            await asyncio.sleep(0.05)
+            await conn.cancel(session_id=session.session_id)
+            await turn
+            live = await server.sessions.get(session.session_id)
+            events = list(await server.sessions.stream(live).history.get_events())
+
+        messages = convert_messages([], events, _NullSerializer())
+        calls = sum(len(m.get("tool_calls") or []) for m in messages)
+        results = sum(1 for m in messages if m.get("role") == "tool")
+        assert calls == results == 2
+
+
+class _ConcurrencyProbeConfig(ModelConfig):
+    """Parks every turn inside the LLM call so concurrency can be observed."""
+
+    def __init__(self, replies: int = 50) -> None:
+        self.config = TestConfig(*["ok"] * replies)
+        self.running = 0
+        self.peak = 0
+        self.release = asyncio.Event()
+
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> "_ConcurrencyProbeClient":
+        return _ConcurrencyProbeClient(self.config.create(), self)
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+class _ConcurrencyProbeClient(LLMClient):
+    def __init__(self, client: LLMClient, probe: _ConcurrencyProbeConfig) -> None:
+        self.client = client
+        self.probe = probe
+
+    async def __call__(self, messages: Sequence[BaseEvent], context: Context, **kwargs: Any) -> ModelResponse:
+        self.probe.running += 1
+        self.probe.peak = max(self.probe.peak, self.probe.running)
+        try:
+            await self.probe.release.wait()
+            return await self.client(messages, context=context, **kwargs)
+        finally:
+            self.probe.running -= 1
+
+
+@pytest.mark.asyncio
+class TestConnectionWideLimits:
+    """Per-session bounds cannot see each other; these bound the connection.
+
+    Without them a Client can open the full session cap and start a paid turn in
+    every one at once.
+    """
+
+    async def test_concurrent_turns_are_capped_across_sessions(self) -> None:
+        probe = _ConcurrencyProbeConfig()
+        server = ACPAgent(
+            Agent("workie", config=probe),
+            sessions=SessionConfig(max_concurrent_turns=3, max_active_prompts=6),
+        )
+
+        async with connect(server) as (conn, _):
+            ids = [(await conn.new_session(cwd="/tmp")).session_id for _ in range(6)]
+            turns = [asyncio.create_task(conn.prompt(session_id=sid, prompt=[acp.text_block("go")])) for sid in ids]
+            await asyncio.sleep(0.1)
+
+            assert probe.peak == 3
+
+            probe.release.set()
+            responses = await asyncio.gather(*turns)
+
+        assert [r.stop_reason for r in responses] == ["end_turn"] * 6
+
+    async def test_prompts_past_the_cap_wait_rather_than_fail(self) -> None:
+        """A burst across separate conversations is traffic, not abuse."""
+        probe = _ConcurrencyProbeConfig()
+        server = ACPAgent(
+            Agent("workie", config=probe),
+            sessions=SessionConfig(max_concurrent_turns=2, max_active_prompts=6),
+        )
+
+        async with connect(server) as (conn, _):
+            ids = [(await conn.new_session(cwd="/tmp")).session_id for _ in range(5)]
+            turns = [asyncio.create_task(conn.prompt(session_id=sid, prompt=[acp.text_block("go")])) for sid in ids]
+            await asyncio.sleep(0.1)
+
+            assert not any(t.done() for t in turns)
+
+            probe.release.set()
+            responses = await asyncio.gather(*turns)
+
+        assert all(r.stop_reason == "end_turn" for r in responses)
+
+    async def test_admission_is_refused_past_max_active_prompts(self) -> None:
+        probe = _ConcurrencyProbeConfig()
+        server = ACPAgent(
+            Agent("workie", config=probe),
+            sessions=SessionConfig(max_concurrent_turns=2, max_active_prompts=4),
+        )
+
+        async with connect(server) as (conn, _):
+            ids = [(await conn.new_session(cwd="/tmp")).session_id for _ in range(5)]
+            turns = [asyncio.create_task(conn.prompt(session_id=sid, prompt=[acp.text_block("go")])) for sid in ids[:4]]
+            await asyncio.sleep(0.1)
+
+            with pytest.raises(acp.RequestError):
+                await conn.prompt(session_id=ids[4], prompt=[acp.text_block("go")])
+
+            probe.release.set()
+            await asyncio.gather(*turns)
+
+    async def test_a_slot_frees_up_once_a_turn_finishes(self) -> None:
+        probe = _ConcurrencyProbeConfig()
+        server = ACPAgent(
+            Agent("workie", config=probe),
+            sessions=SessionConfig(max_concurrent_turns=1, max_active_prompts=2),
+        )
+
+        async with connect(server) as (conn, _):
+            first = await conn.new_session(cwd="/tmp")
+            second = await conn.new_session(cwd="/tmp")
+            probe.release.set()
+
+            assert (await conn.prompt(session_id=first.session_id, prompt=[acp.text_block("a")])).stop_reason
+            assert (await conn.prompt(session_id=second.session_id, prompt=[acp.text_block("b")])).stop_reason
+
+        assert probe.running == 0

--- a/test/acp/test_agent_e2e.py
+++ b/test/acp/test_agent_e2e.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end over a real subprocess, the way an ACP Client actually launches an Agent.
+
+Everything else in this directory drives ``ACPAgent`` in-process. This module
+spawns it with ``run_stdio()`` behind a real pipe, so the stdio transport, JSON-RPC
+framing and process lifecycle are all exercised for real.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import acp
+import pytest
+from acp import schema
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _Recorder:
+    """Minimal ACP Client: records notifications, implements nothing else."""
+
+    def __init__(self) -> None:
+        self.updates: list[tuple[str, Any]] = []
+
+    def updates_for(self, session_id: str) -> list[Any]:
+        return [u for sid, u in self.updates if sid == session_id]
+
+    async def session_update(self, *, session_id: str, update: Any, **kwargs: Any) -> None:
+        self.updates.append((session_id, update))
+
+    async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_a_client_can_launch_and_drive_the_agent_over_stdio() -> None:
+    recorder = _Recorder()
+
+    async with acp.spawn_agent_process(
+        recorder,
+        sys.executable,
+        "-m",
+        "test.acp._stdio_agent",
+        cwd=str(REPO_ROOT),
+    ) as (conn, process):
+        init = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+        assert init.agent_info.name == "workie"
+
+        # Two independent sessions, both prompted.
+        first = await conn.new_session(cwd=str(REPO_ROOT))
+        second = await conn.new_session(cwd=str(REPO_ROOT))
+        assert first.session_id != second.session_id
+
+        for session in (first, second):
+            response = await conn.prompt(
+                session_id=session.session_id,
+                prompt=[acp.text_block("what's 100 + 100")],
+            )
+            assert response.stop_reason == "end_turn"
+
+        for session in (first, second):
+            updates = recorder.updates_for(session.session_id)
+            assert [u.session_update for u in updates] == [
+                "tool_call",
+                "tool_call_update",
+                "agent_message_chunk",
+            ]
+            [text] = [u.content.text for u in updates if isinstance(u, schema.AgentMessageChunk)]
+            assert text == "200"
+
+    # The context manager shuts the subprocess down; it must not be left running.
+    assert process.returncode is not None

--- a/test/acp/test_agent_guard.py
+++ b/test/acp/test_agent_guard.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""ACP ``_meta`` must never displace a validated request field.
+
+The SDK router merges a request's ``_meta`` *over* its canonical parameters, so a
+colliding key silently replaces the real value and leaves no trace. ``_meta`` is
+exactly where an application is encouraged to put data from elsewhere — chat-room
+provenance, say — so that data must not be able to name the session a prompt runs
+against.
+"""
+
+from typing import Any
+
+import acp
+import pytest
+from acp.exceptions import RequestError
+
+from ag2 import Agent
+from ag2.acp import ACPAgent
+from ag2.acp.guard import colliding_meta_keys
+from ag2.acp.testing import connect
+from ag2.testing import TestConfig
+
+
+def _agent(*turns: str) -> Agent:
+    return Agent("workie", config=TestConfig(*(turns or ("ok",))))
+
+
+def _raw(conn: Any) -> Any:
+    return conn._conn if hasattr(conn, "_conn") else conn._connection
+
+
+class TestCollisionDetection:
+    def test_a_reserved_field_is_spotted(self) -> None:
+        params = {"sessionId": "a", "prompt": [], "_meta": {"session_id": "b"}}
+
+        assert colliding_meta_keys("session/prompt", params) == frozenset({"session_id"})
+
+    def test_a_json_alias_is_spotted_too(self) -> None:
+        params = {"sessionId": "a", "prompt": [], "_meta": {"sessionId": "b"}}
+
+        assert colliding_meta_keys("session/prompt", params) == frozenset({"sessionId"})
+
+    def test_namespaced_application_metadata_is_fine(self) -> None:
+        params = {"cwd": "/tmp", "mcpServers": [], "_meta": {"ag2.space": {"room": "!r"}}}
+
+        assert colliding_meta_keys("session/new", params) == frozenset()
+
+    def test_a_request_without_meta_is_fine(self) -> None:
+        assert colliding_meta_keys("session/new", {"cwd": "/tmp", "mcpServers": []}) == frozenset()
+
+
+@pytest.mark.asyncio
+class TestOverrideIsRefused:
+    async def test_meta_cannot_redirect_a_prompt_to_another_session(self) -> None:
+        server = ACPAgent(_agent("ok", "ok"))
+
+        async with connect(server) as (conn, _):
+            victim = (await conn.new_session(cwd="/tmp")).session_id
+            mine = (await conn.new_session(cwd="/tmp")).session_id
+
+            with pytest.raises(RequestError):
+                await _raw(conn).send_request(
+                    "session/prompt",
+                    {
+                        "sessionId": mine,
+                        "prompt": [{"type": "text", "text": "hi"}],
+                        "_meta": {"session_id": victim},
+                    },
+                )
+
+            target = await server.sessions.get(victim)
+            assert list(await server.sessions.stream(target).history.get_events()) == []
+
+    async def test_meta_cannot_replace_the_prompt_payload(self) -> None:
+        server = ACPAgent(_agent())
+
+        async with connect(server) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+
+            with pytest.raises(RequestError):
+                await _raw(conn).send_request(
+                    "session/prompt",
+                    {
+                        "sessionId": session.session_id,
+                        "prompt": [{"type": "text", "text": "harmless"}],
+                        "_meta": {"prompt": [{"type": "text", "text": "substituted"}]},
+                    },
+                )
+
+    async def test_meta_cannot_retarget_a_new_session_s_cwd(self) -> None:
+        server = ACPAgent(_agent())
+
+        async with connect(server) as (conn, _):
+            with pytest.raises(RequestError):
+                await _raw(conn).send_request(
+                    "session/new",
+                    {"cwd": "/tmp", "mcpServers": [], "_meta": {"cwd": "/etc"}},
+                )
+
+    async def test_the_error_names_the_offending_key(self) -> None:
+        server = ACPAgent(_agent())
+
+        async with connect(server) as (conn, _):
+            with pytest.raises(RequestError) as caught:
+                await _raw(conn).send_request(
+                    "session/new",
+                    {"cwd": "/tmp", "mcpServers": [], "_meta": {"cwd": "/etc"}},
+                )
+
+        assert "cwd" in caught.value.data["reason"]
+
+
+@pytest.mark.asyncio
+class TestLegitimateMetadataStillWorks:
+    async def test_namespaced_metadata_reaches_the_session(self) -> None:
+        server = ACPAgent(_agent())
+
+        async with connect(server) as (conn, _):
+            response = await _raw(conn).send_request(
+                "session/new",
+                {"cwd": "/tmp", "mcpServers": [], "_meta": {"ag2.space": {"room": "!r"}}},
+            )
+            session = await server.sessions.get(response["sessionId"])
+
+        assert session.meta == {"ag2.space": {"room": "!r"}}
+
+    async def test_an_ordinary_prompt_is_unaffected(self) -> None:
+        async with connect(ACPAgent(_agent("200"))) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            response = await conn.prompt(
+                session_id=session.session_id,
+                prompt=[acp.text_block("what's 100 + 100")],
+            )
+
+        assert response.stop_reason == "end_turn"
+        assert recorder.updates_for(session.session_id)

--- a/test/acp/test_agent_initialize.py
+++ b/test/acp/test_agent_initialize.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import acp
+import pytest
+from acp.exceptions import RequestError
+
+from ag2 import Agent
+from ag2.acp import ACPAgent, PromptContent, StaticTokenAuth
+from ag2.acp.testing import connect
+from ag2.testing import TestConfig
+
+
+def _agent(*turns: str) -> Agent:
+    return Agent("workie", config=TestConfig(*(turns or ("ok",))))
+
+
+@pytest.mark.asyncio
+class TestHandshake:
+    async def test_negotiates_the_protocol_version(self) -> None:
+        async with connect(ACPAgent(_agent()), initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        assert response.protocol_version == acp.PROTOCOL_VERSION
+
+    async def test_never_negotiates_above_what_it_implements(self) -> None:
+        async with connect(ACPAgent(_agent()), initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION + 5)
+
+        assert response.protocol_version == acp.PROTOCOL_VERSION
+
+    async def test_advertises_the_agent_name_and_version(self) -> None:
+        server = ACPAgent(_agent(), name="custom", version="9.9.9", title="Custom Agent")
+
+        async with connect(server, initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        assert (response.agent_info.name, response.agent_info.version) == ("custom", "9.9.9")
+        assert response.agent_info.title == "Custom Agent"
+
+    async def test_name_defaults_to_the_agent_name(self) -> None:
+        async with connect(ACPAgent(_agent()), initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        assert response.agent_info.name == "workie"
+
+
+@pytest.mark.asyncio
+class TestCapabilitiesAreTruthful:
+    """Anything advertised here must actually work — a Client relies on it."""
+
+    async def test_does_not_advertise_session_loading(self) -> None:
+        async with connect(ACPAgent(_agent()), initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        assert response.agent_capabilities.load_session is False
+
+    async def test_does_not_advertise_mcp_support(self) -> None:
+        async with connect(ACPAgent(_agent()), initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        mcp = response.agent_capabilities.mcp_capabilities
+        assert (mcp.http, mcp.sse, mcp.acp) == (False, False, False)
+
+    async def test_advertises_no_session_operations_beyond_new_prompt_cancel(self) -> None:
+        async with connect(ACPAgent(_agent()), initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        sessions = response.agent_capabilities.session_capabilities
+        assert (sessions.list, sessions.delete, sessions.fork, sessions.resume, sessions.close) == (
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+    async def test_advertises_only_the_prompt_content_it_was_told_to(self) -> None:
+        """See :class:`TestPromptContentIsDeclared` for why audio is not assumed."""
+        async with connect(ACPAgent(_agent()), initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        prompt = response.agent_capabilities.prompt_capabilities
+        assert (prompt.image, prompt.audio, prompt.embedded_context) == (True, False, True)
+
+    async def test_load_session_is_rejected_since_it_is_not_advertised(self) -> None:
+        async with connect(ACPAgent(_agent())) as (conn, _):
+            with pytest.raises(RequestError):
+                await conn.load_session(session_id="anything", cwd="/tmp")
+
+
+@pytest.mark.asyncio
+class TestAuthentication:
+    async def test_no_methods_advertised_without_a_provider(self) -> None:
+        async with connect(ACPAgent(_agent()), initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        assert response.auth_methods == []
+
+    async def test_authenticate_is_rejected_without_a_provider(self) -> None:
+        async with connect(ACPAgent(_agent())) as (conn, _):
+            with pytest.raises(RequestError):
+                await conn.authenticate(method_id="token")
+
+    async def test_provider_methods_are_advertised(self) -> None:
+        server = ACPAgent(_agent(), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server, initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        assert [m.id for m in response.auth_methods] == ["token"]
+
+    async def test_sessions_are_gated_until_authenticated(self) -> None:
+        server = ACPAgent(_agent(), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server) as (conn, _):
+            with pytest.raises(RequestError):
+                await conn.new_session(cwd="/tmp")
+
+    async def test_a_valid_credential_unlocks_sessions(self) -> None:
+        server = ACPAgent(_agent(), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server) as (conn, _):
+            await conn.authenticate(method_id="token", token="s3cret")
+            session = await conn.new_session(cwd="/tmp")
+
+        assert session.session_id
+
+    async def test_a_wrong_credential_is_rejected(self) -> None:
+        server = ACPAgent(_agent(), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server) as (conn, _):
+            with pytest.raises(RequestError):
+                await conn.authenticate(method_id="token", token="wrong")
+
+
+@pytest.mark.asyncio
+class TestConnectionScope:
+    """Authentication and sessions belong to a connection, not to the instance."""
+
+    async def test_a_new_connection_must_authenticate_again(self) -> None:
+        server = ACPAgent(_agent(), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server) as (conn, _):
+            await conn.authenticate(method_id="token", token="s3cret")
+            await conn.new_session(cwd="/tmp")
+
+        async with connect(server) as (conn, _):
+            with pytest.raises(RequestError):
+                await conn.new_session(cwd="/tmp")
+
+    async def test_a_new_connection_cannot_reach_the_previous_one_s_sessions(self) -> None:
+        server = ACPAgent(_agent("ok", "ok"))
+
+        async with connect(server) as (conn, _):
+            leaked = (await conn.new_session(cwd="/tmp")).session_id
+
+        async with connect(server) as (conn, _):
+            with pytest.raises(RequestError):
+                await conn.prompt(session_id=leaked, prompt=[acp.text_block("hi")])
+
+    async def test_re_initializing_one_connection_keeps_its_sessions(self) -> None:
+        """A Client may call initialize again; that must not wipe its own work."""
+        server = ACPAgent(_agent("ok", "ok"))
+
+        async with connect(server) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+            response = await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("hi")])
+
+        assert response.stop_reason == "end_turn"
+
+
+@pytest.mark.asyncio
+class TestPromptContentIsDeclared:
+    """Advertised modalities must match what the model behind the agent accepts."""
+
+    async def test_audio_is_off_by_default(self) -> None:
+        """Most providers AG2 ships reject audio; advertising it invites a failure."""
+        async with connect(ACPAgent(_agent()), initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        assert response.agent_capabilities.prompt_capabilities.audio is False
+
+    async def test_image_and_documents_are_on_by_default(self) -> None:
+        async with connect(ACPAgent(_agent()), initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        prompt = response.agent_capabilities.prompt_capabilities
+        assert (prompt.image, prompt.embedded_context) == (True, True)
+
+    async def test_a_deployment_can_declare_what_its_model_accepts(self) -> None:
+        server = ACPAgent(_agent(), prompt_content=PromptContent(image=False, audio=True, embedded_context=False))
+
+        async with connect(server, initialize=False) as (conn, _):
+            response = await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+
+        prompt = response.agent_capabilities.prompt_capabilities
+        assert (prompt.image, prompt.audio, prompt.embedded_context) == (False, True, False)
+
+
+@pytest.mark.asyncio
+class TestInitializeIsRequired:
+    """The SDK router does not enforce handshake order, so this class does.
+
+    Without it, a reconnecting Client could skip ``initialize`` and thereby skip
+    the scope reset that revokes the previous connection's authentication.
+    """
+
+    async def test_sessions_are_refused_before_initialize(self) -> None:
+        async with connect(ACPAgent(_agent()), initialize=False) as (conn, _):
+            with pytest.raises(RequestError):
+                await conn.new_session(cwd="/tmp")
+
+    async def test_authenticate_is_refused_before_initialize(self) -> None:
+        server = ACPAgent(_agent(), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server, initialize=False) as (conn, _):
+            with pytest.raises(RequestError):
+                await conn.authenticate(method_id="token", token="s3cret")
+
+    async def test_a_reconnect_that_skips_initialize_gets_nothing(self) -> None:
+        """The bypass this guards: authenticate once, reconnect, skip the handshake."""
+        server = ACPAgent(_agent(), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server) as (conn, _):
+            await conn.authenticate(method_id="token", token="s3cret")
+            leaked = (await conn.new_session(cwd="/tmp")).session_id
+
+        async with connect(server, initialize=False) as (conn, _):
+            with pytest.raises(RequestError):
+                await conn.new_session(cwd="/tmp")
+            with pytest.raises(RequestError):
+                await conn.prompt(session_id=leaked, prompt=[acp.text_block("hi")])
+
+    async def test_initializing_then_authenticating_works(self) -> None:
+        server = ACPAgent(_agent(), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server) as (conn, _):
+            await conn.authenticate(method_id="token", token="s3cret")
+            session = await conn.new_session(cwd="/tmp")
+
+        assert session.session_id
+
+
+@pytest.mark.asyncio
+class TestConcurrentConnectionsAreIsolated:
+    """Each connection gets its own authorization and sessions.
+
+    A request carries no connection identity, so authorization state kept on a
+    shared object would answer for whichever connection touched it last. Every
+    connection therefore gets its own scope.
+    """
+
+    async def test_one_connection_s_credential_does_not_authorize_another(self) -> None:
+        server = ACPAgent(_agent("ok", "ok"), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server) as (first, _), connect(server) as (second, _):
+            await second.authenticate(method_id="token", token="s3cret")
+            await second.new_session(cwd="/tmp")
+
+            with pytest.raises(RequestError):
+                await first.new_session(cwd="/tmp")
+
+    async def test_one_connection_cannot_prompt_another_s_session(self) -> None:
+        server = ACPAgent(_agent("ok", "ok"), auth=StaticTokenAuth("s3cret"))
+
+        async with connect(server) as (first, _), connect(server) as (second, _):
+            await second.authenticate(method_id="token", token="s3cret")
+            theirs = (await second.new_session(cwd="/tmp")).session_id
+
+            await first.authenticate(method_id="token", token="s3cret")
+            with pytest.raises(RequestError):
+                await first.prompt(session_id=theirs, prompt=[acp.text_block("hi")])
+
+    async def test_updates_go_only_to_the_connection_that_prompted(self) -> None:
+        server = ACPAgent(_agent("ok", "ok"))
+
+        async with connect(server) as (first, watcher), connect(server) as (second, owner):
+            session = await second.new_session(cwd="/tmp")
+            await second.prompt(session_id=session.session_id, prompt=[acp.text_block("hi")])
+
+            assert owner.updates
+            assert watcher.updates == []
+
+    async def test_each_connection_keeps_its_own_sessions(self) -> None:
+        server = ACPAgent(_agent("ok", "ok"))
+
+        async with connect(server) as (first, _):
+            mine = (await first.new_session(cwd="/tmp")).session_id
+            async with connect(server) as (second, _):
+                theirs = (await second.new_session(cwd="/tmp")).session_id
+
+                assert mine != theirs
+                # The older connection still owns its own session.
+                response = await first.prompt(session_id=mine, prompt=[acp.text_block("hi")])
+
+        assert response.stop_reason == "end_turn"

--- a/test/acp/test_agent_lifecycle.py
+++ b/test/acp/test_agent_lifecycle.py
@@ -1,0 +1,336 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import os
+from collections.abc import Sequence
+from typing import Any
+
+import acp
+import pytest
+from acp import schema
+from acp.core import ClientSideConnection
+from typing_extensions import Self
+
+from ag2 import Agent, Context
+from ag2.acp import ACPAgent, SessionConfig
+from ag2.acp.guard import serve
+from ag2.acp.testing import RecordingClient, connect
+from ag2.config import LLMClient, ModelConfig
+from ag2.events import BaseEvent, ModelResponse, ToolCallEvent
+from ag2.history import MemoryStorage
+from ag2.testing import TestConfig
+
+
+class _HeldClient(LLMClient):
+    """Parks inside the LLM call and records whether the turn was cancelled there."""
+
+    def __init__(self, entered: asyncio.Event, cancelled: asyncio.Event) -> None:
+        self.entered = entered
+        self.cancelled = cancelled
+
+    async def __call__(self, messages: Sequence[BaseEvent], context: Context, **kwargs: Any) -> ModelResponse:
+        self.entered.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+        raise AssertionError("the held turn was never meant to finish")  # pragma: no cover
+
+
+class _HeldConfig(ModelConfig):
+    """A config whose turns hang until something cancels them."""
+
+    def __init__(self) -> None:
+        self.entered = asyncio.Event()
+        self.cancelled = asyncio.Event()
+
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> _HeldClient:
+        return _HeldClient(self.entered, self.cancelled)
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+class _StaticAgent:
+    """An ACP agent object rather than a per-connection factory — ``serve`` takes both.
+
+    Records whether teardown reached it: an object the caller built is the
+    caller's to close, so it should not.
+    """
+
+    def __init__(self) -> None:
+        self.initialized = False
+        self.closed = False
+
+    async def initialize(self, protocol_version: int, **kwargs: Any) -> schema.InitializeResponse:
+        self.initialized = True
+        return schema.InitializeResponse(protocol_version=min(protocol_version, acp.PROTOCOL_VERSION))
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+async def _pipe() -> "tuple[asyncio.StreamReader, asyncio.StreamWriter]":
+    """A one-directional byte pipe as an asyncio reader/writer pair.
+
+    ``ag2.acp.testing.connect`` tears the agent down by *cancelling* it, which is
+    not how a real Client leaves; driving ``serve`` over raw pipes is what lets a
+    test close the far end and exercise the disconnect path ``run_stdio`` sees.
+    """
+    read_fd, write_fd = os.pipe()
+    loop = asyncio.get_running_loop()
+
+    reader = asyncio.StreamReader()
+    await loop.connect_read_pipe(lambda: asyncio.StreamReaderProtocol(reader), os.fdopen(read_fd, "rb", 0))
+    transport, protocol = await loop.connect_write_pipe(asyncio.streams.FlowControlMixin, os.fdopen(write_fd, "wb", 0))
+    return reader, asyncio.StreamWriter(transport, protocol, None, loop)
+
+
+@pytest.mark.asyncio
+class TestSessionsDoNotOutliveTheirConnection:
+    async def test_the_registry_is_empty_after_the_client_disconnects(self) -> None:
+        server = ACPAgent(Agent("workie", config=TestConfig("ok")))
+
+        async with connect(server) as (conn, _):
+            await conn.new_session(cwd="/tmp")
+            assert len(server.sessions) == 1
+
+        assert len(server.sessions) == 0
+
+    async def test_every_session_of_a_connection_goes_at_once(self) -> None:
+        server = ACPAgent(Agent("workie", config=TestConfig("ok")))
+
+        async with connect(server) as (conn, _):
+            for _ in range(3):
+                await conn.new_session(cwd="/tmp")
+            assert len(server.sessions) == 3
+
+        assert len(server.sessions) == 0
+
+    async def test_a_reconnecting_client_cannot_name_the_old_connection_s_session(self) -> None:
+        server = ACPAgent(Agent("workie", config=TestConfig("ok")))
+
+        async with connect(server) as (first, _):
+            stale = (await first.new_session(cwd="/tmp")).session_id
+
+        async with connect(server) as (second, _):
+            with pytest.raises(acp.RequestError):
+                await second.prompt(session_id=stale, prompt=[acp.text_block("still there?")])
+
+    async def test_one_connection_s_teardown_leaves_another_s_sessions_alone(self) -> None:
+        """Scopes are per-connection, so teardown has to be too."""
+        server = ACPAgent(Agent("workie", config=TestConfig("ok")))
+
+        async with connect(server) as (first, _):
+            kept = (await first.new_session(cwd="/tmp")).session_id
+            survivor = server.sessions
+
+            async with connect(server) as (second, _):
+                await second.new_session(cwd="/tmp")
+                doomed = server.sessions
+
+            assert len(doomed) == 0
+            assert len(survivor) == 1
+            assert (await survivor.get(kept)).session_id == kept
+
+
+@pytest.mark.asyncio
+class TestTeardownStopsLiveWork:
+    async def test_a_turn_still_running_at_disconnect_is_cancelled(self) -> None:
+        config = _HeldConfig()
+        server = ACPAgent(Agent("workie", config=config))
+
+        async with connect(server) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            turn = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("slow")]))
+            await asyncio.wait_for(config.entered.wait(), timeout=5)
+
+        assert config.cancelled.is_set()
+        # The request dies with the connection instead of being answered.
+        with pytest.raises(ConnectionError):
+            await asyncio.wait_for(turn, timeout=5)
+
+    async def test_a_busy_session_is_still_dropped_from_the_registry(self) -> None:
+        """A turn in flight must not be able to hold its connection's scope open."""
+        config = _HeldConfig()
+        server = ACPAgent(Agent("workie", config=config))
+
+        async with connect(server) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            turn = asyncio.create_task(conn.prompt(session_id=session.session_id, prompt=[acp.text_block("slow")]))
+            await asyncio.wait_for(config.entered.wait(), timeout=5)
+
+        assert len(server.sessions) == 0
+        with pytest.raises(ConnectionError):
+            await asyncio.wait_for(turn, timeout=5)
+
+
+@pytest.mark.asyncio
+class TestDurableHistoryIsDropped:
+    async def test_a_session_s_history_does_not_outlive_its_connection(self) -> None:
+        """The default storage is in-memory; an injected one keeps orphans visible."""
+        storage = MemoryStorage()
+        server = ACPAgent(Agent("workie", config=TestConfig("answered")), sessions=SessionConfig(storage=storage))
+
+        async with connect(server) as (conn, _):
+            session_id = (await conn.new_session(cwd="/tmp")).session_id
+            await conn.prompt(session_id=session_id, prompt=[acp.text_block("hello")])
+            store = server.sessions
+            session = await store.get(session_id)
+            assert await store.stream(session).history.get_events() != []
+
+        assert list(await store.stream(session).history.get_events()) == []
+
+    async def test_only_the_closing_connection_s_history_is_dropped(self) -> None:
+        storage = MemoryStorage()
+        agent = Agent("workie", config=TestConfig("answered", "answered"))
+        server = ACPAgent(agent, sessions=SessionConfig(storage=storage))
+
+        async with connect(server) as (first, _):
+            kept_id = (await first.new_session(cwd="/tmp")).session_id
+            await first.prompt(session_id=kept_id, prompt=[acp.text_block("hello")])
+            survivor = server.sessions
+            kept = await survivor.get(kept_id)
+
+            async with connect(server) as (second, _):
+                doomed_id = (await second.new_session(cwd="/tmp")).session_id
+                await second.prompt(session_id=doomed_id, prompt=[acp.text_block("hello")])
+                doomed_store = server.sessions
+                doomed = await doomed_store.get(doomed_id)
+
+            assert list(await doomed_store.stream(doomed).history.get_events()) == []
+            assert await survivor.stream(kept).history.get_events() != []
+
+
+@pytest.mark.asyncio
+class TestServeOverStreams:
+    """``run_stdio``'s own path: the Client goes away, nothing cancels the server."""
+
+    async def test_eof_from_the_client_releases_the_scope(self) -> None:
+        server = ACPAgent(Agent("workie", config=TestConfig("ok")))
+        to_agent_r, to_agent_w = await _pipe()
+        to_client_r, to_client_w = await _pipe()
+        served = asyncio.create_task(serve(server.bind, to_agent_r, to_client_w))
+        conn = ClientSideConnection(lambda _agent: RecordingClient(), to_agent_w, to_client_r)
+
+        try:
+            await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+            await conn.new_session(cwd="/tmp")
+            assert len(server.sessions) == 1
+
+            to_agent_w.close()  # EOF on the agent's input: the Client hung up
+            await asyncio.wait_for(served, timeout=5)
+
+            assert len(server.sessions) == 0
+        finally:
+            await conn.close()
+            to_client_w.close()
+
+    async def test_an_agent_object_the_caller_built_is_not_closed(self) -> None:
+        """``serve`` only releases the scope it created; a passed-in agent is not one."""
+        agent = _StaticAgent()
+        to_agent_r, to_agent_w = await _pipe()
+        to_client_r, to_client_w = await _pipe()
+        served = asyncio.create_task(serve(agent, to_agent_r, to_client_w))
+        conn = ClientSideConnection(lambda _agent: RecordingClient(), to_agent_w, to_client_r)
+
+        try:
+            await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
+            to_agent_w.close()
+            await asyncio.wait_for(served, timeout=5)
+
+            assert agent.initialized is True
+            assert agent.closed is False
+        finally:
+            await conn.close()
+            to_client_w.close()
+
+
+@pytest.mark.asyncio
+class TestBackgroundWorkBelongsToTheSession:
+    """A stream carries an inbox and background tasks, not only history.
+
+    A fresh stream per turn would strand work that finished after its own turn
+    and hide it from teardown.
+    """
+
+    @staticmethod
+    def _spawning_agent(ran: list[str]) -> Agent:
+        agent = Agent(
+            "workie",
+            config=TestConfig(ToolCallEvent(name="spawn", arguments="{}"), "ok", "ok"),
+        )
+
+        @agent.tool
+        async def spawn(ctx: Context) -> str:
+            """Start work that deliberately outlives this turn."""
+
+            async def later() -> None:
+                await asyncio.sleep(0.05)
+                ran.append("done")
+
+            ctx.spawn_background(later())
+            return "spawned"
+
+        return agent
+
+    async def test_the_session_keeps_one_stream_across_turns(self) -> None:
+        server = ACPAgent(Agent("workie", config=TestConfig("ok", "ok")))
+
+        async with connect(server) as (conn, _):
+            created = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=created.session_id, prompt=[acp.text_block("one")])
+            session = await server.sessions.get(created.session_id)
+            first = server.sessions.stream(session)
+            await conn.prompt(session_id=created.session_id, prompt=[acp.text_block("two")])
+
+            assert server.sessions.stream(session) is first
+
+    async def test_background_work_is_tracked_where_teardown_can_see_it(self) -> None:
+        ran: list[str] = []
+        server = ACPAgent(self._spawning_agent(ran))
+
+        async with connect(server) as (conn, _):
+            created = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=created.session_id, prompt=[acp.text_block("go")])
+            session = await server.sessions.get(created.session_id)
+
+            assert server.sessions.stream(session)._background_tasks
+
+    async def test_closing_a_session_stops_its_background_work(self) -> None:
+        """Otherwise a closed conversation keeps reaching the outside world."""
+        ran: list[str] = []
+        server = ACPAgent(self._spawning_agent(ran))
+
+        async with connect(server) as (conn, _):
+            created = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=created.session_id, prompt=[acp.text_block("go")])
+            await server.sessions.close(created.session_id)
+            await asyncio.sleep(0.2)
+
+        assert ran == []
+
+    async def test_a_turn_does_not_leave_its_forwarder_behind(self) -> None:
+        """The stream outlives the turn now, so the subscriber must be released.
+
+        Left attached, the second turn would deliver every update twice.
+        """
+        server = ACPAgent(Agent("workie", config=TestConfig("first", "second")))
+
+        async with connect(server) as (conn, recorder):
+            created = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=created.session_id, prompt=[acp.text_block("one")])
+            await conn.prompt(session_id=created.session_id, prompt=[acp.text_block("two")])
+
+        # Two turns, so two message updates. A leaked forwarder would make the
+        # second turn deliver its update once per prompt the session had run.
+        texts = [
+            u.content.text for u in recorder.updates_for(created.session_id) if isinstance(u, schema.AgentMessageChunk)
+        ]
+        assert len(texts) == 2

--- a/test/acp/test_agent_lifecycle.py
+++ b/test/acp/test_agent_lifecycle.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-import os
 from collections.abc import Sequence
 from typing import Any
 
@@ -16,7 +15,7 @@ from typing_extensions import Self
 from ag2 import Agent, Context
 from ag2.acp import ACPAgent, SessionConfig
 from ag2.acp.guard import serve
-from ag2.acp.testing import RecordingClient, connect
+from ag2.acp.testing import RecordingClient, connect, duplex
 from ag2.config import LLMClient, ModelConfig
 from ag2.events import BaseEvent, ModelResponse, ToolCallEvent
 from ag2.history import MemoryStorage
@@ -74,22 +73,6 @@ class _StaticAgent:
 
     async def aclose(self) -> None:
         self.closed = True
-
-
-async def _pipe() -> "tuple[asyncio.StreamReader, asyncio.StreamWriter]":
-    """A one-directional byte pipe as an asyncio reader/writer pair.
-
-    ``ag2.acp.testing.connect`` tears the agent down by *cancelling* it, which is
-    not how a real Client leaves; driving ``serve`` over raw pipes is what lets a
-    test close the far end and exercise the disconnect path ``run_stdio`` sees.
-    """
-    read_fd, write_fd = os.pipe()
-    loop = asyncio.get_running_loop()
-
-    reader = asyncio.StreamReader()
-    await loop.connect_read_pipe(lambda: asyncio.StreamReaderProtocol(reader), os.fdopen(read_fd, "rb", 0))
-    transport, protocol = await loop.connect_write_pipe(asyncio.streams.FlowControlMixin, os.fdopen(write_fd, "wb", 0))
-    return reader, asyncio.StreamWriter(transport, protocol, None, loop)
 
 
 @pytest.mark.asyncio
@@ -214,42 +197,40 @@ class TestServeOverStreams:
 
     async def test_eof_from_the_client_releases_the_scope(self) -> None:
         server = ACPAgent(Agent("workie", config=TestConfig("ok")))
-        to_agent_r, to_agent_w = await _pipe()
-        to_client_r, to_client_w = await _pipe()
-        served = asyncio.create_task(serve(server.bind, to_agent_r, to_client_w))
-        conn = ClientSideConnection(lambda _agent: RecordingClient(), to_agent_w, to_client_r)
+        (agent_r, agent_w), (client_r, client_w) = await duplex()
+        served = asyncio.create_task(serve(server.bind, agent_r, agent_w))
+        conn = ClientSideConnection(lambda _agent: RecordingClient(), client_w, client_r)
 
         try:
             await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
             await conn.new_session(cwd="/tmp")
             assert len(server.sessions) == 1
 
-            to_agent_w.close()  # EOF on the agent's input: the Client hung up
+            client_w.close()  # EOF on the agent's input: the Client hung up
             await asyncio.wait_for(served, timeout=5)
 
             assert len(server.sessions) == 0
         finally:
             await conn.close()
-            to_client_w.close()
+            agent_w.close()
 
     async def test_an_agent_object_the_caller_built_is_not_closed(self) -> None:
         """``serve`` only releases the scope it created; a passed-in agent is not one."""
         agent = _StaticAgent()
-        to_agent_r, to_agent_w = await _pipe()
-        to_client_r, to_client_w = await _pipe()
-        served = asyncio.create_task(serve(agent, to_agent_r, to_client_w))
-        conn = ClientSideConnection(lambda _agent: RecordingClient(), to_agent_w, to_client_r)
+        (agent_r, agent_w), (client_r, client_w) = await duplex()
+        served = asyncio.create_task(serve(agent, agent_r, agent_w))
+        conn = ClientSideConnection(lambda _agent: RecordingClient(), client_w, client_r)
 
         try:
             await conn.initialize(protocol_version=acp.PROTOCOL_VERSION)
-            to_agent_w.close()
+            client_w.close()
             await asyncio.wait_for(served, timeout=5)
 
             assert agent.initialized is True
             assert agent.closed is False
         finally:
             await conn.close()
-            to_client_w.close()
+            agent_w.close()
 
 
 @pytest.mark.asyncio

--- a/test/acp/test_agent_mappers.py
+++ b/test/acp/test_agent_mappers.py
@@ -150,7 +150,7 @@ class TestToolResultText:
     def test_non_string_results_render_as_text(self, value: object, expected: str) -> None:
         assert tool_result_text(ToolResult(value)) == expected
 
-    def test_binary_parts_are_placeheld_not_inlined(self) -> None:
+    def test_binary_parts_get_a_placeholder_not_the_bytes(self) -> None:
         result = ToolResult(BinaryInput(b"\x89PNG", media_type="image/png"))
 
         rendered = tool_result_text(result)

--- a/test/acp/test_agent_mappers.py
+++ b/test/acp/test_agent_mappers.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit coverage for the AG2 -> ACP direction of :mod:`ag2.acp.mappers`."""
+
+import base64
+
+import acp
+import pytest
+from acp import schema
+
+from ag2.acp.mappers import event_to_session_update, prompt_to_inputs, tool_result_text
+from ag2.events import (
+    BinaryInput,
+    ModelMessageChunk,
+    ModelReasoning,
+    ModelResponse,
+    TextInput,
+    ToolCallEvent,
+    ToolErrorEvent,
+    ToolResultEvent,
+)
+from ag2.events.tool_events import ToolResult
+from ag2.events.types import ModelMessage
+
+
+class TestPromptToInputs:
+    def test_text_becomes_text_input(self) -> None:
+        [mapped] = prompt_to_inputs([acp.text_block("hello")])
+
+        assert mapped == TextInput("hello")
+
+    def test_order_is_preserved(self) -> None:
+        mapped = prompt_to_inputs([acp.text_block("one"), acp.text_block("two")])
+
+        assert mapped == [TextInput("one"), TextInput("two")]
+
+    def test_an_image_becomes_binary_input(self) -> None:
+        block = schema.ImageContentBlock(
+            type="image",
+            data=base64.b64encode(b"png-bytes").decode(),
+            mime_type="image/png",
+        )
+
+        [mapped] = prompt_to_inputs([block])
+
+        assert isinstance(mapped, BinaryInput)
+        assert mapped.data == b"png-bytes"
+
+    def test_an_embedded_text_resource_becomes_text(self) -> None:
+        block = schema.EmbeddedResourceContentBlock(
+            type="resource",
+            resource=schema.TextResourceContents(uri="file:///a.md", text="body"),
+        )
+
+        [mapped] = prompt_to_inputs([block])
+
+        assert mapped == TextInput("body")
+
+    def test_an_embedded_blob_uses_the_inlined_bytes(self) -> None:
+        block = schema.EmbeddedResourceContentBlock(
+            type="resource",
+            resource=schema.BlobResourceContents(
+                uri="file:///a.pdf",
+                blob=base64.b64encode(b"%PDF-1.4").decode(),
+                mime_type="application/pdf",
+            ),
+        )
+
+        [mapped] = prompt_to_inputs([block])
+
+        assert isinstance(mapped, BinaryInput)
+        assert mapped.data == b"%PDF-1.4"
+
+    def test_a_resource_link_is_referenced_not_dereferenced(self) -> None:
+        block = schema.ResourceContentBlock(type="resource_link", uri="file:///secret", name="secret")
+
+        [mapped] = prompt_to_inputs([block])
+
+        assert isinstance(mapped, TextInput)
+        assert "file:///secret" in mapped.content
+
+    def test_an_unmappable_block_does_not_drop_the_rest(self) -> None:
+        unmappable = schema.ImageContentBlock(type="image", data="", mime_type="image/png")
+
+        mapped = prompt_to_inputs([unmappable, acp.text_block("kept")])
+
+        assert mapped == [TextInput("kept")]
+
+
+class TestEventToSessionUpdate:
+    def test_a_message_chunk_becomes_an_agent_message_chunk(self) -> None:
+        update = event_to_session_update(ModelMessageChunk("hello"))
+
+        assert isinstance(update, schema.AgentMessageChunk)
+        assert update.content.text == "hello"
+
+    def test_reasoning_is_withheld_by_default(self) -> None:
+        assert event_to_session_update(ModelReasoning("internal")) is None
+
+    def test_reasoning_is_projected_when_opted_in(self) -> None:
+        update = event_to_session_update(ModelReasoning("internal"), stream_thoughts=True)
+
+        assert isinstance(update, schema.AgentThoughtChunk)
+        assert update.content.text == "internal"
+
+    def test_a_tool_call_carries_its_id_name_and_arguments(self) -> None:
+        update = event_to_session_update(ToolCallEvent(id="c1", name="add", arguments='{"a": 1}'))
+
+        assert isinstance(update, schema.ToolCallStart)
+        assert (update.tool_call_id, update.title, update.raw_input) == ("c1", "add", {"a": 1})
+
+    def test_a_tool_result_is_reported_completed(self) -> None:
+        update = event_to_session_update(ToolResultEvent(parent_id="c1", name="add", result=ToolResult("3")))
+
+        assert isinstance(update, schema.ToolCallProgress)
+        assert update.status == "completed"
+        assert update.content[0].content.text == "3"
+
+    def test_a_tool_error_is_reported_failed(self) -> None:
+        event = ToolErrorEvent(parent_id="c1", name="add", result=ToolResult("x"), error=ValueError("kaboom"))
+
+        update = event_to_session_update(event)
+
+        assert isinstance(update, schema.ToolCallProgress)
+        assert update.status == "failed"
+        assert "kaboom" in update.content[0].content.text
+
+    def test_a_tool_error_is_not_mistaken_for_a_success(self) -> None:
+        """``ToolErrorEvent`` subclasses ``ToolResultEvent`` — order matters."""
+        event = ToolErrorEvent(parent_id="c1", name="add", result=ToolResult("x"), error=ValueError("kaboom"))
+
+        assert event_to_session_update(event).status == "failed"
+
+    def test_the_final_response_is_not_projected(self) -> None:
+        """Its text already went out as chunks; re-sending would duplicate the reply."""
+        assert event_to_session_update(ModelResponse(ModelMessage("the whole answer"))) is None
+
+
+class TestToolResultText:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("plain", "plain"),
+            (200, "200"),
+            ({"total": 200}, '{"total": 200}'),
+            ([1, 2], "[1, 2]"),
+        ],
+    )
+    def test_non_string_results_render_as_text(self, value: object, expected: str) -> None:
+        assert tool_result_text(ToolResult(value)) == expected
+
+    def test_binary_parts_are_placeheld_not_inlined(self) -> None:
+        result = ToolResult(BinaryInput(b"\x89PNG", media_type="image/png"))
+
+        rendered = tool_result_text(result)
+
+        assert "PNG" not in rendered
+        assert rendered.startswith("[")

--- a/test/acp/test_agent_prompt.py
+++ b/test/acp/test_agent_prompt.py
@@ -426,7 +426,30 @@ class TestSessionContext:
             session = await server.sessions.get(created.session_id)
 
         # Captured for an embedding application to inspect — and nothing more.
-        assert len(session.mcp_servers) == 1
+        assert session.mcp_servers == [declared]
+
+    async def test_every_declared_transport_round_trips_as_its_own_model(self) -> None:
+        """A recorded server keeps the shape the Client declared it in.
+
+        ``session/new`` crosses the wire as JSON, so a declared server is only
+        ever as good as what comes back out of it — a stdio entry that lands as a
+        dict, or as the wrong union member, is recorded just as happily. Every
+        shape ``NewSessionRequest.mcp_servers`` admits is pinned once, here.
+        """
+        server = ACPAgent(_agent())
+        declared = [
+            schema.HttpMcpServer(type="http", name="over-http", url="http://127.0.0.1:9/mcp", headers=[]),
+            schema.SseMcpServer(type="sse", name="over-sse", url="http://127.0.0.1:9/sse", headers=[]),
+            schema.AcpMcpServer(type="acp", name="over-acp", id="peer-1"),
+            schema.McpServerStdio(name="over-stdio", command="/bin/true", args=["--serve"], env=[]),
+        ]
+
+        async with connect(server) as (conn, _):
+            created = await conn.new_session(cwd="/tmp", mcp_servers=declared)
+            session = await server.sessions.get(created.session_id)
+
+        # Pydantic equality is class-sensitive, so this pins the model too.
+        assert session.mcp_servers == declared
 
 
 @pytest.mark.asyncio

--- a/test/acp/test_agent_prompt.py
+++ b/test/acp/test_agent_prompt.py
@@ -1,0 +1,772 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import threading
+from collections.abc import Sequence
+from typing import Any
+
+import acp
+import pytest
+from acp import schema
+from acp.exceptions import RequestError
+from typing_extensions import Self
+
+from ag2 import Agent, Context
+from ag2.acp import ACPAgent
+from ag2.acp.executor import META_VARIABLE, AgentExecutor, UpdateDeliveryError
+from ag2.acp.sessions import SessionStore
+from ag2.acp.testing import RecordingClient, connect
+from ag2.config import LLMClient, ModelConfig
+from ag2.events import BaseEvent, ModelMessageChunk, ModelResponse, ToolCallEvent
+from ag2.testing import TestConfig
+
+
+class _RecordingClient(LLMClient):
+    """Wraps another client, capturing the full message list sent on each call."""
+
+    def __init__(
+        self,
+        client: LLMClient,
+        sink: list[list[BaseEvent]],
+        variables: list[dict[Any, Any]],
+        prompts: list[list[str]],
+    ) -> None:
+        self.client = client
+        self.sink = sink
+        self.variables = variables
+        self.prompts = prompts
+
+    async def __call__(self, messages: Sequence[BaseEvent], context: Context, **kwargs: Any) -> ModelResponse:
+        self.sink.append(list(messages))
+        self.variables.append(dict(context.variables))
+        self.prompts.append(list(context.prompt))
+        return await self.client(messages, context=context, **kwargs)
+
+
+class _RecordingConfig(ModelConfig):
+    """Records every message list the framework sends to the LLM, per turn."""
+
+    def __init__(self, config: ModelConfig) -> None:
+        self.config = config
+        self.calls: list[list[BaseEvent]] = []
+        self.variables: list[dict[Any, Any]] = []
+        self.prompts: list[list[str]] = []
+
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> _RecordingClient:
+        return _RecordingClient(self.config.create(), self.calls, self.variables, self.prompts)
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+class _StreamingClient(LLMClient):
+    """Emits the reply as chunks first, the way a streaming provider does."""
+
+    def __init__(self, client: LLMClient, chunks: Sequence[str]) -> None:
+        self.client = client
+        self.chunks = chunks
+
+    async def __call__(self, messages: Sequence[BaseEvent], context: Context, **kwargs: Any) -> ModelResponse:
+        for chunk in self.chunks:
+            await context.send(ModelMessageChunk(chunk))
+        return await self.client(messages, context=context, **kwargs)
+
+
+class _StreamingConfig(ModelConfig):
+    """Streams ``chunks`` and then returns their concatenation as the final reply."""
+
+    def __init__(self, *chunks: str) -> None:
+        self.chunks = chunks
+        self.config = TestConfig("".join(chunks))
+
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> _StreamingClient:
+        return _StreamingClient(self.config.create(), self.chunks)
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+def _agent(*turns: object) -> Agent:
+    return Agent("workie", config=TestConfig(*(turns or ("ok",))))
+
+
+def _recording_agent(*turns: object) -> tuple[Agent, _RecordingConfig]:
+    config = _RecordingConfig(TestConfig(*(turns or ("ok",))))
+    return Agent("workie", config=config), config
+
+
+def _texts(updates: list[Any]) -> list[str]:
+    """The text of every ``agent_message_chunk``, in arrival order."""
+    return [u.content.text for u in updates if isinstance(u, schema.AgentMessageChunk)]
+
+
+@pytest.mark.asyncio
+class TestPromptTurn:
+    async def test_the_reply_reaches_the_client(self) -> None:
+        async with connect(ACPAgent(_agent("200"))) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            response = await conn.prompt(
+                session_id=session.session_id,
+                prompt=[acp.text_block("what's 100 + 100")],
+            )
+
+        assert response.stop_reason == "end_turn"
+        assert _texts(recorder.updates_for(session.session_id)) == ["200"]
+
+    async def test_an_unknown_session_is_a_protocol_error(self) -> None:
+        async with connect(ACPAgent(_agent())) as (conn, _):
+            with pytest.raises(RequestError):
+                await conn.prompt(session_id="never-issued", prompt=[acp.text_block("hi")])
+
+    async def test_prompt_text_reaches_the_agent(self) -> None:
+        agent, config = _recording_agent()
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("hello agent")])
+
+        assert "hello agent" in str(config.calls[-1])
+
+    async def test_multiple_text_blocks_all_reach_the_agent(self) -> None:
+        agent, config = _recording_agent()
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(
+                session_id=session.session_id,
+                prompt=[acp.text_block("first"), acp.text_block("second")],
+            )
+
+        rendered = str(config.calls[-1])
+        assert "first" in rendered
+        assert "second" in rendered
+
+    async def test_an_embedded_text_resource_reaches_the_agent(self) -> None:
+        agent, config = _recording_agent()
+        resource = schema.EmbeddedResourceContentBlock(
+            type="resource",
+            resource=schema.TextResourceContents(uri="file:///notes.md", text="the embedded body"),
+        )
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[resource])
+
+        assert "the embedded body" in str(config.calls[-1])
+
+    async def test_an_image_block_is_accepted(self) -> None:
+        image = schema.ImageContentBlock(
+            type="image",
+            data=base64.b64encode(b"fake-png").decode(),
+            mime_type="image/png",
+        )
+
+        async with connect(ACPAgent(_agent("saw it"))) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            response = await conn.prompt(session_id=session.session_id, prompt=[image])
+
+        assert response.stop_reason == "end_turn"
+        assert _texts(recorder.updates_for(session.session_id)) == ["saw it"]
+
+    async def test_a_resource_link_is_referenced_but_never_fetched(self) -> None:
+        agent, config = _recording_agent()
+        link = schema.ResourceContentBlock(type="resource_link", uri="file:///etc/passwd", name="passwd")
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[link])
+
+        rendered = str(config.calls[-1])
+        assert "file:///etc/passwd" in rendered  # the reference is visible
+        assert "root:" not in rendered  # the file itself was not read
+
+    async def test_an_unhandled_turn_failure_becomes_a_protocol_error(self) -> None:
+        agent = _agent(ToolCallEvent(name="boom", arguments="{}"), "recovered")
+
+        @agent.tool
+        def boom() -> str:
+            """Always raises."""
+            raise ValueError("kaboom")
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            with pytest.raises(RequestError):
+                await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+    async def test_a_failure_tells_the_client_what_went_wrong(self) -> None:
+        """The Client is another process — an error without its cause is unusable."""
+        agent = _agent(ToolCallEvent(name="boom", arguments="{}"), "recovered")
+
+        @agent.tool
+        def boom() -> str:
+            """Always raises."""
+            raise ValueError("the specific thing that broke")
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            with pytest.raises(RequestError) as caught:
+                await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        assert caught.value.data == {
+            "reason": "the specific thing that broke",
+            "type": "ValueError",
+        }
+
+    async def test_a_config_failure_reaches_the_client(self) -> None:
+        """The common real-world case: the model rejected the request."""
+
+        class _Exploding(ModelConfig):
+            def copy(self) -> Self:
+                return self
+
+            def create(self) -> LLMClient:
+                raise RuntimeError("Could not resolve authentication method.")
+
+            def create_files_client(self) -> None:
+                raise NotImplementedError
+
+        async with connect(ACPAgent(Agent("workie", config=_Exploding()))) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            with pytest.raises(RequestError) as caught:
+                await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        assert "authentication" in caught.value.data["reason"]
+
+    async def test_a_failing_tool_is_reported_before_the_turn_dies(self) -> None:
+        """The Client learns *why* a turn failed, not just that it did."""
+        agent = _agent(ToolCallEvent(name="boom", arguments="{}"), "recovered")
+
+        @agent.tool
+        def boom() -> str:
+            """Always raises."""
+            raise ValueError("kaboom")
+
+        async with connect(ACPAgent(agent)) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            with pytest.raises(RequestError):
+                await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        [progress] = [u for u in recorder.updates_for(session.session_id) if isinstance(u, schema.ToolCallProgress)]
+        assert progress.status == "failed"
+        assert "kaboom" in progress.content[0].content.text
+
+    async def test_a_failed_turn_does_not_leave_the_session_locked(self) -> None:
+        """A failure must release the turn lock, or the session would hang forever.
+
+        The follow-up prompt still fails — AG2 persists the unhandled tool error
+        and re-raises it on every later turn of that stream (reproducible with a
+        plain ``agent.ask`` on a shared stream, nothing to do with ACP). What
+        matters here is that it *returns* rather than blocking.
+        """
+        agent = _agent(ToolCallEvent(name="boom", arguments="{}"), "recovered")
+
+        @agent.tool
+        def boom() -> str:
+            """Always raises."""
+            raise ValueError("kaboom")
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            for _ in range(2):
+                with pytest.raises(RequestError):
+                    await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+
+@pytest.mark.asyncio
+class TestUpdateProjection:
+    @staticmethod
+    def _adding_agent() -> Agent:
+        agent = _agent(ToolCallEvent(name="add", arguments='{"a": 100, "b": 100}'), "200")
+
+        @agent.tool
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        return agent
+
+    async def test_tool_activity_is_reported_in_order(self) -> None:
+        async with connect(ACPAgent(self._adding_agent())) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("100+100")])
+
+        kinds = [u.session_update for u in recorder.updates_for(session.session_id)]
+        assert kinds == ["tool_call", "tool_call_update", "agent_message_chunk"]
+
+    async def test_a_tool_result_carries_its_value(self) -> None:
+        async with connect(ACPAgent(self._adding_agent())) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("100+100")])
+
+        [progress] = [u for u in recorder.updates_for(session.session_id) if isinstance(u, schema.ToolCallProgress)]
+        assert progress.status == "completed"
+        assert progress.content[0].content.text == "200"
+
+    async def test_a_tool_call_and_its_result_share_an_id(self) -> None:
+        async with connect(ACPAgent(self._adding_agent())) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("100+100")])
+
+        updates = recorder.updates_for(session.session_id)
+        [start] = [u for u in updates if isinstance(u, schema.ToolCallStart)]
+        [progress] = [u for u in updates if isinstance(u, schema.ToolCallProgress)]
+        assert start.tool_call_id == progress.tool_call_id
+
+    async def test_a_tool_call_carries_its_arguments(self) -> None:
+        async with connect(ACPAgent(self._adding_agent())) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("100+100")])
+
+        [start] = [u for u in recorder.updates_for(session.session_id) if isinstance(u, schema.ToolCallStart)]
+        assert start.title == "add"
+        assert start.raw_input == {"a": 100, "b": 100}
+
+    async def test_a_non_streaming_reply_still_reaches_the_client(self) -> None:
+        """No chunks were emitted, so the assembled reply must be sent instead."""
+        async with connect(ACPAgent(_agent("just once"))) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("hi")])
+
+        assert _texts(recorder.updates_for(session.session_id)) == ["just once"]
+
+    async def test_streamed_chunks_reach_the_client_in_order(self) -> None:
+        agent = Agent("workie", config=_StreamingConfig("Paris is ", "the capital ", "of France."))
+
+        async with connect(ACPAgent(agent)) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("capital of France?")])
+
+        assert _texts(recorder.updates_for(session.session_id)) == [
+            "Paris is ",
+            "the capital ",
+            "of France.",
+        ]
+
+    async def test_a_streamed_reply_is_not_repeated_at_the_end(self) -> None:
+        """The final response echoes the whole answer; re-sending it would double it."""
+        agent = Agent("workie", config=_StreamingConfig("Paris is ", "the capital ", "of France."))
+
+        async with connect(ACPAgent(agent)) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("capital of France?")])
+
+        assembled = "".join(_texts(recorder.updates_for(session.session_id)))
+        assert assembled == "Paris is the capital of France."
+
+    async def test_reasoning_is_withheld_by_default(self) -> None:
+        async with connect(ACPAgent(_agent("answer"))) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("hi")])
+
+        thoughts = [u for u in recorder.updates_for(session.session_id) if isinstance(u, schema.AgentThoughtChunk)]
+        assert thoughts == []
+
+
+@pytest.mark.asyncio
+class TestSessionIsolation:
+    async def test_one_session_never_sees_another_prompt(self) -> None:
+        agent, config = _recording_agent()
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            first = await conn.new_session(cwd="/tmp")
+            second = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=first.session_id, prompt=[acp.text_block("secret to first")])
+            await conn.prompt(session_id=second.session_id, prompt=[acp.text_block("hello second")])
+
+        assert "secret to first" not in str(config.calls[-1])
+        assert "hello second" in str(config.calls[-1])
+
+    async def test_history_accumulates_within_one_session(self) -> None:
+        agent, config = _recording_agent()
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("remember this")])
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("and now")])
+
+        assert "remember this" in str(config.calls[-1])
+
+    async def test_every_update_is_tagged_with_its_own_session(self) -> None:
+        async with connect(ACPAgent(_agent("reply"))) as (conn, recorder):
+            first = await conn.new_session(cwd="/tmp")
+            second = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=first.session_id, prompt=[acp.text_block("one")])
+            await conn.prompt(session_id=second.session_id, prompt=[acp.text_block("two")])
+
+        assert len(recorder.updates_for(first.session_id)) == 1
+        assert len(recorder.updates_for(second.session_id)) == 1
+
+
+@pytest.mark.asyncio
+class TestSessionContext:
+    async def test_client_context_is_recorded_but_not_acted_on(self) -> None:
+        server = ACPAgent(_agent())
+
+        async with connect(server) as (conn, _):
+            created = await conn.new_session(cwd="/work", additional_directories=["/extra"])
+            session = await server.sessions.get(created.session_id)
+
+        assert session.cwd == "/work"
+        assert session.additional_directories == ["/extra"]
+
+    async def test_declared_mcp_servers_are_recorded_but_never_connected(self) -> None:
+        server = ACPAgent(_agent())
+        declared = schema.HttpMcpServer(type="http", name="evil", url="http://127.0.0.1:9/mcp", headers=[])
+
+        async with connect(server) as (conn, _):
+            created = await conn.new_session(cwd="/tmp", mcp_servers=[declared])
+            session = await server.sessions.get(created.session_id)
+
+        # Captured for an embedding application to inspect — and nothing more.
+        assert len(session.mcp_servers) == 1
+
+
+@pytest.mark.asyncio
+class TestDeliveryFailures:
+    """A turn must not report success for output the Client never received."""
+
+    class _DeadClient(RecordingClient):
+        async def session_update(self, *, session_id: str, update: Any, **kwargs: Any) -> None:
+            raise ConnectionResetError("client went away")
+
+    async def test_an_undeliverable_turn_is_not_reported_as_end_turn(self) -> None:
+        store = SessionStore()
+        session = await store.create()
+        executor = AgentExecutor(_agent("the answer"))
+
+        with pytest.raises(UpdateDeliveryError):
+            await executor.run_turn(
+                session=session,
+                store=store,
+                client=self._DeadClient(),
+                blocks=[acp.text_block("hi")],
+            )
+
+    async def test_history_survives_a_delivery_failure(self) -> None:
+        """The turn ran; only the telling failed."""
+        store = SessionStore()
+        session = await store.create()
+        executor = AgentExecutor(_agent("the answer"))
+
+        with pytest.raises(UpdateDeliveryError):
+            await executor.run_turn(
+                session=session,
+                store=store,
+                client=self._DeadClient(),
+                blocks=[acp.text_block("hi")],
+            )
+
+        assert list(await store.stream(session).history.get_events())
+
+
+@pytest.mark.asyncio
+class TestRequestMetadata:
+    """ACP `_meta` is where applications put provenance; it must survive intact."""
+
+    @staticmethod
+    def _raw(conn: Any) -> Any:
+        return conn._conn if hasattr(conn, "_conn") else conn._connection
+
+    async def test_wire_meta_is_captured_on_the_session(self) -> None:
+        server = ACPAgent(_agent())
+
+        async with connect(server) as (conn, _):
+            response = await self._raw(conn).send_request(
+                "session/new",
+                {"cwd": "/tmp", "mcpServers": [], "_meta": {"ag2.space": {"room": "!r"}}},
+            )
+            session = await server.sessions.get(response["sessionId"])
+
+        assert session.meta == {"ag2.space": {"room": "!r"}}
+
+    async def test_a_session_without_meta_carries_none(self) -> None:
+        server = ACPAgent(_agent())
+
+        async with connect(server) as (conn, _):
+            created = await conn.new_session(cwd="/tmp")
+            session = await server.sessions.get(created.session_id)
+
+        assert session.meta == {}
+
+    async def test_prompt_meta_reaches_the_agent_as_a_context_variable(self) -> None:
+        agent, config = _recording_agent()
+        server = ACPAgent(agent)
+
+        async with connect(server) as (conn, _):
+            created = await conn.new_session(cwd="/tmp")
+            await self._raw(conn).send_request(
+                "session/prompt",
+                {
+                    "sessionId": created.session_id,
+                    "prompt": [{"type": "text", "text": "hi"}],
+                    "_meta": {"ag2.space": {"event": "$abc"}},
+                },
+            )
+
+        assert config.variables[-1][META_VARIABLE] == {"ag2.space": {"event": "$abc"}}
+
+
+@pytest.mark.asyncio
+class TestDynamicPrompt:
+    """``@agent.prompt`` hooks routinely carry per-request policy.
+
+    An agent that resolves them under ``ask`` but not over ACP is a *less
+    constrained* agent once it is served, which is the opposite of what a
+    transport should do to it.
+    """
+
+    async def test_a_dynamic_prompt_is_resolved(self) -> None:
+        agent, config = _recording_agent()
+
+        @agent.prompt
+        def policy(ctx: Context) -> str:
+            return "POLICY: decline refunds."
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("refund me")])
+
+        assert config.prompts[-1] == ["POLICY: decline refunds."]
+
+    async def test_the_static_prompt_still_comes_first(self) -> None:
+        config = _RecordingConfig(TestConfig("ok"))
+        agent = Agent("workie", prompt="You are workie.", config=config)
+
+        @agent.prompt
+        def policy(ctx: Context) -> str:
+            return "POLICY: decline refunds."
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("hi")])
+
+        assert config.prompts[-1] == ["You are workie.", "POLICY: decline refunds."]
+
+    async def test_a_dynamic_prompt_reads_a_context_variable(self) -> None:
+        config = _RecordingConfig(TestConfig("ok"))
+        agent = Agent("workie", config=config, variables={"tier": "enterprise"})
+
+        @agent.prompt
+        def tiered(ctx: Context) -> str:
+            return f"Caller tier: {ctx.variables['tier']}."
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("hi")])
+
+        assert config.prompts[-1] == ["Caller tier: enterprise."]
+
+    async def test_a_dynamic_prompt_reads_the_client_meta(self) -> None:
+        """The Client's ``_meta`` is per-request, so a hook is where it gets used."""
+        agent, config = _recording_agent()
+
+        @agent.prompt
+        def provenance(ctx: Context) -> str:
+            return f"Room: {ctx.variables[META_VARIABLE]['ag2.space']['room']}."
+
+        store = SessionStore()
+        session = await store.create()
+
+        await AgentExecutor(agent).run_turn(
+            session=session,
+            store=store,
+            client=RecordingClient(),
+            blocks=[acp.text_block("hi")],
+            meta={"ag2.space": {"room": "!r"}},
+        )
+
+        assert config.prompts[-1] == ["Room: !r."]
+
+    async def test_the_prompt_matches_what_ask_sends(self) -> None:
+        """Parity is the whole point: one agent, one prompt, whatever the transport."""
+        config = _RecordingConfig(TestConfig("ok"))
+        agent = Agent("workie", prompt="You are workie.", config=config)
+
+        @agent.prompt
+        def policy(ctx: Context) -> str:
+            return "POLICY: decline refunds."
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("hi")])
+
+        over_acp = config.prompts[-1]
+        await agent.ask("hi")
+
+        assert over_acp == config.prompts[-1]
+
+
+class _MultiCallConfig(ModelConfig):
+    """Streams a different script on each model call of one turn.
+
+    A tool-using turn makes two LLM calls; a chatty model may stream text in both
+    (a "let me check..." preamble, then the answer).
+    """
+
+    def __init__(self, *scripts: Sequence[str], inner: ModelConfig) -> None:
+        self.scripts = scripts
+        self.inner = inner
+
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> LLMClient:
+        return _MultiCallClient(self.inner.create(), self.scripts)
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+class _MultiCallClient(LLMClient):
+    def __init__(self, client: LLMClient, scripts: Sequence[Sequence[str]]) -> None:
+        self.client = client
+        self.scripts = scripts
+        self.call = 0
+
+    async def __call__(self, messages: Sequence[BaseEvent], context: Context, **kwargs: Any) -> ModelResponse:
+        for chunk in self.scripts[min(self.call, len(self.scripts) - 1)]:
+            await context.send(ModelMessageChunk(chunk))
+        self.call += 1
+        return await self.client(messages, context=context, **kwargs)
+
+
+@pytest.mark.asyncio
+class TestStreamingToolTurns:
+    """De-dup must compare against the final model call, not the whole turn."""
+
+    @staticmethod
+    def _agent_streaming_both_calls() -> Agent:
+        config = _MultiCallConfig(
+            ["Let me calculate. "],
+            ["The answer is 4."],
+            inner=TestConfig(ToolCallEvent(name="add", arguments='{"a": 2, "b": 2}'), "The answer is 4."),
+        )
+        agent = Agent("workie", config=config)
+
+        @agent.tool
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        return agent
+
+    async def test_the_answer_is_not_sent_twice(self) -> None:
+        async with connect(ACPAgent(self._agent_streaming_both_calls())) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("2+2")])
+
+        assert _texts(recorder.updates_for(session.session_id)) == [
+            "Let me calculate. ",
+            "The answer is 4.",
+        ]
+
+    async def test_the_preamble_still_reaches_the_client(self) -> None:
+        async with connect(ACPAgent(self._agent_streaming_both_calls())) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("2+2")])
+
+        assert "Let me calculate. " in _texts(recorder.updates_for(session.session_id))
+
+    async def test_a_silent_first_call_still_delivers_the_answer(self) -> None:
+        """The common shape: the tool-selection call streams nothing."""
+        config = _MultiCallConfig(
+            [],
+            ["The answer is 4."],
+            inner=TestConfig(ToolCallEvent(name="add", arguments='{"a": 2, "b": 2}'), "The answer is 4."),
+        )
+        agent = Agent("workie", config=config)
+
+        @agent.tool
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        async with connect(ACPAgent(agent)) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("2+2")])
+
+        assert _texts(recorder.updates_for(session.session_id)) == ["The answer is 4."]
+
+
+@pytest.mark.asyncio
+class TestSessionVariables:
+    """Variables belong to a conversation: they persist in it, and only in it."""
+
+    @staticmethod
+    def _counting_agent(reports: list[tuple[int, int]]) -> Agent:
+        agent = Agent(
+            "workie",
+            variables={"seen": [], "n": 0},
+            config=TestConfig(
+                ToolCallEvent(name="touch", arguments="{}"),
+                "ok",
+                ToolCallEvent(name="touch", arguments="{}"),
+                "ok",
+            ),
+        )
+
+        @agent.tool
+        def touch(ctx: Context) -> str:
+            """Mutate one nested and one top-level variable."""
+            ctx.variables["seen"].append("x")
+            ctx.variables["n"] = ctx.variables["n"] + 1
+            reports.append((len(ctx.variables["seen"]), ctx.variables["n"]))
+            return "done"
+
+        return agent
+
+    async def test_writes_persist_across_turns_of_one_session(self) -> None:
+        """The same continuity ``AgentReply.ask`` gives an off-protocol conversation."""
+        reports: list[tuple[int, int]] = []
+
+        async with connect(ACPAgent(self._counting_agent(reports))) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            for _ in range(2):
+                await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        assert reports == [(1, 1), (2, 2)]
+
+    async def test_a_nested_value_is_not_shared_between_sessions(self) -> None:
+        """A shallow copy would leave this list shared and the count would keep climbing."""
+        reports: list[tuple[int, int]] = []
+
+        async with connect(ACPAgent(self._counting_agent(reports))) as (conn, _):
+            first = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=first.session_id, prompt=[acp.text_block("go")])
+            second = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=second.session_id, prompt=[acp.text_block("go")])
+
+        assert reports == [(1, 1), (1, 1)]
+
+    async def test_the_agent_s_own_defaults_are_never_mutated(self) -> None:
+        reports: list[tuple[int, int]] = []
+        agent = self._counting_agent(reports)
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        assert agent._agent_variables == {"seen": [], "n": 0}
+
+    async def test_an_uncopyable_default_is_shared_rather_than_failing(self) -> None:
+        """Degrading loudly beats refusing to open a session over one odd value.
+
+        ``threading.Lock`` is the shape this guards: a real handle that a deep
+        copy cannot reproduce.
+        """
+        agent = Agent("workie", variables={"lock": threading.Lock()}, config=TestConfig("ok"))
+        server = ACPAgent(agent)
+
+        async with connect(server) as (conn, _):
+            created = await conn.new_session(cwd="/tmp")
+            session = await server.sessions.get(created.session_id)
+
+        assert session.variables["lock"] is agent._agent_variables["lock"]

--- a/test/acp/test_agent_sessions.py
+++ b/test/acp/test_agent_sessions.py
@@ -1,0 +1,559 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from contextlib import suppress
+
+import pytest
+
+from ag2.acp.sessions import (
+    SessionBusyError,
+    SessionConfig,
+    SessionLimitError,
+    SessionStore,
+    UnknownSessionError,
+)
+from ag2.events import ModelMessage
+
+
+@pytest.mark.asyncio
+class TestIdentity:
+    async def test_each_session_gets_a_distinct_id_and_stream(self) -> None:
+        store = SessionStore()
+
+        first = await store.create()
+        second = await store.create()
+
+        assert first.session_id != second.session_id
+        assert first.stream_id != second.stream_id
+
+    async def test_get_returns_the_same_session(self) -> None:
+        store = SessionStore()
+
+        created = await store.create()
+
+        assert await store.get(created.session_id) is created
+
+    async def test_unknown_id_raises(self) -> None:
+        store = SessionStore()
+
+        with pytest.raises(UnknownSessionError):
+            await store.get("never-issued")
+
+    async def test_client_context_is_captured_verbatim(self) -> None:
+        store = SessionStore()
+
+        session = await store.create(cwd="/work", additional_directories=["/extra"], meta={"ag2.space": {"room": "!r"}})
+
+        assert session.cwd == "/work"
+        assert session.additional_directories == ["/extra"]
+        assert session.meta == {"ag2.space": {"room": "!r"}}
+
+
+@pytest.mark.asyncio
+class TestHistoryIsolation:
+    async def test_two_sessions_never_share_history(self) -> None:
+        store = SessionStore()
+        first = await store.create()
+        second = await store.create()
+
+        await store.stream(first).history.replace([ModelMessage("only for first")])
+
+        assert [e.content for e in await store.stream(first).history.get_events()] == ["only for first"]
+        assert list(await store.stream(second).history.get_events()) == []
+
+    async def test_history_accumulates_across_turns_of_one_session(self) -> None:
+        store = SessionStore()
+        session = await store.create()
+
+        await store.stream(session).history.replace([ModelMessage("turn one")])
+        # A *fresh* stream object per turn still reads the session's history back.
+        later = store.stream(session)
+
+        assert [e.content for e in await later.history.get_events()] == ["turn one"]
+
+    async def test_a_session_keeps_one_stream_for_its_lifetime(self) -> None:
+        """A stream carries an inbox and background tasks, not just history.
+
+        Handing out a fresh object per turn would strand anything a background
+        task delivered after its own turn finished.
+        """
+        store = SessionStore()
+        session = await store.create()
+
+        assert store.stream(session) is store.stream(session)
+
+    async def test_a_message_enqueued_during_one_turn_survives_to_the_next(self) -> None:
+        store = SessionStore()
+        session = await store.create()
+
+        store.stream(session).enqueue("late result")
+
+        assert store.stream(session).pending_messages
+
+
+@pytest.mark.asyncio
+class TestQueueing:
+    async def test_concurrent_prompts_on_one_session_run_one_at_a_time(self) -> None:
+        store = SessionStore()
+        session = await store.create()
+        order: list[str] = []
+
+        async def prompt(label: str) -> None:
+            async with session.turn():
+                order.append(f"start {label}")
+                await asyncio.sleep(0.01)
+                order.append(f"end {label}")
+
+        await asyncio.gather(prompt("a"), prompt("b"))
+
+        # Interleaving would give "start a", "start b", "end a", "end b".
+        assert order in (
+            ["start a", "end a", "start b", "end b"],
+            ["start b", "end b", "start a", "end a"],
+        )
+
+    async def test_the_running_turn_does_not_count_against_the_queue(self) -> None:
+        store = SessionStore.from_config(SessionConfig(max_queued=1))
+        session = await store.create()
+        release = asyncio.Event()
+
+        async def blocked() -> None:
+            async with session.turn():
+                await release.wait()
+
+        running = asyncio.create_task(blocked())
+        await asyncio.sleep(0)  # let it take the lock
+
+        assert session.queued == 0  # the holder is running, not queued
+
+        queued = asyncio.create_task(blocked())
+        await asyncio.sleep(0)
+
+        assert session.queued == 1
+
+        release.set()
+        await asyncio.gather(running, queued)
+
+    async def test_queue_overflow_is_rejected(self) -> None:
+        store = SessionStore.from_config(SessionConfig(max_queued=2))
+        session = await store.create()
+        release = asyncio.Event()
+
+        async def blocked() -> None:
+            async with session.turn():
+                await release.wait()
+
+        running = asyncio.create_task(blocked())
+        await asyncio.sleep(0)  # let it take the lock
+        waiters = [asyncio.create_task(blocked()) for _ in range(2)]
+        await asyncio.sleep(0)  # let both queue behind it
+
+        with pytest.raises(SessionBusyError):
+            async with session.turn():
+                pass  # pragma: no cover - the guard fires before the body
+
+        release.set()
+        await asyncio.gather(running, *waiters)
+
+    async def test_queue_drains_and_the_session_is_reusable(self) -> None:
+        store = SessionStore.from_config(SessionConfig(max_queued=1))
+        session = await store.create()
+
+        async with session.turn():
+            pass
+
+        assert session.queued == 0
+        async with session.turn():
+            pass
+
+
+@pytest.mark.asyncio
+class TestCancellation:
+    async def test_cancel_stops_the_running_turn(self) -> None:
+        store = SessionStore()
+        session = await store.create()
+        started = asyncio.Event()
+
+        async def never_finishes() -> None:
+            async with session.turn():
+                started.set()
+                await asyncio.Event().wait()
+
+        session.turn_task = asyncio.create_task(never_finishes())
+        await started.wait()
+
+        await session.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await session.turn_task
+
+    async def test_cancel_also_drops_prompts_queued_behind(self) -> None:
+        store = SessionStore()
+        session = await store.create()
+        started = asyncio.Event()
+        reached_agent = False
+
+        async def running() -> None:
+            async with session.turn():
+                started.set()
+                await asyncio.Event().wait()
+
+        async def queued() -> None:
+            nonlocal reached_agent
+            async with session.turn():
+                reached_agent = True
+
+        session.turn_task = asyncio.create_task(running())
+        await started.wait()
+        waiter = asyncio.create_task(queued())
+        await asyncio.sleep(0)
+
+        await session.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await session.turn_task
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        assert reached_agent is False
+
+    async def test_cancel_leaves_other_sessions_untouched(self) -> None:
+        store = SessionStore()
+        cancelled = await store.create()
+        other = await store.create()
+        finished = False
+
+        async def work() -> None:
+            nonlocal finished
+            async with other.turn():
+                await asyncio.sleep(0.01)
+                finished = True
+
+        task = asyncio.create_task(work())
+        await asyncio.sleep(0)
+
+        await cancelled.cancel()
+        await task
+
+        assert finished is True
+
+    async def test_events_already_emitted_survive_a_cancel(self) -> None:
+        store = SessionStore()
+        session = await store.create()
+        await store.stream(session).history.replace([ModelMessage("already streamed")])
+
+        await session.cancel()
+
+        assert [e.content for e in await store.stream(session).history.get_events()] == ["already streamed"]
+
+
+@pytest.mark.asyncio
+class TestEviction:
+    async def test_lru_overflow_drops_the_oldest_session(self) -> None:
+        store = SessionStore(max_sessions=2)
+
+        first = await store.create()
+        await store.create()
+        await store.create()
+
+        assert len(store) == 2
+        with pytest.raises(UnknownSessionError):
+            await store.get(first.session_id)
+
+    async def test_touching_a_session_saves_it_from_eviction(self) -> None:
+        store = SessionStore(max_sessions=2)
+        first = await store.create()
+        second = await store.create()
+
+        await store.get(first.session_id)  # first is now most-recently used
+        await store.create()
+
+        assert await store.get(first.session_id) is first
+        with pytest.raises(UnknownSessionError):
+            await store.get(second.session_id)
+
+    async def test_idle_sessions_expire(self) -> None:
+        now = 0.0
+        store = SessionStore(ttl=10.0, clock=lambda: now)
+        session = await store.create()
+
+        now = 11.0
+
+        with pytest.raises(UnknownSessionError):
+            await store.get(session.session_id)
+
+    async def test_evicted_history_is_deleted(self) -> None:
+        store = SessionStore(max_sessions=1)
+        first = await store.create()
+        await store.stream(first).history.replace([ModelMessage("gone")])
+
+        await store.create()  # evicts first
+
+        assert list(await store.stream(first).history.get_events()) == []
+
+
+@pytest.mark.asyncio
+class TestClose:
+    async def test_close_drops_the_session_and_its_history(self) -> None:
+        store = SessionStore()
+        session = await store.create()
+        await store.stream(session).history.replace([ModelMessage("gone")])
+
+        await store.close(session.session_id)
+
+        with pytest.raises(UnknownSessionError):
+            await store.get(session.session_id)
+        assert list(await store.stream(session).history.get_events()) == []
+
+    async def test_close_cancels_live_work_and_waits_for_it(self) -> None:
+        """Unlike eviction, an explicit close *does* stop work in progress.
+
+        It also waits for the turn to unwind before deleting history, so the
+        agent's last writes cannot land in a store that has already been purged.
+        """
+        store = SessionStore()
+        session = await store.create()
+        started = asyncio.Event()
+
+        async def running() -> None:
+            async with session.turn():
+                started.set()
+                await asyncio.Event().wait()
+
+        task = asyncio.create_task(running())
+        session.turn_task = task
+        await started.wait()
+
+        await store.close(session.session_id)
+
+        assert task.done()
+        assert task.cancelled()
+
+    async def test_closing_an_unknown_session_raises(self) -> None:
+        store = SessionStore()
+
+        with pytest.raises(UnknownSessionError):
+            await store.close("never-issued")
+
+    async def test_aclose_drops_every_session(self) -> None:
+        store = SessionStore()
+        first = await store.create()
+        second = await store.create()
+
+        await store.aclose()
+
+        assert len(store) == 0
+        for session in (first, second):
+            with pytest.raises(UnknownSessionError):
+                await store.get(session.session_id)
+
+
+def test_invalid_bounds_are_rejected() -> None:
+    with pytest.raises(ValueError):
+        SessionStore(max_sessions=0)
+    with pytest.raises(ValueError):
+        SessionStore(ttl=0)
+    with pytest.raises(ValueError):
+        SessionStore(max_queued=0)
+
+
+@pytest.mark.asyncio
+class TestEvictionSparesLiveWork:
+    """An eviction policy is a memory bound, not a licence to kill running turns."""
+
+    @staticmethod
+    async def _busy(session: object) -> "asyncio.Task[None]":
+        started = asyncio.Event()
+
+        async def hold() -> None:
+            async with session.turn():  # type: ignore[attr-defined]
+                started.set()
+                await asyncio.Event().wait()
+
+        task = asyncio.create_task(hold())
+        session.turn_task = task  # type: ignore[attr-defined]
+        await started.wait()
+        return task
+
+    async def test_pressure_on_the_cap_does_not_cancel_a_running_turn(self) -> None:
+        """Admission fails instead — see :class:`TestTheCapIsAHardBound`."""
+        store = SessionStore(max_sessions=1)
+        busy = await store.create()
+        task = await self._busy(busy)
+
+        with pytest.raises(SessionLimitError):
+            await store.create()
+        await asyncio.sleep(0.01)
+
+        assert not task.done()
+        task.cancel()
+
+    async def test_pressure_on_the_cap_does_not_delete_a_running_session_s_history(self) -> None:
+        store = SessionStore(max_sessions=1)
+        busy = await store.create()
+        await store.stream(busy).history.replace([ModelMessage("mid-turn work")])
+        task = await self._busy(busy)
+
+        with pytest.raises(SessionLimitError):
+            await store.create()
+        await asyncio.sleep(0.01)
+
+        assert [e.content for e in await store.stream(busy).history.get_events()] == ["mid-turn work"]
+        task.cancel()
+
+    async def test_an_idle_session_is_still_evicted(self) -> None:
+        store = SessionStore(max_sessions=1)
+        idle = await store.create()
+
+        await store.create()
+
+        with pytest.raises(UnknownSessionError):
+            await store.get(idle.session_id)
+
+    async def test_the_idle_victim_is_chosen_over_the_busy_one(self) -> None:
+        store = SessionStore(max_sessions=2)
+        busy = await store.create()
+        idle = await store.create()
+        task = await self._busy(busy)
+
+        await store.create()
+
+        assert await store.get(busy.session_id) is busy
+        with pytest.raises(UnknownSessionError):
+            await store.get(idle.session_id)
+        task.cancel()
+
+    async def test_ttl_does_not_expire_a_session_mid_turn(self) -> None:
+        now = 0.0
+        store = SessionStore(ttl=10.0, clock=lambda: now)
+        busy = await store.create()
+        task = await self._busy(busy)
+
+        now = 11.0
+        await store.create()  # any access runs the expiry sweep
+
+        assert await store.get(busy.session_id) is busy
+        assert not task.done()
+        task.cancel()
+
+
+@pytest.mark.asyncio
+class TestEveryIssuedIdIsUsable:
+    """A session id handed to a Client must still be there when it is used."""
+
+    async def test_room_is_made_before_the_session_exists(self) -> None:
+        """A session that gets created is never a candidate for its own eviction.
+
+        Admission now runs *before* the session is built, so the id handed back
+        cannot already have been evicted to make room for itself.
+        """
+        store = SessionStore(max_sessions=2)
+        idle = await store.create()
+
+        fresh = await store.create()
+
+        assert await store.get(fresh.session_id) is fresh
+        assert await store.get(idle.session_id) is idle
+
+    async def test_the_cap_still_holds_when_an_idle_victim_exists(self) -> None:
+        store = SessionStore(max_sessions=1)
+        old = await store.create()
+
+        fresh = await store.create()
+
+        assert await store.get(fresh.session_id) is fresh
+        with pytest.raises(UnknownSessionError):
+            await store.get(old.session_id)
+
+
+@pytest.mark.asyncio
+class TestTtlMeasuresIdleTime:
+    """Expiry is about being unused, not about when the last prompt started."""
+
+    async def test_a_turn_longer_than_the_ttl_does_not_expire_its_session(self) -> None:
+        now = 0.0
+        store = SessionStore(ttl=10.0, clock=lambda: now)
+        session = await store.create()
+        await store.stream(session).history.replace([ModelMessage("slow work")])
+
+        async with session.turn():
+            now = 25.0  # the turn itself outlives the TTL
+
+        assert await store.get(session.session_id) is session
+        assert [e.content for e in await store.stream(session).history.get_events()] == ["slow work"]
+
+    async def test_the_clock_restarts_when_a_turn_finishes(self) -> None:
+        now = 0.0
+        store = SessionStore(ttl=10.0, clock=lambda: now)
+        session = await store.create()
+
+        async with session.turn():
+            now = 25.0
+
+        now = 30.0  # only 5s idle since the turn ended
+        assert await store.get(session.session_id) is session
+
+        now = 45.0  # now genuinely idle past the TTL
+        with pytest.raises(UnknownSessionError):
+            await store.get(session.session_id)
+
+
+@pytest.mark.asyncio
+class TestTheCapIsAHardBound:
+    """A cap that stretches while turns are in flight is not a cap at all."""
+
+    @staticmethod
+    async def _busy(store: SessionStore) -> "tuple[object, asyncio.Task[None]]":
+        session = await store.create()
+        started = asyncio.Event()
+
+        async def hold() -> None:
+            async with session.turn():  # type: ignore[attr-defined]
+                started.set()
+                await asyncio.Event().wait()
+
+        task = asyncio.create_task(hold())
+        session.turn_task = task  # type: ignore[attr-defined]
+        await started.wait()
+        return session, task
+
+    async def test_admission_is_refused_when_nothing_can_be_evicted(self) -> None:
+        store = SessionStore(max_sessions=1)
+        _busy, task = await self._busy(store)
+
+        with pytest.raises(SessionLimitError):
+            await store.create()
+
+        assert len(store) == 1
+        task.cancel()
+
+    async def test_a_client_cannot_grow_the_registry_by_staying_busy(self) -> None:
+        store = SessionStore(max_sessions=2)
+        tasks = []
+        for _ in range(2):
+            _session, task = await self._busy(store)
+            tasks.append(task)
+
+        for _ in range(5):
+            with pytest.raises(SessionLimitError):
+                await store.create()
+
+        assert len(store) == 2
+        for task in tasks:
+            task.cancel()
+
+    async def test_a_slot_frees_up_once_a_turn_finishes(self) -> None:
+        store = SessionStore(max_sessions=1)
+        _session, task = await self._busy(store)
+
+        with pytest.raises(SessionLimitError):
+            await store.create()
+
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+        fresh = await store.create()
+        assert await store.get(fresh.session_id) is fresh
+        assert len(store) == 1

--- a/website/docs/user-guide/acp/client.mdx
+++ b/website/docs/user-guide/acp/client.mdx
@@ -1,6 +1,6 @@
 ---
-title: CLI Coding Agents (ACP)
-sidebarTitle: CLI Agents (ACP)
+title: Driving CLI Coding Agents as an ACP Client
+sidebarTitle: Client
 ---
 
 # Orchestrating CLI Coding Agents
@@ -315,7 +315,7 @@ manager = Agent(
 
     `tools=[...]` (including `.as_tool()` subagents) are served to the CLI agent
     over MCP automatically — see
-    [Your tools inside the CLI agent](/docs/user-guide/cli_agents/#your-tools-inside-the-cli-agent).
+    [Your tools inside the CLI agent](/docs/user-guide/acp/client/#your-tools-inside-the-cli-agent).
 
 ## Configuration reference
 

--- a/website/docs/user-guide/acp/server.mdx
+++ b/website/docs/user-guide/acp/server.mdx
@@ -1,0 +1,281 @@
+---
+title: Serving an Agent over ACP
+sidebarTitle: Server
+---
+
+`#!python ACPAgent` wraps an existing `#!python Agent` and serves it over the
+[Agent Client Protocol](https://agentclientprotocol.com){.external-link target="_blank"} (ACP),
+so any ACP client — an editor, a chat integration, your own tool — can drive it.
+
+This is the mirror of the [Client](/docs/user-guide/acp/client) page, which covers AG2
+*driving* an external CLI coding agent.
+
+```bash
+pip install "ag2[acp]"
+```
+
+## Two roles, and who starts whom
+
+ACP has exactly two sides: **Client** and **Agent**. They map onto your world cleanly —
+the Agent is your AG2 agent, the Client is whatever wants to talk to it.
+
+The part that surprises most people is the direction: **the Client launches the Agent**.
+You are not standing a service up and waiting for traffic. ACP's stable transport is
+stdio, so the Client starts your process and the two talk over the pipe between them. No
+ports, no URLs, nothing to deploy.
+
+!!! note
+    The class is `#!python ACPAgent`, not `ACPServer`. AG2 names each protocol adapter
+    after that protocol's own word for the side that answers — MCP and A2A both call it a
+    *Server*, and ACP has no "server" at all. It is a wrapper around an AG2
+    `#!python Agent`, not a subclass of one.
+
+## Minimal Server
+
+The whole integration is the last line.
+
+```python linenums="1"
+import asyncio
+
+from ag2 import Agent
+from ag2.acp import ACPAgent
+from ag2.config import AnthropicConfig
+from ag2.tools import tool
+
+@tool(description="Add two integers and return the sum as a string.")
+async def calc_add(a: int, b: int) -> str:
+    return f"{a + b}"
+
+async def main() -> None:
+    agent = Agent(
+        name="workie",
+        prompt="You are Workie. Answer briefly.",
+        config=AnthropicConfig(model="claude-haiku-4-5-20251001"),
+        tools=[calc_add],
+    )
+    await ACPAgent(agent).run_stdio()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Point an ACP client at that file and it runs the agent as a subprocess:
+
+```console
+stop_reason: end_turn
+answer: 2 + 2 = 4
+```
+
+!!! warning
+    Inside that process **stdout is the wire**. A stray `#!python print()` corrupts the
+    protocol. Use stderr, or a logger, when you need to debug.
+
+## What Happens in One Turn
+
+| ACP method | What it does |
+|---|---|
+| `#!python initialize` | Negotiates the protocol version and advertises exactly which optional features are implemented |
+| `#!python session/new` | Opens an independent conversation and returns its id |
+| `#!python session/prompt` | Runs one ordinary AG2 turn — tools and all — and returns when it ends |
+| `#!python session/update` | Pushed *during* the turn: text as it is generated, every tool call, every result |
+| `#!python session/cancel` | Stops that session's turn and anything queued behind it |
+
+A prompt is one AG2 turn through the same path `#!python Agent.ask()` uses, so dynamic
+prompts, middleware, observers and tool events all behave exactly as they do off-protocol.
+
+## Sessions
+
+Each `#!python session/new` gets its own conversation. Two things are isolated per session:
+
+- **History.** A session never sees another session's messages.
+- **Context variables.** Seeded by value from the agent's defaults, so writes in one
+  session are invisible to the others, and survive to that session's next prompt.
+
+Concurrent prompts on **one** session queue rather than interleave, matching how
+[`#!python MCPServer`](/docs/user-guide/tools/mcp_servers) already treats overlapping calls on one
+session.
+
+!!! warning "Session isolation is not tenant isolation"
+    Everything else is shared, because every session runs the *same*
+    `#!python Agent`: its tools and whatever state they hold, its dependencies, and any
+    [`#!python KnowledgeStore`](/docs/user-guide/advanced/knowledge_store) attached to it.
+
+    A tool that reads records, or a knowledge store holding one customer's documents, is
+    reachable from every session equally — and, as
+    [Authentication](#authentication) explains, nothing tells that tool which client is
+    asking.
+
+    So sessions separate *conversations*, not *tenants*. Give each tenant its own process
+    and its own `#!python ACPAgent`.
+
+## Cancelling
+
+`#!python session/cancel` names a session, so that is exactly how far it reaches: the turn
+running there stops, anything queued behind it is dropped, and every other session carries
+on untouched.
+
+Two details worth knowing:
+
+- The prompt still **returns** — with `#!python stop_reason="cancelled"`, not an error.
+- Whatever already reached the client stays. Stopping the work does not un-say what was
+  already said.
+
+Cancelling four seconds into a long streamed answer:
+
+```console
+stop_reason: cancelled
+updates kept: 12
+```
+
+How many updates survive depends on how much the model had streamed by then. The point is
+that it is not zero.
+
+If the cancellation lands between a tool call and its result, the transcript is repaired
+before the session is released, so the next prompt still sends a valid conversation to the
+model.
+
+## Configuring the Agent
+
+```python linenums="1"
+from ag2 import Agent
+from ag2.acp import ACPAgent, PromptContent, SessionConfig, StaticTokenAuth
+from ag2.config import AnthropicConfig
+
+agent = Agent(name="workie", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+
+acp_agent = ACPAgent(
+    agent,
+    name="workie",
+    version="1.0.0",
+    sessions=SessionConfig(
+        max_sessions=256,
+        ttl=3600,
+        max_queued=4,
+        max_concurrent_turns=4,
+        max_active_prompts=32,
+    ),
+    auth=StaticTokenAuth("shared-secret"),
+    prompt_content=PromptContent(image=True, audio=False, embedded_context=True),
+    stream_thoughts=False,
+)
+```
+
+| Constructor argument | Purpose |
+|---|---|
+| `#!python agent` | The AG2 `#!python Agent` exposed over ACP |
+| `#!python name` / `#!python version` / `#!python title` | What the `#!python initialize` handshake advertises. `#!python name` defaults to the agent's |
+| `#!python sessions` | Session registry bounds — see [Bounds](#bounds) |
+| `#!python auth` | Authentication provider. `#!python None` (the default) advertises no methods and rejects `#!python authenticate` |
+| `#!python prompt_content` | Which non-text prompt content to advertise — see [Multimodal content](#multimodal-content) |
+| `#!python stream_thoughts` | Whether to forward the agent's reasoning as `#!python agent_thought_chunk` updates. Off by default |
+
+### Bounds
+
+`#!python SessionConfig` bounds both a single session and the connection as a whole.
+
+| Setting | Default | What it bounds |
+|---|---|---|
+| `#!python max_sessions` | 1024 | Conversations held at once. Idle ones are evicted first; a session with work running is never evicted |
+| `#!python ttl` | `#!python None` | Idle expiry in seconds, measured from the last time the session was *used* |
+| `#!python max_queued` | 8 | Prompts waiting behind the running turn **on one session** |
+| `#!python max_concurrent_turns` | 8 | Turns running at once **across all sessions**. Prompts past this wait for a slot |
+| `#!python max_active_prompts` | 64 | Prompts admitted at once across all sessions, running and waiting. Past this they are refused |
+
+The last two are what keep one client from opening every session and starting a paid turn
+in each. `#!python max_concurrent_turns` bounds spend; `#!python max_active_prompts` bounds
+how many request handlers can be parked at once.
+
+### Multimodal content
+
+`#!python PromptContent` declares what the model behind your agent can actually take.
+
+Whether an image or an audio clip *works* depends on the provider, and AG2 has no registry
+of provider modalities to consult — the ACP mapper will happily build an
+`#!python AudioInput` that the Anthropic mapper then rejects. So this is a declaration by
+whoever deploys the agent, not a guess. Audio is off by default because most providers do
+not accept it.
+
+## Authentication
+
+Local stdio needs none: the client already launched the process. A provider becomes
+necessary for a remote transport, or for the ACP Registry.
+
+```python linenums="1"
+from ag2 import Agent
+from ag2.acp import ACPAgent, StaticTokenAuth
+from ag2.config import AnthropicConfig
+
+agent = Agent(name="workie", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+acp_agent = ACPAgent(agent, auth=StaticTokenAuth("shared-secret"))
+```
+
+With a provider attached, session methods are refused until the client authenticates:
+
+```console
+auth methods: ['token']
+unauthenticated session refused: ok
+session opened after auth: True
+```
+
+Implement `#!python AuthProvider` to plug in your own identity system.
+
+!!! warning
+    This seam authenticates a **connection**, not a tenant. `#!python authenticate` returns
+    nothing, so no principal reaches the turn: every authenticated client drives the same
+    agent, tools and knowledge store, and downstream code has no trusted identity to
+    authorize against.
+
+    Serve one tenant per `#!python ACPAgent`. Multi-tenant deployments need one process and
+    one agent per tenant.
+
+## What It Refuses to Pretend
+
+During `#!python initialize` the agent declares what it supports, and the client builds its
+interface from that answer. Claiming a feature that is not wired is worse than admitting
+its absence — the client offers users a button that cannot work.
+
+Reported as **not** supported, because they are not implemented:
+`#!python session/load`, `#!python session/resume`, `#!python session/fork`,
+`#!python session/list`, `#!python session/delete`, client filesystem and terminal access,
+and connecting to client-provided MCP servers.
+
+A `#!python cwd`, an additional directory or an MCP server named by a client is recorded as
+*context* and acted on by nothing. A path a client names is not authority to reach it;
+deciding what to honour belongs to the application embedding the agent.
+
+## Testing
+
+`#!python ag2.acp.testing.connect` wires a real ACP client to your `#!python ACPAgent` over
+an in-memory pipe — genuine protocol, no subprocess to manage. Pair it with
+`#!python TestConfig` so no provider is called.
+
+```python linenums="1"
+import acp
+from acp import schema
+
+from ag2 import Agent
+from ag2.acp import ACPAgent
+from ag2.acp.testing import connect
+from ag2.testing import TestConfig
+
+async def test_the_agent_answers() -> None:
+    agent = Agent(name="workie", config=TestConfig("200"))
+
+    async with connect(ACPAgent(agent)) as (client, recorder):
+        session = await client.new_session(cwd=".")
+        response = await client.prompt(
+            session_id=session.session_id,
+            prompt=[acp.text_block("what's 100 + 100")],
+        )
+
+    assert response.stop_reason == "end_turn"
+    texts = [
+        update.content.text
+        for update in recorder.updates_for(session.session_id)
+        if isinstance(update, schema.AgentMessageChunk)
+    ]
+    assert texts == ["200"]
+```
+
+`#!python recorder` is a `#!python RecordingClient`: it captures every `session/update` the
+agent pushed, so you can assert on what the client actually saw and in what order.

--- a/website/docs/user-guide/acp/server.mdx
+++ b/website/docs/user-guide/acp/server.mdx
@@ -3,9 +3,17 @@ title: Serving an Agent over ACP
 sidebarTitle: Server
 ---
 
-`#!python ACPAgent` wraps an existing `#!python Agent` and serves it over the
+`#!python ACPAgent` gives your agent a user interface you do not have to write.
+
+Wrap an existing `#!python Agent`, serve it over the
 [Agent Client Protocol](https://agentclientprotocol.com){.external-link target="_blank"} (ACP),
-so any ACP client — an editor, a chat integration, your own tool — can drive it.
+and it becomes drivable from any ACP client — editors like Zed, JetBrains, VS Code and
+Neovim, note-taking apps, notebook kernels, chat bridges. Streamed output, tool calls shown
+as they happen, and a working cancel button all come from the client. You write the agent;
+somebody else already wrote the frontend.
+
+That is the trade this page is about: one line of code instead of a websocket server, a
+streaming protocol and a chat UI.
 
 This is the mirror of the [Client](/docs/user-guide/acp/client) page, which covers AG2
 *driving* an external CLI coding agent.
@@ -32,7 +40,7 @@ ports, no URLs, nothing to deploy.
 
 ## Minimal Server
 
-The whole integration is the last line.
+The whole integration is `#!python ACPAgent(agent).run_stdio()`.
 
 ```python linenums="1"
 import asyncio
@@ -42,17 +50,18 @@ from ag2.acp import ACPAgent
 from ag2.config import AnthropicConfig
 from ag2.tools import tool
 
-@tool(description="Add two integers and return the sum as a string.")
+@tool(description="Add two integers.")
 async def calc_add(a: int, b: int) -> str:
-    return f"{a + b}"
+    return str(a + b)
+
+agent = Agent(
+    name="workie",
+    prompt="You are a concise assistant. Use tools when they help.",
+    config=AnthropicConfig(model="claude-sonnet-4-6", streaming=True),
+    tools=[calc_add],
+)
 
 async def main() -> None:
-    agent = Agent(
-        name="workie",
-        prompt="You are Workie. Answer briefly.",
-        config=AnthropicConfig(model="claude-haiku-4-5-20251001"),
-        tools=[calc_add],
-    )
     await ACPAgent(agent).run_stdio()
 
 if __name__ == "__main__":
@@ -66,6 +75,34 @@ stop_reason: end_turn
 answer: 2 + 2 = 4
 ```
 
+The same file, ready to run, is at
+[`examples/acp/server_stdio.py`](https://github.com/ag2ai/ag2/blob/main/examples/acp/server_stdio.py){.external-link target="_blank"}.
+
+## Pointing a Client at It
+
+Every client configures a custom agent the same way — a command, its arguments, and an
+environment. Zed's `#!json settings.json`, for example:
+
+```json
+{
+  "agent_servers": {
+    "workie": {
+      "type": "custom",
+      "command": "/abs/path/to/.venv/bin/python",
+      "args": ["/abs/path/to/examples/acp/server_stdio.py"],
+      "env": { "ANTHROPIC_API_KEY": "sk-ant-..." }
+    }
+  }
+}
+```
+
+!!! warning "Name the virtualenv's interpreter by path"
+    Your virtualenv is **not** activated for that process. A bare
+    `#!json "command": "python"` resolves against the client's own `#!bash PATH` to an
+    interpreter that does not have `#!bash ag2` installed — and the failure surfaces only
+    as the client reporting that the agent would not start. Give the interpreter and the
+    script by full path, and pass credentials through `#!json "env"`.
+
 !!! warning
     Inside that process **stdout is the wire**. A stray `#!python print()` corrupts the
     protocol. Use stderr, or a logger, when you need to debug.
@@ -77,11 +114,22 @@ answer: 2 + 2 = 4
 | `#!python initialize` | Negotiates the protocol version and advertises exactly which optional features are implemented |
 | `#!python session/new` | Opens an independent conversation and returns its id |
 | `#!python session/prompt` | Runs one ordinary AG2 turn — tools and all — and returns when it ends |
-| `#!python session/update` | Pushed *during* the turn: text as it is generated, every tool call, every result |
+| `#!python session/update` | Pushed *during* the turn: the answer as it is produced, every tool call, every result |
 | `#!python session/cancel` | Stops that session's turn and anything queued behind it |
 
 A prompt is one AG2 turn through the same path `#!python Agent.ask()` uses, so dynamic
 prompts, middleware, observers and tool events all behave exactly as they do off-protocol.
+
+!!! warning "Token-by-token output needs `#!python streaming=True`"
+    Every AG2 model config defaults to `#!python streaming=False`, and that default decides
+    what a client's window actually does. Without it the answer reaches the client as **one**
+    `#!python agent_message_chunk`, sent once the turn is already over: no text appears while
+    the model works, and a `#!python session/cancel` mid-turn leaves the user with nothing at
+    all, because nothing had been sent yet.
+
+    Turn it on in the config you hand the agent — `#!python AnthropicConfig(model=...,
+    streaming=True)`, and the same flag on the other providers. Tool calls are reported live
+    either way; it is the *text* that waits.
 
 ## Sessions
 
@@ -108,6 +156,19 @@ session.
     So sessions separate *conversations*, not *tenants*. Give each tenant its own process
     and its own `#!python ACPAgent`.
 
+!!! warning "A CLI-agent backend keeps its own conversation state"
+    The isolation above is AG2's to enforce, and it holds for a model config. It does not
+    survive a backend that remembers on its own. Serving an `#!python Agent` whose config is
+    a CLI-agent preset — [`#!python ClaudeCodeConfig`](/docs/user-guide/acp/client) and the
+    others — nests one protocol inside the other: your `#!python ACPAgent` answers ACP while
+    the agent behind it *speaks* ACP to a CLI subprocess.
+
+    AG2 does its part, opening a separate CLI session per `#!python session/new`. But the
+    CLI is one process with one `#!python cwd` — a config-level setting, not a per-session
+    one — and in practice it answers a fresh session with the previous one's context. Treat
+    every session on such a deployment as sharing one conversation, and give a caller that
+    must not see another's history its own process.
+
 ## Cancelling
 
 `#!python session/cancel` names a session, so that is exactly how far it reaches: the turn
@@ -128,7 +189,8 @@ updates kept: 12
 ```
 
 How many updates survive depends on how much the model had streamed by then. The point is
-that it is not zero.
+that it is not zero — on a `#!python streaming=True` config. On the default it *is* zero,
+for the reason above: nothing had been sent yet.
 
 If the cancellation lands between a tool call and its result, the transcript is repaired
 before the session is released, so the next prompt still sends a valid conversation to the
@@ -234,10 +296,25 @@ During `#!python initialize` the agent declares what it supports, and the client
 interface from that answer. Claiming a feature that is not wired is worse than admitting
 its absence — the client offers users a button that cannot work.
 
-Reported as **not** supported, because they are not implemented:
-`#!python session/load`, `#!python session/resume`, `#!python session/fork`,
-`#!python session/list`, `#!python session/delete`, client filesystem and terminal access,
-and connecting to client-provided MCP servers.
+Reported as **not** supported: `#!python session/load`, `#!python session/resume`,
+`#!python session/fork`, `#!python session/list`, `#!python session/delete`, and connecting
+to client-provided MCP servers over any transport. The client's own filesystem and terminal
+methods are never called either — those the client offers, so there is nothing to declare.
+
+These are optional parts of the protocol, not missing pieces of this one. ACP grew up
+around coding agents, and most of that list exists to serve them — a client offering its
+open buffers and its terminal to an agent whose job is editing your repository.
+
+!!! note "Your agent still reaches files — through its own tools"
+    Serving over ACP changes nothing about what an agent can do. Give it a file tool, a
+    shell tool or a database tool and they work exactly as they do in
+    `#!python agent.ask()`. What the client's filesystem methods would add on top is
+    narrower than it sounds: the editor's *unsaved buffer* contents, and permission prompts
+    mediated by the editor rather than by your own tool.
+
+    If what you want is an agent that edits your repository from inside your editor, the
+    [Client](/docs/user-guide/acp/client) page is the other direction — AG2 driving Claude
+    Code or Codex, which already do that.
 
 A `#!python cwd`, an additional directory or an MCP server named by a client is recorded as
 *context* and acted on by nothing. A path a client names is not authority to reach it;
@@ -245,12 +322,13 @@ deciding what to honour belongs to the application embedding the agent.
 
 ## Testing
 
-`#!python ag2.acp.testing.connect` wires a real ACP client to your `#!python ACPAgent` over
-an in-memory pipe — genuine protocol, no subprocess to manage. Pair it with
-`#!python TestConfig` so no provider is called.
+`#!python ag2.acp.testing.connect` wires a real ACP client to your `#!python ACPAgent`
+inside the test process — genuine protocol, no subprocess to manage and no port to bind.
+Pair it with `#!python TestConfig` so no provider is called.
 
 ```python linenums="1"
 import acp
+import pytest
 from acp import schema
 
 from ag2 import Agent
@@ -258,6 +336,7 @@ from ag2.acp import ACPAgent
 from ag2.acp.testing import connect
 from ag2.testing import TestConfig
 
+@pytest.mark.asyncio
 async def test_the_agent_answers() -> None:
     agent = Agent(name="workie", config=TestConfig("200"))
 

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -14,7 +14,12 @@
         "measurementId": "G-2GN2KN2CE4"
     }
   },
-  "redirects": [],
+  "redirects": [
+    {
+      "source": "/docs/user-guide/cli_agents",
+      "destination": "/docs/user-guide/acp/client"
+    }
+  ],
   "search": {
     "prompt": "Search or ask..."
   },
@@ -168,7 +173,13 @@
             "docs/user-guide/a2ui/capabilities"
           ]
         },
-        "docs/user-guide/cli_agents",
+        {
+          "group": "ACP",
+          "pages": [
+            "docs/user-guide/acp/server",
+            "docs/user-guide/acp/client"
+          ]
+        },
         "docs/user-guide/coding_with_ai"
       ]
     },

--- a/website/mkdocs/mkdocs.yml
+++ b/website/mkdocs/mkdocs.yml
@@ -78,6 +78,7 @@ plugins:
       redirect_maps:
         docs/quick-start.md: docs/user-guide/quick-start.md
         docs/user-guide/contribution_policy.md: docs/contributor-guide/contribution_policy.md
+        docs/user-guide/cli_agents.md: docs/user-guide/acp/client.md
   - glightbox:                   # image zoom
       manual: true
   - macros:                      # Jinja templates


### PR DESCRIPTION
## Why are these changes needed?

`ag2/acp/` is currently client-only: `ACPConfig` + `ACPClient` let an AG2 `Agent` *drive* 1an external CLI coding agent (Claude Code, Codex, OpenCode, Kilo Code) over ACP. Nothing served the other role, so an AG2 agent could not be plugged into an ACP Client.

This adds the serving half, alongside the existing `MCPServer` and `A2AServer`:

```python
from ag2 import Agent
from ag2.acp import ACPAgent

await ACPAgent(agent).run_stdio()
```

### Naming

`ACPAgent`, not `ACPServer`. AG2 names each protocol adapter after that protocol's own word for the side that answers — MCP and A2A both call it a *Server*, and ACP has no "server" at all: its two roles are Client and Agent. The class is a wrapper around an AG2 `Agent`, not a subclass of one.

### What it does

* **`initialize`** — negotiates ACP v1 and advertises only what is implemented. Session loading, Client-provided MCP servers, and every session operation past new/prompt/cancel   are reported as unsupported because they are.
* **`session/new`** — each session is an independent conversation with its own history and its own context variables. `cwd`, additional directories and declared MCP servers are recorded as context and acted on by nothing: a path named by a Client is not authority to reach it.
* **`session/prompt`** — one prompt is one ordinary AG2 turn, through the same `_prepare_turn` path an off-protocol `ask()` uses, so dynamic prompts and context dependencies behave identically. Text, image, audio and embedded documents are mapped to AG2 inputs.
* **`session/update`** — agent text, reasoning (opt-in), tool calls and tool results are projected as they happen, in stream order, without re-sending the final answer that was already streamed.
* **`session/cancel`** — cancels that session's running turn and everything queued behind it, leaving other sessions alone. Events already delivered are kept, and any tool call the cancellation cut short is closed off so the transcript stays valid to send to a provider.

### Bounds and safety

* Concurrent prompts on one session queue rather than interleave, matching how `MCPServer` already treats overlapping calls on one session.
* Session count, per-session queue depth, connection-wide concurrent turns and connection-wide admitted prompts are all bounded, with an idle TTL. Eviction never cancels a running turn; admission is refused instead.
* Authorization and sessions are per *connection*, not per instance — the SDK is given a factory so each connection gets its own scope.
* ACP `_meta` is refused when it would overwrite a validated request field. The SDK router merges `_meta` over the canonical parameters, so a colliding key silently replaces the real value; `ag2/acp/guard.py` rejects those requests before the merge. This is worth raising upstream — it affects any agent built on the SDK, not just AG2.

### Deliberately not included

Session load/resume/fork/list, remote transport, Client filesystem and terminal access, connecting to Client-provided MCP servers, elicitation and permission requests, and ACP Registry conformance. None of these are advertised, so a Client will not assume them.

`AuthProvider` is an admission gate only — it decides whether a Client may connect, not which Client it is. No principal reaches the turn, so an authenticated deployment must serve one tenant per instance. This is documented in `ag2/acp/auth.py`; carrying a principal is deferred until a downstream consumer defines the requirement.

### Tests

177 tests in `test/acp/test_agent_*.py`, driven through the real `acp` SDK over an in-process transport, plus an end-to-end test that spawns `run_stdio()` as a subprocess. No test calls a real provider.

Runnable examples were kept out of this PR and will follow separately.

### Related findings

Two pre-existing issues were found while building this and are **not** fixed here:

* `ag2/a2a/executor.py` skips `@agent.prompt` hooks the same way this did — A2A-served agents silently drop their dynamic prompts. Reproduced; needs its own fix because A2A also appends extension prompt lines.
* `ag2/mcp/sessions.py` builds a fresh `MemoryStream` per call, which strands background task results and hides them from teardown. Same pattern this PR moved away from.

## Related issue number

<!-- none -->

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
