### PR TITLE
docs(a2ui): simplify A2A extension setup

### DIFF
--- a/website/docs/user-guide/a2ui/a2a.mdx
+++ b/website/docs/user-guide/a2ui/a2a.mdx
@@ -33,14 +33,13 @@ from ag2.a2ui.a2a import (
 
 ## Minimal Server
 
-Wrap a plain `#!python Agent` in `#!python A2UIAgentExecutor` (with the same flat A2UI kwargs as `#!python A2UIServer`, including `#!python actions=` for clickable buttons), pass it to `#!python A2AServer` via `#!python executor=`, and advertise A2UI support on the card with a `#!python card_modifier` that appends the extension:
+Wrap a plain `#!python Agent` in `#!python A2UIAgentExecutor` (with the same flat A2UI kwargs as `#!python A2UIServer`, including `#!python actions=` for clickable buttons), pass it to `#!python A2AServer` via `#!python executor=`, and advertise A2UI support directly on the card with `#!python build_card(extensions=...)`:
 
-```python linenums="1" hl_lines="10-12 18"
+```python linenums="1" hl_lines="19-24 26"
 import uvicorn
-from a2a.types import AgentCard
 
 from ag2 import Agent
-from ag2.a2a import A2AServer
+from ag2.a2a import A2AServer, build_card
 from ag2.a2ui import a2ui_action
 from ag2.a2ui.a2a import A2UIAgentExecutor, get_a2ui_agent_extension
 from ag2.config import AnthropicConfig
@@ -55,12 +54,14 @@ def build_app():
     # the agent stays plain.
     executor = A2UIAgentExecutor(agent, actions=[book_table], protocol_version="v0.9")
 
-    async def advertise_a2ui(card: AgentCard) -> AgentCard:
-        card.capabilities.extensions.append(get_a2ui_agent_extension(version=executor.protocol_version))
-        return card
-
-    server = A2AServer(agent, executor=executor, card_modifier=advertise_a2ui)
-    return server.build_jsonrpc(url="http://127.0.0.1:8000")
+    a2ui_extension = get_a2ui_agent_extension(version=executor.protocol_version)
+    card = build_card(
+        agent,
+        url="http://127.0.0.1:8000",
+        extensions=[a2ui_extension],
+    )
+    server = A2AServer(agent, executor=executor)
+    return server.build_jsonrpc(url="http://127.0.0.1:8000", card=card)
 
 app = build_app()
 
@@ -68,7 +69,20 @@ if __name__ == "__main__":
     uvicorn.run(app, host="127.0.0.1", port=8000)
 ```
 
-A client connects by pointing `#!python A2AConfig(card_url=...)` at the card URL, exactly as for any A2A agent — see the [A2A client](/docs/user-guide/a2a/client) page.
+A2UI is opt-in rather than a native AG2 extension, so the client must activate the advertised URI explicitly. Only `#!python urn:ag2:client-tools:v1`, which every AG2 client implements, is activated natively without appearing in `#!python A2AConfig.extensions`:
+
+```python linenums="1" hl_lines="4-8"
+from ag2.a2a import A2AConfig
+from ag2.a2ui.a2a import get_a2ui_agent_extension
+
+a2ui_uri = get_a2ui_agent_extension(version="v0.9").uri
+config = A2AConfig(
+    card_url="http://127.0.0.1:8000",
+    extensions=[a2ui_uri],
+)
+```
+
+See the [A2A client extensions](/docs/user-guide/a2a/client#extensions) section for the activation and validation rules.
 
 !!! tip
     `#!python get_a2ui_agent_extension()` takes `#!python supported_catalog_ids=` and `#!python accepts_inline_catalogs=` to describe which [catalogs](/docs/user-guide/a2ui/capabilities) the agent renders. With no arguments it advertises the version's default "basic" catalog.


### PR DESCRIPTION
## Why are these changes needed?

The A2UI-over-A2A guide used a card modifier for extension advertisement even though `build_card(extensions=...)` provides a shorter, direct API. It also did not show that clients must explicitly opt into the advertised A2UI extension URI.

This updates the server example to build the card with the A2UI extension, adds the matching client configuration, and documents why A2UI remains opt-in while the universal AG2 client-tools extension is native.

## Related issue number

Closes #3137

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

Documentation-only change; the existing A2A card and extension tests cover the APIs used by the examples.

Local validation:

- `uv run ./scripts/docs_build_mkdocs.sh`
- `uv run prek run --files website/docs/user-guide/a2ui/a2a.mdx`
- `uv run pytest -q test/a2a/test_card.py test/a2a/test_extensions.py` (48 passed)

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
