### PR TITLE
fix(gemini): allow builtin tools alongside function calling

### DIFF
--- a/ag2/config/gemini/gemini_client.py
+++ b/ag2/config/gemini/gemini_client.py
@@ -125,7 +125,7 @@ class GeminiClient(LLMClient):
         system_instruction = build_system_instruction(prompt)
         tool_list = list(tools)
         gemini_tools = build_tools(tool_list)
-        gemini_tool_config = build_tool_config(tool_list)
+        gemini_tool_config = build_tool_config(tool_list, vertexai=bool(self._client.vertexai))
 
         cache_kwargs: dict[str, Any] = {}
         if self._cached_content:

--- a/ag2/config/gemini/mappers.py
+++ b/ag2/config/gemini/mappers.py
@@ -147,21 +147,41 @@ def build_tools(schemas: list[ToolSchema]) -> list[types.Tool] | None:
     return result or None
 
 
-def build_tool_config(schemas: list[ToolSchema]) -> types.ToolConfig | None:
+#: Schemas ``build_tools`` maps onto Gemini's server-side (builtin) tools.
+SERVER_SIDE_SCHEMAS: tuple[type[ToolSchema], ...] = (
+    WebSearchToolSchema,
+    WebFetchToolSchema,
+    CodeExecutionToolSchema,
+    FileSearchToolSchema,
+    GoogleMapsToolSchema,
+)
+
+
+def build_tool_config(schemas: list[ToolSchema], *, vertexai: bool = False) -> types.ToolConfig | None:
     """Build a Gemini ToolConfig for schemas that require one.
 
-    Currently only Google Maps geo-biasing (lat/lng) needs a
-    ``retrieval_config``; returns ``None`` when nothing does.
+    Google Maps geo-biasing (lat/lng) needs a ``retrieval_config``.
+
+    Returns ``None`` when nothing needs a config.
     """
+    config: types.ToolConfig | None = None
+
     for t in schemas:
         if isinstance(t, GoogleMapsToolSchema) and t.latitude is not None and t.longitude is not None:
-            return types.ToolConfig(
-                retrieval_config=types.RetrievalConfig(
-                    lat_lng=types.LatLng(latitude=t.latitude, longitude=t.longitude),
-                    language_code=t.language_code,
-                )
+            config = config or types.ToolConfig()
+            config.retrieval_config = types.RetrievalConfig(
+                lat_lng=types.LatLng(latitude=t.latitude, longitude=t.longitude),
+                language_code=t.language_code,
             )
-    return None
+
+    mixes_server_side_with_functions = any(isinstance(t, SERVER_SIDE_SCHEMAS) for t in schemas) and any(
+        isinstance(t, FunctionToolSchema) for t in schemas
+    )
+    if mixes_server_side_with_functions and not vertexai:
+        config = config or types.ToolConfig()
+        config.include_server_side_tool_invocations = True
+
+    return config
 
 
 _URL_EXTENSION_TO_MIME: dict[str, str] = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ gemini = [
     "google-api-core",
     # Version bounds: local types in gemini_types.py are tested for subset compatibility
     # with the SDK (local can have extra fields for forward compatibility).
-    "google-genai>=1.20.0,<3.0",
+    "google-genai>=1.68.0,<3.0",
     "google-cloud-aiplatform",
     "google-auth",
     "pillow",

--- a/test/config/gemini/test_gemini_tool_config_request.py
+++ b/test/config/gemini/test_gemini_tool_config_request.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from fast_depends.use import SerializerCls
+from google.oauth2.credentials import Credentials
+
+from ag2 import Context, MemoryStream
+from ag2.config.gemini import GeminiClient
+from ag2.events import ModelRequest, TextInput
+from ag2.tools import WebSearchTool, tool
+from ag2.tools.tool import Tool
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    return f"{city}: 22C, sunny"
+
+
+def _capturing_client(captured: dict[str, Any]) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "candidates": [{"content": {"role": "model", "parts": [{"text": "ok"}]}, "finishReason": "STOP"}],
+                "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2},
+            },
+        )
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+async def _send(client: GeminiClient, tools: list[Tool]) -> None:
+    context = Context(stream=MemoryStream())
+    schemas = [s for t in tools for s in await t.schemas(context)]
+
+    await client(
+        messages=[ModelRequest([TextInput("capital of France?")])],
+        context=context,
+        tools=schemas,
+        response_schema=None,
+        serializer=SerializerCls,
+    )
+
+
+@pytest.mark.asyncio
+class TestToolConfigOnTheWire:
+    async def test_builtin_with_function_tool_sends_flag(self) -> None:
+        captured: dict[str, Any] = {}
+        client = GeminiClient(
+            model="gemini-3.6-flash",
+            api_key="test",
+            vertexai=False,
+            http_client=_capturing_client(captured),
+        )
+
+        await _send(client, [WebSearchTool(), get_weather])
+
+        assert captured["body"]["toolConfig"] == {"includeServerSideToolInvocations": True}
+
+    async def test_builtin_alone_sends_no_tool_config(self) -> None:
+        captured: dict[str, Any] = {}
+        client = GeminiClient(
+            model="gemini-3.6-flash",
+            api_key="test",
+            vertexai=False,
+            http_client=_capturing_client(captured),
+        )
+
+        await _send(client, [WebSearchTool()])
+
+        assert "toolConfig" not in captured["body"]
+
+    async def test_vertexai_omits_flag(self) -> None:
+        captured: dict[str, Any] = {}
+        client = GeminiClient(
+            model="gemini-3.6-flash",
+            vertexai=True,
+            credentials=Credentials(token="fake-token"),
+            project="test-project",
+            location="us-central1",
+            http_client=_capturing_client(captured),
+        )
+
+        await _send(client, [WebSearchTool(), get_weather])
+
+        assert "toolConfig" not in captured["body"]

--- a/test/config/gemini/tools/test_tool_config.py
+++ b/test/config/gemini/tools/test_tool_config.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from google.genai import types
+
+from ag2 import Context
+from ag2.config.gemini.mappers import build_tool_config
+from ag2.tools.builtin.code_execution import CodeExecutionTool
+from ag2.tools.builtin.file_search import FileSearchTool
+from ag2.tools.builtin.google_maps import GoogleMapsTool
+from ag2.tools.builtin.web_fetch import WebFetchTool
+from ag2.tools.builtin.web_search import WebSearchTool
+from ag2.tools.schemas import ToolSchema
+from ag2.tools.tool import Tool
+from test.config._helpers import make_tool
+
+SERVER_SIDE_TOOLS: list[Tool] = [
+    WebSearchTool(),
+    WebFetchTool(),
+    CodeExecutionTool(),
+    FileSearchTool(store_names=["projects/p/locations/l/fileSearchStores/s"]),
+    GoogleMapsTool(),
+]
+
+
+@pytest.mark.asyncio
+class TestServerSideInvocations:
+    """Gemini rejects builtins alongside function calling unless the flag is set."""
+
+    @pytest.mark.parametrize("tool", SERVER_SIDE_TOOLS, ids=lambda t: type(t).__name__)
+    async def test_mixed_with_function_tool_enables_flag(self, tool: Tool, context: Context) -> None:
+        [server_side] = await tool.schemas(context)
+
+        assert build_tool_config([make_tool().schema, server_side]) == types.ToolConfig(
+            include_server_side_tool_invocations=True
+        )
+
+    @pytest.mark.parametrize("tool", SERVER_SIDE_TOOLS, ids=lambda t: type(t).__name__)
+    async def test_server_side_alone_needs_no_config(self, tool: Tool, context: Context) -> None:
+        [server_side] = await tool.schemas(context)
+
+        assert build_tool_config([server_side]) is None
+
+    async def test_function_tools_alone_need_no_config(self) -> None:
+        assert build_tool_config([make_tool().schema]) is None
+
+    async def test_all_builtins_mixed_with_function_tool(self, context: Context) -> None:
+        schemas: list[ToolSchema] = [make_tool().schema]
+        for tool in SERVER_SIDE_TOOLS:
+            schemas.extend(await tool.schemas(context))
+
+        assert build_tool_config(schemas) == types.ToolConfig(include_server_side_tool_invocations=True)
+
+    async def test_vertexai_leaves_flag_unset(self, context: Context) -> None:
+        """Vertex AI does not support ``include_server_side_tool_invocations``."""
+        [server_side] = await WebSearchTool().schemas(context)
+
+        assert build_tool_config([make_tool().schema, server_side], vertexai=True) is None
+
+
+@pytest.mark.asyncio
+class TestGeoBiasCombined:
+    async def test_geo_bias_kept_alongside_another_builtin(self, context: Context) -> None:
+        [maps] = await GoogleMapsTool(latitude=37.42, longitude=-122.08, language_code="en").schemas(context)
+        [search] = await WebSearchTool().schemas(context)
+
+        assert build_tool_config([maps, search]) == types.ToolConfig(
+            retrieval_config=types.RetrievalConfig(
+                lat_lng=types.LatLng(latitude=37.42, longitude=-122.08),
+                language_code="en",
+            )
+        )
+
+    async def test_geo_bias_mixed_with_function_tool(self, context: Context) -> None:
+        [maps] = await GoogleMapsTool(latitude=37.42, longitude=-122.08, language_code="en").schemas(context)
+
+        assert build_tool_config([make_tool().schema, maps]) == types.ToolConfig(
+            retrieval_config=types.RetrievalConfig(
+                lat_lng=types.LatLng(latitude=37.42, longitude=-122.08),
+                language_code="en",
+            ),
+            include_server_side_tool_invocations=True,
+        )
+
+    async def test_geo_bias_on_vertexai_keeps_retrieval_config(self, context: Context) -> None:
+        [maps] = await GoogleMapsTool(latitude=37.42, longitude=-122.08, language_code="en").schemas(context)
+
+        assert build_tool_config([make_tool().schema, maps], vertexai=True) == types.ToolConfig(
+            retrieval_config=types.RetrievalConfig(
+                lat_lng=types.LatLng(latitude=37.42, longitude=-122.08),
+                language_code="en",
+            )
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -303,7 +303,7 @@ requires-dist = [
     { name = "google-api-core", marker = "extra == 'gemini'" },
     { name = "google-auth", marker = "extra == 'gemini'" },
     { name = "google-cloud-aiplatform", marker = "extra == 'gemini'" },
-    { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.20.0,<3.0" },
+    { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.68.0,<3.0" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "jsonschema", marker = "extra == 'a2ui'", specifier = ">=4.18.0,<5" },
     { name = "jsonschema", marker = "extra == 'gemini'" },


### PR DESCRIPTION
## Why are these changes needed?

Passing a Gemini server-side builtin tool (`WebSearchTool`, `WebFetchTool`, `CodeExecutionTool`, …) together with any function tool failed:

```
400 INVALID_ARGUMENT: Please enable tool_config.include_server_side_tool_invocations
to use Built-in tools with Function calling.
```

Each kind worked alone — only the mix failed. `build_tool_config` never set that field and there was no way for a caller to set it, so builtin tools were unusable for any agent that also carries function tools.

`build_tool_config` now sets `include_server_side_tool_invocations=True` when a server-side builtin is combined with a function tool. The field is not supported on Vertex AI, so it is left unset there.

Two related changes:

- `build_tool_config` accumulates instead of returning on the first match, so Google Maps geo-biasing combined with another builtin keeps its `retrieval_config`.
- `google-genai` floor raised to `>=1.68.0` — the release that added the field. On 1.67.0 setting it raises `ValueError` (the SDK models are `extra="forbid"`).

Verified live against `gemini-3.1-pro-preview`, `gemini-3.6-flash` and `gemini-3.5-flash-lite`: the mix returns the 400 before the change and succeeds after, on both the streaming and non-streaming paths.

## Related issue number

None.

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
