### PR TITLE
fix(test): de-flake transport demux delivery assertions

### DIFF
--- a/test/network/_helpers.py
+++ b/test/network/_helpers.py
@@ -10,6 +10,8 @@
 * :func:`wait_for_text_count` — poll a channel's WAL until ``EV_TEXT``
   count reaches a threshold; conversation/discussion adapters have no
   terminal event to await on.
+* :func:`wait_for_delivery` — poll one recipient's captured envelopes
+  until a given text lands; for per-recipient delivery assertions.
 """
 
 import asyncio
@@ -22,7 +24,7 @@ from ag2.config import LLMClient, ModelConfig
 from ag2.events import BaseEvent, ModelMessage, ModelResponse
 from ag2.network import EV_TEXT, Envelope, Hub
 
-__all__ = ("ScriptedConfig", "_MockClock", "wait_for_text_count")
+__all__ = ("ScriptedConfig", "_MockClock", "wait_for_delivery", "wait_for_text_count")
 
 
 class _MockClock:
@@ -113,3 +115,23 @@ async def wait_for_text_count(
             return wal
         await asyncio.sleep(0.02)
     raise asyncio.TimeoutError(f"channel {channel_id!r} never reached {expected} EV_TEXT envelopes")
+
+
+async def wait_for_delivery(
+    received: "Sequence[Envelope]",
+    text: str,
+    *,
+    timeout: float = 5.0,
+) -> None:
+    """Poll a capture list until an ``EV_TEXT`` envelope carrying ``text`` lands.
+
+    The hub fans out to each recipient in turn, so one participant's copy can
+    land several event-loop turns after another's; polling avoids encoding a
+    guess about the slowest recipient.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if any(e.event_type == EV_TEXT and e.event_data.get("text") == text for e in received):
+            return
+        await asyncio.sleep(0.02)
+    raise asyncio.TimeoutError(f"no EV_TEXT envelope carrying {text!r} was delivered within {timeout}s")

--- a/test/network/test_transport_demux.py
+++ b/test/network/test_transport_demux.py
@@ -29,7 +29,10 @@ from ag2.network import (
     Resume,
 )
 
-from ._helpers import ScriptedConfig
+from ._helpers import ScriptedConfig, wait_for_delivery
+
+# Window for a forbidden delivery to show up before a negative assertion runs.
+SETTLE = 0.05
 
 
 def _agent(name: str) -> Agent:
@@ -104,7 +107,8 @@ async def test_targeted_envelope_delivered_to_only_named_recipient() -> None:
 
     # Targeted to bob only.
     await channel.send("private to bob", audience=[bob.agent_id])
-    await asyncio.sleep(0.05)
+    await wait_for_delivery(received_bob, "private to bob")
+    await asyncio.sleep(SETTLE)  # let carol/alice deliveries land, if any
 
     bob_text = [e for e in received_bob if e.event_type == EV_TEXT and e.event_data.get("text") == "private to bob"]
     carol_text = [e for e in received_carol if e.event_type == EV_TEXT and e.event_data.get("text") == "private to bob"]
@@ -157,7 +161,10 @@ async def test_broadcast_envelope_delivered_to_all_non_sender() -> None:
     channel = await alice.open(type="discussion", target=["bob", "carol"])
 
     await channel.send("hello everyone", audience=None)
-    await asyncio.sleep(0.05)
+    # Each recipient awaited separately: carol's copy lands after bob's.
+    await wait_for_delivery(received_bob, "hello everyone")
+    await wait_for_delivery(received_carol, "hello everyone")
+    await asyncio.sleep(SETTLE)  # let an alice delivery land, if any
 
     # Both non-sender participants see it; alice (sender) does not.
     assert any(e.event_data.get("text") == "hello everyone" for e in received_bob)
@@ -224,7 +231,7 @@ async def test_two_hub_clients_share_one_hub_isolated_endpoints() -> None:
 
     channel = await alice.open(type="conversation", target="bob")
     await channel.send("cross-tenant", audience=[bob.agent_id])
-    await asyncio.sleep(0.05)
+    await wait_for_delivery(received_bob, "cross-tenant")
 
     assert any(e.event_data.get("text") == "cross-tenant" for e in received_bob)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://docs.ag2.ai/latest/docs/contributor-guide/contributing before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test/network/test_transport_demux.py` waited a fixed `asyncio.sleep(0.05)` after a send before asserting on delivery. The hub fans an envelope out to each recipient in turn, so the second recipient's copy lands after the first's — when the fan-out takes longer than the sleep budget, the assertion races it.

This is not hypothetical: it failed on CI in #3146 as `test_broadcast_envelope_delivered_to_all_non_sender` on `test-ubuntu (3.10)`, with the signature `bob` delivered / `carol` not — the same ordering. That PR touches no network code, so a loaded runner was the only variable.

The sleep budget is the whole of it. Same scenario, delivery to the second recipient artificially delayed:

```
 fan-out delay | OLD fixed sleep(0.05) | NEW wait_for_delivery
---------------+-----------------------+----------------------
          0.0s |              3/3 pass |             3/3 pass
         0.02s |              3/3 pass |             3/3 pass
         0.06s |              0/3 pass |             3/3 pass
          0.2s |              0/3 pass |             3/3 pass
          0.5s |              0/3 pass |             3/3 pass
```

The three fixed sleeps are replaced with `wait_for_delivery()`, a poll added to `test/network/_helpers.py` alongside the existing `wait_for_text_count()` and following the same shape (deadline, 20 ms poll, `asyncio.TimeoutError` naming what never arrived). It waits exactly as long as the fan-out actually takes, up to a 5 s ceiling.

Two of the three tests also carry *negative* assertions (`carol` must not receive a targeted envelope; the sender must not see its own echo). An absence cannot be polled for, so those keep a settle window — now named `SETTLE = 0.05` and taken **after** the expected delivery has landed rather than instead of waiting for it. The negative assertions are therefore no weaker than before, and the positive ones no longer depend on timing.

Verification:

- `test/network/` — 481 passed.
- `test_transport_demux.py` — 25 consecutive runs, 0 failures (and under CPU contention).
- No new `ruff` findings (35 before and after, all pre-existing) and no new `mypy` findings (9 before and after, all pre-existing in these files).

Only 3.10 was affected on CI and I could not reproduce there locally, so the delay table above is the evidence that the mechanism is fixed rather than the timing merely nudged.

## Related issue number

None. Surfaced while reviewing #3146, whose CI failure this explains — that PR should go green on a re-run regardless of this change.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally. <!-- test-only change; no user-facing docs affected -->
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. <!-- this PR is the test change -->
- [x] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [ ] I understand the changes in this PR and can explain them in my own words.
- [ ] I have verified that the PR description accurately reflects the actual diff.
- [ ] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
