### PR TITLE
fix: fix: correct parameter name typo and grammar across multiple files

### DIFF
--- a/autogen/agentchat/contrib/captainagent/tool_retriever.py
+++ b/autogen/agentchat/contrib/captainagent/tool_retriever.py
@@ -76,7 +76,7 @@ You have access to the following functions. You can write python code to call th
         return
 
     def bind_user_proxy(self, agent: UserProxyAgent, tool_root: str | list):
-        """Updates user proxy agent with a executor so that code executor can successfully execute function-related code.
+        """Updates user proxy agent with an executor so that code executor can successfully execute function-related code.
         Returns an updated user proxy.
         """
         if isinstance(tool_root, str):

--- a/autogen/agentchat/contrib/graph_rag/graph_query_engine.py
+++ b/autogen/agentchat/contrib/graph_rag/graph_query_engine.py
@@ -26,7 +26,7 @@ class GraphStoreQueryResult:
 
 @runtime_checkable
 class GraphQueryEngine(Protocol):
-    """An abstract base class that represents a graph query engine on top of a underlying graph database.
+    """An abstract base class that represents a graph query engine on top of an underlying graph database.
 
     This interface defines the basic methods for graph-based RAG.
     """

--- a/autogen/agentchat/realtime/experimental/realtime_swarm.py
+++ b/autogen/agentchat/realtime/experimental/realtime_swarm.py
@@ -57,13 +57,13 @@ def message_to_dict(message: dict[str, Any] | str) -> dict[str, Any]:
         return dict(message)
 
 
-def parse_oai_message(message: dict[str, Any] | str, role: str, adressee: Agent) -> dict[str, Any]:
+def parse_oai_message(message: dict[str, Any] | str, role: str, addressee: Agent) -> dict[str, Any]:
     """Parse a message into an OpenAI-compatible message format.
 
     Args:
         message: The message to parse.
         role: The role associated with the message.
-        adressee: The agent that will receive the message.
+        addressee: The agent that will receive the message.
 
     Returns:
         The parsed message in OpenAI-compatible format.
@@ -104,7 +104,7 @@ def parse_oai_message(message: dict[str, Any] | str, role: str, adressee: Agent)
 
     # Add a name field if missing
     if "name" not in oai_message:
-        oai_message["name"] = adressee.name
+        oai_message["name"] = addressee.name
 
     return oai_message
 

--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -961,7 +961,7 @@ class OpenAIWrapper:
         after removing extra kwargs.
 
         For Azure models/deployment names there's a convenience modification of model removing dots in
-        the it's value (Azure deployment names can't have dots). I.e. if you have Azure deployment name
+        its value (Azure deployment names can't have dots). I.e. if you have Azure deployment name
         "gpt-35-turbo" and define model "gpt-3.5-turbo" in the config the function will remove the dot
         from the name and create a client that connects to "gpt-35-turbo" Azure deployment.
         """

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -4,7 +4,7 @@
 #
 # Portions derived from https://github.com/microsoft/autogen are under the MIT License.
 # SPDX-License-Identifier: MIT
-"""Create a OpenAI-compatible client for Gemini features.
+"""Create an OpenAI-compatible client for Gemini features.
 
 Example:
     ```python


### PR DESCRIPTION
Fix: fix: correct parameter name typo and grammar across multiple files