### PR TITLE
update acp to 0.12.1

### DIFF
--- a/ag2/acp/bridge.py
+++ b/ag2/acp/bridge.py
@@ -19,7 +19,7 @@ from acp import schema
 
 from ag2.events.types import BinaryResult
 
-from .dispatch import InboundUpdates
+from .dispatch import InOrderUpdates
 from .elicitation import resolve_elicitation_response
 from .mappers import block_text, block_to_files, map_session_update
 from .permissions import resolve_permission_option_id
@@ -157,9 +157,9 @@ class BridgeState:
         self._turn_files: list[BinaryResult] = []
         self._turn_worked = False
         self.terminals = TerminalManager(config.fs_root or config.cwd)
-        # Owned here because the connection is built from this bridge and a turn
-        # is read out of this bridge: both ends of `settle()` are already here.
-        self.updates = InboundUpdates()
+        # Owned here rather than per-connection: it orders the updates of whatever
+        # connection this bridge is currently serving, and only one is ever live.
+        self.updates = InOrderUpdates()
 
     def begin_turn(self) -> None:
         self._turn_parts = []
@@ -241,7 +241,10 @@ class ACPBridge(acp.Client):
         self.state = state
 
     async def session_update(self, session_id: str, update: SessionUpdate, **kwargs: Any) -> None:
-        await self.state.handle_update(update)
+        # Serialized: the SDK spawns a task per notification, so without this the
+        # handlers can interleave and chunks land out of order (see `dispatch`).
+        async with self.state.updates.in_order():
+            await self.state.handle_update(update)
 
     async def request_permission(
         self,

--- a/ag2/acp/client.py
+++ b/ag2/acp/client.py
@@ -46,11 +46,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Ceiling on waiting for received `session/update`s to finish being handled. Only
-# approached if a handler is wedged — the normal wait is a scheduling round or
-# two — and exceeding it costs the tail of the turn's text, never a hung turn.
-_UPDATE_SETTLE_TIMEOUT = 10.0
-
 
 def _elicitation_capabilities(policy: "ElicitationPolicy") -> schema.ElicitationCapabilities | None:
     """What ``initialize`` advertises for elicitation, per policy.
@@ -210,21 +205,12 @@ class ACPClient:
             await session.close()
             raise
 
-        # The prompt response arriving does not mean the `session/update`s that
-        # preceded it on the wire have been handled — see `dispatch`. Reading the
-        # turn now would cut off its tail, so wait for them first. Bounded only
-        # against a wedged update handler: the normal wait is the time it takes to
-        # drain a queue whose items are already there.
-        try:
-            await asyncio.wait_for(state.updates.settle(), _UPDATE_SETTLE_TIMEOUT)
-        except asyncio.TimeoutError:
-            logger.warning(
-                "Timed out after %.0fs waiting for streamed updates to be handled; "
-                "the reply may be missing its tail (agent=%r).",
-                _UPDATE_SETTLE_TIMEOUT,
-                self.config._agent_label,
-            )
-
+        # The turn is read out below without waiting on anything: since SDK 0.12.1
+        # `conn.prompt` itself does not return until every `session/update` handler
+        # this session has in flight has returned, so the response arriving means
+        # the tail has landed. A wedged handler therefore holds up the prompt, and
+        # is bounded by `turn_timeout` — the same ceiling as a wedged agent. Order
+        # among those handlers is AG2's own doing; see `dispatch`.
         if response is not None:
             session.sent_count = new_count
 

--- a/ag2/acp/config.py
+++ b/ag2/acp/config.py
@@ -16,7 +16,7 @@ Claude Code, Codex, OpenCode and Kilo Code ACP adapters respectively.
 """
 
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 from typing_extensions import Self
 
@@ -40,21 +40,6 @@ if TYPE_CHECKING:
     # (see ``acp.testing``) — the process handle is optional precisely so a
     # connection that has no process can satisfy this.
     ConnectHook = Callable[["acp.Client"], "AbstractAsyncContextManager[tuple[ClientSideConnection, Process | None]]"]
-
-
-def _dispatch_kwargs(client: "acp.Client") -> dict[str, Any]:
-    """Connection arguments that make this client's notifications waitable.
-
-    Read off the bridge the connection hook already receives, so no hook signature
-    has to carry them (see :mod:`~ag2.acp.dispatch`). A client that is not an AG2
-    bridge — a double standing in for one — gets the SDK's own defaults.
-
-    ``ACPBridge`` is imported inside the function, as ``acp`` itself is below: the
-    bridge pulls in the SDK, and importing ``ag2.acp.config`` must not.
-    """
-    from .bridge import ACPBridge
-
-    return client.state.updates.connection_kwargs() if isinstance(client, ACPBridge) else {}
 
 
 PermissionPolicy = Literal["ask", "auto", "deny"]
@@ -196,7 +181,6 @@ class ACPConfig:
             env=self.env,
             cwd=self.cwd,
             use_unstable_protocol=True,
-            **_dispatch_kwargs(client),
         )
 
     def _gateway_address(self) -> GatewayAddress:

--- a/ag2/acp/dispatch.py
+++ b/ag2/acp/dispatch.py
@@ -1,109 +1,51 @@
 # Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-"""Make inbound ACP notifications handled in wire order, and waitable.
+"""Make inbound ``session/update`` notifications handled in wire order.
 
-The SDK's receive loop is not order-preserving across message kinds. A response
-is correlated inline, while a notification is published to a queue whose
-consumer dispatches it as a fire-and-forget task and marks the queue entry done
-the moment that task is *created*. Two consequences, both visible to a caller:
-``session/prompt`` can return while ``session/update``s that preceded it on the
-wire are still unhandled, so the turn read out at that moment is short by
-whatever has not landed; and concurrent handler tasks can interleave, so chunks
-can be handled out of the order the agent sent them.
+The SDK spawns each inbound notification as its own task: the receive loop reads
+a message and calls ``create_task`` on the handler, so two ``session/update``
+handlers that both await — and AG2's does, it sends an event to the run's stream —
+can interleave. Chunks then land out of the order the agent sent them, and the
+assembled reply is scrambled rather than short.
 
-``Connection`` takes both the queue and the dispatcher as arguments, which is the
-seam used here: :class:`_InOrderDispatcher` *awaits* each notification instead of
-spawning it, so the dispatcher's own sequential loop becomes the ordering, and
-the queue entry is marked done only once the handler has returned. That is what
-makes :meth:`InboundUpdates.settle` exact — ``join()`` returns when every
-notification read off the wire has been handled, with nothing to poll or time.
+Completeness, the other half of this, is the SDK's own since 0.12.1: a
+``ClientSideConnection`` tracks the ``session/update`` handlers it has in flight
+per session and ``session/prompt`` does not return until they have all returned.
+So a caller that reads the turn out after the prompt response sees every update
+that preceded it on the wire. That is what this module used to arrange itself, by
+handing ``Connection`` a queue it could ``join()``; the queue is gone from the SDK
+and the guarantee is now upstream, but the ordering is not.
 
-The trade-off: an inbound *request* published behind a notification now waits for
-that notification's handler. For AG2 that means a ``session/request_permission``
-arriving mid-stream is delayed by one ``handle_update``, which sends an event to
-the run's stream — bounded by whatever the caller's subscribers do. Requests
-themselves still run concurrently once dispatched, so a permission prompt
-awaiting a human never blocks the updates behind it.
+Ordering is recovered with a lock rather than a queue, because task *creation* is
+already in wire order: the receive loop is sequential, so handler tasks start in
+the order their messages were read, and each one takes this lock as its first
+await. ``asyncio.Lock`` hands off to waiters in the order they arrived, so the
+lock's order is the wire's order. The trade-off is that a slow handler holds up
+the updates behind it — bounded by the run's own subscribers, and by the turn
+timeout above it, since ``prompt`` is waiting on the same handlers.
 """
 
-from typing import Any
+import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 
-from acp.task import (
-    DefaultMessageDispatcher,
-    InMemoryMessageQueue,
-    MessageDispatcher,
-    MessageQueue,
-    MessageStateStore,
-    NotificationRunner,
-    RequestRunner,
-    TaskSupervisor,
-)
-
-__all__ = ["InboundUpdates"]
+__all__ = ["InOrderUpdates"]
 
 
-class _InOrderDispatcher(DefaultMessageDispatcher):
-    """``DefaultMessageDispatcher``, but notifications are awaited, not spawned."""
+class InOrderUpdates:
+    """The per-bridge lock that makes update handling sequential.
 
-    def __init__(self, *, notification_runner: NotificationRunner, **kwargs: Any) -> None:
-        super().__init__(notification_runner=notification_runner, **kwargs)
-        # Held separately rather than reaching for the base class's own copy.
-        self._run_notification = notification_runner
-
-    async def _dispatch_notification(self, message: dict[str, Any]) -> None:
-        # The base class's loop calls ``task_done()`` once this returns, so
-        # awaiting here is also what makes "done" mean "handled".
-        await self._run_notification(message)
-
-
-class InboundUpdates:
-    """Per-connection notification plumbing, and the wait a turn does on it.
-
-    One of these is owned by the bridge (:class:`~.bridge.BridgeState`), whose
-    connection hooks splat :attr:`connection_kwargs` into the SDK call that builds
-    the connection. A bridge with no connection yet — or a test double that never
-    builds a real one — simply never has anything to settle.
+    One of these is owned by the bridge (:class:`~.bridge.BridgeState`) and taken
+    by its ``session_update`` route. A bridge with no connection — a test double
+    that calls ``handle_update`` directly — simply never contends on it.
     """
 
     def __init__(self) -> None:
-        self._queue: MessageQueue | None = None
+        self._lock = asyncio.Lock()
 
-    def connection_kwargs(self) -> dict[str, Any]:
-        """What to pass to ``spawn_agent_process`` / ``connect_to_agent``.
-
-        The queue is minted here rather than left to ``Connection``, because it is
-        what :meth:`settle` waits on and so this side needs the reference. One
-        fresh queue per call: a queue is closed along with the connection that
-        drained it, so a second connection cannot be handed the first one's.
-        """
-        self._queue = InMemoryMessageQueue()
-        return {"queue": self._queue, "dispatcher_factory": self._make_dispatcher}
-
-    def _make_dispatcher(
-        self,
-        queue: MessageQueue,
-        supervisor: TaskSupervisor,
-        store: MessageStateStore,
-        request_runner: RequestRunner,
-        notification_runner: NotificationRunner,
-    ) -> MessageDispatcher:
-        return _InOrderDispatcher(
-            queue=queue,
-            supervisor=supervisor,
-            store=store,
-            request_runner=request_runner,
-            notification_runner=notification_runner,
-        )
-
-    async def settle(self) -> None:
-        """Wait until every notification read off the wire has been handled.
-
-        Every notification the agent sent before its ``session/prompt`` response
-        was published to the queue before that response was read, so a caller
-        that reaches here after the response awaits exactly this turn's updates.
-        A bridge whose connection never went through here — an in-process test
-        double calls ``session_update`` directly — has nothing to wait for.
-        """
-        if self._queue is not None:
-            await self._queue.join()
+    @asynccontextmanager
+    async def in_order(self) -> AsyncGenerator[None]:
+        """Hold off the updates read after this one until this one is handled."""
+        async with self._lock:
+            yield

--- a/ag2/acp/remote.py
+++ b/ag2/acp/remote.py
@@ -35,7 +35,7 @@ from acp.core import ClientSideConnection
 from acp.http.client import AcpHttpStatusError, create_http_stream
 from acp.ws.client import create_websocket_stream
 
-from .config import ACPConfig, _dispatch_kwargs
+from .config import ACPConfig
 from .tool_gateway import GatewayAddress, MCPCapabilityError
 from .transport import ACPTransport, resolve_transport
 
@@ -178,7 +178,7 @@ async def open_remote_connection(
     # `use_unstable_protocol` registers the `elicitation/*` client routes, as on
     # the subprocess path; without it the SDK answers the agent's question with
     # method-not-found before the bridge ever sees it.
-    conn = acp.connect_to_agent(client, stream, use_unstable_protocol=True, **_dispatch_kwargs(client))
+    conn = acp.connect_to_agent(client, stream, use_unstable_protocol=True)
     try:
         yield conn, None
     finally:

--- a/ag2/acp/testing.py
+++ b/ag2/acp/testing.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, cast
 import acp
 from acp import schema
 
-from .config import ACPConfig, _dispatch_kwargs
+from .config import ACPConfig
 from .types import SessionUpdate
 
 if TYPE_CHECKING:
@@ -373,11 +373,9 @@ def _duplex_connect(agent: "Callable[[acp.Client], Any] | Any") -> "ConnectHook"
         # so it is cancelled with the connection rather than outliving the test.
         agent_conn = AgentSideConnection(agent, agent_writer, agent_reader, listening=False)
         serving = asyncio.ensure_future(agent_conn.listen())
-        # The same arguments the real transports pass, `_dispatch_kwargs` included:
-        # a harness that connected differently would not be exercising AG2's wiring.
-        conn = acp.connect_to_agent(
-            client, client_writer, client_reader, use_unstable_protocol=True, **_dispatch_kwargs(client)
-        )
+        # The same arguments the real transports pass: a harness that connected
+        # differently would not be exercising AG2's wiring.
+        conn = acp.connect_to_agent(client, client_writer, client_reader, use_unstable_protocol=True)
         try:
             yield conn, None
         finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
 a2a = ["a2a-sdk>=1.1.0,<2"]
 a2ui = ["jsonschema>=4.18.0,<5", "starlette>=0.40,<2"]
 acp = [
-    "agent-client-protocol>=0.12.0,<0.13",
+    "agent-client-protocol>=0.12.1,<0.13",
     # Tool exposure to CLI agents runs an in-process HTTP MCP server, also requiring starlette and uvicorn
     "ag2[mcp]",
     "starlette>=0.40,<2",

--- a/test/acp/test_update_settling.py
+++ b/test/acp/test_update_settling.py
@@ -1,17 +1,17 @@
 # Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-"""A turn is read out only once the updates that preceded its response are handled.
+"""A turn reads out every update that preceded its response, in the order sent.
 
-The SDK's receive loop is not order-preserving across message kinds: a response
-resolves inline, while a notification is published to a queue whose consumer
-dispatches it as a fire-and-forget task — and marks the queue entry done as soon
-as that task is *created*. So ``session/prompt`` can complete while earlier
-``session/update``s are still unhandled, and a turn read at that moment is short
-by whatever has not landed.
+Two guarantees, from two places. Completeness is the SDK's: ``session/prompt``
+does not return until the session's in-flight ``session/update`` handlers have
+returned, so a turn read after the response is not short of its tail. Order is
+AG2's: the SDK spawns a task per notification, so handlers that await — and this
+one does, it sends to the run's stream — would otherwise interleave and scramble
+the chunks (see :mod:`ag2.acp.dispatch`).
 
 This needs a real ACP connection: ``fake_acp_config`` calls the client's
-``session_update`` directly, so it never goes near the queue that causes this.
+``session_update`` directly, so it never spawns the tasks that cause this.
 ``duplex_acp_config`` gives the genuine connection without a subprocess.
 """
 
@@ -25,8 +25,8 @@ from ag2 import Agent
 from ag2.acp.testing import duplex_acp_config
 from ag2.events import ModelMessageChunk
 
-# Enough that the dispatcher cannot plausibly finish them all within the one
-# scheduling round the prompt response takes, and small enough to stay fast.
+# Enough that unserialized handlers cannot plausibly stay in order by luck, and
+# small enough to stay fast.
 CHUNKS = 200
 
 # Each chunk is one digit of its own index, so the assembled text pins order as
@@ -65,7 +65,7 @@ class ChunkingAgent:
 
 @pytest.mark.asyncio
 async def test_every_streamed_chunk_reaches_the_reply_in_order() -> None:
-    """Before the settle, this lost a slice of the tail on most runs."""
+    """Unguarded, this loses the tail (no settle) or scrambles it (no ordering)."""
     cfg = duplex_acp_config(ChunkingAgent)
 
     try:
@@ -82,12 +82,10 @@ async def test_every_streamed_chunk_reaches_the_reply_in_order() -> None:
 async def test_the_stream_and_the_reply_carry_the_same_chunks() -> None:
     """Nothing is dropped or reordered between the stream and the assembled body.
 
-    Before the settle these disagreed: every chunk reached the stream while the
-    body was short, so a caller watching events saw output the reply then lost.
-
     Order is asserted on the stream too, not just on the body: updates are handled
     one at a time in the order they were read off the wire, so a subscriber sees
-    the agent's chunks in the order the agent sent them.
+    the agent's chunks in the order the agent sent them. Drop that serialization
+    and this is the test that fails — the stream shows the interleaving directly.
     """
     chunks: list[str] = []
     cfg = duplex_acp_config(ChunkingAgent)

--- a/uv.lock
+++ b/uv.lock
@@ -69,7 +69,7 @@ wheels = [
 
 [[package]]
 name = "ag2"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -299,7 +299,7 @@ requires-dist = [
     { name = "a2a-sdk", marker = "extra == 'a2a'", specifier = ">=1.1.0,<2" },
     { name = "ag-ui-protocol", marker = "extra == 'ag-ui'", specifier = ">=0.1.15,<0.2" },
     { name = "ag2", extras = ["mcp"], marker = "extra == 'acp'" },
-    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.12,<0.13" },
+    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.12.1,<0.13" },
     { name = "anthropic", extras = ["vertex"], marker = "extra == 'anthropic'", specifier = ">=0.116.0,<1" },
     { name = "anyio", specifier = ">=4.0.0,<5.0.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34.149" },
@@ -524,14 +524,14 @@ types = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.12.0"
+version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/50/65bfb4e3e13f350a52c368cbfc4bc36a1b3b3f34a6b3f5a2e3551e1bd63b/agent_client_protocol-0.12.0.tar.gz", hash = "sha256:4d42ac680388556b038cb6dd58dbbbd1561f9e545a334c1a352cc055f98b1c79", size = 135037, upload-time = "2026-08-01T15:58:22.35Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/95/2c28ca34e545ce0282e88272aa3a8abdf8f3f926a0492f567ea11acd071b/agent_client_protocol-0.12.1.tar.gz", hash = "sha256:9963ccb590ed96d7dc542c9c023e90676fc76b1c6562e21a9ee112f4fbcb0095", size = 130605, upload-time = "2026-08-16T14:08:22.545Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/c7/b84b8698879464bd8f869551bac31454bed14a3a22910f65d9693f3701bd/agent_client_protocol-0.12.0-py3-none-any.whl", hash = "sha256:233626748034896214de118f5cf5a319484ad2186705fd595219afee92237ccc", size = 92992, upload-time = "2026-08-01T15:58:21.216Z" },
+    { url = "https://files.pythonhosted.org/packages/21/61/0a2186c8ca53cf464767d4c4fb7fd9e23f48ce4547c2fa0d1c83a4d52410/agent_client_protocol-0.12.1-py3-none-any.whl", hash = "sha256:aaf3cc301ed87d9e2c4ccb91adfe1cd58784355f6ce7e513f50e7ca2391862ef", size = 85929, upload-time = "2026-08-16T14:08:21.307Z" },
 ]
 
 [package.optional-dependencies]
@@ -712,9 +712,9 @@ name = "aiologic"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sniffio", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "wrapt", marker = "python_full_version < '3.13'" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/a7/809482759f40079f4c4328c7318bf569ae25d457f5017aad30a1b9aafedc/aiologic-0.17.0.tar.gz", hash = "sha256:65aa058e858c94cd208badb188e7f00b54dcabb3ba85b34f794db98074d108b9", size = 251625, upload-time = "2026-06-14T12:24:35.367Z" }
 wheels = [
@@ -1521,8 +1521,8 @@ name = "culsans"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiologic", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "aiologic" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
 wheels = [
@@ -1881,7 +1881,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2423,12 +2423,12 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "google-api-core", marker = "python_full_version < '3.13'" },
-    { name = "google-auth", marker = "python_full_version < '3.13'" },
-    { name = "google-cloud-core", marker = "python_full_version < '3.13'" },
-    { name = "google-crc32c", marker = "python_full_version < '3.13'" },
-    { name = "google-resumable-media", marker = "python_full_version < '3.13'" },
-    { name = "requests", marker = "python_full_version < '3.13'" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/76/4d965702e96bb67976e755bed9828fa50306dca003dbee08b67f41dd265e/google_cloud_storage-2.19.0.tar.gz", hash = "sha256:cd05e9e7191ba6cb68934d8eb76054d9be4562aa89dbc4236feee4d7d51342b2", size = 5535488, upload-time = "2024-12-05T01:35:06.49Z" }
 wheels = [
@@ -2454,12 +2454,12 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "google-api-core", marker = "python_full_version >= '3.13'" },
-    { name = "google-auth", marker = "python_full_version >= '3.13'" },
-    { name = "google-cloud-core", marker = "python_full_version >= '3.13'" },
-    { name = "google-crc32c", marker = "python_full_version >= '3.13'" },
-    { name = "google-resumable-media", marker = "python_full_version >= '3.13'" },
-    { name = "requests", marker = "python_full_version >= '3.13'" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/72/86f94e1639a8bcd9d33e8e01b49afcaa1c3a13bda7683c681717e0901e15/google_cloud_storage-3.12.0.tar.gz", hash = "sha256:03ae9847c6babb368f35f054126b8a08cbc0e3266efb990eb17b9926a45cf3be", size = 17338620, upload-time = "2026-06-12T18:03:29.215Z" }
 wheels = [
@@ -2589,7 +2589,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
 wheels = [
@@ -2664,7 +2664,7 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version >= '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
 wheels = [
@@ -2742,9 +2742,9 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "googleapis-common-protos", marker = "python_full_version < '3.13'" },
-    { name = "grpcio", version = "1.78.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "protobuf", marker = "python_full_version < '3.13'" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio", version = "1.78.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/cd/89ce482a931b543b92cdd9b2888805518c4620e0094409acb8c81dd4610a/grpcio_status-1.78.0.tar.gz", hash = "sha256:a34cfd28101bfea84b5aa0f936b4b423019e9213882907166af6b3bddc59e189", size = 13808, upload-time = "2026-02-06T10:01:48.034Z" }
 wheels = [
@@ -2770,9 +2770,9 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "googleapis-common-protos", marker = "python_full_version >= '3.13'" },
-    { name = "grpcio", version = "1.81.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "protobuf", marker = "python_full_version >= '3.13'" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio", version = "1.81.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/26/0aa9168c87882381fd810d140c279a2490ed6aee655f0515d6f56c5ca404/grpcio_status-1.81.1.tar.gz", hash = "sha256:9389a03e746017b10f0630c064289201458f3ce01f5d7ef4b0bebc1ef6cf82ad", size = 13923, upload-time = "2026-06-11T12:58:48.636Z" }
 wheels = [
@@ -3046,17 +3046,17 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -3092,18 +3092,18 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
@@ -3115,7 +3115,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -4690,7 +4690,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -6606,9 +6606,9 @@ name = "tinyfish"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "tenacity", marker = "python_full_version >= '3.11'" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "tenacity" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/0d/ce597e06fc30b80e76946abdc7a7bd56c16360bbf098108ea05988bce43c/tinyfish-0.5.0.tar.gz", hash = "sha256:1e9d97b9badb591d6839fbcbf01a503cc33a4a5d729553baa345ca4de3c522a4", size = 74916, upload-time = "2026-08-04T21:37:42.74Z" }
 wheels = [


### PR DESCRIPTION

The extra pinned `agent-client-protocol>=0.12.0,<0.13`, so CI resolved the new
release the day it shipped. 0.12.1 deletes `acp/task/dispatcher.py`, `queue.py`
and `state.py`, and `Connection.__init__` no longer accepts `queue` /
`dispatcher_factory` — so the seam `ag2.acp.dispatch` was built on is gone
entirely, not just renamed. (Nothing else moved: `schema.py` has the same 284
models with the same fields, and `__init__.py`, `meta.py`, `interfaces.py`,
`core.py` and `helpers.py` are byte-identical between the two releases.)

That seam bought AG2 two things, and 0.12.1 changes who owns each:

* **Completeness** — a turn read out after the prompt response is not short of
  its tail. Now upstream's: `ClientSideConnection.prompt()` tracks the session's
  in-flight `session/update` handlers and does not return until they have
  returned. AG2's manual `settle()` wait (and its `_UPDATE_SETTLE_TIMEOUT`) is
  therefore deleted from `ACPClient`.
* **Ordering** — chunks are handled in the order the agent sent them. Still
  AG2's: the SDK spawns a task per notification, so handlers that await — and
  AG2's does, it sends an event to the run's stream — interleave and scramble
  the stream. `dispatch.InOrderUpdates` now recovers this with a lock instead of
  a queue: notification tasks are *created* in wire order by the sequential
  receive loop, and `asyncio.Lock` hands off to waiters in arrival order, so the
  lock's order is the wire's order. The bridge's `session_update` route holds it
  across `handle_update`.

`_dispatch_kwargs` is dropped from the subprocess, remote and in-process-duplex
connection paths, since there is nothing left to inject. The floor moves to
`>=0.12.1`: on 0.12.0 this code would lose the completeness guarantee silently.

One behavior change worth noting: a wedged update handler now holds up
`conn.prompt` and is bounded by `turn_timeout` — the same ceiling as a wedged
agent — rather than by a separate 10s wait that logged a warning and read the
turn out short.

## Related issue number

None — regression from an upstream release, not a filed issue.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

`test/acp/test_update_settling.py` already covers both guarantees and needed no
new cases — its module docs are updated to say which side owns which. The two
halves were verified separately: with the lock removed,
`test_the_stream_and_the_reply_carry_the_same_chunks` fails on scrambled digits
(`01234567980124356890712436578901…`) while the body stays complete, confirming
that settle is genuinely upstream's now and that the lock is load-bearing.

Test runs: `test/acp` 401 passed on both 3.14 and 3.10 (the matrix entry from the
failing run); full non-LLM suite 4215 passed, 1 skipped, 1 xfailed. `ruff
check`/`format` clean, `uv lock --check` clean.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
