### PR TITLE
refactor: annotate contextmanager returns as Generator, not Iterator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Cross-cutting and hard-to-reverse design decisions are recorded in `docs/adr/`, 
 ## Code Style Guidelines
 
 - Do not use `from __future__ import annotations`.
+- With `@contextmanager` / `@asynccontextmanager`, annotate the return type as `Generator[T]` / `AsyncGenerator[T]`, never `Iterator[T]` / `AsyncIterator[T]`. The decorator needs a real generator — it calls `throw()` / `athrow()` on it — so the iterator form is an under-specification that typeshed marks deprecated. Import them from `collections.abc` (not `typing`) and omit the default send type: `AsyncGenerator[None]`, not `AsyncGenerator[None, None]`.
 - Do not use global variables or top-level side-effect function calls unless the user explicitly allows it.
 - For filesystem paths, use `pathlib.Path` internally. Public signatures should accept `str | os.PathLike[str]`.
 - Top-level imports from `ag2.*` are for common APIs that are broadly reusable across scenarios and core agent flows.

--- a/ag2/a2a/_session.py
+++ b/ag2/a2a/_session.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -28,7 +28,7 @@ def with_tenant(config: A2AConfig, override: str | None, **kwargs: Any) -> dict[
 
 
 @asynccontextmanager
-async def open_session(config: A2AConfig) -> AsyncIterator[tuple[Client, ClientCallContext | None]]:
+async def open_session(config: A2AConfig) -> AsyncGenerator[tuple[Client, ClientCallContext | None]]:
     """Open a short-lived A2A SDK client for one-shot RPCs.
 
     Combines the httpx client, card resolution, and SDK factory into a

--- a/ag2/acp/sessions.py
+++ b/ag2/acp/sessions.py
@@ -20,7 +20,7 @@ import asyncio
 import logging
 import time
 from collections import OrderedDict
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from typing import Any
@@ -254,7 +254,7 @@ class AgentSession:
             task.cancel()
 
     @asynccontextmanager
-    async def recovery(self) -> AsyncIterator[None]:
+    async def recovery(self) -> AsyncGenerator[None]:
         """Hold the turn lock for post-cancellation repair.
 
         Repairing a cancelled turn is a read-modify-write over the session's
@@ -270,7 +270,7 @@ class AgentSession:
             yield
 
     @asynccontextmanager
-    async def turn(self) -> AsyncIterator[None]:
+    async def turn(self) -> AsyncGenerator[None]:
         """Hold this session's turn lock for the duration of one prompt.
 
         Concurrent prompts on one session queue rather than interleave —
@@ -410,7 +410,7 @@ class SessionStore:
         return self._active_prompts
 
     @asynccontextmanager
-    async def admit(self) -> AsyncIterator[None]:
+    async def admit(self) -> AsyncGenerator[None]:
         """Admit one prompt against the connection-wide bounds.
 
         Wraps the whole prompt, *outside* the session's own turn lock, so a
@@ -428,7 +428,7 @@ class SessionStore:
             self._active_prompts -= 1
 
     @asynccontextmanager
-    async def running_turn(self) -> AsyncIterator[None]:
+    async def running_turn(self) -> AsyncGenerator[None]:
         """Hold one of the connection's concurrent-turn slots.
 
         Taken *inside* the session's turn lock, so a prompt waiting its turn on a

--- a/ag2/agent.py
+++ b/ag2/agent.py
@@ -19,7 +19,7 @@ import asyncio
 import json
 import logging
 import types
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping, Sequence
+from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable, Mapping, Sequence
 from contextlib import AsyncExitStack, ExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass
 from functools import partial
@@ -1284,7 +1284,7 @@ class Agent(PluginTarget, Generic[TResult]):
         additional_middleware: Iterable[MiddlewareFactory] = (),
         additional_observers: Iterable[Observer] = (),
         response_schema: Omittable[ResponseProto[Any] | type | None] = omit,
-    ) -> "AsyncIterator[Callable[[], Awaitable[AgentReply[Any, Any]]]]":
+    ) -> "AsyncGenerator[Callable[[], Awaitable[AgentReply[Any, Any]]]]":
         """Open a turn scope and yield a ``drive`` callable that runs it once.
 
         Sets up everything a turn needs and keeps it live across the ``yield``:
@@ -1527,7 +1527,7 @@ class _KnowledgeContext:
         self.__bootstrapped = None
 
     @asynccontextmanager
-    async def enter(self, context: "Context") -> AsyncIterator[None]:
+    async def enter(self, context: "Context") -> AsyncGenerator[None]:
         store = self.config.store
 
         if not self.__bootstrapped:
@@ -1564,7 +1564,7 @@ class _KnowledgeContext:
 
 class _FakeKnowledgeContext:
     @asynccontextmanager
-    async def enter(self, context: "Context") -> AsyncIterator[None]:
+    async def enter(self, context: "Context") -> AsyncGenerator[None]:
         yield
 
 
@@ -1630,7 +1630,7 @@ async def _observer_lifecycle(
     observers: Sequence[Observer],
     stack: ExitStack,
     context: Context,
-) -> AsyncIterator[None]:
+) -> AsyncGenerator[None]:
     """Register ``observers`` on ``stack`` and bracket the turn with lifecycle events.
 
     Observers subscribe to the stream under the caller's ``ExitStack``, then an

--- a/ag2/extensions/daytona/environment.py
+++ b/ag2/extensions/daytona/environment.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import threading
-from collections.abc import AsyncIterator, Hashable
+from collections.abc import AsyncGenerator, Hashable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -102,7 +102,7 @@ class DaytonaEnvironment:
     async def open(
         self,
         context: "ConversationContext | None" = None,
-    ) -> AsyncIterator[DaytonaSandbox]:
+    ) -> AsyncGenerator[DaytonaSandbox]:
         api_key = resolve_variable(self._api_key, context, param_name="api_key") if context else self._api_key
         api_url = resolve_variable(self._api_url, context, param_name="api_url") if context else self._api_url
         target = resolve_variable(self._target, context, param_name="target") if context else self._target

--- a/ag2/extensions/docker/environment.py
+++ b/ag2/extensions/docker/environment.py
@@ -4,7 +4,7 @@
 
 import os
 import threading
-from collections.abc import AsyncIterator, Hashable
+from collections.abc import AsyncGenerator, Hashable
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
@@ -75,7 +75,7 @@ class DockerEnvironment:
     async def open(
         self,
         context: "ConversationContext | None" = None,
-    ) -> AsyncIterator[DockerSandbox]:
+    ) -> AsyncGenerator[DockerSandbox]:
         image = resolve_variable(self._image, context, param_name="image") if context else self._image
         env_vars = (
             resolve_variable(self._env_vars, context, param_name="env_vars") if context else self._env_vars

--- a/ag2/extensions/tools/search/tinyfish.py
+++ b/ag2/extensions/tools/search/tinyfish.py
@@ -12,7 +12,7 @@ Docs: https://docs.ag2.ai/docs/user-guide/extensions/tools/search/tinyfish/
 """
 
 import os
-from collections.abc import Iterable, Iterator
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, TypeAlias
@@ -39,7 +39,7 @@ def _safe_url(url: str) -> bool:
 
 
 @contextmanager
-def _tinyfish_api_integration() -> Iterator[None]:
+def _tinyfish_api_integration() -> Generator[None]:
     previous = os.environ.get(_API_INTEGRATION_ENV_VAR)
     os.environ[_API_INTEGRATION_ENV_VAR] = _API_INTEGRATION
     try:

--- a/ag2/live/cascade.py
+++ b/ag2/live/cascade.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-from collections.abc import AsyncIterator, Callable, Iterable, Sequence
+from collections.abc import AsyncGenerator, Callable, Iterable, Sequence
 from contextlib import asynccontextmanager, suppress
 
 from fast_depends.library.serializer import SerializerProto
@@ -89,7 +89,7 @@ class CascadeConfig(RealtimeConfig):
         instructions: Iterable[str] = (),
         tools: Iterable[ToolSchema] = (),
         serializer: SerializerProto,
-    ) -> AsyncIterator[None]:
+    ) -> AsyncGenerator[None]:
         client: LLMClient = self._model.create()
         detector = self._turn_detector()
         schemas = list(tools)

--- a/ag2/live/gemini.py
+++ b/ag2/live/gemini.py
@@ -4,7 +4,7 @@
 
 import asyncio
 import json
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncGenerator, Iterable
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -191,7 +191,7 @@ class RealTimeConfig(RealtimeConfig):
         instructions: Iterable[str] = (),
         tools: Iterable[ToolSchema] = (),
         serializer: SerializerProto,
-    ) -> AsyncIterator[None]:
+    ) -> AsyncGenerator[None]:
         final_config = self._build_session(instructions=instructions, tools=tools)
 
         async with self.client.aio.live.connect(model=self.model, config=final_config) as session:

--- a/ag2/live/openai.py
+++ b/ag2/live/openai.py
@@ -4,7 +4,7 @@
 
 import asyncio
 import base64
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncGenerator, Iterable
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
@@ -292,7 +292,7 @@ class RealTimeConfig(RealtimeConfig):
         instructions: Iterable[str] = (),
         tools: Iterable[ToolSchema] = (),
         serializer: SerializerProto,
-    ) -> AsyncIterator[None]:
+    ) -> AsyncGenerator[None]:
         final_session = self._build_session(instructions=instructions, tools=tools)
 
         async with self.client.realtime.connect(model=self.model) as conn:

--- a/ag2/live/realtime.py
+++ b/ag2/live/realtime.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import AsyncIterator, Callable, Iterable
+from collections.abc import AsyncGenerator, Callable, Iterable
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager, suppress
 from typing import Any, Protocol
 
@@ -113,7 +113,7 @@ class LiveAgent(PluginTarget):
         middleware: Iterable[MiddlewareFactory] = (),
         observers: Iterable[Observer] = (),
         hitl_hook: HumanHook | None = None,
-    ) -> AsyncIterator[ConversationContext]:
+    ) -> AsyncGenerator[ConversationContext]:
         stream = self._stream if self._stream is not None else MemoryStream()
 
         context = ConversationContext(

--- a/ag2/mcp/executor.py
+++ b/ag2/mcp/executor.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -205,7 +205,7 @@ class _Counter:
 
 
 @asynccontextmanager
-async def _stateless_stream() -> AsyncIterator[MemoryStream]:
+async def _stateless_stream() -> AsyncGenerator[MemoryStream]:
     """A fresh per-call stream — no shared history, no cross-call lock."""
     yield MemoryStream()
 

--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib.metadata
-from collections.abc import AsyncIterator, Callable, Sequence
+from collections.abc import AsyncGenerator, Callable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -68,7 +68,7 @@ def _session_manager_lifespan(manager: StreamableHTTPSessionManager) -> "Lifespa
     """
 
     @asynccontextmanager
-    async def lifespan(_: Starlette) -> AsyncIterator[None]:
+    async def lifespan(_: Starlette) -> AsyncGenerator[None]:
         async with manager.run():
             yield
 

--- a/ag2/mcp/sessions.py
+++ b/ag2/mcp/sessions.py
@@ -5,7 +5,7 @@
 import asyncio
 import time
 from collections import OrderedDict
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from uuid import UUID, uuid4
@@ -85,7 +85,7 @@ class SessionStore:
         self._clock = clock
 
     @asynccontextmanager
-    async def session(self, session_id: str) -> AsyncIterator[MemoryStream]:
+    async def session(self, session_id: str) -> AsyncGenerator[MemoryStream]:
         """Yield ``session_id``'s stream while holding its per-session turn lock.
 
         Holding the lock for the duration of the turn serializes concurrent calls

--- a/ag2/mcp/testing.py
+++ b/ag2/mcp/testing.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import httpx
@@ -19,7 +19,7 @@ async def connect(
     *,
     raise_exceptions: bool = True,
     **session_kwargs: object,
-) -> AsyncIterator[ClientSession]:
+) -> AsyncGenerator[ClientSession]:
     """Yield an in-process, initialized MCP ``ClientSession`` talking to ``mcp_server``.
 
     Dispatches directly into the wrapped low-level server over in-memory streams
@@ -37,7 +37,7 @@ async def connect(
 
 
 @asynccontextmanager
-async def serve(server: MCPServer, *, base_url: str = "http://test") -> AsyncIterator[httpx.AsyncClient]:
+async def serve(server: MCPServer, *, base_url: str = "http://test") -> AsyncGenerator[httpx.AsyncClient]:
     """Yield an ``httpx.AsyncClient`` bound to ``server`` over the in-memory ASGI transport.
 
     Drives the ASGI ``lifespan`` protocol so the streamable-HTTP session manager

--- a/ag2/network/transport/ws.py
+++ b/ag2/network/transport/ws.py
@@ -25,7 +25,7 @@ import contextlib
 import functools
 import json
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from websockets.asyncio.client import connect as _ws_connect
@@ -267,7 +267,7 @@ async def serve_ws(
     ssl_context: Any = None,
     ping_interval: float | None = 20.0,
     ping_timeout: float | None = 20.0,
-) -> AsyncIterator["_WsServer"]:
+) -> AsyncGenerator["_WsServer"]:
     """Run a WebSocket server bound to a hub.
 
     Each incoming connection becomes a :class:`WsLinkEndpoint`

--- a/ag2/stream.py
+++ b/ag2/stream.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-from collections.abc import AsyncIterator, Callable, Coroutine, Iterator
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine, Generator
 from contextlib import AsyncExitStack, asynccontextmanager, contextmanager
 from functools import partial
 from typing import Any, overload
@@ -31,7 +31,7 @@ class ABCStream(Stream):
         *,
         interrupt: bool = False,
         sync_to_thread: bool = True,
-    ) -> Iterator[None]:
+    ) -> Generator[None]:
         sub_id = self.subscribe(
             func,
             interrupt=interrupt,
@@ -44,7 +44,7 @@ class ABCStream(Stream):
             self.unsubscribe(sub_id)
 
     @contextmanager
-    def join(self, *, max_events: int | None = None) -> Iterator[AsyncIterator[BaseEvent]]:
+    def join(self, *, max_events: int | None = None) -> Generator[AsyncIterator[BaseEvent]]:
         queue = asyncio.Queue[BaseEvent]()
 
         async def write_events(event: BaseEvent) -> None:
@@ -77,7 +77,7 @@ class ABCStream(Stream):
     async def get(
         self,
         condition: ClassInfo | Condition,
-    ) -> AsyncIterator[asyncio.Future[BaseEvent]]:
+    ) -> AsyncGenerator[asyncio.Future[BaseEvent]]:
         result = asyncio.Future[BaseEvent]()
 
         async def wait_result(event: BaseEvent) -> None:

--- a/ag2/tools/sandbox/adapter/code.py
+++ b/ag2/tools/sandbox/adapter/code.py
@@ -13,7 +13,7 @@ from ag2.tools.sandbox.base import Sandbox
 from ag2.tools.sandbox.factory import SandboxFactory, SingletonFactory
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncGenerator
 
     from ag2.context import ConversationContext
 
@@ -149,6 +149,6 @@ class CodeAdapter:
     async def _open(
         self,
         context: "ConversationContext | None",
-    ) -> "AsyncIterator[Sandbox]":
+    ) -> "AsyncGenerator[Sandbox]":
         async with self._factory.open(context) as sb:
             yield sb

--- a/ag2/tools/sandbox/factory.py
+++ b/ag2/tools/sandbox/factory.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
@@ -86,7 +86,7 @@ class SingletonFactory:
     async def open(
         self,
         context: "ConversationContext | None" = None,
-    ) -> AsyncIterator[Sandbox]:
+    ) -> AsyncGenerator[Sandbox]:
         del context
         yield self._sandbox
 

--- a/ag2/tools/toolkits/mcp_server/toolkit.py
+++ b/ag2/tools/toolkits/mcp_server/toolkit.py
@@ -4,7 +4,7 @@
 
 import asyncio
 import base64
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncGenerator, Iterable
 from contextlib import AsyncExitStack, ExitStack, asynccontextmanager
 from dataclasses import replace
 from typing import Any, get_args
@@ -61,7 +61,7 @@ AnyMCPConfig = MCPServerConfig | MCPStdioServerConfig
 
 
 @asynccontextmanager
-async def _mcp_session(config: AnyMCPConfig) -> AsyncIterator[ClientSession]:
+async def _mcp_session(config: AnyMCPConfig) -> AsyncGenerator[ClientSession]:
     """Open a short-lived MCP ``ClientSession`` for one operation.
 
     Dispatches on the config type — HTTP/streamable-http for

--- a/test/providers/test_network_cross_process_smoke.py
+++ b/test/providers/test_network_cross_process_smoke.py
@@ -36,7 +36,7 @@ present (loaded from ``.env`` at repo root).
 import asyncio
 import contextlib
 import os
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from pathlib import Path
 
 import pytest
@@ -113,7 +113,7 @@ def _gemini(keys: dict[str, str]) -> GeminiConfig:
 
 
 @contextlib.asynccontextmanager
-async def _network() -> AsyncIterator[tuple[Hub, str, list[HubClient]]]:
+async def _network() -> AsyncGenerator[tuple[Hub, str, list[HubClient]]]:
     """Start a hub on a loopback ``serve_ws`` port.
 
     Yields ``(hub, ws_url, clients)``. The hub object is held by the

--- a/test/tools/skills/test_toolkit.py
+++ b/test/tools/skills/test_toolkit.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import asdict
 from pathlib import Path, PurePosixPath
@@ -277,7 +277,7 @@ class _RemoteFactory:
         self.sandbox = _FakeRemoteSandbox()
 
     @asynccontextmanager
-    async def open(self, context: object = None) -> AsyncIterator[Sandbox]:
+    async def open(self, context: object = None) -> AsyncGenerator[Sandbox]:
         yield self.sandbox
 
 

--- a/test/tools/test_local_shell.py
+++ b/test/tools/test_local_shell.py
@@ -5,7 +5,7 @@
 import asyncio
 import json
 import sys
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path, PurePosixPath
 
@@ -417,7 +417,7 @@ class _RecordingFactory:
         self._sandbox = _LoopRecordingSandbox(self.loops)
 
     @asynccontextmanager
-    async def open(self, context: object = None) -> "AsyncIterator[_LoopRecordingSandbox]":
+    async def open(self, context: object = None) -> "AsyncGenerator[_LoopRecordingSandbox]":
         yield self._sandbox
 
 


### PR DESCRIPTION
## Why are these changes needed?

In typeshed's `stdlib/contextlib.pyi`, `contextmanager` and `asynccontextmanager` each have two overloads, and the one accepting `Iterator[T]` / `AsyncIterator[T]` carries a `@deprecated` marker. pyright 1.1.409+ and Pylance therefore flag 31 sites across `ag2/` and `test/` with *The function "asynccontextmanager" is deprecated* — wording that overstates the case, since the decorator itself is not going anywhere.

The diagnostic is still worth acting on rather than silencing, because the underlying point is real: `_AsyncGeneratorContextManager.__aexit__` calls `gen.athrow()`, so the decorator requires an actual generator. `AsyncIterator` is an under-specification — it type-checks, while a plain non-generator async iterator handed to the decorator fails at runtime.

The codebase was already split on this: of the 43 decorated context managers in tracked code, 12 used the generator form before this PR. This makes the convention uniform and writes it down.

### What changed

- **31 return annotations** on decorated functions: 28 × `AsyncIterator[T]` → `AsyncGenerator[T]`, 3 × `Iterator[T]` → `Generator[T]`.
- **21 `from collections.abc import …` lines** adjusted. The old name is dropped only where nothing else in the file still uses it — `ag2/stream.py` keeps `AsyncIterator` because there it is nested: `Generator[AsyncIterator[BaseEvent]]`.
- **Undecorated functions are deliberately untouched** — 24 `AsyncIterator` return annotations remain on undecorated functions in `ag2/` (27 `AsyncIterator[...]` occurrences in total). Outside the decorator, `AsyncIterator` is the correct consumer-facing type and narrowing it to `AsyncGenerator` would over-promise.
- The **single-argument form** is used throughout: `AsyncGenerator[None]`, not `AsyncGenerator[None, None]`.
- The rule is recorded in `AGENTS.md` under *Code Style Guidelines*, next to the existing `from __future__ import annotations` rule, so the pattern does not creep back in.

One file is knowingly left alone: `docs/superpowers/plans/2026-07-23-acp-tool-gateway.md` shows the old form in a historical plan snapshot, and the code that plan produced already uses `AsyncGenerator`. Plan documents record what was planned at the time and are not retrofitted.

### Why the single-argument form is safe on Python 3.10

`AGENTS.md` forbids `from __future__ import annotations`, so on every version before 3.14 (PEP 649) these return annotations are evaluated at definition time — arity is a runtime concern, not just a type-checker one. Every site imports from `collections.abc`, whose `types.GenericAlias` does not enforce the number of type arguments, so `AsyncGenerator[None]` builds fine on 3.10. `typing.AsyncGenerator[None]` would raise `TypeError: Too few arguments`, but no site imports from `typing`. pyright with `pythonVersion = "3.10"` accepts the single-argument form as well, since typeshed gives the send type a PEP 696 default.

## Related issue number

None — this came out of the Pylance diagnostic showing up across the repository rather than a filed issue.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
  - No pages under `website/` reference the pattern, so nothing on the docs site needed updating. The contributor-facing rule went into `AGENTS.md`.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
  - No tests added: this changes annotations only, with no runtime behaviour change. The existing suites are the regression check instead. Locally, `test/mcp test/a2a test/live test/tools test/network test/agent test/extensions test/*.py` gives 1727 passed, 1 skipped, 1 xfailed.
- [x] I've made sure all auto checks have passed.

Beyond CI, one check worth calling out because the pipeline does not run it: **pyright** with `pythonVersion = "3.10"` and `reportDeprecated` enabled reports **0** remaining contextmanager deprecations (down from 31) and **0** type-argument arity errors. The 14 diagnostics that remain are pre-existing and unrelated (absent optional dependencies, a deprecation inside the `exa` SDK, `bool.__invert__` in tests). `ruff check` and `ruff format --check` are clean across 932 files.

The arity question is the one that genuinely needed the matrix rather than a type checker, since these annotations are evaluated at definition time on everything below 3.14 — and `test-ubuntu (3.10)` passes, alongside 3.11 through 3.14, macOS and Windows.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
