### PR TITLE
feat(acp): let a host answer a served agent's human-input request

### DIFF
--- a/ag2/acp/agent.py
+++ b/ag2/acp/agent.py
@@ -43,6 +43,8 @@ from .sessions import (
 )
 
 if TYPE_CHECKING:
+    from ag2.hitl import HumanHook
+
     from .types import ContentBlock, McpServer
 
 logger = logging.getLogger(__name__)
@@ -137,6 +139,18 @@ class ACPAgent:
         prompt_content: Which non-text prompt content to advertise as supported.
             See :class:`PromptContent` — it depends on the model behind the
             agent, so it is declared rather than guessed.
+        hitl_hook: How to answer a turn that calls ``context.input()``. ``None``
+            (the default) fails the turn with
+            :class:`~ag2.acp.executor.HumanInputUnsupportedError`, because ACP
+            elicitation is not wired on this side and there is genuinely nobody
+            to ask. An application that *can* reach a human by its own means —
+            its own chat surface, a queue, an approval UI — passes a hook here
+            and its return value becomes the answer. Same shape as
+            ``Agent(hitl_hook=...)``, dependency injection included; it replaces
+            the served agent's own hook for ACP-driven turns, so bind it per
+            connection (see :meth:`bind`) if the human differs per Client. This
+            is deliberately invisible on the wire: no capability is advertised
+            and no ACP method is called.
     """
 
     __slots__ = (
@@ -163,6 +177,7 @@ class ACPAgent:
         auth: AuthProvider | None = None,
         stream_thoughts: bool = False,
         prompt_content: PromptContent | None = None,
+        hitl_hook: "HumanHook | None" = None,
     ) -> None:
         self._agent = agent
         self._name = name or agent.name
@@ -172,7 +187,7 @@ class ACPAgent:
         self._stream_thoughts = stream_thoughts
         self._prompt_content = prompt_content or PromptContent()
         config = sessions if isinstance(sessions, SessionConfig) else SessionConfig()
-        self._executor = AgentExecutor(agent, stream_thoughts=stream_thoughts)
+        self._executor = AgentExecutor(agent, stream_thoughts=stream_thoughts, hitl_hook=hitl_hook)
         self._session_config = config
         # The most recently opened connection, so ``sessions`` has something to
         # point at. Authorization and sessions live on the scope, never here.

--- a/ag2/acp/executor.py
+++ b/ag2/acp/executor.py
@@ -23,6 +23,7 @@ from ag2.agent import Agent
 from ag2.context import ConversationContext
 from ag2.events import (
     BaseEvent,
+    HumanInputRequest,
     ModelMessageChunk,
     ModelRequest,
     ModelResponse,
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from ag2.context import SubId
+    from ag2.hitl import HumanHook
     from ag2.stream import MemoryStream
 
     from .sessions import AgentSession, SessionStore
@@ -77,17 +79,20 @@ class UpdateDeliveryError(RuntimeError):
 
 
 class HumanInputUnsupportedError(RuntimeError):
-    """Raised when an agent asks for human input over a transport that has none.
+    """Raised when an agent asks for human input and no ``hitl_hook`` was given.
 
-    ACP elicitation is not wired in this version. Failing loudly beats hanging
-    forever on a prompt the Client will never be asked to answer.
+    ACP elicitation is not wired in this version, so the protocol itself has no
+    way to put the question to the Client. Failing loudly beats hanging forever
+    on a prompt nobody will be asked to answer. A host that can reach a human by
+    its own means passes ``ACPAgent(..., hitl_hook=...)`` and never sees this.
     """
 
     def __init__(self) -> None:
         super().__init__(
             "The agent requested human input, but ACPAgent does not implement ACP "
-            "elicitation yet, so there is nobody to ask. Remove the human-input step "
-            "or serve this agent over a transport that supports it."
+            "elicitation yet, so there is nobody to ask. Pass ACPAgent(..., hitl_hook=...) "
+            "to answer from the hosting application, remove the human-input step, or serve "
+            "this agent over a transport that supports it."
         )
 
 
@@ -102,11 +107,21 @@ class AgentExecutor:
     dependencies through the same path every off-protocol turn uses.
     """
 
-    __slots__ = ("_agent", "_stream_thoughts")
+    __slots__ = ("_agent", "_stream_thoughts", "_hitl_hook")
 
-    def __init__(self, agent: Agent, *, stream_thoughts: bool = False) -> None:
+    def __init__(
+        self,
+        agent: Agent,
+        *,
+        stream_thoughts: bool = False,
+        hitl_hook: "HumanHook | None" = None,
+    ) -> None:
         self._agent = agent
         self._stream_thoughts = stream_thoughts
+        # ``None`` keeps the transport honest: with nobody to ask, a turn that
+        # requests human input fails rather than hanging on an answer that is
+        # never coming. A host that *does* have a human supplies the hook.
+        self._hitl_hook: HumanHook = _reject_human_input if hitl_hook is None else hitl_hook
 
     @property
     def agent(self) -> Agent:
@@ -280,7 +295,7 @@ class AgentExecutor:
             initial_event,
             context=context,
             client=client,
-            hitl_hook=_reject_human_input,
+            hitl_hook=self._hitl_hook,
         )
 
 
@@ -395,8 +410,13 @@ async def heal_cancelled_turn(stream: "MemoryStream") -> int:
     return closed
 
 
-async def _reject_human_input(event: BaseEvent, context: Any) -> str:
-    """``hitl_hook`` that fails the turn instead of waiting forever.
+async def _reject_human_input(event: HumanInputRequest) -> str:
+    """Default ``hitl_hook``: fail the turn instead of waiting forever.
+
+    Takes the request and nothing else, because a hook is resolved the way a
+    tool is: an un-annotated second parameter is read as another *field* to fill
+    from the event, and the turn then dies of a validation error naming this
+    function instead of the error that explains the problem.
 
     Declared as returning ``str`` to satisfy the hook signature; it never
     returns. See :class:`HumanInputUnsupportedError`.

--- a/test/acp/test_agent_hitl.py
+++ b/test/acp/test_agent_hitl.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Answering a served agent's ``context.input()`` from the hosting application."""
+
+from typing import Any
+
+import acp
+import pytest
+from acp.exceptions import RequestError
+from dirty_equals import IsPartialDict
+
+from ag2 import Agent, Context
+from ag2.acp import ACPAgent
+from ag2.acp.testing import connect
+from ag2.events import HumanInputRequest, HumanMessage, ToolCallEvent
+from ag2.hitl import HumanHook
+from ag2.testing import TestConfig
+
+QUESTION = "which colour?"
+
+
+def _asking_agent(
+    *,
+    hitl_hook: HumanHook | None = None,
+    variables: dict[Any, Any] | None = None,
+) -> tuple[Agent, list[str]]:
+    """An agent whose one tool stops to ask the human, and the answers it got."""
+    agent = Agent(
+        "workie",
+        config=TestConfig(ToolCallEvent(name="ask_human", arguments="{}"), "done"),
+        hitl_hook=hitl_hook,
+        variables=variables,
+    )
+    answers: list[str] = []
+
+    @agent.tool
+    async def ask_human(context: Context) -> str:
+        """Put a question to the human and report the answer."""
+        answer = await context.input(QUESTION)
+        answers.append(answer)
+        return answer
+
+    return agent, answers
+
+
+@pytest.mark.asyncio
+class TestWithoutAHook:
+    """The default: no human is reachable, so say so instead of hanging."""
+
+    async def test_the_turn_fails_rather_than_waiting_forever(self) -> None:
+        agent, answers = _asking_agent()
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            with pytest.raises(RequestError) as caught:
+                await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        assert caught.value.data == IsPartialDict({"type": "HumanInputUnsupportedError"})
+        assert answers == []
+
+    async def test_the_failure_names_the_way_out(self) -> None:
+        """The Client is another process; a bare error leaves nobody a next step."""
+        agent, _ = _asking_agent()
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            with pytest.raises(RequestError) as caught:
+                await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        assert "hitl_hook" in caught.value.data["reason"]  # type: ignore[index]
+
+    async def test_the_served_agents_own_hook_is_not_used(self) -> None:
+        """An agent's own hook may read a console — which is the ACP transport.
+
+        Serving over stdio makes stdin the protocol's, so a hook the agent
+        carries for off-protocol use is exactly the thing that must not run here.
+        Reaching a human over ACP is the host's decision, made per connection.
+        """
+        agent, answers = _asking_agent(hitl_hook=lambda event: HumanMessage("from the agent's own hook"))
+
+        async with connect(ACPAgent(agent)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            with pytest.raises(RequestError):
+                await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        assert answers == []
+
+
+@pytest.mark.asyncio
+class TestWithAHook:
+    async def test_the_hooks_answer_completes_the_turn(self) -> None:
+        agent, answers = _asking_agent()
+
+        def answer(event: HumanInputRequest) -> str:
+            return "blue"
+
+        async with connect(ACPAgent(agent, hitl_hook=answer)) as (conn, recorder):
+            session = await conn.new_session(cwd="/tmp")
+            response = await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        assert response.stop_reason == "end_turn"
+        assert answers == ["blue"]
+
+    async def test_the_hook_is_given_the_question(self) -> None:
+        agent, _ = _asking_agent()
+        asked: list[str] = []
+
+        def answer(event: HumanInputRequest) -> str:
+            asked.append(event.content)
+            return "blue"
+
+        async with connect(ACPAgent(agent, hitl_hook=answer)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        assert asked == [QUESTION]
+
+    async def test_an_async_hook_is_awaited(self) -> None:
+        """A host that reaches its human over a network cannot answer synchronously."""
+        agent, answers = _asking_agent()
+
+        async def answer(event: HumanInputRequest) -> HumanMessage:
+            return HumanMessage("green")
+
+        async with connect(ACPAgent(agent, hitl_hook=answer)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        assert answers == ["green"]
+
+    async def test_the_hook_resolves_context_like_any_other(self) -> None:
+        """It is an ordinary AG2 hook, so the session's variables reach it."""
+        agent, answers = _asking_agent(variables={"caller": "ada"})
+
+        async def answer(event: HumanInputRequest, context: Context) -> str:
+            return str(context.variables["caller"])
+
+        async with connect(ACPAgent(agent, hitl_hook=answer)) as (conn, _):
+            session = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=session.session_id, prompt=[acp.text_block("go")])
+
+        assert answers == ["ada"]
+
+    async def test_each_session_asks_again(self) -> None:
+        """The hook is per-connection state, not a once-per-agent answer."""
+        agent, answers = _asking_agent()
+        replies = iter(["first", "second"])
+
+        def answer(event: HumanInputRequest) -> str:
+            return next(replies)
+
+        async with connect(ACPAgent(agent, hitl_hook=answer)) as (conn, _):
+            one = await conn.new_session(cwd="/tmp")
+            two = await conn.new_session(cwd="/tmp")
+            await conn.prompt(session_id=one.session_id, prompt=[acp.text_block("go")])
+            await conn.prompt(session_id=two.session_id, prompt=[acp.text_block("go")])
+
+        assert answers == ["first", "second"]

--- a/website/docs/user-guide/acp/server.mdx
+++ b/website/docs/user-guide/acp/server.mdx
@@ -230,6 +230,7 @@ acp_agent = ACPAgent(
 | `#!python auth` | Authentication provider. `#!python None` (the default) advertises no methods and rejects `#!python authenticate` |
 | `#!python prompt_content` | Which non-text prompt content to advertise — see [Multimodal content](#multimodal-content) |
 | `#!python stream_thoughts` | Whether to forward the agent's reasoning as `#!python agent_thought_chunk` updates. Off by default |
+| `#!python hitl_hook` | How to answer a turn that calls `#!python context.input()` — see [Human input](#human-input). `#!python None` (the default) fails such a turn |
 
 ### Bounds
 
@@ -289,6 +290,54 @@ Implement `#!python AuthProvider` to plug in your own identity system.
 
     Serve one tenant per `#!python ACPAgent`. Multi-tenant deployments need one process and
     one agent per tenant.
+
+## Human Input
+
+A turn can stop and ask its user something — `#!python context.input()` inside a tool, or an
+`#!python approval_required()` middleware gating one. ACP has an elicitation method for
+exactly this, and this side does not implement it yet, so by default there is genuinely
+nobody to ask: the turn fails with `#!python HumanInputUnsupportedError` rather than hanging
+on an answer that is never coming.
+
+An application hosting the agent often *can* reach the human by its own means — its own chat
+surface, an approval queue, a ticket. Pass a `#!python hitl_hook` and its return value
+becomes what `#!python context.input()` returns:
+
+```python linenums="1" hl_lines="14-17 19"
+import asyncio
+
+from ag2 import Agent
+from ag2.acp import ACPAgent
+from ag2.config import AnthropicConfig
+from ag2.events import HumanInputRequest
+
+agent = Agent(name="workie", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+
+# Stand-ins for however the host already reaches its user.
+questions: asyncio.Queue[str] = asyncio.Queue()
+answers: asyncio.Queue[str] = asyncio.Queue()
+
+async def ask_our_user(event: HumanInputRequest) -> str:
+    # event.content is the message the tool passed to context.input()
+    await questions.put(event.content)
+    return await answers.get()
+
+acp_agent = ACPAgent(agent, hitl_hook=ask_our_user)
+```
+
+It is an ordinary AG2 HITL hook — the same shape as
+[`#!python Agent(hitl_hook=...)`](/docs/user-guide/context/human_in_the_loop), sync or async,
+with dependency injection and the session's variables available.
+
+!!! note "It replaces the served agent's own hook"
+    An agent's own `#!python hitl_hook` is *not* used for ACP-driven turns, with or without
+    this argument. A hook written for `#!python agent.ask()` typically reads a console — and
+    over stdio the console is the protocol. Who the human is, and how to reach them, is the
+    host's decision.
+
+Nothing about this is visible on the wire: no capability is advertised, no ACP method is
+called, and a client cannot tell that a turn paused. Client-driven approvals — the agent
+asking *through* the protocol — need ACP elicitation on this side, which is not wired yet.
 
 ## What It Refuses to Pretend
 


### PR DESCRIPTION
## Why are these changes needed?

`ACPAgent` hard-wires human input to a rejection — `AgentExecutor._dispatch` passes a private `_reject_human_input` hook, so any `context.input()` in an ACP-driven turn (directly in a tool, or via `approval_required()` middleware) fails the turn. The executor is built inside `ACPAgent.__init__`, so a hosting application had no way to override it.

That default is right when nothing can reach a human: ACP elicitation is not wired on the Agent side, so the protocol genuinely has nobody to ask, and failing beats hanging on an answer that is never coming. But an application hosting the agent often *can* reach its user by its own means — its own chat surface, an approval queue, a ticket — and had no seam to say so.

This is requested by [AG2 Assistant](https://github.com/ag2ai/ag2-assistant), which serves an `Agent` over ACP and has its own human-in-the-loop machinery it cannot currently use.

### What changed

**`ACPAgent(..., hitl_hook=...)`** — passed through to `AgentExecutor`, which hands it to `Agent._execute` wherever it passed `_reject_human_input` before. It is an ordinary AG2 HITL hook: the same shape as `Agent(hitl_hook=...)`, sync or async, with dependency injection and the session's variables available.

```python
async def ask_our_user(event: HumanInputRequest) -> str:
    # event.content is the message the tool passed to context.input()
    return await my_approval_queue.ask(event.content)

acp_agent = ACPAgent(agent, hitl_hook=ask_our_user)
```

Backward compatible in both directions:

- `None` (the default) is exactly today's behaviour — `HumanInputUnsupportedError`.
- The **served agent's own** `hitl_hook` stays overridden, with or without this argument. A hook written for `agent.ask()` typically reads a console, and over stdio the console *is* the protocol. Who the human is, and how to reach them, is the host's decision — so it is made per `ACPAgent`, alongside the per-connection `bind` scope.

Deliberately protocol-invisible: no capability is advertised, no ACP method is called, a client cannot tell a turn paused. Client-driven approvals — the agent asking *through* the protocol — still need ACP `session/request_permission` / elicitation on this side, which remains unwired and out of scope here.

**Drive-by fix: the rejection path never actually raised its own error.** `_reject_human_input` was declared `(event: BaseEvent, context: Any)`. A HITL hook is resolved the way a tool is, so that un-annotated second parameter was read as another *field* to fill from the event — and the turn died of a pydantic `ValidationError` naming the private function:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for _reject_human_input
context
  Field required [type=missing, ...]
```

`HumanInputUnsupportedError` — the whole point of that path, and the one message that tells a client operator what to do — never reached anyone. The hook now takes the request and nothing else, and the message gained a line pointing at `hitl_hook=`. Found by writing the first test to actually exercise this path; it was untested before.

## Related issue number

None.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

Docs: a new **Human Input** section on the ACP Server page, plus a row in the constructor table.

Tests: `test/acp/test_agent_hitl.py`, 8 tests through the real protocol via `ag2.acp.testing.connect` — no hook fails the turn and names the way out, the served agent's own hook is not used, sync/async hooks both answer, the hook sees the question, resolves `Context` and session variables, and answers each session separately.

`test/acp/` is green apart from two failures in `test_update_settling.py` that reproduce on an unmodified `main` (client-side chunk ordering, unrelated to this change).

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
