### PR TITLE
fix: await async scorer results

### DIFF
--- a/ag2/eval/scorer.py
+++ b/ag2/eval/scorer.py
@@ -22,8 +22,10 @@ matches LangSmith's settled shape::
             return False
         return calls[0].arguments.get("city") == reference_outputs["city"]
 
-Scorers can be sync or async — the decorator handles both. They should
-be pure functions of their inputs (no I/O, no global state).
+Scorers can be sync or async: the wrapper calls the scorer and awaits
+the *result* whenever it is awaitable, so plain functions, ``async def``
+functions, and callable objects with an ``async def __call__`` all work.
+They should be pure functions of their inputs (no I/O, no global state).
 
 Return values are normalized into one or more :class:`Feedback` records:
 
@@ -81,7 +83,8 @@ class Scorer:
     closure's function name.
 
     Args:
-        fn: The scoring function. May be sync or async. May declare any
+        fn: The scoring function. May be sync or async — anything whose
+            result is awaitable is awaited. May declare any
             subset of the injectable parameters (``inputs``, ``outputs``,
             ``reference_outputs``, ``trace``, ``task``); anything else
             raises ``TypeError`` at construction time.
@@ -98,6 +101,12 @@ class Scorer:
         *,
         key: str | None = None,
     ) -> None:
+        if isinstance(fn, Scorer):
+            raise TypeError(
+                f"scorer {(key if key is not None else fn.key)!r}: cannot wrap a Scorer; its "
+                f"feedback already carries its own key, so this one would be silently discarded — "
+                f"pass the underlying function instead"
+            )
         self._fn = fn
         self._key = key if key is not None else getattr(fn, "__name__", "scorer")
         self._params = _validate_signature(fn, self._key)

--- a/ag2/eval/scorer.py
+++ b/ag2/eval/scorer.py
@@ -90,7 +90,7 @@ class Scorer:
             :class:`~ag2.eval.RunResult` use this key.
     """
 
-    __slots__ = ("_fn", "_key", "_params", "_is_async")
+    __slots__ = ("_fn", "_key", "_params")
 
     def __init__(
         self,
@@ -101,7 +101,6 @@ class Scorer:
         self._fn = fn
         self._key = key if key is not None else getattr(fn, "__name__", "scorer")
         self._params = _validate_signature(fn, self._key)
-        self._is_async = inspect.iscoroutinefunction(fn)
 
     @property
     def key(self) -> str:
@@ -134,10 +133,9 @@ class Scorer:
         call_args = {name: available[name] for name in self._params}
 
         try:
-            if self._is_async:
-                result = await self._fn(**call_args)
-            else:
-                result = self._fn(**call_args)
+            result = self._fn(**call_args)
+            if inspect.isawaitable(result):
+                result = await result
         except Exception as exc:
             logger.warning("Scorer %r raised %s: %s", self._key, type(exc).__name__, exc)
             return [

--- a/test/eval/test_scorer_decorator.py
+++ b/test/eval/test_scorer_decorator.py
@@ -11,6 +11,7 @@ Covers the three responsibilities the decorator owns:
 * exception capture (a raising scorer never fails the run)
 """
 
+from collections.abc import Awaitable
 from typing import Any
 
 import pytest
@@ -26,11 +27,6 @@ def _trace(*events: Any, duration_ms: int = 0) -> Trace:
 def _task(task_id: str = "t-0", **kwargs: Any) -> Task:
     inputs = kwargs.pop("inputs", {"input": "hi"})
     return Task(task_id=task_id, inputs=inputs, **kwargs)
-
-
-class AsyncCallableScorer:
-    async def __call__(self, trace: Trace) -> bool:
-        return len(trace.events) == 0
 
 
 async def _run(
@@ -263,8 +259,8 @@ class TestExceptionCapture:
         assert "KeyError" in fb.comment
 
 
+@pytest.mark.asyncio
 class TestAsyncScorers:
-    @pytest.mark.asyncio
     async def test_async_scorer_awaited(self) -> None:
         @scorer
         async def async_pass(trace: Trace) -> bool:
@@ -272,11 +268,25 @@ class TestAsyncScorers:
 
         assert await _run(async_pass) == [Feedback(key="async_pass", score=True)]
 
-    @pytest.mark.asyncio
     async def test_async_callable_object_awaited(self) -> None:
-        async_callable = Scorer(AsyncCallableScorer(), key="async_callable")
+        class AsyncCallable:
+            async def __call__(self, trace: Trace) -> bool:
+                return len(trace.events) == 0
 
-        assert await _run(async_callable) == [Feedback(key="async_callable", score=True)]
+        s = Scorer(AsyncCallable(), key="async_callable")
+
+        assert await _run(s) == [Feedback(key="async_callable", score=True)]
+
+    async def test_sync_callable_returning_awaitable_awaited(self) -> None:
+        async def judge(trace: Trace) -> bool:
+            return len(trace.events) == 0
+
+        def wrapper(trace: Trace) -> Awaitable[bool]:
+            return judge(trace)
+
+        s = Scorer(wrapper, key="sync_wrapper")
+
+        assert await _run(s) == [Feedback(key="sync_wrapper", score=True)]
 
 
 class TestScorerConstruction:
@@ -296,3 +306,11 @@ class TestScorerConstruction:
             return True
 
         assert my_check.key == "my_check"
+
+    def test_wrapping_a_scorer_is_rejected(self) -> None:
+        @scorer
+        async def inner(trace: Trace) -> bool:
+            return True
+
+        with pytest.raises(TypeError, match="cannot wrap a Scorer"):
+            Scorer(inner, key="outer")

--- a/test/eval/test_scorer_decorator.py
+++ b/test/eval/test_scorer_decorator.py
@@ -28,6 +28,11 @@ def _task(task_id: str = "t-0", **kwargs: Any) -> Task:
     return Task(task_id=task_id, inputs=inputs, **kwargs)
 
 
+class AsyncCallableScorer:
+    async def __call__(self, trace: Trace) -> bool:
+        return len(trace.events) == 0
+
+
 async def _run(
     s: Scorer,
     *,
@@ -266,6 +271,12 @@ class TestAsyncScorers:
             return len(trace.events) == 0
 
         assert await _run(async_pass) == [Feedback(key="async_pass", score=True)]
+
+    @pytest.mark.asyncio
+    async def test_async_callable_object_awaited(self) -> None:
+        async_callable = Scorer(AsyncCallableScorer(), key="async_callable")
+
+        assert await _run(async_callable) == [Feedback(key="async_callable", score=True)]
 
 
 class TestScorerConstruction:

--- a/website/docs/user-guide/evaluation/scorers.mdx
+++ b/website/docs/user-guide/evaluation/scorers.mdx
@@ -240,7 +240,7 @@ This is by design — one broken scorer should never kill an eval over 100 tasks
 
 ## Sync vs async
 
-Either works. The framework detects async with `#!python inspect.iscoroutinefunction` and awaits accordingly:
+Either works. The framework calls the scorer and then awaits the *result* if it is awaitable — so a plain `#!python async def` works, and so does any other callable whose return value is a coroutine (a class with an `#!python async def __call__`, or a sync wrapper that hands back an awaitable):
 
 ```python linenums="1"
 @scorer


### PR DESCRIPTION
## Why are these changes needed?

`Scorer` decided whether to await by inspecting the *callable* (`inspect.iscoroutinefunction(fn)`), but needing an await is a property of the *returned value*. For a class with `async def __call__` the coroutine flag lives on `type(obj).__call__`, not on the instance, so the check returned `False`, the coroutine was never awaited, and it reached feedback normalization as an unsupported type — `ScorerReturnTypeError` plus an unawaited-coroutine warning.

The scorer is now called once and the result is awaited whenever it is awaitable — the idiom already used in `ag2/eval/scorers/human_pairwise.py`.

**What changed**

- `Scorer` awaits by result instead of by callable type, which fixes objects with an `async def __call__` and sync wrappers that return an awaitable.
- `Scorer(...)` now raises `TypeError` when handed another `Scorer`; awaiting by result would otherwise silently discard the outer `key`.
- `scorers.mdx` and the docstrings no longer name `inspect.iscoroutinefunction` and describe the awaitable-result contract instead.
- Three regression tests: async `__call__` object, sync wrapper returning an awaitable, wrapping guard.

**Public API:** unchanged — no signature or type changes. `ScorerFn` already accepted these callables; two previously broken shapes now work, and wrapping a `Scorer` in a `Scorer` fails at construction rather than at call time.

## Related issue number

Closes #3190

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
  - Green except `test-windows`, which timed out in the Node sandbox adapter test (`test_javascript_via_put_file_when_node_available`), unrelated to `ag2/eval`; `build-check` fails only as its aggregator.

## AI assistance

<!-- Statements below are the original author's, covering commit 8cd52a1. -->

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] I reviewed, tested, and validated all code and text before submitting.
