### PR TITLE
docs: fix broken user guide links

### DIFF
--- a/website/docs/user-guide/ag-ui/backend-deepdive.mdx
+++ b/website/docs/user-guide/ag-ui/backend-deepdive.mdx
@@ -6,7 +6,7 @@ description: "Authentication, tools, and tools context for AG-UI endpoints in AG
 
 This page expands on the backend of the AG-UI integration: how to secure your endpoint, how tool calls are represented in the protocol, and how to pass per-request context into your tools.
 
-If you haven’t set up an AG-UI endpoint yet, start with the [AG-UI overview](../){.internal-link}.
+If you haven’t set up an AG-UI endpoint yet, start with the [AG-UI overview](/docs/user-guide/ag-ui/index){.internal-link}.
 
 ## Authentication
 
@@ -123,7 +123,7 @@ In this setup:
 - The **agent** can call those tools during the run.
 - The **frontend** executes/handles the tool and renders the UI.
 
-For a production-ready React/Next.js client that supports frontend tools, backend tools, streaming, and shared state, see the [CopilotKit UI quickstart](../copilotkit-quickstart){.internal-link} and CopilotKit’s docs on:
+For a production-ready React/Next.js client that supports frontend tools, backend tools, streaming, and shared state, see the [CopilotKit UI quickstart](/docs/user-guide/ag-ui/copilotkit-quickstart){.internal-link} and CopilotKit’s docs on:
 
 - [Backend tools](https://docs.copilotkit.ai/ag2/generative-ui/backend-tools){.external-link target="_blank"}
 - [Frontend tools](https://docs.copilotkit.ai/ag2/generative-ui/frontend-tools){.external-link target="_blank"}
@@ -131,5 +131,5 @@ For a production-ready React/Next.js client that supports frontend tools, backen
 
 ## See also
 
-- [AG-UI overview](../){.internal-link}
-- [CopilotKit quickstart](../copilotkit-quickstart){.internal-link}
+- [AG-UI overview](/docs/user-guide/ag-ui/index){.internal-link}
+- [CopilotKit quickstart](/docs/user-guide/ag-ui/copilotkit-quickstart){.internal-link}

--- a/website/docs/user-guide/context/inject.mdx
+++ b/website/docs/user-guide/context/inject.mdx
@@ -11,7 +11,7 @@ Dependency Injection (DI) is a design pattern used to pass complex objects or se
 
 ## Dependencies
 
-The key difference between [Variables](../variables){.internal-link} and Dependencies is their intended use case. Variables are designed to pass lightweight, serializable state (like strings, flags, or configuration IDs) between the LLM, tools, and agents. Dependencies, on the other hand, are meant for complex objects that have specific behaviors and lifecycle management, such as database connections, HTTP sessions, or clients for external APIs.
+The key difference between [Variables](/docs/user-guide/context/variables){.internal-link} and Dependencies is their intended use case. Variables are designed to pass lightweight, serializable state (like strings, flags, or configuration IDs) between the LLM, tools, and agents. Dependencies, on the other hand, are meant for complex objects that have specific behaviors and lifecycle management, such as database connections, HTTP sessions, or clients for external APIs.
 
 ### Agent Dependencies
 

--- a/website/docs/user-guide/depends.mdx
+++ b/website/docs/user-guide/depends.mdx
@@ -7,7 +7,7 @@ sidebarTitle: Depends
 
 The `Depends` mechanism allows you to calculate and inject dependencies dynamically at execution time.
 
-The key difference with [Dependency Injection](../context/inject){.internal-link} is their execution model. `Inject` is used to retrieve static objects or configurations that have already been created (like an existing database connection or API key). `Depends`, on the other hand, executes a callable function *during* the tool's invocation to resolve the dependency.
+The key difference with [Dependency Injection](/docs/user-guide/context/inject){.internal-link} is their execution model. `Inject` is used to retrieve static objects or configurations that have already been created (like an existing database connection or API key). `Depends`, on the other hand, executes a callable function *during* the tool's invocation to resolve the dependency.
 
 Under the hood, `Depends` uses the exact same mechanism and design philosophy as [FastAPI's dependency injection system](https://fastapi.tiangolo.com/tutorial/dependencies/){.external-link target="_blank"}.
 

--- a/website/docs/user-guide/middleware.mdx
+++ b/website/docs/user-guide/middleware.mdx
@@ -531,4 +531,4 @@ If you are unsure where a behavior belongs, use this rule of thumb:
     - Use **tool-scoped** `middleware=[...]` on `@tool` / `Agent.tool` / `Toolkit.tool` when the behavior applies only to that tool’s definition; see [Tool middleware](/docs/user-guide/tools/tool_middleware){.internal-link}.
 - Use `on_human_input()` when the behavior is about intercepting, logging, or transforming human-in-the-loop requests and responses.
 
-For related runtime customization patterns, see [Tools](/docs/user-guide/tools/tools), [Tool middleware](/docs/user-guide/tools/tool_middleware), [Prompt Management](../system_prompts), and [Events Streaming](../advanced/stream).
+For related runtime customization patterns, see [Tools](/docs/user-guide/tools/tools), [Tool middleware](/docs/user-guide/tools/tool_middleware), [Prompt Management](/docs/user-guide/system_prompts), and [Events Streaming](/docs/user-guide/advanced/stream).


### PR DESCRIPTION
## Why are these changes needed?

Several user guide pages use relative internal links even though the documentation requires absolute paths. These links resolve incorrectly from nested pages.

This change replaces seven relative links with canonical routes listed in `website/mint-json-template.json.jinja`.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

Validation performed:

- `git diff --check`
- Local relative-link checker
- Verified every target against `website/mint-json-template.json.jinja`

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
