### PR TITLE
docs(website): fix directory links and broken heading anchors

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -142,7 +142,7 @@ Example — adding a page inside a nested group:
 
 ### Links
 
-- **Internal links**: use absolute paths from the docs root: `[Agent Tools](/docs/user-guide/tools/)`. Do not use relative paths.
+- **Internal links**: use absolute paths from the docs root: `[Agent Tools](/docs/user-guide/tools/tools)`. Do not use relative paths.
 - **External links**: append `{.external-link target="_blank"}` after the markdown link. Use descriptive anchor text — do **not** use bare URLs or generic text like "here" or "this link".
 
 Good: `[OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/){.external-link target="_blank"}`

--- a/website/docs/user-guide/a2a/client.mdx
+++ b/website/docs/user-guide/a2a/client.mdx
@@ -182,7 +182,7 @@ The card and the activation list are reconciled before the first request goes ou
 
 `#!python urn:ag2:client-tools:v1` is the exception to the second rule: AG2 implements it natively, so a card may require it without the client listing it explicitly.
 
-Activation covers every request the config makes, not just `#!python ask`. The one-shot [task](/docs/user-guide/a2a/tasks) and push-notification helpers open their own connection from the same `#!python A2AConfig`, so they activate the same URIs and run the same reconciliation — a server enforcing a `#!python required=True` extension sees a consistent client on the conversational and the administrative path alike.
+Activation covers every request the config makes, not just `#!python ask`. The one-shot [task](/docs/user-guide/a2a/tasks_and_push) and push-notification helpers open their own connection from the same `#!python A2AConfig`, so they activate the same URIs and run the same reconciliation — a server enforcing a `#!python required=True` extension sees a consistent client on the conversational and the administrative path alike.
 
 ```python linenums="1" hl_lines="5-6"
 from ag2.a2a.errors import A2AExtensionNotSupportedError

--- a/website/docs/user-guide/a2ui/a2a.mdx
+++ b/website/docs/user-guide/a2ui/a2a.mdx
@@ -3,7 +3,7 @@ title: Serving A2UI over A2A
 sidebarTitle: A2A Transport
 ---
 
-A2UI's wire is transport-agnostic, so the same validated A2UI messages can ride an [A2A](/docs/user-guide/a2a/) exchange instead of the built-in [REST adapter](/docs/user-guide/a2ui/server). The `#!python ag2.a2ui.a2a` submodule wraps a plain `#!python ag2.Agent` in an `#!python A2UIAgentExecutor`, plugs it into a standard `#!python A2AServer`, and carries each turn's A2UI messages as a canonical A2A `#!python DataPart`.
+A2UI's wire is transport-agnostic, so the same validated A2UI messages can ride an [A2A](/docs/user-guide/a2a/overview) exchange instead of the built-in [REST adapter](/docs/user-guide/a2ui/server). The `#!python ag2.a2ui.a2a` submodule wraps a plain `#!python ag2.Agent` in an `#!python A2UIAgentExecutor`, plugs it into a standard `#!python A2AServer`, and carries each turn's A2UI messages as a canonical A2A `#!python DataPart`.
 
 !!! note
     This page assumes familiarity with the [A2A server](/docs/user-guide/a2a/server). The A2UI integration is a drop-in `#!python executor` for the same `#!python A2AServer` — everything you know about cards, transports, and tasks still applies.

--- a/website/docs/user-guide/ag-ui/channels.mdx
+++ b/website/docs/user-guide/ag-ui/channels.mdx
@@ -11,7 +11,7 @@ The same AG2 agent that powers your in-app copilot can also run as a bot in mess
 
 ## How it fits together
 
-Your AG2 server stays where it is, serving the agent through `AGUIStream` exactly as in the [basic server example](/docs/user-guide/ag-ui/#basic-server-example). A channel is a separate long-running Node process built with [`@copilotkit/channels`](https://www.npmjs.com/package/@copilotkit/channels){.external-link target="_blank"}, connected through [CopilotKit Intelligence](https://docs.copilotkit.ai/slack/ag2/intelligence){.external-link target="_blank"}. Intelligence holds the platform connection and credentials, receives each platform event, and delivers the turn over a persistent gateway connection to your channel process, which runs your agent over AG-UI and streams the reply back into the platform thread.
+Your AG2 server stays where it is, serving the agent through `AGUIStream` exactly as in the [basic server example](/docs/user-guide/ag-ui/index#basic-server-example). A channel is a separate long-running Node process built with [`@copilotkit/channels`](https://www.npmjs.com/package/@copilotkit/channels){.external-link target="_blank"}, connected through [CopilotKit Intelligence](https://docs.copilotkit.ai/slack/ag2/intelligence){.external-link target="_blank"}. Intelligence holds the platform connection and credentials, receives each platform event, and delivers the turn over a persistent gateway connection to your channel process, which runs your agent over AG-UI and streams the reply back into the platform thread.
 
 ```text
 Slack  ──►  CopilotKit Intelligence  ──►  channel process (Node)  ──►  AG2 server (AGUIStream)
@@ -82,7 +82,7 @@ const listener = createCopilotNodeListener({ runtime });
 await listener.channels.ready({ timeoutMs: 15_000 }); // fail startup loudly on a broken config
 ```
 
-Run the channel process alongside the AG-UI server from the [basic server example](/docs/user-guide/ag-ui/#basic-server-example). Both credentials come from the Intelligence dashboard — the API key under **API Keys**, the Code on the Channel you created there:
+Run the channel process alongside the AG-UI server from the [basic server example](/docs/user-guide/ag-ui/index#basic-server-example). Both credentials come from the Intelligence dashboard — the API key under **API Keys**, the Code on the Channel you created there:
 
 ```bash
 uvicorn run_ag_ui:app --reload --port 8000   # terminal 1 — AG2 server
@@ -116,7 +116,7 @@ Discord, Teams, Telegram, and WhatsApp connect the same way — a managed connec
 
 ## Next steps
 
-1. Build the AG-UI endpoint from the [basic server example](/docs/user-guide/ag-ui/#basic-server-example) if you have not already.
+1. Build the AG-UI endpoint from the [basic server example](/docs/user-guide/ag-ui/index#basic-server-example) if you have not already.
 2. Create the Channel in CopilotKit Intelligence and connect Slack there, then export the API key and the Channel's Code.
 3. Start the channel process, invite the app to a Slack channel, and mention it.
 4. For a web UI on the same endpoint, follow the [CopilotKit UI quickstart](/docs/user-guide/ag-ui/copilotkit-quickstart).

--- a/website/docs/user-guide/agent_harness.mdx
+++ b/website/docs/user-guide/agent_harness.mdx
@@ -176,7 +176,7 @@ When you opt in via `tasks=TaskConfig(...)`, the Agent exposes two tools to the 
 
 The LLM is told (via the tool descriptions) that it can call `run_subtask` multiple times in parallel within a single response, and that `run_subtasks` is the deliberate fan-out form. Each child gets a fresh `MemoryStream` and the parent's tools (filtered by `TaskConfig`).
 
-For a more explicit, named delegate where the parent LLM sees a tool like `task_researcher` instead of generic `run_subtask`, use [`Agent.as_tool()`](#agent-as-tool). The two patterns can coexist: a coordinator can have both auto-injected sub-tasks and a named `task_researcher` tool.
+For a more explicit, named delegate where the parent LLM sees a tool like `task_researcher` instead of generic `run_subtask`, use [`Agent.as_tool()`](#agentas_tool). The two patterns can coexist: a coordinator can have both auto-injected sub-tasks and a named `task_researcher` tool.
 
 See [Subagents](/docs/user-guide/subagents) for the full sub-task delegation guide — context flow and custom streams for self-delegation via `as_tool()`.
 

--- a/website/docs/user-guide/network/discussion.mdx
+++ b/website/docs/user-guide/network/discussion.mdx
@@ -147,7 +147,7 @@ Today only `#!python ORDERING_ROUND_ROBIN` ships. The knob is `#!python knobs={"
 `#!python discussion` never auto-closes. The example below caps at 6 turns and calls `#!python channel.close()`, but four other patterns work for `#!python discussion` too:
 
 * **App-side cap** — count turns and call `#!python channel.close()` (canonical, simplest).
-* **Agent-side tool** — any participant calls a tool that closes the channel. See [Closing Channels → Agent-side tool](/docs/user-guide/network/termination#pattern-2--agent-side-tool).
+* **Agent-side tool** — any participant calls a tool that closes the channel. See [Closing Channels → Agent-side tool](/docs/user-guide/network/termination#pattern-2-agent-side-tool).
 * **Custom adapter** — subclass `#!python DiscussionAdapter` to fold `#!python turn_count` and emit `#!python CLOSING` at a cap (or switch to `#!python workflow` with `#!python TransitionGraph.round_robin(max_turns=N)`).
 * **TTL / expectations** — safety nets only.
 

--- a/website/docs/user-guide/network/pattern_cookbook/hierarchical.mdx
+++ b/website/docs/user-guide/network/pattern_cookbook/hierarchical.mdx
@@ -40,7 +40,7 @@ for the coordinator graph.
   researcher had a chance to speak, terminating the workflow prematurely.
   Making the writer the terminal speaker sidesteps this hazard entirely:
   parallel calls to `#!python delegate_researcher` and `#!python delegate_writer`
-  are safe because [first-emitted-wins](/docs/user-guide/network/workflow#first-emitted-wins)
+  are safe because [first-emitted-wins](/docs/user-guide/network/workflow#custom-graphs)
   picks researcher (the other tool runs but its `#!python Handoff` doesn't
   drive routing), and the writer step still runs in its own dedicated
   round once researcher returns.


### PR DESCRIPTION
## Why are these changes needed?

Follow-up to #3195. That PR converted the last relative user-guide links to
absolute paths; sweeping **every** internal link against the built site turned
up two further classes of breakage.

Neither class is visible to CI: `scripts/broken-links-check.sh` runs muffet with
`--ignore-fragments`, so heading anchors are never validated, and the
directory-link problem produces a valid-but-wrong destination rather than a 404.

**Directory-style links resolve to the wrong page.** `fix_internal_references()`
maps `/docs/user-guide/<dir>/` to the *alphabetically first* `.md` in that
directory, not to the section's landing page:

| link | landed on | should be |
|---|---|---|
| `/docs/user-guide/ag-ui/` (×3, channels.mdx) | Backend deep dive | AG-UI overview |
| `/docs/user-guide/a2a/` (a2ui/a2a.mdx) | A2A Advanced | A2A Protocol Overview |

**One genuine 404.** `a2a/client.mdx` linked `/docs/user-guide/a2a/tasks`; the
page is `tasks_and_push`.

**Three heading anchors never matched the slug MkDocs generates:**

| link | actual slug |
|---|---|
| `termination#pattern-2--agent-side-tool` | `pattern-2-agent-side-tool` |
| `agent_harness#agent-as-tool` | `agentas_tool` |
| `workflow#first-emitted-wins` | no such section exists |

**Root cause.** `website/AGENTS.md` documented the directory form as the example
to follow — `[Agent Tools](/docs/user-guide/tools/)`, which itself resolves to
`approval_required`. Retargeting the example stops the guideline from
reproducing the bug in future pages.

### One judgement call for reviewers

`workflow.mdx` has no `first-emitted-wins` section at all. The rule it refers to
is stated in a paragraph inside `## Custom Graphs`, so the link now points
there. The alternative is to add an explicit heading for the rule in
`workflow.mdx` — happy to do that instead if maintainers prefer.

## Related issue number

Follow-up to #3195. No issue.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/.
- [x] I've added tests (if relevant) — n/a, docs only; verification below.
- [ ] I've made sure all auto checks have passed.

Verification performed:

- `python docs.py build --force` — exit 0, 0 warnings, no `no such anchor` or
  `unrecognized relative link` diagnostics.
- Crawled the built site end-to-end (178 pages): every internal link checked for
  HTTP status **and** for the presence of its fragment `id` in the target page —
  0 broken. The crawler was validated against deliberately injected breakage
  (both a bad anchor and a 404) to confirm it actually detects failures.
- Each changed link opened in a real browser: correct destination page, anchor
  present in the DOM, page scrolled to it.
- `pre-commit run --files ...` on every changed file — all passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
