### PR TITLE
feat(extensions/search): add Serply search toolkit

### DIFF
--- a/ag2/extensions/tools/search/__init__.py
+++ b/ag2/extensions/tools/search/__init__.py
@@ -14,10 +14,12 @@ try:
 except ImportError as e:
     TinyFishSearchToolkit = missing_additional_dependency("TinyFishSearchToolkit", "tinyfish>=0.2.3", e)  # type: ignore[misc]
 
+from .serply import SerplySearchToolkit
 from .xquik import XquikSearchToolkit
 
 __all__ = (
     "ExaToolkit",
+    "SerplySearchToolkit",
     "TinyFishSearchToolkit",
     "XquikSearchToolkit",
 )

--- a/ag2/extensions/tools/search/serply.py
+++ b/ag2/extensions/tools/search/serply.py
@@ -1,0 +1,290 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serply search extension for AG2.
+
+Serply exposes Google web, Google News and Google Scholar results through one
+REST API. This extension wraps the three endpoints as agent tools.
+
+Maintainer: googio
+Docs: https://docs.ag2.ai/docs/user-guide/extensions/tools/search/serply/
+"""
+
+import html
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Annotated, Any
+
+import httpx
+from pydantic import Field
+
+from ag2.annotations import Context, Variable
+from ag2.events import ToolResult
+from ag2.middleware import ToolMiddleware
+from ag2.tools.builtin._resolve import resolve_variable
+from ag2.tools.final import Toolkit, tool
+from ag2.tools.final.function_tool import FunctionTool
+
+# Serply sits behind Cloudflare, which rejects requests without a User-Agent.
+_USER_AGENT = "ag2-serply-extension"
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+@dataclass(slots=True)
+class SerplyWebResult:
+    title: str
+    link: str
+    description: str = ""
+    position: int | None = None
+
+
+@dataclass(slots=True)
+class SerplyWebSearchResponse:
+    query: str
+    results: list[SerplyWebResult] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class SerplyNewsResult:
+    title: str
+    link: str
+    published: str = ""
+    source: str = ""
+    summary: str = ""
+
+
+@dataclass(slots=True)
+class SerplyNewsSearchResponse:
+    query: str
+    results: list[SerplyNewsResult] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class SerplyScholarResult:
+    title: str
+    link: str
+    authors: str = ""
+    description: str = ""
+    citations: int | None = None
+
+
+@dataclass(slots=True)
+class SerplyScholarSearchResponse:
+    query: str
+    results: list[SerplyScholarResult] = field(default_factory=list)
+
+
+def _text(raw: dict[str, Any], key: str) -> str:
+    value = raw.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _int(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _items(raw: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    items = raw.get(key)
+    return [item for item in items if isinstance(item, dict)] if isinstance(items, list) else []
+
+
+def _plain_text(fragment: str) -> str:
+    """Flatten the HTML fragment Google News uses for entry summaries."""
+    return " ".join(_TAG_RE.sub(" ", html.unescape(fragment)).split())
+
+
+class SerplySearchToolkit(Toolkit):
+    """Toolkit that searches Google web, news and scholar results through the Serply REST API.
+
+    Passing the toolkit to an agent registers ``serply_web_search``,
+    ``serply_news_search`` and ``serply_scholar_search``. To use a subset, or
+    to customise per-tool defaults, call the factory methods and pass the
+    returned tools to the agent::
+
+        toolkit = SerplySearchToolkit(api_key=...)
+
+        # all three tools
+        agent = Agent("a", config=config, tools=[toolkit])
+
+        # only web search, with custom defaults
+        agent = Agent("a", config=config, tools=[toolkit.web(num=5, gl="us")])
+
+    Optional defaults can be fixed when the toolkit or tool is constructed,
+    or supplied through AG2 ``Variable`` values at runtime.
+
+    A Serply ``api_key`` is required.
+    """
+
+    __slots__ = ("_api_key", "_base_url", "_timeout")
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str = "https://api.serply.io",
+        timeout: float = 60.0,
+        num: int | Variable | None = None,
+        gl: str | Variable | None = None,
+        hl: str | Variable | None = None,
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key is required")
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+        super().__init__(
+            self.web(num=num, gl=gl, hl=hl),
+            self.news(gl=gl, hl=hl),
+            self.scholar(num=num, gl=gl, hl=hl),
+            name="serply_search_toolkit",
+            middleware=middleware,
+        )
+
+    def web(
+        self,
+        *,
+        num: int | Variable | None = None,
+        gl: str | Variable | None = None,
+        hl: str | Variable | None = None,
+        name: str = "serply_web_search",
+        description: str = (
+            "Search the web with Google through Serply. Returns ranked results with titles, snippets, and URLs."
+        ),
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> FunctionTool:
+        @tool(name=name, description=description, middleware=middleware)
+        async def serply_web_search(
+            query: Annotated[str, Field(description="The web search query string.")],
+            ctx: Context,
+        ) -> ToolResult:
+            """Search Google web results through Serply."""
+            raw = await self._get(
+                "/v1/search/",
+                {
+                    "q": query,
+                    "num": resolve_variable(num, ctx, param_name="num"),
+                    "gl": resolve_variable(gl, ctx, param_name="gl"),
+                    "hl": resolve_variable(hl, ctx, param_name="hl"),
+                },
+            )
+            return ToolResult(
+                SerplyWebSearchResponse(
+                    query=query,
+                    results=[
+                        SerplyWebResult(
+                            title=_text(item, "title"),
+                            link=_text(item, "link"),
+                            description=_text(item, "description"),
+                            position=_int(item.get("position")),
+                        )
+                        for item in _items(raw, "results")
+                    ],
+                )
+            )
+
+        return serply_web_search
+
+    def news(
+        self,
+        *,
+        gl: str | Variable | None = None,
+        hl: str | Variable | None = None,
+        name: str = "serply_news_search",
+        description: str = (
+            "Search Google News through Serply. Returns recent articles with titles, sources, publish dates, and URLs."
+        ),
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> FunctionTool:
+        @tool(name=name, description=description, middleware=middleware)
+        async def serply_news_search(
+            query: Annotated[str, Field(description="The news search query string.")],
+            ctx: Context,
+        ) -> ToolResult:
+            """Search Google News through Serply."""
+            raw = await self._get(
+                "/v1/news/",
+                {
+                    "q": query,
+                    "gl": resolve_variable(gl, ctx, param_name="gl"),
+                    "hl": resolve_variable(hl, ctx, param_name="hl"),
+                },
+            )
+            results = []
+            for item in _items(raw, "entries"):
+                source = item.get("source")
+                results.append(
+                    SerplyNewsResult(
+                        title=_text(item, "title"),
+                        link=_text(item, "link"),
+                        published=_text(item, "published"),
+                        source=_text(source, "title") if isinstance(source, dict) else "",
+                        summary=_plain_text(_text(item, "summary")),
+                    )
+                )
+            return ToolResult(SerplyNewsSearchResponse(query=query, results=results))
+
+        return serply_news_search
+
+    def scholar(
+        self,
+        *,
+        num: int | Variable | None = None,
+        gl: str | Variable | None = None,
+        hl: str | Variable | None = None,
+        name: str = "serply_scholar_search",
+        description: str = (
+            "Search Google Scholar through Serply. Returns academic articles with titles, authors, "
+            "citation counts, and URLs."
+        ),
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> FunctionTool:
+        @tool(name=name, description=description, middleware=middleware)
+        async def serply_scholar_search(
+            query: Annotated[str, Field(description="The academic search query string.")],
+            ctx: Context,
+        ) -> ToolResult:
+            """Search Google Scholar through Serply."""
+            raw = await self._get(
+                "/v1/scholar/",
+                {
+                    "q": query,
+                    "num": resolve_variable(num, ctx, param_name="num"),
+                    "gl": resolve_variable(gl, ctx, param_name="gl"),
+                    "hl": resolve_variable(hl, ctx, param_name="hl"),
+                },
+            )
+            results = []
+            for item in _items(raw, "articles"):
+                author = item.get("author")
+                extras = item.get("extras")
+                citations = extras.get("citations") if isinstance(extras, dict) else None
+                results.append(
+                    SerplyScholarResult(
+                        title=_text(item, "title"),
+                        link=_text(item, "link"),
+                        authors=_text(author, "names") if isinstance(author, dict) else "",
+                        description=_text(item, "description"),
+                        citations=_int(citations.get("count")) if isinstance(citations, dict) else None,
+                    )
+                )
+            return ToolResult(SerplyScholarSearchResponse(query=query, results=results))
+
+        return serply_scholar_search
+
+    async def _get(self, path: str, params: dict[str, Any]) -> dict[str, Any]:
+        request_params = {key: value for key, value in params.items() if value is not None}
+
+        async with httpx.AsyncClient(
+            base_url=self._base_url,
+            headers={"X-Api-Key": self._api_key, "User-Agent": _USER_AGENT},
+            timeout=self._timeout,
+        ) as client:
+            response = await client.get(path, params=request_params)
+            response.raise_for_status()
+
+        raw = response.json()
+        return raw if isinstance(raw, dict) else {}

--- a/ag2/extensions/tools/search/serply.py
+++ b/ag2/extensions/tools/search/serply.py
@@ -11,8 +11,6 @@ Maintainer: googio
 Docs: https://docs.ag2.ai/docs/user-guide/extensions/tools/search/serply/
 """
 
-import html
-import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, TypeAlias
@@ -33,7 +31,12 @@ ProxyLocation: TypeAlias = Literal["EU", "CA", "US", "IE", "GB", "FR", "DE", "SE
 # User-Agent. Unrelated to Serply's own ``X-User-Agent`` header, which Serply
 # documents as a desktop/mobile switch but does not currently act on.
 _USER_AGENT = "ag2-serply-extension"
-_TAG_RE = re.compile(r"<[^>]+>")
+
+# Google News ignores `num` server-side — it answers with its whole feed, seen at
+# 49-105 entries whose links are ~284-character opaque redirects. Left uncapped a
+# single news call lands ~15k tokens in the model's context, so the cap is applied
+# here instead.
+_NEWS_MAX_RESULTS = 10
 
 
 @dataclass(slots=True)
@@ -56,7 +59,6 @@ class SerplyNewsResult:
     link: str
     published: str = ""
     source: str = ""
-    summary: str = ""
 
 
 @dataclass(slots=True)
@@ -70,7 +72,7 @@ class SerplyScholarResult:
     title: str
     link: str
     authors: str = ""
-    description: str = ""
+    pdf_link: str = ""
     citations: int | None = None
 
 
@@ -106,15 +108,6 @@ def _nested(raw: Any, *keys: str) -> Any:
             return None
         raw = raw.get(key)
     return raw
-
-
-def _plain_text(fragment: str) -> str:
-    """Flatten the HTML fragment Google News uses for entry summaries.
-
-    Tags are stripped *before* entities are decoded, so escaped angle brackets in
-    the summary text survive rather than being decoded into markup and dropped.
-    """
-    return " ".join(html.unescape(_TAG_RE.sub(" ", fragment)).split())
 
 
 async def _get(
@@ -195,8 +188,9 @@ class SerplySearchToolkit(Toolkit):
             timeout: Per-request timeout in seconds.
             proxy: Proxy URL for the outgoing HTTP connection.
             verify: Whether to verify the server's TLS certificate.
-            num: Default number of results. Applies to web and scholar search;
-                Google News returns its own feed size.
+            num: Default number of results. Web and scholar send it to the API;
+                news truncates the feed client-side, because Google News ignores
+                the parameter and answers with its whole feed.
             gl: Default Google country code, forwarded as a query parameter.
             hl: Default Google interface language, forwarded as a query parameter.
             proxy_location: Default region Serply searches from, sent as the
@@ -218,7 +212,7 @@ class SerplySearchToolkit(Toolkit):
 
         super().__init__(
             self.web(num=num, gl=gl, hl=hl, proxy_location=proxy_location),
-            self.news(gl=gl, hl=hl, proxy_location=proxy_location),
+            self.news(num=num, gl=gl, hl=hl, proxy_location=proxy_location),
             self.scholar(num=num, gl=gl, hl=hl, proxy_location=proxy_location),
             name="serply_search_toolkit",
             middleware=middleware,
@@ -290,6 +284,7 @@ class SerplySearchToolkit(Toolkit):
     def news(
         self,
         *,
+        num: int | Variable | None = None,
         gl: str | Variable | None = None,
         hl: str | Variable | None = None,
         proxy_location: ProxyLocation | Variable | None = None,
@@ -302,6 +297,9 @@ class SerplySearchToolkit(Toolkit):
         """Build the Google News search tool.
 
         Args:
+            num: Maximum number of articles to return. Google News ignores this
+                server-side, so the feed is truncated client-side. Defaults to
+                ``_NEWS_MAX_RESULTS``.
             gl: Google country code, forwarded as a query parameter.
             hl: Google interface language, forwarded as a query parameter.
             proxy_location: Region to search from (``X-Proxy-Location`` header).
@@ -320,6 +318,7 @@ class SerplySearchToolkit(Toolkit):
             ctx: Context,
         ) -> ToolResult:
             """Search Google News through Serply."""
+            limit = _int(resolve_variable(num, ctx, param_name="num"))
             raw = await _get(
                 client_kwargs,
                 "/v1/news/",
@@ -339,9 +338,8 @@ class SerplySearchToolkit(Toolkit):
                             link=_text(item, "link"),
                             published=_text(item, "published"),
                             source=_text(item.get("source"), "title"),
-                            summary=_plain_text(_text(item, "summary")),
                         )
-                        for item in _items(raw, "entries")
+                        for item in _items(raw, "entries")[: limit if limit and limit > 0 else _NEWS_MAX_RESULTS]
                     ],
                 )
             )
@@ -403,7 +401,7 @@ class SerplySearchToolkit(Toolkit):
                             title=_text(item, "title"),
                             link=_text(item, "link"),
                             authors=_text(item.get("author"), "names"),
-                            description=_text(item, "description"),
+                            pdf_link=_text(item.get("doc"), "link"),
                             citations=_int(_nested(item, "extras", "citations", "count")),
                         )
                         for item in _items(raw, "articles")

--- a/ag2/extensions/tools/search/serply.py
+++ b/ag2/extensions/tools/search/serply.py
@@ -15,7 +15,7 @@ import html
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal, TypeAlias
 
 import httpx
 from pydantic import Field
@@ -27,7 +27,11 @@ from ag2.tools.builtin._resolve import resolve_variable
 from ag2.tools.final import Toolkit, tool
 from ag2.tools.final.function_tool import FunctionTool
 
-# Serply sits behind Cloudflare, which rejects requests without a User-Agent.
+ProxyLocation: TypeAlias = Literal["EU", "CA", "US", "IE", "GB", "FR", "DE", "SE", "IN", "JP", "KR", "SG", "AU", "BR"]
+
+# Serply sits behind Cloudflare, which blocks httpx's default ``python-httpx/*``
+# User-Agent. Unrelated to Serply's own ``X-User-Agent`` header, which Serply
+# documents as a desktop/mobile switch but does not currently act on.
 _USER_AGENT = "ag2-serply-extension"
 _TAG_RE = re.compile(r"<[^>]+>")
 
@@ -76,23 +80,73 @@ class SerplyScholarSearchResponse:
     results: list[SerplyScholarResult] = field(default_factory=list)
 
 
-def _text(raw: dict[str, Any], key: str) -> str:
+def _text(raw: Any, key: str) -> str:
+    """Return ``raw[key]`` when *raw* is a mapping holding a string there, else ``""``."""
+    if not isinstance(raw, dict):
+        return ""
     value = raw.get(key)
     return value if isinstance(value, str) else ""
 
 
 def _int(value: Any) -> int | None:
+    """Return *value* when it is a real integer, else ``None`` (``bool`` is not an integer here)."""
     return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 def _items(raw: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    """Return the mappings inside the list at ``raw[key]``, skipping anything else."""
     items = raw.get(key)
     return [item for item in items if isinstance(item, dict)] if isinstance(items, list) else []
 
 
+def _nested(raw: Any, *keys: str) -> Any:
+    """Walk *keys* through nested mappings, returning ``None`` as soon as one is missing."""
+    for key in keys:
+        if not isinstance(raw, dict):
+            return None
+        raw = raw.get(key)
+    return raw
+
+
 def _plain_text(fragment: str) -> str:
-    """Flatten the HTML fragment Google News uses for entry summaries."""
-    return " ".join(_TAG_RE.sub(" ", html.unescape(fragment)).split())
+    """Flatten the HTML fragment Google News uses for entry summaries.
+
+    Tags are stripped *before* entities are decoded, so escaped angle brackets in
+    the summary text survive rather than being decoded into markup and dropped.
+    """
+    return " ".join(html.unescape(_TAG_RE.sub(" ", fragment)).split())
+
+
+async def _get(
+    client_kwargs: dict[str, Any],
+    path: str,
+    params: dict[str, Any],
+    headers: dict[str, Any],
+) -> dict[str, Any]:
+    """Run one GET against the Serply REST API.
+
+    Args:
+        client_kwargs: Keyword arguments for the ``httpx.AsyncClient`` to open.
+        path: Endpoint path, resolved against the client's base URL.
+        params: Query parameters. Entries with a ``None`` value are dropped.
+        headers: Per-request headers. Entries with a ``None`` value are dropped.
+
+    Returns:
+        The decoded JSON object, or an empty dict when the payload is not an object.
+
+    Raises:
+        httpx.HTTPStatusError: If Serply answers with a non-2xx status code.
+    """
+    async with httpx.AsyncClient(**client_kwargs) as client:
+        response = await client.get(
+            path,
+            params={key: value for key, value in params.items() if value is not None},
+            headers={key: value for key, value in headers.items() if value is not None},
+        )
+        response.raise_for_status()
+        raw = response.json()
+
+    return raw if isinstance(raw, dict) else {}
 
 
 class SerplySearchToolkit(Toolkit):
@@ -117,7 +171,7 @@ class SerplySearchToolkit(Toolkit):
     A Serply ``api_key`` is required.
     """
 
-    __slots__ = ("_api_key", "_base_url", "_timeout")
+    __slots__ = ("_api_key", "_base_url", "_timeout", "_proxy", "_verify")
 
     def __init__(
         self,
@@ -125,21 +179,47 @@ class SerplySearchToolkit(Toolkit):
         *,
         base_url: str = "https://api.serply.io",
         timeout: float = 60.0,
+        proxy: str | None = None,
+        verify: bool = True,
         num: int | Variable | None = None,
         gl: str | Variable | None = None,
         hl: str | Variable | None = None,
+        proxy_location: ProxyLocation | Variable | None = None,
         middleware: Iterable[ToolMiddleware] = (),
     ) -> None:
+        """Build the toolkit and its three default tools.
+
+        Args:
+            api_key: Serply API key, sent as the ``X-Api-Key`` header.
+            base_url: Serply API root. Trailing slashes are stripped.
+            timeout: Per-request timeout in seconds.
+            proxy: Proxy URL for the outgoing HTTP connection.
+            verify: Whether to verify the server's TLS certificate.
+            num: Default number of results. Applies to web and scholar search;
+                Google News returns its own feed size.
+            gl: Default Google country code, forwarded as a query parameter.
+            hl: Default Google interface language, forwarded as a query parameter.
+            proxy_location: Default region Serply searches from, sent as the
+                ``X-Proxy-Location`` header. This is Serply's documented way to
+                target results geographically, and it is best-effort: Serply may
+                answer from a nearby region instead of the one asked for.
+            middleware: Middleware applied to every tool in the toolkit.
+
+        Raises:
+            ValueError: If *api_key* is empty.
+        """
         if not api_key:
             raise ValueError("api_key is required")
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
+        self._proxy = proxy
+        self._verify = verify
 
         super().__init__(
-            self.web(num=num, gl=gl, hl=hl),
-            self.news(gl=gl, hl=hl),
-            self.scholar(num=num, gl=gl, hl=hl),
+            self.web(num=num, gl=gl, hl=hl, proxy_location=proxy_location),
+            self.news(gl=gl, hl=hl, proxy_location=proxy_location),
+            self.scholar(num=num, gl=gl, hl=hl, proxy_location=proxy_location),
             name="serply_search_toolkit",
             middleware=middleware,
         )
@@ -150,19 +230,37 @@ class SerplySearchToolkit(Toolkit):
         num: int | Variable | None = None,
         gl: str | Variable | None = None,
         hl: str | Variable | None = None,
+        proxy_location: ProxyLocation | Variable | None = None,
         name: str = "serply_web_search",
         description: str = (
             "Search the web with Google through Serply. Returns ranked results with titles, snippets, and URLs."
         ),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
+        """Build the Google web search tool.
+
+        Args:
+            num: Number of results to request.
+            gl: Google country code, forwarded as a query parameter.
+            hl: Google interface language, forwarded as a query parameter.
+            proxy_location: Region to search from (``X-Proxy-Location`` header).
+            name: Tool name registered with the agent.
+            description: Tool description shown to the model.
+            middleware: Middleware applied to this tool.
+
+        Returns:
+            A ``FunctionTool`` that queries Serply's ``/v1/search/`` endpoint.
+        """
+        client_kwargs = self._client_kwargs()
+
         @tool(name=name, description=description, middleware=middleware)
         async def serply_web_search(
             query: Annotated[str, Field(description="The web search query string.")],
             ctx: Context,
         ) -> ToolResult:
             """Search Google web results through Serply."""
-            raw = await self._get(
+            raw = await _get(
+                client_kwargs,
                 "/v1/search/",
                 {
                     "q": query,
@@ -170,6 +268,7 @@ class SerplySearchToolkit(Toolkit):
                     "gl": resolve_variable(gl, ctx, param_name="gl"),
                     "hl": resolve_variable(hl, ctx, param_name="hl"),
                 },
+                {"X-Proxy-Location": resolve_variable(proxy_location, ctx, param_name="proxy_location")},
             )
             return ToolResult(
                 SerplyWebSearchResponse(
@@ -193,39 +292,59 @@ class SerplySearchToolkit(Toolkit):
         *,
         gl: str | Variable | None = None,
         hl: str | Variable | None = None,
+        proxy_location: ProxyLocation | Variable | None = None,
         name: str = "serply_news_search",
         description: str = (
             "Search Google News through Serply. Returns recent articles with titles, sources, publish dates, and URLs."
         ),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
+        """Build the Google News search tool.
+
+        Args:
+            gl: Google country code, forwarded as a query parameter.
+            hl: Google interface language, forwarded as a query parameter.
+            proxy_location: Region to search from (``X-Proxy-Location`` header).
+            name: Tool name registered with the agent.
+            description: Tool description shown to the model.
+            middleware: Middleware applied to this tool.
+
+        Returns:
+            A ``FunctionTool`` that queries Serply's ``/v1/news/`` endpoint.
+        """
+        client_kwargs = self._client_kwargs()
+
         @tool(name=name, description=description, middleware=middleware)
         async def serply_news_search(
             query: Annotated[str, Field(description="The news search query string.")],
             ctx: Context,
         ) -> ToolResult:
             """Search Google News through Serply."""
-            raw = await self._get(
+            raw = await _get(
+                client_kwargs,
                 "/v1/news/",
                 {
                     "q": query,
                     "gl": resolve_variable(gl, ctx, param_name="gl"),
                     "hl": resolve_variable(hl, ctx, param_name="hl"),
                 },
+                {"X-Proxy-Location": resolve_variable(proxy_location, ctx, param_name="proxy_location")},
             )
-            results = []
-            for item in _items(raw, "entries"):
-                source = item.get("source")
-                results.append(
-                    SerplyNewsResult(
-                        title=_text(item, "title"),
-                        link=_text(item, "link"),
-                        published=_text(item, "published"),
-                        source=_text(source, "title") if isinstance(source, dict) else "",
-                        summary=_plain_text(_text(item, "summary")),
-                    )
+            return ToolResult(
+                SerplyNewsSearchResponse(
+                    query=query,
+                    results=[
+                        SerplyNewsResult(
+                            title=_text(item, "title"),
+                            link=_text(item, "link"),
+                            published=_text(item, "published"),
+                            source=_text(item.get("source"), "title"),
+                            summary=_plain_text(_text(item, "summary")),
+                        )
+                        for item in _items(raw, "entries")
+                    ],
                 )
-            return ToolResult(SerplyNewsSearchResponse(query=query, results=results))
+            )
 
         return serply_news_search
 
@@ -235,6 +354,7 @@ class SerplySearchToolkit(Toolkit):
         num: int | Variable | None = None,
         gl: str | Variable | None = None,
         hl: str | Variable | None = None,
+        proxy_location: ProxyLocation | Variable | None = None,
         name: str = "serply_scholar_search",
         description: str = (
             "Search Google Scholar through Serply. Returns academic articles with titles, authors, "
@@ -242,13 +362,30 @@ class SerplySearchToolkit(Toolkit):
         ),
         middleware: Iterable[ToolMiddleware] = (),
     ) -> FunctionTool:
+        """Build the Google Scholar search tool.
+
+        Args:
+            num: Number of results to request.
+            gl: Google country code, forwarded as a query parameter.
+            hl: Google interface language, forwarded as a query parameter.
+            proxy_location: Region to search from (``X-Proxy-Location`` header).
+            name: Tool name registered with the agent.
+            description: Tool description shown to the model.
+            middleware: Middleware applied to this tool.
+
+        Returns:
+            A ``FunctionTool`` that queries Serply's ``/v1/scholar/`` endpoint.
+        """
+        client_kwargs = self._client_kwargs()
+
         @tool(name=name, description=description, middleware=middleware)
         async def serply_scholar_search(
             query: Annotated[str, Field(description="The academic search query string.")],
             ctx: Context,
         ) -> ToolResult:
             """Search Google Scholar through Serply."""
-            raw = await self._get(
+            raw = await _get(
+                client_kwargs,
                 "/v1/scholar/",
                 {
                     "q": query,
@@ -256,35 +393,32 @@ class SerplySearchToolkit(Toolkit):
                     "gl": resolve_variable(gl, ctx, param_name="gl"),
                     "hl": resolve_variable(hl, ctx, param_name="hl"),
                 },
+                {"X-Proxy-Location": resolve_variable(proxy_location, ctx, param_name="proxy_location")},
             )
-            results = []
-            for item in _items(raw, "articles"):
-                author = item.get("author")
-                extras = item.get("extras")
-                citations = extras.get("citations") if isinstance(extras, dict) else None
-                results.append(
-                    SerplyScholarResult(
-                        title=_text(item, "title"),
-                        link=_text(item, "link"),
-                        authors=_text(author, "names") if isinstance(author, dict) else "",
-                        description=_text(item, "description"),
-                        citations=_int(citations.get("count")) if isinstance(citations, dict) else None,
-                    )
+            return ToolResult(
+                SerplyScholarSearchResponse(
+                    query=query,
+                    results=[
+                        SerplyScholarResult(
+                            title=_text(item, "title"),
+                            link=_text(item, "link"),
+                            authors=_text(item.get("author"), "names"),
+                            description=_text(item, "description"),
+                            citations=_int(_nested(item, "extras", "citations", "count")),
+                        )
+                        for item in _items(raw, "articles")
+                    ],
                 )
-            return ToolResult(SerplyScholarSearchResponse(query=query, results=results))
+            )
 
         return serply_scholar_search
 
-    async def _get(self, path: str, params: dict[str, Any]) -> dict[str, Any]:
-        request_params = {key: value for key, value in params.items() if value is not None}
-
-        async with httpx.AsyncClient(
-            base_url=self._base_url,
-            headers={"X-Api-Key": self._api_key, "User-Agent": _USER_AGENT},
-            timeout=self._timeout,
-        ) as client:
-            response = await client.get(path, params=request_params)
-            response.raise_for_status()
-
-        raw = response.json()
-        return raw if isinstance(raw, dict) else {}
+    def _client_kwargs(self) -> dict[str, Any]:
+        """Snapshot the connection settings as ``httpx.AsyncClient`` keyword arguments."""
+        return {
+            "base_url": self._base_url,
+            "headers": {"X-Api-Key": self._api_key, "User-Agent": _USER_AGENT},
+            "timeout": self._timeout,
+            "proxy": self._proxy,
+            "verify": self._verify,
+        }

--- a/test/extensions/tools/search/test_serply.py
+++ b/test/extensions/tools/search/test_serply.py
@@ -1,0 +1,286 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import httpx
+import pytest
+import respx
+from dirty_equals import IsPartialDict
+
+from ag2 import Agent, Context, DataInput, Variable
+from ag2.events import ModelResponse, ToolCallEvent, ToolCallsEvent, ToolResultsEvent
+from ag2.extensions.tools.search.serply import (
+    SerplyNewsResult,
+    SerplyNewsSearchResponse,
+    SerplyScholarResult,
+    SerplyScholarSearchResponse,
+    SerplySearchToolkit,
+    SerplyWebResult,
+    SerplyWebSearchResponse,
+)
+from ag2.testing import TestConfig, TrackingConfig
+from ag2.tools.final.function_tool import FunctionToolSchema
+
+SERPLY_BASE_URL = "https://api.serply.io"
+
+
+def _tool_call_config(
+    arguments: dict[str, object],
+    *,
+    tool_name: str = "serply_web_search",
+    final_reply: str = "done",
+) -> TestConfig:
+    return TestConfig(
+        ModelResponse(
+            tool_calls=ToolCallsEvent([
+                ToolCallEvent(arguments=json.dumps(arguments), name=tool_name),
+            ]),
+        ),
+        final_reply,
+    )
+
+
+@pytest.mark.asyncio
+class TestSchema:
+    async def test_default_schemas(self, context: Context) -> None:
+        toolkit = SerplySearchToolkit(api_key="test")
+
+        schemas = list(await toolkit.schemas(context))
+
+        names = []
+        for schema in schemas:
+            assert isinstance(schema, FunctionToolSchema)
+            names.append(schema.function.name)
+            assert schema.function.parameters == IsPartialDict({
+                "required": ["query"],
+                "properties": IsPartialDict({"query": IsPartialDict({"type": "string"})}),
+            })
+        assert names == ["serply_web_search", "serply_news_search", "serply_scholar_search"]
+
+    async def test_custom_name_and_description(self, context: Context) -> None:
+        toolkit = SerplySearchToolkit(api_key="test")
+        custom = toolkit.scholar(name="find_papers", description="Find academic papers.")
+
+        [schema] = list(await custom.schemas(context))
+
+        assert schema.function.name == "find_papers"
+        assert schema.function.description == "Find academic papers."
+
+    async def test_empty_api_key_raises_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="api_key is required"):
+            SerplySearchToolkit("")
+
+
+@pytest.mark.asyncio
+class TestWebSearch:
+    @respx.mock
+    async def test_returns_structured_results(self) -> None:
+        respx.get(f"{SERPLY_BASE_URL}/v1/search/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "title": "AG2 docs",
+                            "link": "https://docs.ag2.ai",
+                            "description": "AG2 documentation.",
+                            "position": 1,
+                            "metadata": {"display_url": "docs.ag2.ai"},
+                        },
+                        {"title": "No description", "link": "https://example.com"},
+                        "not-a-result",
+                    ],
+                    "related_searches": [],
+                },
+            )
+        )
+        toolkit = SerplySearchToolkit(api_key="test")
+        config = TrackingConfig(_tool_call_config({"query": "AG2"}))
+        agent = Agent("a", config=config, tools=[toolkit])
+
+        await agent.ask("search")
+
+        tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            SerplyWebSearchResponse(
+                query="AG2",
+                results=[
+                    SerplyWebResult(
+                        title="AG2 docs",
+                        link="https://docs.ag2.ai",
+                        description="AG2 documentation.",
+                        position=1,
+                    ),
+                    SerplyWebResult(title="No description", link="https://example.com"),
+                ],
+            )
+        )
+
+    @respx.mock
+    async def test_forwards_search_defaults_and_headers(self) -> None:
+        route = respx.get(f"{SERPLY_BASE_URL}/v1/search/").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = SerplySearchToolkit(api_key="test-key", num=5, gl="us", hl="en")
+        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
+
+        await agent.ask("search")
+
+        assert dict(route.calls.last.request.url.params) == {"q": "AG2", "num": "5", "gl": "us", "hl": "en"}
+        assert route.calls.last.request.headers["X-Api-Key"] == "test-key"
+        assert route.calls.last.request.headers["User-Agent"] == "ag2-serply-extension"
+
+    @respx.mock
+    async def test_omits_unset_params(self) -> None:
+        route = respx.get(f"{SERPLY_BASE_URL}/v1/search/").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = SerplySearchToolkit(api_key="test")
+        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
+
+        await agent.ask("search")
+
+        assert dict(route.calls.last.request.url.params) == {"q": "AG2"}
+
+    @respx.mock
+    async def test_custom_base_url(self) -> None:
+        route = respx.get("https://proxy.example.com/serply/v1/search/").mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+        toolkit = SerplySearchToolkit(api_key="test", base_url="https://proxy.example.com/serply/")
+        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
+
+        await agent.ask("search")
+
+        assert route.called
+
+    @respx.mock
+    async def test_http_error_raises(self) -> None:
+        respx.get(f"{SERPLY_BASE_URL}/v1/search/").mock(
+            return_value=httpx.Response(401, json={"detail": "Invalid API key"})
+        )
+        toolkit = SerplySearchToolkit(api_key="bad")
+        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await agent.ask("search")
+
+
+@pytest.mark.asyncio
+class TestNewsSearch:
+    @respx.mock
+    async def test_returns_structured_results(self) -> None:
+        route = respx.get(f"{SERPLY_BASE_URL}/v1/news/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "title": "AG2 1.0 released - Example News",
+                            "link": "https://news.example.com/ag2",
+                            "published": "Wed, 26 Aug 2026 12:00:00 GMT",
+                            "source": {"href": "https://news.example.com", "title": "Example News"},
+                            "summary": '<a href="https://news.example.com/ag2">AG2 1.0 &amp; more</a>&nbsp;<b>Example</b>',
+                        }
+                    ]
+                },
+            )
+        )
+        toolkit = SerplySearchToolkit(api_key="test", num=5, gl="us")
+        config = TrackingConfig(_tool_call_config({"query": "AG2"}, tool_name="serply_news_search"))
+        agent = Agent("a", config=config, tools=[toolkit])
+
+        await agent.ask("search")
+
+        tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            SerplyNewsSearchResponse(
+                query="AG2",
+                results=[
+                    SerplyNewsResult(
+                        title="AG2 1.0 released - Example News",
+                        link="https://news.example.com/ag2",
+                        published="Wed, 26 Aug 2026 12:00:00 GMT",
+                        source="Example News",
+                        summary="AG2 1.0 & more Example",
+                    )
+                ],
+            )
+        )
+        assert dict(route.calls.last.request.url.params) == {"q": "AG2", "gl": "us"}
+
+
+@pytest.mark.asyncio
+class TestScholarSearch:
+    @respx.mock
+    async def test_returns_structured_results(self) -> None:
+        respx.get(f"{SERPLY_BASE_URL}/v1/scholar/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "articles": [
+                        {
+                            "title": "JADE - A FIPA-compliant agent framework",
+                            "link": "https://example.org/jade.pdf",
+                            "author": {
+                                "names": "F. Bellifemine, A. Poggi, G. Rimassa - 1999",
+                                "authors": [{"name": "F. Bellifemine", "link": "https://openalex.org/A1"}],
+                            },
+                            "description": "F. Bellifemine, A. Poggi, G. Rimassa - 1999",
+                            "extras": {"citations": {"count": 986, "link": "https://example.org/cites"}},
+                        },
+                        {"title": "Untracked paper", "link": "https://example.org/paper"},
+                    ]
+                },
+            )
+        )
+        toolkit = SerplySearchToolkit(api_key="test")
+        config = TrackingConfig(_tool_call_config({"query": "agent frameworks"}, tool_name="serply_scholar_search"))
+        agent = Agent("a", config=config, tools=[toolkit.scholar()])
+
+        await agent.ask("search")
+
+        tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            SerplyScholarSearchResponse(
+                query="agent frameworks",
+                results=[
+                    SerplyScholarResult(
+                        title="JADE - A FIPA-compliant agent framework",
+                        link="https://example.org/jade.pdf",
+                        authors="F. Bellifemine, A. Poggi, G. Rimassa - 1999",
+                        description="F. Bellifemine, A. Poggi, G. Rimassa - 1999",
+                        citations=986,
+                    ),
+                    SerplyScholarResult(title="Untracked paper", link="https://example.org/paper"),
+                ],
+            )
+        )
+
+
+@pytest.mark.asyncio
+class TestVariables:
+    @respx.mock
+    async def test_resolves_runtime_values(self) -> None:
+        route = respx.get(f"{SERPLY_BASE_URL}/v1/search/").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = SerplySearchToolkit(api_key="test")
+        search_tool = toolkit.web(gl=Variable(), num=Variable("result_limit"))
+        agent = Agent(
+            "a",
+            config=_tool_call_config({"query": "AG2"}),
+            tools=[search_tool],
+            variables={"gl": "de", "result_limit": 10},
+        )
+
+        await agent.ask("search")
+
+        assert dict(route.calls.last.request.url.params) == {"q": "AG2", "gl": "de", "num": "10"}
+
+    async def test_missing_variable_raises(self) -> None:
+        toolkit = SerplySearchToolkit(api_key="test")
+        agent = Agent(
+            "a",
+            config=_tool_call_config({"query": "AG2"}),
+            tools=[toolkit.web(num=Variable("result_limit"))],
+        )
+
+        with pytest.raises(KeyError):
+            await agent.ask("search")

--- a/test/extensions/tools/search/test_serply.py
+++ b/test/extensions/tools/search/test_serply.py
@@ -178,13 +178,12 @@ class TestNewsSearch:
                             "link": "https://news.example.com/ag2",
                             "published": "Wed, 26 Aug 2026 12:00:00 GMT",
                             "source": {"href": "https://news.example.com", "title": "Example News"},
-                            "summary": '<a href="https://news.example.com/ag2">AG2 1.0 &amp; more</a>&nbsp;<b>Example</b>',
                         }
                     ]
                 },
             )
         )
-        toolkit = SerplySearchToolkit(api_key="test", num=5, gl="us")
+        toolkit = SerplySearchToolkit(api_key="test", gl="us")
         config = TrackingConfig(_tool_call_config({"query": "AG2"}, tool_name="serply_news_search"))
         agent = Agent("a", config=config, tools=[toolkit])
 
@@ -200,12 +199,77 @@ class TestNewsSearch:
                         link="https://news.example.com/ag2",
                         published="Wed, 26 Aug 2026 12:00:00 GMT",
                         source="Example News",
-                        summary="AG2 1.0 & more Example",
                     )
                 ],
             )
         )
         assert dict(route.calls.last.request.url.params) == {"q": "AG2", "gl": "us"}
+
+
+@pytest.mark.asyncio
+class TestNewsResultCap:
+    @staticmethod
+    def _feed(count: int) -> dict[str, object]:
+        return {"entries": [{"title": f"Article {i}", "link": f"https://news.example.com/{i}"} for i in range(count)]}
+
+    @respx.mock
+    async def test_caps_the_feed_when_num_is_unset(self) -> None:
+        respx.get(f"{SERPLY_BASE_URL}/v1/news/").mock(return_value=httpx.Response(200, json=self._feed(60)))
+        toolkit = SerplySearchToolkit(api_key="test")
+        config = TrackingConfig(_tool_call_config({"query": "AG2"}, tool_name="serply_news_search"))
+        agent = Agent("a", config=config, tools=[toolkit])
+
+        await agent.ask("search")
+
+        tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            SerplyNewsSearchResponse(
+                query="AG2",
+                results=[
+                    SerplyNewsResult(title=f"Article {i}", link=f"https://news.example.com/{i}") for i in range(10)
+                ],
+            )
+        )
+
+    @respx.mock
+    async def test_num_truncates_the_feed_client_side(self) -> None:
+        route = respx.get(f"{SERPLY_BASE_URL}/v1/news/").mock(return_value=httpx.Response(200, json=self._feed(60)))
+        toolkit = SerplySearchToolkit(api_key="test", num=3)
+        config = TrackingConfig(_tool_call_config({"query": "AG2"}, tool_name="serply_news_search"))
+        agent = Agent("a", config=config, tools=[toolkit])
+
+        await agent.ask("search")
+
+        tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            SerplyNewsSearchResponse(
+                query="AG2",
+                results=[
+                    SerplyNewsResult(title=f"Article {i}", link=f"https://news.example.com/{i}") for i in range(3)
+                ],
+            )
+        )
+        # Google News ignores `num` server-side, so it must not be sent.
+        assert dict(route.calls.last.request.url.params) == {"q": "AG2"}
+
+    @respx.mock
+    async def test_num_resolves_from_a_variable(self) -> None:
+        respx.get(f"{SERPLY_BASE_URL}/v1/news/").mock(return_value=httpx.Response(200, json=self._feed(60)))
+        toolkit = SerplySearchToolkit(api_key="test")
+        config = TrackingConfig(_tool_call_config({"query": "AG2"}, tool_name="serply_news_search"))
+        agent = Agent("a", config=config, tools=[toolkit.news(num=Variable("cap"))], variables={"cap": 2})
+
+        await agent.ask("search")
+
+        tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            SerplyNewsSearchResponse(
+                query="AG2",
+                results=[
+                    SerplyNewsResult(title=f"Article {i}", link=f"https://news.example.com/{i}") for i in range(2)
+                ],
+            )
+        )
 
 
 @pytest.mark.asyncio
@@ -225,6 +289,7 @@ class TestScholarSearch:
                                 "authors": [{"name": "F. Bellifemine", "link": "https://openalex.org/A1"}],
                             },
                             "description": "F. Bellifemine, A. Poggi, G. Rimassa - 1999",
+                            "doc": {"link": "https://example.org/jade-oa.pdf", "type": "PDF"},
                             "extras": {"citations": {"count": 986, "link": "https://example.org/cites"}},
                         },
                         {"title": "Untracked paper", "link": "https://example.org/paper"},
@@ -247,7 +312,7 @@ class TestScholarSearch:
                         title="JADE - A FIPA-compliant agent framework",
                         link="https://example.org/jade.pdf",
                         authors="F. Bellifemine, A. Poggi, G. Rimassa - 1999",
-                        description="F. Bellifemine, A. Poggi, G. Rimassa - 1999",
+                        pdf_link="https://example.org/jade-oa.pdf",
                         citations=986,
                     ),
                     SerplyScholarResult(title="Untracked paper", link="https://example.org/paper"),
@@ -288,42 +353,6 @@ class TestVariables:
 
 @pytest.mark.asyncio
 class TestPayloadHandling:
-    @respx.mock
-    async def test_escaped_angle_brackets_survive_summary_flattening(self) -> None:
-        respx.get(f"{SERPLY_BASE_URL}/v1/news/").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "entries": [
-                        {
-                            "title": "Market cap &lt; $1T",
-                            "link": "https://news.example.com/cap",
-                            "summary": "<b>Prices</b>: 5 &lt; 10 &gt; 3",
-                        }
-                    ]
-                },
-            )
-        )
-        toolkit = SerplySearchToolkit(api_key="test")
-        config = TrackingConfig(_tool_call_config({"query": "market"}, tool_name="serply_news_search"))
-        agent = Agent("a", config=config, tools=[toolkit])
-
-        await agent.ask("search")
-
-        tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
-        assert tool_results_event.results[0].result.parts[0] == DataInput(
-            SerplyNewsSearchResponse(
-                query="market",
-                results=[
-                    SerplyNewsResult(
-                        title="Market cap &lt; $1T",
-                        link="https://news.example.com/cap",
-                        summary="Prices : 5 < 10 > 3",
-                    )
-                ],
-            )
-        )
-
     @respx.mock
     async def test_boolean_citation_count_is_dropped(self) -> None:
         respx.get(f"{SERPLY_BASE_URL}/v1/scholar/").mock(

--- a/test/extensions/tools/search/test_serply.py
+++ b/test/extensions/tools/search/test_serply.py
@@ -284,3 +284,152 @@ class TestVariables:
 
         with pytest.raises(KeyError):
             await agent.ask("search")
+
+
+@pytest.mark.asyncio
+class TestPayloadHandling:
+    @respx.mock
+    async def test_escaped_angle_brackets_survive_summary_flattening(self) -> None:
+        respx.get(f"{SERPLY_BASE_URL}/v1/news/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "title": "Market cap &lt; $1T",
+                            "link": "https://news.example.com/cap",
+                            "summary": "<b>Prices</b>: 5 &lt; 10 &gt; 3",
+                        }
+                    ]
+                },
+            )
+        )
+        toolkit = SerplySearchToolkit(api_key="test")
+        config = TrackingConfig(_tool_call_config({"query": "market"}, tool_name="serply_news_search"))
+        agent = Agent("a", config=config, tools=[toolkit])
+
+        await agent.ask("search")
+
+        tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            SerplyNewsSearchResponse(
+                query="market",
+                results=[
+                    SerplyNewsResult(
+                        title="Market cap &lt; $1T",
+                        link="https://news.example.com/cap",
+                        summary="Prices : 5 < 10 > 3",
+                    )
+                ],
+            )
+        )
+
+    @respx.mock
+    async def test_boolean_citation_count_is_dropped(self) -> None:
+        respx.get(f"{SERPLY_BASE_URL}/v1/scholar/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "articles": [
+                        {
+                            "title": "A paper",
+                            "link": "https://example.org/paper",
+                            "extras": {"citations": {"count": True}},
+                        }
+                    ]
+                },
+            )
+        )
+        toolkit = SerplySearchToolkit(api_key="test")
+        config = TrackingConfig(_tool_call_config({"query": "papers"}, tool_name="serply_scholar_search"))
+        agent = Agent("a", config=config, tools=[toolkit])
+
+        await agent.ask("search")
+
+        tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            SerplyScholarSearchResponse(
+                query="papers",
+                results=[SerplyScholarResult(title="A paper", link="https://example.org/paper")],
+            )
+        )
+
+    @respx.mock
+    async def test_non_object_payload_yields_no_results(self) -> None:
+        respx.get(f"{SERPLY_BASE_URL}/v1/search/").mock(return_value=httpx.Response(200, json=["unexpected"]))
+        toolkit = SerplySearchToolkit(api_key="test")
+        config = TrackingConfig(_tool_call_config({"query": "AG2"}))
+        agent = Agent("a", config=config, tools=[toolkit])
+
+        await agent.ask("search")
+
+        tool_results_event: ToolResultsEvent = config.mock.call_args_list[1].args[0]
+        assert tool_results_event.results[0].result.parts[0] == DataInput(
+            SerplyWebSearchResponse(query="AG2", results=[])
+        )
+
+
+@pytest.mark.asyncio
+class TestConnection:
+    @respx.mock
+    async def test_duplicate_trailing_slashes_are_stripped_from_base_url(self) -> None:
+        route = respx.get("https://proxy.example.com/serply/v1/search/").mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+        toolkit = SerplySearchToolkit(api_key="test", base_url="https://proxy.example.com/serply//")
+        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
+
+        await agent.ask("search")
+
+        assert route.called
+
+    @respx.mock
+    async def test_accepts_proxy_and_tls_verify_settings(self) -> None:
+        route = respx.get(f"{SERPLY_BASE_URL}/v1/search/").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = SerplySearchToolkit(api_key="test", proxy="http://proxy.example.com:3128", verify=False)
+        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
+
+        await agent.ask("search")
+
+        assert route.called
+
+    @respx.mock
+    async def test_forwards_proxy_location_header(self) -> None:
+        route = respx.get(f"{SERPLY_BASE_URL}/v1/news/").mock(return_value=httpx.Response(200, json={"entries": []}))
+        toolkit = SerplySearchToolkit(api_key="test", proxy_location="US")
+        agent = Agent(
+            "a",
+            config=_tool_call_config({"query": "AG2"}, tool_name="serply_news_search"),
+            tools=[toolkit],
+        )
+
+        await agent.ask("search")
+
+        assert route.calls.last.request.headers["X-Proxy-Location"] == "US"
+
+    @respx.mock
+    async def test_omits_unset_proxy_location_header(self) -> None:
+        route = respx.get(f"{SERPLY_BASE_URL}/v1/search/").mock(return_value=httpx.Response(200, json={"results": []}))
+        toolkit = SerplySearchToolkit(api_key="test")
+        agent = Agent("a", config=_tool_call_config({"query": "AG2"}), tools=[toolkit])
+
+        await agent.ask("search")
+
+        assert "X-Proxy-Location" not in route.calls.last.request.headers
+
+    @respx.mock
+    async def test_resolves_header_variable(self) -> None:
+        route = respx.get(f"{SERPLY_BASE_URL}/v1/scholar/").mock(
+            return_value=httpx.Response(200, json={"articles": []})
+        )
+        toolkit = SerplySearchToolkit(api_key="test")
+        agent = Agent(
+            "a",
+            config=_tool_call_config({"query": "AG2"}, tool_name="serply_scholar_search"),
+            tools=[toolkit.scholar(proxy_location=Variable("region"))],
+            variables={"region": "DE"},
+        )
+
+        await agent.ask("search")
+
+        assert route.calls.last.request.headers["X-Proxy-Location"] == "DE"

--- a/website/docs/user-guide/extensions/tools/search/serply.mdx
+++ b/website/docs/user-guide/extensions/tools/search/serply.mdx
@@ -36,13 +36,16 @@ Constructor defaults are applied to the toolkit's default tools:
 ```python linenums="1"
 toolkit = SerplySearchToolkit(
     api_key=...,
-    num=5,     # number of results for serply_web_search and serply_scholar_search
-    gl="us",   # Google country code for all three tools
-    hl="en",   # Google interface language for all three tools
+    num=5,                # number of results for serply_web_search and serply_scholar_search
+    gl="us",              # Google country code, forwarded as a query parameter
+    hl="en",              # Google interface language, forwarded as a query parameter
+    proxy_location="US",  # region Serply searches from (X-Proxy-Location header)
 )
 ```
 
 `num` is not applied to `serply_news_search`: Google News returns its own feed size.
+
+`proxy_location` is Serply's documented way to target results geographically, and it is best-effort: Serply answers from a proxy pool, so the region it actually used (returned as `device_region` in the raw payload) may be a nearby one rather than the one requested. `gl` and `hl` are separate — they are passed straight through to Google as query parameters and change the result set on their own. Use `proxy_location` for where the search originates and `gl`/`hl` for Google's own country and language selection.
 
 ## Picking a subset of tools
 
@@ -58,7 +61,23 @@ agent = Agent(
 )
 ```
 
-Every factory method also accepts `name` and `description` overrides for the registered tool. All configurable defaults on `SerplySearchToolkit` and its factory methods accept a `Variable` for deferred context resolution.
+Every factory method also accepts `name` and `description` overrides for the registered tool, plus the same `num` / `gl` / `hl` / `proxy_location` defaults as the constructor. All of those accept a `Variable` for deferred context resolution.
+
+## Connection settings
+
+The toolkit opens one `httpx.AsyncClient` per request. Override how that client connects:
+
+```python linenums="1"
+toolkit = SerplySearchToolkit(
+    api_key=...,
+    base_url="https://api.serply.io",  # override to route through your own gateway
+    timeout=60.0,                      # per-request timeout in seconds
+    proxy="http://proxy.internal:3128",
+    verify=True,                       # set False only to skip TLS verification
+)
+```
+
+A non-2xx response raises `httpx.HTTPStatusError`. A response body that is not a JSON object, or an individual result that does not match the expected shape, is skipped rather than raised on, so a partial payload still yields the results it does contain.
 
 ## Result
 

--- a/website/docs/user-guide/extensions/tools/search/serply.mdx
+++ b/website/docs/user-guide/extensions/tools/search/serply.mdx
@@ -1,0 +1,86 @@
+---
+title: Serply Search
+sidebarTitle: Serply Search
+---
+
+`SerplySearchToolkit` gives an agent three related tools powered by [Serply](https://serply.io){.external-link target="_blank"}: Google web search, Google News search, and Google Scholar search. Use it when an agent needs current web results, recent news coverage, or academic articles with citation counts from a single API key.
+
+!!! note
+    Requires a Serply API key. No extra package is needed: the toolkit talks to the REST API with `httpx`, which AG2 already depends on.
+
+```python linenums="1"
+import os
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.extensions.tools.search import SerplySearchToolkit
+
+agent = Agent(
+    "researcher",
+    config=AnthropicConfig(model="claude-sonnet-4-6"),
+    tools=[SerplySearchToolkit(api_key=os.environ["SERPLY_API_KEY"])],
+)
+```
+
+## Tools
+
+| Tool | Description |
+| :--- | :--- |
+| `serply_web_search` | Search Google web results and return ranked results with position, title, snippet, and URL |
+| `serply_news_search` | Search Google News and return recent articles with title, source, publish date, summary, and URL |
+| `serply_scholar_search` | Search Google Scholar and return articles with title, authors, citation count, and URL |
+
+## Shared defaults
+
+Constructor defaults are applied to the toolkit's default tools:
+
+```python linenums="1"
+toolkit = SerplySearchToolkit(
+    api_key=...,
+    num=5,     # number of results for serply_web_search and serply_scholar_search
+    gl="us",   # Google country code for all three tools
+    hl="en",   # Google interface language for all three tools
+)
+```
+
+`num` is not applied to `serply_news_search`: Google News returns its own feed size.
+
+## Picking a subset of tools
+
+Each tool is exposed as a factory method on the toolkit (`toolkit.web()`, `toolkit.news()`, `toolkit.scholar()`). Call the method to get a ready-to-use tool, then pass only the ones you need to the agent:
+
+```python linenums="1"
+toolkit = SerplySearchToolkit(api_key=...)
+
+agent = Agent(
+    "researcher",
+    config=config,
+    tools=[toolkit.web(num=5), toolkit.scholar(num=10)],
+)
+```
+
+Every factory method also accepts `name` and `description` overrides for the registered tool. All configurable defaults on `SerplySearchToolkit` and its factory methods accept a `Variable` for deferred context resolution.
+
+## Result
+
+`serply_web_search` returns a `SerplyWebSearchResponse`:
+
+| Field | Description |
+| :--- | :--- |
+| `query` | The search query the agent executed |
+| `results` | List of `SerplyWebResult` (`title`, `link`, `description`, `position`) |
+
+`serply_news_search` returns a `SerplyNewsSearchResponse`:
+
+| Field | Description |
+| :--- | :--- |
+| `query` | The search query the agent executed |
+| `results` | List of `SerplyNewsResult` (`title`, `link`, `published`, `source`, `summary`); the summary is returned as plain text |
+
+`serply_scholar_search` returns a `SerplyScholarSearchResponse`:
+
+| Field | Description |
+| :--- | :--- |
+| `query` | The search query the agent executed |
+| `results` | List of `SerplyScholarResult` (`title`, `link`, `authors`, `description`, `citations`) |
+
+Request parameters and response fields are documented in the [Serply API docs](https://serply.io/docs){.external-link target="_blank"}.

--- a/website/docs/user-guide/extensions/tools/search/serply.mdx
+++ b/website/docs/user-guide/extensions/tools/search/serply.mdx
@@ -26,8 +26,8 @@ agent = Agent(
 | Tool | Description |
 | :--- | :--- |
 | `serply_web_search` | Search Google web results and return ranked results with position, title, snippet, and URL |
-| `serply_news_search` | Search Google News and return recent articles with title, source, publish date, summary, and URL |
-| `serply_scholar_search` | Search Google Scholar and return articles with title, authors, citation count, and URL |
+| `serply_news_search` | Search Google News and return recent articles with title, source, publish date, and URL |
+| `serply_scholar_search` | Search Google Scholar and return articles with title, authors, citation count, URL, and an open-access PDF link when one exists |
 
 ## Shared defaults
 
@@ -36,14 +36,14 @@ Constructor defaults are applied to the toolkit's default tools:
 ```python linenums="1"
 toolkit = SerplySearchToolkit(
     api_key=...,
-    num=5,                # number of results for serply_web_search and serply_scholar_search
+    num=5,                # number of results, for all three tools
     gl="us",              # Google country code, forwarded as a query parameter
     hl="en",              # Google interface language, forwarded as a query parameter
     proxy_location="US",  # region Serply searches from (X-Proxy-Location header)
 )
 ```
 
-`num` is not applied to `serply_news_search`: Google News returns its own feed size.
+`num` reaches Serply as a query parameter for web and scholar search. Google News ignores it and answers with its whole feed — 49 to 105 articles in practice, whose links are ~284-character Google redirects — so `serply_news_search` truncates the feed itself. When `num` is unset it returns the 10 most recent articles; left uncapped, one news call would put roughly 15k tokens into the model's context.
 
 `proxy_location` is Serply's documented way to target results geographically, and it is best-effort: Serply answers from a proxy pool, so the region it actually used (returned as `device_region` in the raw payload) may be a nearby one rather than the one requested. `gl` and `hl` are separate — they are passed straight through to Google as query parameters and change the result set on their own. Use `proxy_location` for where the search originates and `gl`/`hl` for Google's own country and language selection.
 
@@ -93,13 +93,17 @@ A non-2xx response raises `httpx.HTTPStatusError`. A response body that is not a
 | Field | Description |
 | :--- | :--- |
 | `query` | The search query the agent executed |
-| `results` | List of `SerplyNewsResult` (`title`, `link`, `published`, `source`, `summary`); the summary is returned as plain text |
+| `results` | List of `SerplyNewsResult` (`title`, `link`, `published`, `source`); `link` is a Google News redirect, not the publisher's own URL |
 
 `serply_scholar_search` returns a `SerplyScholarSearchResponse`:
 
 | Field | Description |
 | :--- | :--- |
 | `query` | The search query the agent executed |
-| `results` | List of `SerplyScholarResult` (`title`, `link`, `authors`, `description`, `citations`) |
+| `results` | List of `SerplyScholarResult` (`title`, `link`, `authors`, `pdf_link`, `citations`) |
+
+`pdf_link` is Serply's open-access link for the article and is empty when it has none. `citations` is sourced from OpenAlex rather than Google Scholar's own count; treat it as an indication of impact rather than an exact figure.
+
+For queries that trigger a Google local pack, `serply_web_search` may return a top-ranked result whose `link` points back into `google.com` instead of the business's own site.
 
 Request parameters and response fields are documented in the [Serply API docs](https://serply.io/docs){.external-link target="_blank"}.

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -252,6 +252,7 @@
               "group": "Search",
               "pages": [
                 "docs/user-guide/extensions/tools/search/exa",
+                "docs/user-guide/extensions/tools/search/serply",
                 "docs/user-guide/extensions/tools/search/tinyfish",
                 "docs/user-guide/extensions/tools/search/xquik"
               ]


### PR DESCRIPTION
## Why are these changes needed?

Adds `SerplySearchToolkit`, an Extension under `ag2/extensions/tools/search/` that exposes [Serply](https://serply.io) as agent tools. Serply serves Google web, Google News and Google Scholar results from one REST API key, so the toolkit registers three tools:

- `serply_web_search` (`/v1/search/`) - ranked web results with title, snippet, URL, position
- `serply_news_search` (`/v1/news/`) - recent news with title, source, publish date, plain-text summary, URL
- `serply_scholar_search` (`/v1/scholar/`) - academic articles with title, authors, citation count, URL

Shape follows the existing search extensions: raw `httpx` like Xquik (no new dependency, `httpx` is already a core dep, so it is imported directly in `__init__.py` rather than behind `missing_additional_dependency`), and the multi-tool factory pattern of TinyFish (`toolkit.web()` / `toolkit.news()` / `toolkit.scholar()` for subsets and per-tool defaults). Shared defaults `num`, `gl`, `hl` accept `Variable` for runtime resolution. Responses are `slots` dataclasses; malformed items are skipped rather than raised on.

Includes respx-based tests (schemas, request params/headers, response mapping for all three endpoints, HTTP errors, `Variable` resolution), the docs page `website/docs/user-guide/extensions/tools/search/serply.mdx`, and the nav entry. All three tools were also exercised against the live API.

Disclosure: I work with Serply, the provider behind this API.

## Related issue number

N/A - extension addition per the Core vs Extensions contribution policy; happy to open one if preferred.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

AI assistance was used for drafting the code and tests; they were reviewed, run locally (ruff, mypy, pytest, license-header hook) and verified against the live Serply API before submission.
