### PR TITLE
feat(mcp): implement modern era conversation handling

### DIFF
--- a/ag2/mcp/errors.py
+++ b/ag2/mcp/errors.py
@@ -44,3 +44,18 @@ class MCPPromptNotFoundError(MCPServerError):
 
     def __init__(self, name: str) -> None:
         super().__init__(f"No prompt named {name!r}.")
+
+
+class UnknownConversationError(MCPServerError):
+    """Raised when a presented conversation handle names no live conversation.
+
+    Reported to the caller as a *tool execution* error rather than a JSON-RPC
+    one: the protocol draws that line so the model can recover by starting a new
+    conversation instead of failing the turn. A handle created by a different
+    principal raises this too, so the error does not disclose that it exists.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Unknown or expired conversation handle. Omit the 'conversation' argument to start a new conversation."
+        )

--- a/ag2/mcp/executor.py
+++ b/ag2/mcp/executor.py
@@ -9,8 +9,9 @@ from typing import TYPE_CHECKING, Any
 
 from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.auth.provider import AccessToken
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, ContentBlock, TextContent
 from mcp.types import Tool as MCPTool
+from mcp_types.version import MODERN_PROTOCOL_VERSIONS
 from pydantic import ValidationError
 
 from ag2.agent import Agent
@@ -23,10 +24,10 @@ from ag2.events import (
 )
 from ag2.stream import MemoryStream
 
-from .errors import MCPAgentConfigError
+from .errors import MCPAgentConfigError, UnknownConversationError
 from .info import build_ask_tool, object_output_schema
 from .mappers import reply_to_content, to_structured_dict, tool_error
-from .sessions import STDIO_SESSION, SessionStore
+from .sessions import STDIO_SESSION, Conversation, SessionStore
 
 if TYPE_CHECKING:
     from mcp.server.context import ServerRequestContext
@@ -35,6 +36,12 @@ if TYPE_CHECKING:
 # executor builds one for every outcome — success, structured success, and error.
 
 _LOGGER_NAME = "ag2.mcp"
+
+# Where a conversation handle travels back in a result's ``_meta``, for clients
+# threading it programmatically. Reverse-DNS from the project's domain, as the
+# ``_meta`` key rules require; prefixes whose second label is ``mcp`` or
+# ``modelcontextprotocol`` are reserved and are not used here.
+CONVERSATION_META_KEY = "ai.ag2/conversation"
 
 
 @dataclass(slots=True)
@@ -60,11 +67,20 @@ class AgentExecutor:
 
     Without a ``session_store`` each call is stateless: a fresh
     :class:`MemoryStream` is created per invocation (mirroring the A2A executor)
-    so any server replica can handle any request. With a ``session_store``,
-    history is keyed by the transport's ``mcp-session-id`` (or a per-process
-    sentinel over stdio) and accumulates across calls. While the agent runs, its
-    stream events are forwarded to the MCP client as progress / log notifications
-    when ``stream_progress`` is enabled.
+    so any server replica can handle any request.
+
+    With a ``session_store`` the conversation a call lands in depends on the
+    protocol era, because each era sanctions a different mechanism:
+
+    * **Handshake era** (revisions up to 2025-11-25) — history is keyed by the
+      MCP session the ``initialize`` handshake opened, or by a per-process
+      sentinel over stdio, and accumulates across calls.
+    * **Modern era** (2026-07-28) — there is no MCP session, and the revision
+      forbids deriving context from connection or process identity, so an
+      unnamed call starts a fresh conversation.
+
+    While the agent runs, its stream events are forwarded to the MCP client as
+    progress / log notifications when ``stream_progress`` is enabled.
     """
 
     __slots__ = ("_agent", "_tool_name", "_tool_description", "_stream_progress", "_context_provider", "_session_store")
@@ -93,6 +109,7 @@ class AgentExecutor:
                 tool_name=self._tool_name,
                 tool_description=self._tool_description,
                 response_schema=self._agent._response_schema,
+                conversation_bounds=self._session_store.bounds if self._session_store is not None else None,
             )
         ]
 
@@ -102,6 +119,7 @@ class AgentExecutor:
         *,
         message: str,
         context: str | None = None,
+        conversation: str | None = None,
         request_context: "ServerRequestContext[Any, Any]",
     ) -> CallToolResult:
         if name != self._tool_name:
@@ -111,57 +129,90 @@ class AgentExecutor:
         if not message:
             return tool_error("Missing required 'message' argument.")
 
-        # The stream is held for the whole turn: for a keyed session that means
-        # holding its turn lock, serializing concurrent same-session calls.
-        async with self._stream_cm(request_context) as stream:
-            if self._stream_progress:
-                self._wire_progress(stream, request_context)
+        # The conversation is held for the whole turn: for a keyed one that means
+        # holding its turn lock, serializing concurrent same-conversation calls.
+        try:
+            async with self._conversation_cm(request_context, conversation) as convo:
+                return await self._turn(convo, message, context, request_context)
+        except UnknownConversationError as e:
+            # A tool-level error, never a JSON-RPC one: the protocol draws that
+            # line so the model can start a new conversation rather than fail the
+            # turn. Only resolving the conversation raises this.
+            return tool_error(str(e))
 
-            # Optional per-request context (variables/tools/prompt) from the host,
-            # derived from the authenticated token. Omitted fields keep ask()'s
-            # defaults, so without a provider this is the stateless behavior.
-            ask_kwargs: dict[str, Any] = {}
-            if self._context_provider is not None:
-                ctx = await self._context_provider(get_access_token())
-                if ctx.variables is not None:
-                    ask_kwargs["variables"] = ctx.variables
-                if ctx.tools is not None:
-                    ask_kwargs["tools"] = ctx.tools
-                if ctx.prompt is not None:
-                    ask_kwargs["prompt"] = ctx.prompt
+    async def _turn(
+        self,
+        convo: Conversation,
+        message: str,
+        context: str | None,
+        request_context: "ServerRequestContext[Any, Any]",
+    ) -> CallToolResult:
+        """Run one agent turn inside ``convo`` and shape its reply into a result."""
+        if self._stream_progress:
+            self._wire_progress(convo.stream, request_context)
 
-            reply = await self._agent.ask(*_build_inputs(message, context), stream=stream, **ask_kwargs)
-            content = reply_to_content(reply)
+        # Optional per-request context (variables/tools/prompt) from the host,
+        # derived from the authenticated token. Omitted fields keep ask()'s
+        # defaults, so without a provider this is the stateless behavior.
+        ask_kwargs: dict[str, Any] = {}
+        if self._context_provider is not None:
+            ctx = await self._context_provider(get_access_token())
+            if ctx.variables is not None:
+                ask_kwargs["variables"] = ctx.variables
+            if ctx.tools is not None:
+                ask_kwargs["tools"] = ctx.tools
+            if ctx.prompt is not None:
+                ask_kwargs["prompt"] = ctx.prompt
 
-            if not self._has_object_output():
-                return CallToolResult(content=content)
+        reply = await self._agent.ask(*_build_inputs(message, context), stream=convo.stream, **ask_kwargs)
+        content = reply_to_content(reply)
 
-            try:
-                validated = await reply.content()
-            except ValidationError as e:
-                return CallToolResult(
-                    content=[TextContent(type="text", text=f"Structured-output validation failed: {e}")],
-                    isError=True,
-                )
-            structured = to_structured_dict(validated)
-            if structured is None:
-                return CallToolResult(
-                    content=content,
-                    isError=True,
-                )
-            return CallToolResult(content=content, structuredContent=structured)
+        if not self._has_object_output():
+            return _result(content, handle=convo.handle)
 
-    def _stream_cm(
-        self, request_context: "ServerRequestContext[Any, Any]"
-    ) -> AbstractAsyncContextManager[MemoryStream]:
-        """The stream context for this call: a keyed session (continuing history,
-        turn-locked) or a fresh stateless stream."""
-        if self._session_store is not None:
-            session_id = _session_id(request_context)
-            if session_id is not None:
-                return self._session_store.session(session_id)
-        # No store, or no server-issued session id (stateless HTTP) — stay stateless.
-        return _stateless_stream()
+        try:
+            validated = await reply.content()
+        except ValidationError as e:
+            return _result(
+                [TextContent(type="text", text=f"Structured-output validation failed: {e}")],
+                handle=convo.handle,
+                is_error=True,
+            )
+        structured = to_structured_dict(validated)
+        if structured is None:
+            return _result(content, handle=convo.handle, is_error=True)
+        return _result(content, handle=convo.handle, structured=structured)
+
+    def _conversation_cm(
+        self,
+        request_context: "ServerRequestContext[Any, Any]",
+        conversation: str | None,
+    ) -> AbstractAsyncContextManager[Conversation]:
+        """The conversation this call runs in, resolved in the order the protocol allows.
+
+        A named conversation wins in either era. Otherwise the handshake era
+        falls back to the MCP session it already has, and the modern era — which
+        has none, and may not derive one from the connection or the process —
+        starts a fresh one. A handle the registry does not know raises rather
+        than falling through: falling through would let a caller name a
+        conversation of their choosing and evict other callers' out of the bound.
+
+        Either name is answerable only to the principal that created it, on every
+        call rather than at creation. A handle is revalidated here, by the store,
+        because a handle travels through model context and logs. An MCP session
+        id needs no check of ours: the transport already refuses a session id
+        presented with a credential other than the one that opened it, answering
+        as though the session did not exist, so a swapped credential never
+        reaches this far with that name.
+        """
+        if self._session_store is None:
+            return _stateless_conversation()
+        principal = _principal()
+        if conversation is not None:
+            return self._session_store.by_handle(conversation, principal=principal)
+        if not _is_modern(request_context) and (session_id := _session_id(request_context)) is not None:
+            return self._session_store.session(session_id, principal=principal)
+        return self._session_store.fresh(principal=principal)
 
     def _has_object_output(self) -> bool:
         return object_output_schema(self._agent._response_schema) is not None
@@ -203,17 +254,73 @@ class _Counter:
 
 
 @asynccontextmanager
-async def _stateless_stream() -> AsyncGenerator[MemoryStream]:
-    """A fresh per-call stream — no shared history, no cross-call lock."""
-    yield MemoryStream()
+async def _stateless_conversation() -> AsyncGenerator[Conversation]:
+    """A fresh per-call stream — no shared history, no cross-call lock, no handle."""
+    yield Conversation(stream=MemoryStream())
+
+
+def _result(
+    content: list[ContentBlock],
+    *,
+    handle: str | None,
+    structured: dict[str, Any] | None = None,
+    is_error: bool = False,
+) -> CallToolResult:
+    """The tool result, carrying the conversation handle for both of its readers.
+
+    A text block, because the protocol puts recovery from an expired handle on
+    the model and the model does not read protocol metadata; and ``_meta``, for
+    clients threading it programmatically. ``structuredContent`` is deliberately
+    left alone: on this tool it is the agent's response schema, advertised
+    verbatim as ``outputSchema``, which MCP requires structured content to
+    conform to — a server field mixed in would break the tool's own contract.
+    """
+    if handle is None:
+        return CallToolResult(content=content, structuredContent=structured, isError=is_error)
+    return CallToolResult(
+        content=[*content, TextContent(type="text", text=_handle_text(handle))],
+        structuredContent=structured,
+        isError=is_error,
+        _meta={CONVERSATION_META_KEY: handle},
+    )
+
+
+def _handle_text(handle: str) -> str:
+    return f"Conversation handle: {handle}\nPass it back as the 'conversation' argument to continue this conversation."
+
+
+def _principal() -> str | None:
+    """Who this call is on behalf of, or ``None`` when no authentication is configured.
+
+    The access token's subject, falling back to its client id, which is always
+    present. With nothing to bind to, a conversation handle is the sole
+    credential for the conversation it names.
+    """
+    token = get_access_token()
+    if token is None:
+        return None
+    return token.subject or token.client_id
+
+
+def _is_modern(request_context: "ServerRequestContext[Any, Any]") -> bool:
+    """Whether this call arrived on a modern-era (2026-07-28) revision.
+
+    The negotiated protocol version is a first-class field of the request
+    context, so this reads the same over HTTP and over streams — the era is a
+    protocol fact, not a transport detail. The membership test comes from the
+    SDK's own registry so a new modern revision needs no change here.
+    """
+    return request_context.protocol_version in MODERN_PROTOCOL_VERSIONS
 
 
 def _session_id(request_context: "ServerRequestContext[Any, Any]") -> str | None:
-    """Extract the session key for this call.
+    """Extract the MCP session key for this call — handshake era only.
 
     Over streamable HTTP the transport's ``Request`` carries an ``mcp-session-id``
     header (present only when the transport runs stateful); over stdio there is no
-    HTTP request, so all turns share one per-process session.
+    HTTP request, so all turns share one per-process session. The modern era
+    issues no session id and forbids keying on the process, so callers must
+    establish the era before consulting this.
     """
     request = getattr(request_context, "request", None)
     if request is None:

--- a/ag2/mcp/executor.py
+++ b/ag2/mcp/executor.py
@@ -27,7 +27,7 @@ from ag2.stream import MemoryStream
 from .errors import MCPAgentConfigError, UnknownConversationError
 from .info import build_ask_tool, object_output_schema
 from .mappers import reply_to_content, to_structured_dict, tool_error
-from .sessions import STDIO_SESSION, Conversation, SessionStore
+from .sessions import CONVERSATION_META_KEY, STDIO_SESSION, Conversation, SessionStore
 
 if TYPE_CHECKING:
     from mcp.server.context import ServerRequestContext
@@ -36,12 +36,6 @@ if TYPE_CHECKING:
 # executor builds one for every outcome — success, structured success, and error.
 
 _LOGGER_NAME = "ag2.mcp"
-
-# Where a conversation handle travels back in a result's ``_meta``, for clients
-# threading it programmatically. Reverse-DNS from the project's domain, as the
-# ``_meta`` key rules require; prefixes whose second label is ``mcp`` or
-# ``modelcontextprotocol`` are reserved and are not used here.
-CONVERSATION_META_KEY = "ai.ag2/conversation"
 
 
 @dataclass(slots=True)
@@ -69,15 +63,11 @@ class AgentExecutor:
     :class:`MemoryStream` is created per invocation (mirroring the A2A executor)
     so any server replica can handle any request.
 
-    With a ``session_store`` the conversation a call lands in depends on the
-    protocol era, because each era sanctions a different mechanism:
-
-    * **Handshake era** (revisions up to 2025-11-25) — history is keyed by the
-      MCP session the ``initialize`` handshake opened, or by a per-process
-      sentinel over stdio, and accumulates across calls.
-    * **Modern era** (2026-07-28) — there is no MCP session, and the revision
-      forbids deriving context from connection or process identity, so an
-      unnamed call starts a fresh conversation.
+    With a ``session_store`` the conversation a call lands in depends on whether
+    the caller named one and on the protocol era, because each era sanctions a
+    different mechanism. :class:`~ag2.mcp.MCPServer` carries that table — the one
+    a user reads — and :meth:`_conversation_cm` below is where it is decided;
+    restating it here would give it a second copy to drift from.
 
     While the agent runs, its stream events are forwarded to the MCP client as
     progress / log notifications when ``stream_progress`` is enabled.
@@ -138,6 +128,19 @@ class AgentExecutor:
         # Nothing is lost: no minted handle is blank.
         if conversation is not None and not conversation.strip():
             conversation = None
+
+        # Conversations are off, so a presented handle names nothing here and
+        # never could: this server mints none. Saying so is the whole point —
+        # accepting the argument and dropping it would hand the caller the
+        # unannounced loss of continuity this argument exists to remove. It is
+        # deliberately not ``UnknownConversationError``: that error's remedy is
+        # to retry without the argument, which here would not restore continuity
+        # either, and the handle is not unknown so much as unsupported.
+        if conversation is not None and self._session_store is None:
+            return tool_error(
+                "This server does not maintain conversations, so the 'conversation' argument is "
+                "not supported; omit it. Each call is independent."
+            )
 
         # The conversation is held for the whole turn: for a keyed one that means
         # holding its turn lock, serializing concurrent same-conversation calls.

--- a/ag2/mcp/executor.py
+++ b/ag2/mcp/executor.py
@@ -129,6 +129,16 @@ class AgentExecutor:
         if not message:
             return tool_error("Missing required 'message' argument.")
 
+        # A blank handle names no conversation, so it is read as no conversation
+        # rather than as an unknown one. The caller this matters for is the model:
+        # the handle is put in readable content precisely because the model drives
+        # the argument, and a model given an optional string argument routinely
+        # sends "" instead of leaving the key out — which would make its every
+        # first call an error and leave it unable to start a conversation at all.
+        # Nothing is lost: no minted handle is blank.
+        if conversation is not None and not conversation.strip():
+            conversation = None
+
         # The conversation is held for the whole turn: for a keyed one that means
         # holding its turn lock, serializing concurrent same-conversation calls.
         try:

--- a/ag2/mcp/info.py
+++ b/ag2/mcp/info.py
@@ -75,9 +75,10 @@ def build_ask_tool(
 
 def _lifetime_sentence(bounds: ConversationBounds) -> str:
     """How long a conversation lives, in a sentence a client can read."""
-    bound = f"a conversation is dropped once it is not among the {bounds.max_conversations} most recently used"
+    # A fragment rather than a clause, so it reads as the tail of either branch.
+    bound = f"once it is not among the {bounds.max_conversations} most recently used"
     if bounds.ttl is None:
-        return f"Lifetime: {bound}."
+        return f"Lifetime: a conversation is dropped {bound}."
     return f"Lifetime: a conversation is dropped after {bounds.ttl:g} seconds idle, or {bound}."
 
 

--- a/ag2/mcp/info.py
+++ b/ag2/mcp/info.py
@@ -8,6 +8,8 @@ from mcp.types import Tool as MCPTool
 
 from ag2.agent import Agent
 
+from .sessions import ConversationBounds
+
 if TYPE_CHECKING:
     from ag2.response import ResponseProto
 
@@ -18,6 +20,7 @@ def build_ask_tool(
     tool_name: str = "ask",
     tool_description: str | None = None,
     response_schema: "ResponseProto[Any] | None" = None,
+    conversation_bounds: ConversationBounds | None = None,
 ) -> MCPTool:
     """Build the single conversational MCP tool that fronts ``agent.ask()``.
 
@@ -26,6 +29,15 @@ def build_ask_tool(
     ``response_schema`` is an object schema, it is advertised as the tool's
     ``outputSchema`` so MCP clients receive validated ``structuredContent``
     (see :mod:`ag2.mcp.executor`).
+
+    ``conversation_bounds`` — the registry's bound and idle expiry — adds the
+    optional ``conversation`` argument that continues a conversation, and is
+    worded into its description because the protocol requires a stateful
+    handle's lifetime to be documented there. Pass ``None`` when conversations
+    are off: advertising an argument that cannot work would invite a guaranteed
+    error, and suppressing it mirrors how ``outputSchema`` appears only when the
+    agent has a response schema. The variation is by server configuration, fixed
+    for the process — not by connection state, which the protocol forbids.
     """
     input_schema: dict[str, Any] = {
         "type": "object",
@@ -41,6 +53,15 @@ def build_ask_tool(
         },
         "required": ["message"],
     }
+    if conversation_bounds is not None:
+        input_schema["properties"]["conversation"] = {
+            "type": "string",
+            "description": (
+                "Opaque handle naming the conversation to continue, as returned by an earlier "
+                "call to this tool. Omit it to start a new conversation; the handle for it comes "
+                f"back with the reply. {_lifetime_sentence(conversation_bounds)}"
+            ),
+        }
     kwargs: dict[str, Any] = {
         "name": tool_name,
         "description": tool_description or f"Send a message to the '{agent.name}' AG2 agent and receive its reply.",
@@ -50,6 +71,14 @@ def build_ask_tool(
     if output_schema is not None:
         kwargs["outputSchema"] = output_schema
     return MCPTool(**kwargs)
+
+
+def _lifetime_sentence(bounds: ConversationBounds) -> str:
+    """How long a conversation lives, in a sentence a client can read."""
+    bound = f"a conversation is dropped once it is not among the {bounds.max_conversations} most recently used"
+    if bounds.ttl is None:
+        return f"Lifetime: {bound}."
+    return f"Lifetime: a conversation is dropped after {bounds.ttl:g} seconds idle, or {bound}."
 
 
 def object_output_schema(response_schema: "ResponseProto[Any] | None") -> dict[str, Any] | None:

--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -130,7 +130,9 @@ class MCPServer:
     only by naming it. The name is an opaque handle the server mints and returns
     — in a text content block and in the result's ``_meta`` under
     ``ai.ag2/conversation`` — and never one the caller chooses. A handle the
-    server does not recognise is a tool-level error, not a fresh conversation.
+    server does not recognise is a tool-level error, not a fresh conversation;
+    under ``sessions=False`` — where the argument is not advertised and no handle
+    is ever minted — presenting one is likewise refused rather than dropped.
 
     A conversation is bound to the principal that created it (the access token's
     subject, falling back to its client id) and that binding is revalidated on

--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -113,13 +113,38 @@ class MCPServer:
     after init. Only protocol revision 2026-07-28 clients see the hints — older
     revisions drop the fields at serialization.
 
-    ``sessions`` controls multi-turn history. By default (``True``) each MCP
-    session (keyed by the transport's ``mcp-session-id``, or a per-process key
-    over stdio) keeps its own conversation history that accumulates across calls;
-    pass a :class:`~ag2.mcp.sessions.SessionConfig` to tune the bound /
-    TTL / backend, or ``False`` to make every call stateless. A stateless HTTP
-    transport (``stateless=True``) issues no session id, so it stays stateless
-    regardless of this setting.
+    ``sessions`` controls multi-turn history. By default (``True``) a
+    conversation history accumulates across ``tools/call`` invocations; pass a
+    :class:`~ag2.mcp.sessions.SessionConfig` to tune the bound / TTL / backend,
+    or ``False`` to make every call stateless. Which conversation a call lands in
+    is decided by the protocol era, since each era sanctions a different
+    mechanism:
+
+    | a conversation named? | handshake era (up to 2025-11-25)                     | modern era (2026-07-28) |
+    |-----------------------|------------------------------------------------------|-------------------------|
+    | yes                   | that conversation                                    | that conversation       |
+    | no                    | the MCP session's own history (per-process on stdio)  | a fresh conversation    |
+
+    The modern era has no MCP session and forbids deriving context from
+    connection or process identity, so a caller there continues a conversation
+    only by naming it. The name is an opaque handle the server mints and returns
+    — in a text content block and in the result's ``_meta`` under
+    ``ai.ag2/conversation`` — and never one the caller chooses. A handle the
+    server does not recognise is a tool-level error, not a fresh conversation.
+
+    A conversation is bound to the principal that created it (the access token's
+    subject, falling back to its client id) and that binding is revalidated on
+    every call, so a leaked handle does not expose one caller's history to
+    another. **With no** ``security`` **configured there is no principal to bind
+    to, and the handle is then the only credential for the conversation it
+    names** — it travels through readable content, so treat it as one.
+
+    ``stateless`` governs the *handshake* era only: it stops the HTTP transport
+    issuing an ``mcp-session-id``, so handshake-era calls have no session to key
+    on and start fresh. Modern-era requests are single exchanges that never carry
+    a session id in the first place, so the flag does not reach them. Pairing
+    ``stateless=True`` with ``sessions=True`` is a valid configuration — no
+    transport session, conversations named explicitly.
 
     ``resources`` / ``resource_templates`` / ``prompts`` expose MCP resources and
     prompts alongside the conversational tool; the corresponding capability is
@@ -284,6 +309,7 @@ class MCPServer:
                 params.name,
                 message=arguments.get("message", ""),
                 context=arguments.get("context"),
+                conversation=arguments.get("conversation"),
                 request_context=ctx,
             )
         except Exception as e:

--- a/ag2/mcp/sessions.py
+++ b/ag2/mcp/sessions.py
@@ -21,6 +21,14 @@ from .errors import UnknownConversationError
 # forbids establishing context from connection or process identity.
 STDIO_SESSION = "stdio"
 
+# Where a conversation handle travels back in a result's ``_meta``, for clients
+# threading it programmatically. Reverse-DNS from the project's domain, as the
+# ``_meta`` key rules require; prefixes whose second label is ``mcp`` or
+# ``modelcontextprotocol`` are reserved and are not used here. It lives beside
+# the conversation it names rather than in the executor so that reading it needs
+# no ``ag2[mcp]`` install.
+CONVERSATION_META_KEY = "ai.ag2/conversation"
+
 
 @dataclass(frozen=True, slots=True)
 class SessionConfig:
@@ -182,12 +190,18 @@ class SessionStore:
         async with self._held(entry) as conversation:
             yield conversation
 
-    async def acquire(self, session_id: str) -> MemoryStream:
+    async def acquire(self, session_id: str, *, principal: str | None = None) -> MemoryStream:
         """Return a stream carrying ``session_id``'s accumulated conversation.
 
         Does not hold the turn lock — prefer :meth:`session` on the serving path.
+
+        ``principal`` is recorded when this call is what creates the conversation,
+        exactly as :meth:`session` records it, so the handle minted alongside it
+        stays reachable through :meth:`by_handle` by the same caller. Defaulting
+        it to ``None`` and ignoring the argument would mint a conversation no
+        authenticated caller could ever name.
         """
-        entry = await self._entry(session_id, principal=None)
+        entry = await self._entry(session_id, principal=principal)
         return MemoryStream(storage=self._storage, id=entry.stream_id)
 
     @asynccontextmanager
@@ -249,6 +263,7 @@ class SessionStore:
 
 
 __all__ = (
+    "CONVERSATION_META_KEY",
     "STDIO_SESSION",
     "Conversation",
     "ConversationBounds",

--- a/ag2/mcp/sessions.py
+++ b/ag2/mcp/sessions.py
@@ -13,26 +13,39 @@ from uuid import UUID, uuid4
 from ag2.history import MemoryStorage, Storage
 from ag2.stream import MemoryStream
 
-# Sentinel session id for stdio: that transport carries no ``mcp-session-id`` and
-# serves a single client per process, so all turns share one accumulating stream.
+from .errors import UnknownConversationError
+
+# Sentinel MCP session id for stdio: that transport carries no ``mcp-session-id``
+# and serves a single client per process, so all handshake-era turns share one
+# accumulating conversation. Withdrawn from the modern era, whose revision
+# forbids establishing context from connection or process identity.
 STDIO_SESSION = "stdio"
 
 
 @dataclass(frozen=True, slots=True)
 class SessionConfig:
-    """Tunables for session-keyed multi-turn history on :class:`MCPServer`.
+    """Tunables for multi-turn conversation history on :class:`MCPServer`.
 
-    Each MCP session (keyed by the transport's ``mcp-session-id``) gets its own
-    conversation history that accumulates across ``tools/call`` invocations. The
+    Each conversation gets its own history that accumulates across ``tools/call``
+    invocations, whichever name it goes by — a *conversation handle* the caller
+    threads through, or the MCP session a handshake-era caller already has. The
     registry is bounded so a long-lived server cannot leak memory:
 
-    * ``max_sessions`` — LRU cap; the least-recently-used session's history is
-      dropped once the cap is exceeded.
-    * ``ttl`` — optional idle expiry in seconds; a session untouched for longer
-      than this has its history dropped on the next access (``None`` = no expiry).
-    * ``storage`` — pluggable history backend shared across sessions (each keyed
-      by its own stream id). Defaults to an in-memory :class:`MemoryStorage`;
-      pass e.g. a Redis-backed :class:`Storage` for cross-replica continuity.
+    * ``max_sessions`` — LRU cap; the least-recently-used conversation's history
+      is dropped once the cap is exceeded. Any call that names no conversation
+      and has no MCP session to fall back on gets a fresh one — every modern-era
+      call, and every handshake-era call on a ``stateless=True`` transport — so
+      one-shot traffic occupies slots too; size the cap for the call rate and set
+      a ``ttl`` alongside it.
+    * ``ttl`` — optional idle expiry in seconds; a conversation untouched for
+      longer than this has its history dropped on the next access (``None`` = no
+      expiry).
+    * ``storage`` — pluggable history backend shared across conversations (each
+      keyed by its own stream id). Defaults to an in-memory :class:`MemoryStorage`;
+      pass e.g. a Redis-backed :class:`Storage` to keep histories out of process
+      memory. Note that the registry mapping a conversation's *name* to its
+      history is per-process either way, so a shared backend does not on its own
+      make a handle usable against another replica.
     """
 
     max_sessions: int = 1024
@@ -40,30 +53,68 @@ class SessionConfig:
     storage: Storage | None = None
 
 
-class _Entry:
-    __slots__ = ("stream_id", "last", "turn_lock")
+@dataclass(frozen=True, slots=True)
+class ConversationBounds:
+    """How long a conversation lives in a :class:`SessionStore`.
 
-    def __init__(self, stream_id: UUID, last: float) -> None:
+    The store reports its configured bound and idle expiry as data; the tool
+    descriptor words them for a client. The protocol requires a stateful handle's
+    lifetime to be stated in the tool description, and a store that returned the
+    sentence itself would put client-facing prose behind the registry.
+    """
+
+    max_conversations: int
+    ttl: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Conversation:
+    """One conversation as the serving path sees it: its stream and its handle.
+
+    ``handle`` is the opaque, server-minted name a caller presents to continue
+    this conversation. It is ``None`` only for a stateless call, which has no
+    conversation to continue.
+    """
+
+    stream: MemoryStream
+    handle: str | None = None
+
+
+class _Entry:
+    __slots__ = ("stream_id", "handle", "principal", "last", "turn_lock")
+
+    def __init__(self, stream_id: UUID, handle: str, principal: str | None, last: float) -> None:
         self.stream_id = stream_id
+        self.handle = handle
+        # The principal that created this conversation, revalidated on every
+        # handle lookup. ``None`` when no authentication is configured, in which
+        # case the handle is the sole credential.
+        self.principal = principal
         self.last = last
-        # Serializes turns of one session: a fresh MemoryStream is handed out per
-        # call, so the agent's per-stream turn lock can't serialize same-session
-        # concurrency — this entry-scoped lock does.
+        # Serializes turns of one conversation: a fresh MemoryStream is handed
+        # out per call, so the agent's per-stream turn lock can't serialize
+        # same-conversation concurrency — this entry-scoped lock does.
         self.turn_lock = asyncio.Lock()
 
 
 class SessionStore:
-    """Bounded LRU registry mapping an ``mcp-session-id`` to a persistent stream.
+    """Bounded LRU registry mapping a conversation's key to a persistent stream.
 
-    Each session is bound to a stable :class:`~uuid.UUID` stream id over a shared
-    :class:`Storage`; :meth:`acquire` returns a *fresh* :class:`MemoryStream`
-    object on every call (so per-call progress subscribers never accumulate) that
-    reads prior turns back from storage — mirroring the subagents'
-    ``persistent_stream`` pattern. Eviction (LRU overflow + idle TTL) drops the
-    evicted session's stored history so memory stays bounded.
+    The key is an opaque string: a *conversation handle* this store minted, or —
+    in the handshake era, where the protocol has one — the caller's MCP session
+    id. The store never derives a key itself, and never adopts one from a caller:
+    :meth:`by_handle` resolves only handles it minted, so a caller cannot name a
+    conversation of their choosing and evict other callers' out of the bound.
+
+    Each conversation is bound to a stable :class:`~uuid.UUID` stream id over a
+    shared :class:`Storage`; the serving methods return a *fresh*
+    :class:`MemoryStream` object on every call (so per-call progress subscribers
+    never accumulate) that reads prior turns back from storage — mirroring the
+    subagents' ``persistent_stream`` pattern. Eviction (LRU overflow + idle TTL)
+    drops the evicted conversation's stored history so memory stays bounded.
     """
 
-    __slots__ = ("_storage", "_max", "_ttl", "_entries", "_lock", "_clock")
+    __slots__ = ("_storage", "_max", "_ttl", "_entries", "_by_handle", "_lock", "_clock")
 
     def __init__(
         self,
@@ -81,40 +132,103 @@ class SessionStore:
         self._max = max_sessions
         self._ttl = ttl
         self._entries: OrderedDict[str, _Entry] = OrderedDict()
+        self._by_handle: dict[str, str] = {}
         self._lock = asyncio.Lock()
         self._clock = clock
 
+    @property
+    def bounds(self) -> ConversationBounds:
+        """The configured bound and idle expiry, for a client-facing description.
+
+        Reported as data rather than prose so the sentence the tool advertises
+        cannot drift from the configuration behind it.
+        """
+        return ConversationBounds(max_conversations=self._max, ttl=self._ttl)
+
     @asynccontextmanager
-    async def session(self, session_id: str) -> AsyncGenerator[MemoryStream]:
-        """Yield ``session_id``'s stream while holding its per-session turn lock.
+    async def session(self, session_id: str, *, principal: str | None = None) -> AsyncGenerator[Conversation]:
+        """Yield the conversation named by ``session_id``, holding its turn lock.
 
         Holding the lock for the duration of the turn serializes concurrent calls
-        on the same session, so their accumulated history can't interleave.
+        on the same conversation, so their accumulated history can't interleave.
         """
-        entry = await self._entry(session_id)
-        async with entry.turn_lock:
-            yield MemoryStream(storage=self._storage, id=entry.stream_id)
+        entry = await self._entry(session_id, principal=principal)
+        async with self._held(entry) as conversation:
+            yield conversation
+
+    @asynccontextmanager
+    async def fresh(self, *, principal: str | None = None) -> AsyncGenerator[Conversation]:
+        """Mint a conversation under a new handle and yield it, holding its turn lock.
+
+        The handle is a version-4 UUID: opaque and unguessable, as the protocol
+        requires of a stateful handle, and incidentally ASCII- and header-safe.
+        """
+        handle = str(uuid4())
+        entry = await self._entry(handle, principal=principal, handle=handle)
+        async with self._held(entry) as conversation:
+            yield conversation
+
+    @asynccontextmanager
+    async def by_handle(self, handle: str, *, principal: str | None = None) -> AsyncGenerator[Conversation]:
+        """Yield the conversation ``handle`` names, holding its turn lock.
+
+        Raises:
+            UnknownConversationError: when no live conversation carries that
+                handle, or when it was created by a different principal. Both
+                read the same from outside, so the error does not disclose that
+                an unreachable handle exists.
+        """
+        entry = await self._handle_entry(handle, principal)
+        async with self._held(entry) as conversation:
+            yield conversation
 
     async def acquire(self, session_id: str) -> MemoryStream:
-        """Return a stream carrying ``session_id``'s accumulated history.
+        """Return a stream carrying ``session_id``'s accumulated conversation.
 
         Does not hold the turn lock — prefer :meth:`session` on the serving path.
         """
-        entry = await self._entry(session_id)
+        entry = await self._entry(session_id, principal=None)
         return MemoryStream(storage=self._storage, id=entry.stream_id)
 
-    async def _entry(self, session_id: str) -> _Entry:
+    @asynccontextmanager
+    async def _held(self, entry: _Entry) -> AsyncGenerator[Conversation]:
+        """Yield ``entry``'s conversation while holding its turn lock.
+
+        Every serving method ends here: a fresh :class:`MemoryStream` object per
+        call (so per-call progress subscribers never accumulate) reading prior
+        turns back from storage, handed out under the entry's turn lock.
+        """
+        async with entry.turn_lock:
+            yield Conversation(stream=MemoryStream(storage=self._storage, id=entry.stream_id), handle=entry.handle)
+
+    async def _entry(self, key: str, *, principal: str | None, handle: str | None = None) -> _Entry:
         async with self._lock:
             now = self._clock()
             await self._evict_expired(now)
-            entry = self._entries.get(session_id)
+            entry = self._entries.get(key)
             if entry is None:
-                entry = _Entry(stream_id=uuid4(), last=now)
-                self._entries[session_id] = entry
+                entry = _Entry(stream_id=uuid4(), handle=handle or str(uuid4()), principal=principal, last=now)
+                self._entries[key] = entry
+                self._by_handle[entry.handle] = key
             else:
                 entry.last = now
-                self._entries.move_to_end(session_id)
+                self._entries.move_to_end(key)
             await self._evict_overflow()
+            return entry
+
+    async def _handle_entry(self, handle: str, principal: str | None) -> _Entry:
+        async with self._lock:
+            now = self._clock()
+            await self._evict_expired(now)
+            key = self._by_handle.get(handle)
+            entry = self._entries.get(key) if key is not None else None
+            # Authorization is revalidated here, on every call rather than at
+            # creation, because a handle travels through model context and logs
+            # and a credential can be swapped or revoked between two calls.
+            if key is None or entry is None or entry.principal != principal:
+                raise UnknownConversationError()
+            entry.last = now
+            self._entries.move_to_end(key)
             return entry
 
     async def _evict_expired(self, now: float) -> None:
@@ -122,17 +236,22 @@ class SessionStore:
             return
         expired = [sid for sid, e in self._entries.items() if now - e.last > self._ttl]
         for sid in expired:
-            entry = self._entries.pop(sid)
-            await self._storage.drop_history(entry.stream_id)
+            await self._drop(sid)
 
     async def _evict_overflow(self) -> None:
         while len(self._entries) > self._max:
-            _sid, entry = self._entries.popitem(last=False)
-            await self._storage.drop_history(entry.stream_id)
+            await self._drop(next(iter(self._entries)))
+
+    async def _drop(self, key: str) -> None:
+        entry = self._entries.pop(key)
+        self._by_handle.pop(entry.handle, None)
+        await self._storage.drop_history(entry.stream_id)
 
 
 __all__ = (
     "STDIO_SESSION",
+    "Conversation",
+    "ConversationBounds",
     "SessionConfig",
     "SessionStore",
 )

--- a/ag2/mcp/testing.py
+++ b/ag2/mcp/testing.py
@@ -4,13 +4,16 @@
 
 import asyncio
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
+from types import TracebackType
 
 import anyio
 import httpx
 from mcp import ClientSession
+from mcp.client import Client
 from mcp.server.lowlevel import Server
 from mcp.shared.memory import MessageStream, create_client_server_memory_streams
+from mcp_types.version import LATEST_MODERN_VERSION
 
 from .server import MCPServer
 
@@ -36,15 +39,82 @@ async def connect(
     contract here — an initialized ``ClientSession`` — is held steady across it.
     """
     async with (
+        _served_streams(mcp_server.server, raise_exceptions) as streams,
+        ClientSession(*streams, **session_kwargs) as session,  # type: ignore[arg-type]
+    ):
+        await session.initialize()
+        yield session
+
+
+@asynccontextmanager
+async def connect_modern(
+    mcp_server: MCPServer,
+    *,
+    raise_exceptions: bool = True,
+    **client_kwargs: object,
+) -> AsyncGenerator[ClientSession]:
+    """Yield an in-process ``ClientSession`` talking to ``mcp_server`` at revision 2026-07-28.
+
+    The modern-era counterpart of :func:`connect` — same shape, same yielded
+    contract, but the connection is pinned to the modern revision instead of
+    negotiating the newest handshake one, so a test reads the same either way.
+
+    The transport is the same in-memory duplex stream pair :func:`connect` uses,
+    which is the shape a stdio client takes; the low-level server picks its era
+    from the client's first request, so this reaches the modern era's *stream*
+    semantics and not only its HTTP ones.
+
+    A thin wrapper over the SDK's own ``Client`` with the revision forced, rather
+    than that client imported into test modules: absorbing this kind of SDK churn
+    is what this module is for.
+    """
+    async with Client(
+        _MemoryTransport(mcp_server.server, raise_exceptions=raise_exceptions),
+        mode=LATEST_MODERN_VERSION,
+        raise_exceptions=raise_exceptions,
+        **client_kwargs,  # type: ignore[arg-type]
+    ) as client:
+        yield client.session
+
+
+class _MemoryTransport:
+    """An ``mcp.client.Transport`` serving a low-level server over memory streams.
+
+    The stream pair :func:`connect` builds inline, repackaged as the transport
+    object ``Client`` takes — the SDK's own in-memory transport is private, and
+    this keeps :func:`connect` and :func:`connect_modern` on one wire shape.
+    """
+
+    __slots__ = ("_server", "_raise_exceptions", "_stack")
+
+    def __init__(self, server: Server, *, raise_exceptions: bool) -> None:
+        self._server = server
+        self._raise_exceptions = raise_exceptions
+        self._stack = AsyncExitStack()
+
+    async def __aenter__(self) -> MessageStream:
+        return await self._stack.enter_async_context(_served_streams(self._server, self._raise_exceptions))
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self._stack.__aexit__(exc_type, exc, tb)
+
+
+@asynccontextmanager
+async def _served_streams(server: Server, raise_exceptions: bool) -> AsyncGenerator[MessageStream]:
+    """Yield the client half of a memory stream pair whose server half is being served."""
+    async with (
         create_client_server_memory_streams() as (client_streams, server_streams),
         anyio.create_task_group() as tg,
     ):
-        tg.start_soon(_run_server, mcp_server.server, server_streams, raise_exceptions)
-        async with ClientSession(*client_streams, **session_kwargs) as session:  # type: ignore[arg-type]
-            await session.initialize()
-            yield session
-        # The server task runs until cancelled; the client is done, so end it here
-        # rather than leaving the task group waiting on it.
+        tg.start_soon(_run_server, server, server_streams, raise_exceptions)
+        yield client_streams
+        # As in ``connect``: the server task runs until cancelled, and the client
+        # is done, so end it here rather than leaving the task group waiting.
         tg.cancel_scope.cancel()
 
 

--- a/docs/adr/0015-mcp-conversation-continuity-by-handle.md
+++ b/docs/adr/0015-mcp-conversation-continuity-by-handle.md
@@ -1,0 +1,89 @@
+---
+status: accepted
+date: 2026-08-27
+---
+
+# 15. MCP conversation continuity is named by a server-minted handle
+
+## Context
+
+`ag2.mcp.MCPServer` exposes an agent as an MCP server whose conversational tool
+keeps multi-turn history. Until now that history was keyed by the transport's
+`mcp-session-id`, falling back to a per-process sentinel over stdio.
+
+MCP protocol revision 2026-07-28 (the *modern era*) removed the session: each
+request is a self-contained POST, no `initialize` handshake, no session id. It
+also states that connections do not represent conversations, that clients may
+interleave unrelated requests on one transport, and that servers must not use
+connection or process identity to establish context.
+
+So the old keying gave a modern-era client one of two wrong behaviours, silently:
+over HTTP every call started empty, and over stdio every call on the process
+shared one history — the second being a direct non-conformance.
+
+## Decision
+
+Continuity stops riding on the transport and becomes something the caller names.
+
+1. **A handle names the conversation.** The conversational tool gains an optional
+   `conversation` argument. Omitted — or presented blank, which names nothing and
+   which is what a model tends to send for an optional string — the call starts
+   fresh and the server mints an opaque version-4 UUID; presented, the
+   conversation continues. Handles are
+   minted by the server and **never** adopted from the caller — with a bounded
+   LRU registry, a caller-chosen key would let anyone evict other callers'
+   conversations.
+2. **Each era keeps the mechanism its own revision sanctions.** With no
+   conversation named, the handshake era still keys on its MCP session (the
+   per-process sentinel over stdio); the modern era, which has neither, starts
+   fresh. The process fallback is withdrawn from the modern era only.
+3. **The handle travels back twice, and never in `structuredContent`.** In a text
+   content block, because the protocol puts recovery from an expired handle on
+   the model and the model does not read protocol metadata; and in the result's
+   `_meta` under `ai.ag2/conversation`, for programmatic clients. Not in
+   `structuredContent`: on this tool that field is the agent's response schema,
+   advertised verbatim as `outputSchema`, which MCP requires structured content
+   to conform to — a server field mixed in would break the tool's own contract.
+4. **An unknown or expired handle is a tool execution error**, not a JSON-RPC
+   one. The protocol draws that line so the model can start a new conversation
+   rather than fail the turn. It is never a fall-through to the transport
+   session, which would reintroduce the silent degradation this exists to remove.
+5. **A conversation records its principal and revalidates on every call.** The
+   access token's subject, falling back to its client id. A mismatch yields the
+   same error as an unknown handle, so it does not disclose that the handle
+   exists. Session-named conversations need no check of ours: the transport
+   already refuses a session id presented with a different credential.
+
+## Consequences
+
+- A modern-era client gets multi-turn behaviour it previously could not have, on
+  every transport, and a stdio client's unrelated requests stay unrelated.
+- **Handshake-era results change shape**: every reply now carries the handle
+  block and `_meta`, whether or not the caller ever names a conversation. This is
+  a deliberate resolution of a tension in the spec — one user story asks that the
+  handshake era be untouched, another that a handle come back on the first call
+  in both eras. The second won: a handshake-era client that wants explicit
+  handles can then migrate ahead of changing protocol revision.
+- Any call that names no conversation and has no MCP session to fall back on
+  occupies an LRU slot — every modern-era call, and every handshake-era call on a
+  `stateless=True` transport. Operators serving one-shot traffic should size
+  `max_sessions` for the call rate and set a `ttl`.
+- With no authentication configured there is no principal to bind to, and the
+  handle is the sole credential for the conversation it names — and it travels
+  through readable content.
+- `stateless=True` with `sessions=True` becomes a coherent configuration ("no
+  transport session, conversations by handle") rather than a contradiction, so no
+  construction-time validation was added.
+
+## Alternatives considered
+
+- **Mirroring the handle into an HTTP header** (the `x-mcp-header` extension).
+  Optional for servers by the protocol's own wording, and there is no sticky
+  deployment to serve. Adding it later is additive; removing it after a
+  deployment depends on it is not.
+- **Retiring transport-keyed continuity entirely.** Handshake-era revisions have
+  a protocol session and keying on it is correct there; dropping it would remove
+  working multi-turn behaviour from every current client.
+- **Rejecting `stateless=True` with `sessions=True` at construction.** The
+  pairing was contradictory only while continuity depended on the transport
+  issuing a session id.

--- a/docs/adr/0015-mcp-conversation-continuity-by-handle.md
+++ b/docs/adr/0015-mcp-conversation-continuity-by-handle.md
@@ -48,6 +48,12 @@ Continuity stops riding on the transport and becomes something the caller names.
    one. The protocol draws that line so the model can start a new conversation
    rather than fail the turn. It is never a fall-through to the transport
    session, which would reintroduce the silent degradation this exists to remove.
+   With conversations off altogether there is no registry to consult and no
+   handle this server could have minted, so a presented one is refused as
+   *unsupported* rather than accepted and dropped — the same reason, a different
+   remedy: retrying without the argument would not restore continuity there, so
+   the caller is told continuity is unavailable instead of inferring it from a
+   reply that quietly forgot.
 5. **A conversation records its principal and revalidates on every call.** The
    access token's subject, falling back to its client id. A mismatch yields the
    same error as an unknown handle, so it does not disclose that the handle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ perplexity = ["perplexityai>=0.30.0,<1"]
 # === MCP (ag2.mcp) ===
 mcp = [
     "mcp>=2.0.0,<3",
+    "mcp-types>=2.0.0,<3",
     # imported directly to validate tool arguments; `mcp` requires it too, so this
     # only pins what is already installed
     "jsonschema>=4.20.0,<5",

--- a/test/acp/test_tool_gateway.py
+++ b/test/acp/test_tool_gateway.py
@@ -14,7 +14,10 @@ import pytest
 from acp import schema
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
+from mcp.server.streamable_http import CONTENT_TYPE_JSON, CONTENT_TYPE_SSE, MCP_SESSION_ID_HEADER
+from mcp.shared.inbound import MCP_PROTOCOL_VERSION_HEADER
 from mcp.types import CallToolResult
+from mcp_types.version import LATEST_HANDSHAKE_VERSION
 
 from ag2.acp.bridge import BridgeState
 from ag2.acp.config import ACPConfig
@@ -83,6 +86,25 @@ def test_capability_error_message_names_agent() -> None:
     assert "expose_tools" in str(err)
 
 
+_MCP_HEADERS = {"Accept": f"{CONTENT_TYPE_JSON}, {CONTENT_TYPE_SSE}", "Content-Type": CONTENT_TYPE_JSON}
+_INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": LATEST_HANDSHAKE_VERSION,
+        "capabilities": {},
+        "clientInfo": {"name": "t", "version": "1"},
+    },
+}
+_CALL_ADD = {
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/call",
+    "params": {"name": "add", "arguments": {"a": 2, "b": 3}},
+}
+
+
 def _fn_add() -> FunctionToolSchema:
     return FunctionToolSchema(
         function=FunctionDefinition(
@@ -114,6 +136,37 @@ async def test_gateway_serves_tools_list_over_http() -> None:
         assert tool.input_schema["required"] == ["a", "b"]
     finally:
         await gateway.close()
+
+
+@pytest.mark.asyncio
+async def test_gateway_issues_no_session_and_still_serves_a_call() -> None:
+    """The gateway is per-turn and per-request, so it hands out no MCP session.
+
+    A session would be pure overhead on a server created for one turn: nothing
+    outlives a request, so there is no cross-call state for a session id to name.
+    The tool call in the same test keeps the header assertion honest — a server
+    that answered nothing would issue no session id either.
+    """
+    state = BridgeState(ACPConfig())
+    state.context = _FakeContext(lambda call: ToolResultEvent.from_call(call, "sum is 5"))
+    gateway = ToolGateway(state, [_fn_add()])
+    url = await gateway.start()
+    try:
+        async with httpx.AsyncClient() as client:
+            initialize = await client.post(f"{url}/", headers=_MCP_HEADERS, json=_INITIALIZE)
+            called = await client.post(
+                f"{url}/",
+                headers={**_MCP_HEADERS, MCP_PROTOCOL_VERSION_HEADER: LATEST_HANDSHAKE_VERSION},
+                json=_CALL_ADD,
+            )
+    finally:
+        await gateway.close()
+
+    assert initialize.status_code == 200
+    assert MCP_SESSION_ID_HEADER not in initialize.headers
+    assert called.status_code == 200
+    assert MCP_SESSION_ID_HEADER not in called.headers
+    assert called.json()["result"]["content"] == [{"type": "text", "text": "sum is 5"}]
 
 
 @pytest.mark.asyncio

--- a/test/mcp/_helpers.py
+++ b/test/mcp/_helpers.py
@@ -10,7 +10,7 @@ from typing_extensions import Self
 from ag2 import Agent, Context
 from ag2.config.client import LLMClient
 from ag2.config.config import ModelConfig
-from ag2.events import BaseEvent, ModelMessage, ModelMessageChunk, ModelResponse
+from ag2.events import BaseEvent, ModelMessage, ModelMessageChunk, ModelRequest, ModelResponse, TextInput
 
 
 class ChunkConfig(ModelConfig):
@@ -49,3 +49,49 @@ class ChunkClient(LLMClient):
 
 def make_agent(*, name: str = "test-agent", prompt: str = "", config: ModelConfig, **kwargs: Any) -> Agent:
     return Agent(name, prompt, config=config, **kwargs)
+
+
+class RecordingConfig(ModelConfig):
+    """Records the whole message list the framework sends the LLM on each turn.
+
+    ``TrackingConfig`` keeps only each turn's last message, but a conversation is
+    exactly what accumulates *before* it — so continuity tests read the full list
+    through :attr:`prompts`.
+    """
+
+    def __init__(self, config: ModelConfig) -> None:
+        self.config = config
+        self.calls: list[list[BaseEvent]] = []
+
+    @property
+    def prompts(self) -> list[list[str]]:
+        """The text inputs replayed on each turn: one list per turn, in order."""
+        return [
+            [
+                part.content
+                for m in call
+                if isinstance(m, ModelRequest)
+                for part in m.parts
+                if isinstance(part, TextInput)
+            ]
+            for call in self.calls
+        ]
+
+    def copy(self) -> Self:
+        return self
+
+    def create(self) -> "RecordingClient":
+        return RecordingClient(self.config.create(), self.calls)
+
+    def create_files_client(self) -> None:
+        raise NotImplementedError
+
+
+class RecordingClient(LLMClient):
+    def __init__(self, client: LLMClient, sink: list[list[BaseEvent]]) -> None:
+        self.client = client
+        self.sink = sink
+
+    async def __call__(self, messages: Sequence[BaseEvent], context: Context, **kwargs: Any) -> ModelResponse:
+        self.sink.append(list(messages))
+        return await self.client(messages, context=context, **kwargs)

--- a/test/mcp/test_conversations.py
+++ b/test/mcp/test_conversations.py
@@ -13,9 +13,11 @@ from uuid import UUID, uuid4
 
 import httpx
 import pytest
+from dirty_equals import IsPartialDict, IsStr
 from mcp.server.streamable_http import CONTENT_TYPE_JSON, CONTENT_TYPE_SSE, MCP_SESSION_ID_HEADER
 from mcp.shared.inbound import MCP_METHOD_HEADER, MCP_NAME_HEADER, MCP_PROTOCOL_VERSION_HEADER
 from mcp.types import CallToolResult, TextContent
+from mcp.types import Tool as MCPTool
 from mcp_types import CLIENT_CAPABILITIES_META_KEY, PROTOCOL_VERSION_META_KEY
 from mcp_types.version import LATEST_HANDSHAKE_VERSION, LATEST_MODERN_VERSION
 from pydantic import BaseModel
@@ -25,8 +27,8 @@ from ag2.context import StreamId
 from ag2.events import BaseEvent, ModelRequest, TextInput
 from ag2.history import MemoryStorage
 from ag2.mcp import MCPFunctionTool, MCPServer, SessionConfig
-from ag2.mcp.executor import CONVERSATION_META_KEY
 from ag2.mcp.security import AccessToken, oauth2_scheme, require
+from ag2.mcp.sessions import CONVERSATION_META_KEY
 from ag2.mcp.testing import connect, connect_modern, serve
 from ag2.mcp.tools import ToolContext
 from ag2.testing import TestConfig
@@ -251,6 +253,11 @@ def _handle(result: CallToolResult) -> str:
     return result.meta[CONVERSATION_META_KEY]
 
 
+def _modern_handle(result: dict[str, Any]) -> str:
+    """:func:`_handle` for the raw JSON a modern-era POST returns."""
+    return str(result["_meta"][CONVERSATION_META_KEY])
+
+
 @pytest.mark.asyncio
 class TestConversationHandle:
     """Continuity the caller names, which is the only kind the modern era has."""
@@ -410,6 +417,11 @@ class TestUnknownHandle:
         assert config.prompts == [["first"]]
 
 
+def _conversation_argument(tool: MCPTool) -> dict[str, Any]:
+    """The advertised ``conversation`` argument, or ``{}`` when it is not offered."""
+    return tool.input_schema["properties"].get("conversation", {})
+
+
 @pytest.mark.asyncio
 class TestAdvertisedConversationArgument:
     async def test_present_when_conversations_are_enabled(self) -> None:
@@ -418,7 +430,7 @@ class TestAdvertisedConversationArgument:
         async with connect(server) as session:
             (tool,) = (await session.list_tools()).tools
 
-        assert "conversation" in tool.input_schema["properties"]
+        assert _conversation_argument(tool) == IsPartialDict({"type": "string"})
         assert tool.input_schema["required"] == ["message"]
 
     async def test_absent_when_conversations_are_disabled(self) -> None:
@@ -427,7 +439,7 @@ class TestAdvertisedConversationArgument:
         async with connect(server) as session:
             (tool,) = (await session.list_tools()).tools
 
-        assert "conversation" not in tool.input_schema["properties"]
+        assert _conversation_argument(tool) == {}
 
     async def test_description_states_the_configured_lifetime(self) -> None:
         server = MCPServer(
@@ -438,9 +450,33 @@ class TestAdvertisedConversationArgument:
         async with connect(server) as session:
             (tool,) = (await session.list_tools()).tools
 
-        description = tool.input_schema["properties"]["conversation"]["description"]
-        assert "900" in description
-        assert "64" in description
+        assert _conversation_argument(tool) == IsPartialDict({"description": IsStr(regex=r".*\b900\b.*\b64\b.*")})
+
+    async def test_presenting_one_anyway_is_refused_not_dropped(self) -> None:
+        """With conversations off, a handle is answered, not quietly discarded.
+
+        The server mints no handles, so omitting the argument would not restore
+        continuity either — which is why this is refused as unsupported rather
+        than reported as an unknown handle.
+        """
+        config = RecordingConfig(TestConfig("ok"))
+        server = MCPServer(_agent(config), sessions=False)
+
+        async with connect(server) as session:
+            result = await session.call_tool("ask", {"message": "first", "conversation": str(uuid4())})
+
+        assert result.is_error is True
+        assert result.content == [
+            TextContent(
+                type="text",
+                text=(
+                    "This server does not maintain conversations, so the 'conversation' argument is "
+                    "not supported; omit it. Each call is independent."
+                ),
+            )
+        ]
+        # Refused before the agent ran: a rejected call is not half a turn.
+        assert config.prompts == []
 
 
 @pytest.mark.asyncio
@@ -484,7 +520,7 @@ async def test_stateless_transport_serves_conversations_by_handle() -> None:
         first, response = await _modern_call_with_response(client, "first", request_id=1)
         # The one assertion that is genuinely about HTTP: no session comes back.
         assert MCP_SESSION_ID_HEADER not in response.headers
-        handle = first["_meta"][CONVERSATION_META_KEY]
+        handle = _modern_handle(first)
         await _modern_call(client, "second", request_id=2, conversation=handle)
 
     assert config.prompts == [["first"], ["first", "second"]]
@@ -580,7 +616,7 @@ class TestPrincipalBinding:
 
         async with serve(_authenticated(config)) as client:
             first = await _modern_call(client, "first", request_id=1, token="alice")
-            handle = first["_meta"][CONVERSATION_META_KEY]
+            handle = _modern_handle(first)
             await _modern_call(client, "second", request_id=2, conversation=handle, token="alice")
 
         assert config.prompts == [["first"], ["first", "second"]]
@@ -590,7 +626,7 @@ class TestPrincipalBinding:
 
         async with serve(_authenticated(config)) as client:
             first = await _modern_call(client, "first", request_id=1, token="alice")
-            handle = first["_meta"][CONVERSATION_META_KEY]
+            handle = _modern_handle(first)
             stolen = await _modern_call(client, "second", request_id=2, conversation=handle, token="bob")
             unknown = await _modern_call(client, "second", request_id=3, conversation=str(uuid4()), token="bob")
 
@@ -605,7 +641,7 @@ class TestPrincipalBinding:
 
         async with serve(_authenticated(config)) as client:
             first = await _modern_call(client, "first", request_id=1, token="alice")
-            handle = first["_meta"][CONVERSATION_META_KEY]
+            handle = _modern_handle(first)
             continued = await _modern_call(client, "second", request_id=2, conversation=handle, token="alice")
             swapped = await _modern_call(client, "third", request_id=3, conversation=handle, token="bob")
 
@@ -648,7 +684,7 @@ class TestPrincipalBinding:
 
         async with serve(_authenticated(config)) as client:
             first = await _modern_call(client, "first", request_id=1, token="kiosk")
-            handle = first["_meta"][CONVERSATION_META_KEY]
+            handle = _modern_handle(first)
             same = await _modern_call(client, "second", request_id=2, conversation=handle, token="kiosk")
             other = await _modern_call(client, "third", request_id=3, conversation=handle, token="other-kiosk")
 

--- a/test/mcp/test_conversations.py
+++ b/test/mcp/test_conversations.py
@@ -1,0 +1,609 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""What a caller observes of a served agent's conversation continuity.
+
+Every assertion here is on what a client sees — the turns the agent was given —
+never on how the key behind them was derived.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from mcp.server.streamable_http import CONTENT_TYPE_JSON, CONTENT_TYPE_SSE, MCP_SESSION_ID_HEADER
+from mcp.shared.inbound import MCP_METHOD_HEADER, MCP_NAME_HEADER, MCP_PROTOCOL_VERSION_HEADER
+from mcp.types import CallToolResult, TextContent
+from mcp_types import CLIENT_CAPABILITIES_META_KEY, PROTOCOL_VERSION_META_KEY
+from mcp_types.version import LATEST_HANDSHAKE_VERSION, LATEST_MODERN_VERSION
+from pydantic import BaseModel
+
+from ag2 import Agent, Context
+from ag2.context import StreamId
+from ag2.events import BaseEvent, ModelRequest, TextInput
+from ag2.history import MemoryStorage
+from ag2.mcp import MCPFunctionTool, MCPServer, SessionConfig
+from ag2.mcp.executor import CONVERSATION_META_KEY
+from ag2.mcp.security import AccessToken, oauth2_scheme, require
+from ag2.mcp.testing import connect, connect_modern, serve
+from ag2.mcp.tools import ToolContext
+from ag2.testing import TestConfig
+
+from ._helpers import RecordingConfig
+
+_JSON = {"Accept": f"{CONTENT_TYPE_JSON}, {CONTENT_TYPE_SSE}", "Content-Type": CONTENT_TYPE_JSON}
+
+
+class Weather(BaseModel):
+    city: str
+    temp_c: float
+
+
+def _agent(config: RecordingConfig) -> Agent:
+    return Agent("greeter", config=config)
+
+
+def _echo(arguments: dict[str, Any], _ctx: ToolContext) -> str:
+    return str(arguments["text"])
+
+
+class _RecordingStorage(MemoryStorage):
+    """A ``Storage`` that also remembers which streams were written through it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.stream_ids: list[StreamId] = []
+
+    async def save_event(self, event: BaseEvent, context: Context) -> None:
+        if context.stream.id not in self.stream_ids:
+            self.stream_ids.append(context.stream.id)
+        await super().save_event(event, context)
+
+
+def _texts(events: Iterable[BaseEvent]) -> list[str]:
+    """The user-side text of each turn recorded in ``events``."""
+    return [
+        part.content for e in events if isinstance(e, ModelRequest) for part in e.parts if isinstance(part, TextInput)
+    ]
+
+
+async def _modern_call(
+    client: httpx.AsyncClient,
+    message: str,
+    *,
+    request_id: int,
+    conversation: str | None = None,
+    token: str | None = None,
+) -> dict[str, Any]:
+    """POST one ``tools/call`` as a modern-era client and return its result."""
+    result, _response = await _modern_call_with_response(
+        client, message, request_id=request_id, conversation=conversation, token=token
+    )
+    return result
+
+
+async def _modern_call_with_response(
+    client: httpx.AsyncClient,
+    message: str,
+    *,
+    request_id: int,
+    conversation: str | None = None,
+    token: str | None = None,
+) -> tuple[dict[str, Any], httpx.Response]:
+    """POST one ``tools/call`` as a modern-era client, keeping the HTTP response.
+
+    No handshake: the version/capabilities envelope rides in ``params._meta``,
+    and the revision requires the method and tool name in headers too. The
+    response itself is returned for the assertions that are about HTTP.
+    """
+    arguments: dict[str, Any] = {"message": message}
+    if conversation is not None:
+        arguments["conversation"] = conversation
+    headers = {
+        **_JSON,
+        MCP_PROTOCOL_VERSION_HEADER: LATEST_MODERN_VERSION,
+        MCP_METHOD_HEADER: "tools/call",
+        MCP_NAME_HEADER: "ask",
+    }
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    response = await client.post(
+        "/mcp",
+        headers=headers,
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {
+                "name": "ask",
+                "arguments": arguments,
+                "_meta": {
+                    PROTOCOL_VERSION_META_KEY: LATEST_MODERN_VERSION,
+                    CLIENT_CAPABILITIES_META_KEY: {},
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    return response.json()["result"], response
+
+
+async def _open_handshake_session(
+    client: httpx.AsyncClient, *, request_id: int, token: str | None = None
+) -> dict[str, str]:
+    """Run the ``initialize`` handshake and return the headers its session needs."""
+    opening = _JSON if token is None else {**_JSON, "Authorization": f"Bearer {token}"}
+    response = await client.post(
+        "/mcp",
+        headers=opening,
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": LATEST_HANDSHAKE_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "t", "version": "1"},
+            },
+        },
+    )
+    assert response.status_code == 200
+    session_id = response.headers[MCP_SESSION_ID_HEADER]
+    headers = {**opening, MCP_PROTOCOL_VERSION_HEADER: LATEST_HANDSHAKE_VERSION, MCP_SESSION_ID_HEADER: session_id}
+    await client.post("/mcp", headers=headers, json={"jsonrpc": "2.0", "method": "notifications/initialized"})
+    return headers
+
+
+async def _handshake_call(
+    client: httpx.AsyncClient, headers: dict[str, str], message: str, *, request_id: int
+) -> dict[str, Any]:
+    response = await client.post(
+        "/mcp",
+        headers=headers,
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": "ask", "arguments": {"message": message}},
+        },
+    )
+    assert response.status_code == 200
+    return response.json()["result"]
+
+
+@pytest.mark.asyncio
+class TestModernEraStartsFresh:
+    """2026-07-28: a connection is not a conversation, and neither is a process.
+
+    The revision says servers must not use connection or process identity to
+    establish context, and it issues nothing else to key on — so an unnamed
+    conversation starts empty on every transport.
+    """
+
+    async def test_stream_calls_do_not_share_a_conversation(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        server = MCPServer(_agent(config))
+
+        async with connect_modern(server) as session:
+            await session.call_tool("ask", {"message": "first"})
+            await session.call_tool("ask", {"message": "second"})
+
+        assert config.prompts == [["first"], ["second"]]
+
+    async def test_http_calls_do_not_share_a_conversation(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        app = MCPServer(_agent(config), json_response=True)
+
+        async with serve(app) as client:
+            await _modern_call(client, "first", request_id=1)
+            await _modern_call(client, "second", request_id=2)
+
+        assert config.prompts == [["first"], ["second"]]
+
+
+@pytest.mark.asyncio
+class TestHandshakeEraContinuity:
+    """Up to 2025-11-25 the session exists at the protocol level, so it keys history.
+
+    Pinned against regression: withdrawing the process fallback from the modern
+    era must not withdraw it from the era whose revisions prescribe it.
+    """
+
+    async def test_stdio_style_stream_accumulates(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        server = MCPServer(_agent(config))
+
+        async with connect(server) as session:
+            await session.call_tool("ask", {"message": "first"})
+            await session.call_tool("ask", {"message": "second"})
+
+        assert config.prompts == [["first"], ["first", "second"]]
+
+    async def test_http_session_accumulates(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        app = MCPServer(_agent(config), json_response=True)
+
+        async with serve(app) as client:
+            headers = await _open_handshake_session(client, request_id=1)
+            await _handshake_call(client, headers, "first", request_id=2)
+            await _handshake_call(client, headers, "second", request_id=3)
+
+        assert config.prompts == [["first"], ["first", "second"]]
+
+    async def test_different_http_sessions_are_isolated(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        app = MCPServer(_agent(config), json_response=True)
+
+        async with serve(app) as client:
+            first = await _open_handshake_session(client, request_id=1)
+            second = await _open_handshake_session(client, request_id=2)
+            await _handshake_call(client, first, "first", request_id=3)
+            await _handshake_call(client, second, "second", request_id=4)
+
+        assert config.prompts == [["first"], ["second"]]
+
+
+def _handle(result: CallToolResult) -> str:
+    """The conversation handle a result carries, as a programmatic client reads it."""
+    assert result.meta is not None
+    return result.meta[CONVERSATION_META_KEY]
+
+
+@pytest.mark.asyncio
+class TestConversationHandle:
+    """Continuity the caller names, which is the only kind the modern era has."""
+
+    async def test_modern_era_continues_by_handle(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        server = MCPServer(_agent(config))
+
+        async with connect_modern(server) as session:
+            first = await session.call_tool("ask", {"message": "first"})
+            await session.call_tool("ask", {"message": "second", "conversation": _handle(first)})
+
+        assert config.prompts == [["first"], ["first", "second"]]
+
+    async def test_handshake_era_continues_by_handle(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        server = MCPServer(_agent(config))
+
+        async with connect(server) as session:
+            first = await session.call_tool("ask", {"message": "first"})
+            await session.call_tool("ask", {"message": "second", "conversation": _handle(first)})
+
+        assert config.prompts == [["first"], ["first", "second"]]
+
+    async def test_different_handles_stay_isolated(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok", "ok", "ok"))
+        server = MCPServer(_agent(config))
+
+        async with connect_modern(server) as session:
+            one = _handle(await session.call_tool("ask", {"message": "one"}))
+            two = _handle(await session.call_tool("ask", {"message": "two"}))
+            await session.call_tool("ask", {"message": "one again", "conversation": one})
+            await session.call_tool("ask", {"message": "two again", "conversation": two})
+
+        assert one != two
+        assert config.prompts == [
+            ["one"],
+            ["two"],
+            ["one", "one again"],
+            ["two", "two again"],
+        ]
+
+    async def test_handle_is_readable_and_machine_readable_and_they_agree(self) -> None:
+        server = MCPServer(_agent(RecordingConfig(TestConfig("hello"))))
+
+        async with connect_modern(server) as session:
+            result = await session.call_tool("ask", {"message": "hi"})
+
+        handle = _handle(result)
+        # The agent's own reply leads; the handle rides in the block after it, so
+        # the model can recover from an expired one without reading `_meta`.
+        reply, trailer = result.content
+        assert reply == TextContent(type="text", text="hello")
+        assert handle in trailer.text
+
+    async def test_handles_are_unguessable(self) -> None:
+        server = MCPServer(_agent(RecordingConfig(TestConfig("ok", "ok"))))
+
+        async with connect_modern(server) as session:
+            first = _handle(await session.call_tool("ask", {"message": "one"}))
+            second = _handle(await session.call_tool("ask", {"message": "two"}))
+
+        # Version-4 UUIDs: opaque, unguessable, and header-safe.
+        assert UUID(first).version == 4
+        assert UUID(second).version == 4
+        assert first != second
+
+
+@pytest.mark.asyncio
+class TestUnknownHandle:
+    """A handle the registry does not know is an error, never a fall-through.
+
+    Falling through to the transport session would let any caller name a
+    conversation with a string of their choosing and evict other callers'
+    conversations out of a bounded registry.
+    """
+
+    async def test_is_an_error_flagged_result_not_a_protocol_error(self) -> None:
+        server = MCPServer(_agent(RecordingConfig(TestConfig("ok"))))
+
+        async with connect_modern(server) as session:
+            result = await session.call_tool("ask", {"message": "hi", "conversation": str(uuid4())})
+
+        assert result.is_error is True
+
+    async def test_does_not_start_a_conversation_under_the_supplied_string(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        server = MCPServer(_agent(config))
+        chosen = str(uuid4())
+
+        async with connect_modern(server) as session:
+            rejected = await session.call_tool("ask", {"message": "first", "conversation": chosen})
+            retried = await session.call_tool("ask", {"message": "second", "conversation": chosen})
+
+        assert rejected.is_error is True
+        assert retried.is_error is True
+        # Neither call reached the agent, so nothing was adopted under `chosen`.
+        assert config.prompts == []
+
+    async def test_does_not_fall_back_to_the_transport_session(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        server = MCPServer(_agent(config))
+
+        async with connect(server) as session:
+            await session.call_tool("ask", {"message": "first"})
+            rejected = await session.call_tool("ask", {"message": "second", "conversation": str(uuid4())})
+
+        assert rejected.is_error is True
+        # The handshake-era session's own history is untouched by the rejected call.
+        assert config.prompts == [["first"]]
+
+
+@pytest.mark.asyncio
+class TestAdvertisedConversationArgument:
+    async def test_present_when_conversations_are_enabled(self) -> None:
+        server = MCPServer(_agent(RecordingConfig(TestConfig("ok"))))
+
+        async with connect(server) as session:
+            (tool,) = (await session.list_tools()).tools
+
+        assert "conversation" in tool.input_schema["properties"]
+        assert tool.input_schema["required"] == ["message"]
+
+    async def test_absent_when_conversations_are_disabled(self) -> None:
+        server = MCPServer(_agent(RecordingConfig(TestConfig("ok"))), sessions=False)
+
+        async with connect(server) as session:
+            (tool,) = (await session.list_tools()).tools
+
+        assert "conversation" not in tool.input_schema["properties"]
+
+    async def test_description_states_the_configured_lifetime(self) -> None:
+        server = MCPServer(
+            _agent(RecordingConfig(TestConfig("ok"))),
+            sessions=SessionConfig(max_sessions=64, ttl=900.0),
+        )
+
+        async with connect(server) as session:
+            (tool,) = (await session.list_tools()).tools
+
+        description = tool.input_schema["properties"]["conversation"]["description"]
+        assert "900" in description
+        assert "64" in description
+
+
+@pytest.mark.asyncio
+async def test_structured_content_is_exactly_the_output_schema() -> None:
+    """``structuredContent`` is the agent's response schema, and nothing else.
+
+    It is advertised verbatim as the tool's ``outputSchema``, which MCP requires
+    structured content to conform to, so a server field mixed in would break the
+    tool's own declared contract.
+    """
+    agent = Agent(
+        "weather",
+        config=TestConfig('{"city": "SF", "temp_c": 18.5}'),
+        response_schema=Weather,
+    )
+    server = MCPServer(agent)
+
+    async with connect_modern(server) as session:
+        (tool,) = (await session.list_tools()).tools
+        result = await session.call_tool("ask", {"message": "weather in SF?"})
+
+    assert result.structured_content == {"city": "SF", "temp_c": 18.5}
+    assert tool.output_schema is not None
+    assert set(tool.output_schema["properties"]) == {"city", "temp_c"}
+    # The handle still travels, just not through the declared output contract.
+    assert _handle(result)
+
+
+@pytest.mark.asyncio
+async def test_stateless_transport_serves_conversations_by_handle() -> None:
+    """``stateless=True`` with ``sessions=True`` is coherent, not contradictory.
+
+    It was contradictory only while continuity depended on the transport issuing
+    a session id; with handles it means "no transport session, conversations by
+    handle", so it constructs without complaint and serves them.
+    """
+    config = RecordingConfig(TestConfig("ok", "ok"))
+    app = MCPServer(_agent(config), stateless=True, json_response=True)
+
+    async with serve(app) as client:
+        first, response = await _modern_call_with_response(client, "first", request_id=1)
+        # The one assertion that is genuinely about HTTP: no session comes back.
+        assert MCP_SESSION_ID_HEADER not in response.headers
+        handle = first["_meta"][CONVERSATION_META_KEY]
+        await _modern_call(client, "second", request_id=2, conversation=handle)
+
+    assert config.prompts == [["first"], ["first", "second"]]
+
+
+@pytest.mark.asyncio
+class TestRegistryGuaranteesApplyToHandles:
+    """The registry keys on an opaque string, so a handle drops into it unchanged."""
+
+    async def test_the_bound_evicts_a_handle_named_conversation(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok", "ok"))
+        server = MCPServer(_agent(config), sessions=SessionConfig(max_sessions=1))
+
+        async with connect_modern(server) as session:
+            evicted = _handle(await session.call_tool("ask", {"message": "one"}))
+            await session.call_tool("ask", {"message": "two"})
+            result = await session.call_tool("ask", {"message": "one again", "conversation": evicted})
+
+        assert result.is_error is True
+
+    async def test_the_configured_storage_backend_holds_the_history(self) -> None:
+        storage = _RecordingStorage()
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        server = MCPServer(_agent(config), sessions=SessionConfig(storage=storage))
+
+        async with connect_modern(server) as session:
+            first = _handle(await session.call_tool("ask", {"message": "first"}))
+            await session.call_tool("ask", {"message": "second", "conversation": first})
+
+        # One conversation, its turns replayed from the backend the operator
+        # configured — the same path a session-named conversation takes.
+        (stream_id,) = storage.stream_ids
+        assert _texts(await storage.get_history(stream_id)) == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_custom_tools_are_untouched() -> None:
+    """The handle applies to the conversational tool; a custom tool's state is its own."""
+    server = MCPServer(
+        _agent(RecordingConfig(TestConfig("ok"))),
+        tools=[MCPFunctionTool(name="echo", description="Echo", handler=_echo)],
+    )
+
+    async with connect_modern(server) as session:
+        tools = {t.name: t for t in (await session.list_tools()).tools}
+        result = await session.call_tool("echo", {"text": "hi"})
+
+    assert "conversation" not in tools["echo"].input_schema.get("properties", {})
+    assert result.meta is None or CONVERSATION_META_KEY not in result.meta
+    # One block and no trailer: the handle never rides on a custom tool's reply.
+    assert result.content == [TextContent(type="text", text="hi")]
+
+
+_TOKENS = {
+    "alice": AccessToken(token="alice", client_id="shared-client", scopes=[], subject="alice"),
+    "bob": AccessToken(token="bob", client_id="shared-client", scopes=[], subject="bob"),
+    # No subject: the identity falls back to the client id, which is always present.
+    "kiosk": AccessToken(token="kiosk", client_id="kiosk-client", scopes=[]),
+    "other-kiosk": AccessToken(token="other-kiosk", client_id="other-kiosk-client", scopes=[]),
+}
+
+
+class _TokenVerifier:
+    """Accepts the fixture tokens above and nothing else."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        return _TOKENS.get(token)
+
+
+def _authenticated(config: RecordingConfig) -> MCPServer:
+    return MCPServer(
+        _agent(config),
+        json_response=True,
+        security=require(
+            oauth2_scheme(url="https://auth.example.com"),
+            resource_url="http://test/mcp",
+            verifier=_TokenVerifier(),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+class TestPrincipalBinding:
+    """A handle names a conversation; it does not on its own confer the right to read one.
+
+    The handle comes back in readable content, so it passes through the model's
+    context, the client's logs and any tracing in between — further than a
+    transport header ever went.
+    """
+
+    async def test_the_creating_principal_continues_normally(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+
+        async with serve(_authenticated(config)) as client:
+            first = await _modern_call(client, "first", request_id=1, token="alice")
+            handle = first["_meta"][CONVERSATION_META_KEY]
+            await _modern_call(client, "second", request_id=2, conversation=handle, token="alice")
+
+        assert config.prompts == [["first"], ["first", "second"]]
+
+    async def test_another_principal_is_refused_indistinguishably(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+
+        async with serve(_authenticated(config)) as client:
+            first = await _modern_call(client, "first", request_id=1, token="alice")
+            handle = first["_meta"][CONVERSATION_META_KEY]
+            stolen = await _modern_call(client, "second", request_id=2, conversation=handle, token="bob")
+            unknown = await _modern_call(client, "second", request_id=3, conversation=str(uuid4()), token="bob")
+
+        assert stolen["isError"] is True
+        # Byte-for-byte the unknown-handle answer, so it does not disclose that
+        # the handle exists.
+        assert stolen["content"] == unknown["content"]
+        assert config.prompts == [["first"]]
+
+    async def test_the_binding_is_checked_on_every_call_not_only_at_creation(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok", "ok"))
+
+        async with serve(_authenticated(config)) as client:
+            first = await _modern_call(client, "first", request_id=1, token="alice")
+            handle = first["_meta"][CONVERSATION_META_KEY]
+            continued = await _modern_call(client, "second", request_id=2, conversation=handle, token="alice")
+            swapped = await _modern_call(client, "third", request_id=3, conversation=handle, token="bob")
+
+        assert continued["isError"] is False
+        # The conversation was live and reachable a call earlier: the swapped
+        # credential is what stops it, not the handle having gone away.
+        assert swapped["isError"] is True
+
+    async def test_a_session_named_conversation_is_unreachable_by_another_principal(self) -> None:
+        """The other name a conversation goes by is closed to a swapped credential too.
+
+        A handshake-era conversation is keyed by the MCP session, which ag2 does
+        not revalidate — it does not have to. The transport refuses a session id
+        presented with a credential other than the one that opened it, answering
+        as though the session did not exist, so the swapped caller never reaches
+        the conversation to begin with.
+        """
+        config = RecordingConfig(TestConfig("ok", "ok"))
+
+        async with serve(_authenticated(config)) as client:
+            headers = await _open_handshake_session(client, request_id=1, token="alice")
+            await _handshake_call(client, headers, "first", request_id=2)
+            swapped = await client.post(
+                "/mcp",
+                headers={**headers, "Authorization": "Bearer bob"},
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {"name": "ask", "arguments": {"message": "second"}},
+                },
+            )
+
+        assert swapped.status_code == 404
+        # Alice's turn is the only one the agent ever saw.
+        assert config.prompts == [["first"]]
+
+    async def test_a_token_with_no_subject_binds_via_its_client_id(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok", "ok"))
+
+        async with serve(_authenticated(config)) as client:
+            first = await _modern_call(client, "first", request_id=1, token="kiosk")
+            handle = first["_meta"][CONVERSATION_META_KEY]
+            same = await _modern_call(client, "second", request_id=2, conversation=handle, token="kiosk")
+            other = await _modern_call(client, "third", request_id=3, conversation=handle, token="other-kiosk")
+
+        assert same["isError"] is False
+        assert other["isError"] is True

--- a/test/mcp/test_conversations.py
+++ b/test/mcp/test_conversations.py
@@ -320,6 +320,53 @@ class TestConversationHandle:
 
 
 @pytest.mark.asyncio
+class TestBlankHandle:
+    """A blank handle names no conversation, so it reads as none being named.
+
+    The reader of the handle channel is the model, and a model given an optional
+    string argument routinely sends ``""`` rather than omitting the key. Read as
+    an unknown handle, that would make its every first call an error and leave it
+    unable to start a conversation at all.
+    """
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\n"])
+    async def test_starts_a_new_conversation_in_the_modern_era(self, blank: str) -> None:
+        config = RecordingConfig(TestConfig("ok"))
+        server = MCPServer(_agent(config))
+
+        async with connect_modern(server) as session:
+            result = await session.call_tool("ask", {"message": "first", "conversation": blank})
+
+        assert result.is_error is False
+        # A handle comes back, so the caller that could not omit the key can still
+        # continue what it just started.
+        assert UUID(_handle(result)).version == 4
+        assert config.prompts == [["first"]]
+
+    async def test_the_conversation_it_started_continues_by_its_handle(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        server = MCPServer(_agent(config))
+
+        async with connect_modern(server) as session:
+            first = await session.call_tool("ask", {"message": "first", "conversation": ""})
+            await session.call_tool("ask", {"message": "second", "conversation": _handle(first)})
+
+        assert config.prompts == [["first"], ["first", "second"]]
+
+    async def test_falls_back_to_the_transport_session_in_the_handshake_era(self) -> None:
+        config = RecordingConfig(TestConfig("ok", "ok"))
+        server = MCPServer(_agent(config))
+
+        # Naming nothing is what a blank handle means, so the handshake era keys on
+        # the session it has — as it does for a call that omits the argument.
+        async with connect(server) as session:
+            await session.call_tool("ask", {"message": "first", "conversation": ""})
+            await session.call_tool("ask", {"message": "second", "conversation": ""})
+
+        assert config.prompts == [["first"], ["first", "second"]]
+
+
+@pytest.mark.asyncio
 class TestUnknownHandle:
     """A handle the registry does not know is an error, never a fall-through.
 

--- a/test/mcp/test_custom_tools.py
+++ b/test/mcp/test_custom_tools.py
@@ -50,7 +50,7 @@ class TestCustomTools:
         async with connect(server) as session:
             result = await session.call_tool("ask", {"message": "hi"})
 
-        assert result.content == [TextContent(type="text", text="hello")]
+        assert result.content[0] == TextContent(type="text", text="hello")
 
     async def test_sync_handler_runs(self) -> None:
         def sync_handler(args: dict[str, Any], _ctx: ToolContext) -> TextContent:

--- a/test/mcp/test_e2e_modern.py
+++ b/test/mcp/test_e2e_modern.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from mcp.types import TextContent
+from mcp_types.version import LATEST_MODERN_VERSION
+
+from ag2 import Agent
+from ag2.mcp import MCPServer
+from ag2.mcp.testing import connect_modern
+from ag2.testing import TestConfig
+
+
+@pytest.mark.asyncio
+class TestE2EModern:
+    """The served agent, driven over protocol revision 2026-07-28.
+
+    The handshake-era suites reach the same server through ``connect``; these
+    pin that the modern-era seam reaches it too, so the era's own semantics can
+    be asserted rather than inferred.
+    """
+
+    async def test_negotiated_version_is_the_modern_revision(self) -> None:
+        server = MCPServer(Agent("greeter", config=TestConfig("hi")))
+
+        async with connect_modern(server) as session:
+            negotiated = session.protocol_version
+
+        assert negotiated == LATEST_MODERN_VERSION
+
+    async def test_list_tools_exposes_ask(self) -> None:
+        server = MCPServer(Agent("greeter", "Be nice.", config=TestConfig("hi")))
+
+        async with connect_modern(server) as session:
+            tools = await session.list_tools()
+
+        assert [t.name for t in tools.tools] == ["ask"]
+
+    async def test_call_tool_returns_reply(self) -> None:
+        server = MCPServer(Agent("greeter", config=TestConfig("hello there!")))
+
+        async with connect_modern(server) as session:
+            result = await session.call_tool("ask", {"message": "hi"})
+
+        assert result.is_error is False
+        reply, _trailer = result.content
+        assert reply == TextContent(type="text", text="hello there!")

--- a/test/mcp/test_e2e_text.py
+++ b/test/mcp/test_e2e_text.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from mcp.types import TextContent
 
 from ag2 import Agent
 from ag2.events import ModelRequest, TextInput
@@ -28,7 +29,9 @@ class TestE2EText:
             result = await session.call_tool("ask", {"message": "hi"})
 
         assert result.is_error is False
-        assert [c.text for c in result.content if c.type == "text"] == ["hello there!"]
+        # The reply leads; the conversation handle rides in the block after it.
+        reply, _trailer = result.content
+        assert reply == TextContent(type="text", text="hello there!")
 
     async def test_context_is_prepended(self) -> None:
         tracking = TrackingConfig(TestConfig("ok"))
@@ -49,4 +52,5 @@ class TestE2EText:
             result = await session.call_tool("chat", {"message": "hi"})
 
         assert [t.name for t in tools.tools] == ["chat"]
-        assert [c.text for c in result.content if c.type == "text"] == ["yo"]
+        reply, _trailer = result.content
+        assert reply == TextContent(type="text", text="yo")

--- a/test/mcp/test_progress.py
+++ b/test/mcp/test_progress.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from mcp.types import TextContent
 
 from ag2 import Agent
 from ag2.events import ToolCallEvent
@@ -32,7 +33,8 @@ class TestProgress:
         assert [m for _, _, m in updates] == ["Hello, ", "world!"]
         assert [p for p, _, _ in updates] == [1.0, 2.0]
         # Final body is still returned in full.
-        assert [c.text for c in result.content if c.type == "text"] == ["Hello, world!"]
+        reply, _trailer = result.content
+        assert reply == TextContent(type="text", text="Hello, world!")
 
     async def test_no_progress_without_token(self) -> None:
         agent = make_agent(config=ChunkConfig("a", "b"))
@@ -72,4 +74,5 @@ class TestProgress:
             result = await session.call_tool("ask", {"message": "go"})
 
         assert result.is_error is False
-        assert [c.text for c in result.content if c.type == "text"] == ["done"]
+        reply, _trailer = result.content
+        assert reply == TextContent(type="text", text="done")

--- a/test/mcp/test_sessions.py
+++ b/test/mcp/test_sessions.py
@@ -3,64 +3,39 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-from collections.abc import Sequence
 from types import SimpleNamespace
-from typing import Any
+from uuid import uuid4
 
 import pytest
-from typing_extensions import Self
+from mcp_types.version import LATEST_HANDSHAKE_VERSION
 
-from ag2 import Agent, Context
-from ag2.config import LLMClient, ModelConfig
-from ag2.events import BaseEvent, ModelResponse
+from ag2 import Agent
+from ag2.mcp.errors import UnknownConversationError
 from ag2.mcp.executor import AgentExecutor, _session_id
 from ag2.mcp.sessions import STDIO_SESSION, SessionConfig, SessionStore
 from ag2.testing import TestConfig
 
-
-class _RecordingClient(LLMClient):
-    """Wraps another client, capturing the full message list sent on each call."""
-
-    def __init__(self, client: LLMClient, sink: list[list[BaseEvent]]) -> None:
-        self.client = client
-        self.sink = sink
-
-    async def __call__(self, messages: Sequence[BaseEvent], context: Context, **kwargs: Any) -> ModelResponse:
-        self.sink.append(list(messages))
-        return await self.client(messages, context=context, **kwargs)
-
-
-class _RecordingConfig(ModelConfig):
-    """Records the messages the framework sends to the LLM across every turn."""
-
-    def __init__(self, config: ModelConfig) -> None:
-        self.config = config
-        self.calls: list[list[BaseEvent]] = []
-
-    def copy(self) -> Self:
-        return self
-
-    def create(self) -> _RecordingClient:
-        return _RecordingClient(self.config.create(), self.calls)
-
-    def create_files_client(self) -> None:
-        raise NotImplementedError
+from ._helpers import RecordingConfig
 
 
 def _request_context(session_id: str | None) -> SimpleNamespace:
-    """A minimal stand-in for the transport's RequestContext (HTTP shape)."""
+    """A minimal stand-in for the transport's RequestContext (HTTP shape).
+
+    Carries a handshake-era protocol version, the era in which an MCP session
+    exists at all and so the only one in which it can key a conversation.
+    """
     headers = {"mcp-session-id": session_id} if session_id is not None else {}
-    return SimpleNamespace(request=SimpleNamespace(headers=headers))
+    return SimpleNamespace(request=SimpleNamespace(headers=headers), protocol_version=LATEST_HANDSHAKE_VERSION)
 
 
 def _stdio_request_context() -> SimpleNamespace:
-    return SimpleNamespace(request=None)
+    return SimpleNamespace(request=None, protocol_version=LATEST_HANDSHAKE_VERSION)
 
 
 @pytest.mark.asyncio
 class TestMultiTurnHistory:
     async def test_same_session_accumulates_history(self) -> None:
-        config = _RecordingConfig(TestConfig("ok"))
+        config = RecordingConfig(TestConfig("ok"))
         executor = AgentExecutor(Agent("a", config=config), stream_progress=False, session_store=SessionStore())
         rc = _request_context("sess-1")
 
@@ -72,7 +47,7 @@ class TestMultiTurnHistory:
         assert len(config.calls[1]) > len(config.calls[0])
 
     async def test_different_sessions_are_isolated(self) -> None:
-        config = _RecordingConfig(TestConfig("ok"))
+        config = RecordingConfig(TestConfig("ok"))
         executor = AgentExecutor(Agent("a", config=config), stream_progress=False, session_store=SessionStore())
 
         await executor.call("ask", message="first", request_context=_request_context("sess-1"))
@@ -82,7 +57,7 @@ class TestMultiTurnHistory:
         assert len(config.calls[1]) == len(config.calls[0])
 
     async def test_stateless_when_sessions_disabled(self) -> None:
-        config = _RecordingConfig(TestConfig("ok"))
+        config = RecordingConfig(TestConfig("ok"))
         executor = AgentExecutor(Agent("a", config=config), stream_progress=False, session_store=None)
         rc = _request_context("sess-1")
 
@@ -93,7 +68,7 @@ class TestMultiTurnHistory:
         assert len(config.calls[1]) == len(config.calls[0])
 
     async def test_stateless_http_without_session_id(self) -> None:
-        config = _RecordingConfig(TestConfig("ok"))
+        config = RecordingConfig(TestConfig("ok"))
         executor = AgentExecutor(Agent("a", config=config), stream_progress=False, session_store=SessionStore())
 
         # HTTP request but no server-issued mcp-session-id (stateless transport).
@@ -163,6 +138,87 @@ class TestSessionStore:
         original = (await store.acquire("a")).id
         clock["t"] = 5.0
         assert (await store.acquire("a")).id == original
+
+
+@pytest.mark.asyncio
+class TestHandleNamedConversations:
+    """A handle is just another key, so the registry's guarantees carry over."""
+
+    async def test_fresh_mints_a_handle_that_resolves_to_the_same_stream(self) -> None:
+        store = SessionStore()
+
+        async with store.fresh() as minted:
+            assert minted.handle is not None
+            handle = minted.handle
+            stream_id = minted.stream.id
+
+        async with store.by_handle(handle) as continued:
+            assert continued.stream.id == stream_id
+
+    async def test_two_fresh_conversations_are_isolated(self) -> None:
+        store = SessionStore()
+
+        async with store.fresh() as one, store.fresh() as two:
+            assert one.handle != two.handle
+            assert one.stream.id != two.stream.id
+
+    async def test_a_handle_the_store_never_minted_is_rejected(self) -> None:
+        store = SessionStore()
+
+        with pytest.raises(UnknownConversationError):
+            async with store.by_handle(str(uuid4())):
+                pass
+
+    async def test_a_session_named_conversation_also_has_a_handle(self) -> None:
+        store = SessionStore()
+
+        async with store.session("sess-1") as named:
+            assert named.handle is not None
+            handle, stream_id = named.handle, named.stream.id
+
+        # The handle names the same conversation the MCP session does, so a
+        # handshake-era caller can migrate to explicit handles without losing it.
+        async with store.by_handle(handle) as continued:
+            assert continued.stream.id == stream_id
+
+    async def test_idle_expiry_drops_a_handle_named_conversation(self) -> None:
+        clock = {"t": 0.0}
+        store = SessionStore(ttl=10.0, clock=lambda: clock["t"])
+
+        async with store.fresh() as minted:
+            handle = minted.handle
+        assert handle is not None
+        clock["t"] = 20.0
+
+        with pytest.raises(UnknownConversationError):
+            async with store.by_handle(handle):
+                pass
+
+    async def test_lru_overflow_drops_a_handle_named_conversation(self) -> None:
+        store = SessionStore(max_sessions=1)
+
+        async with store.fresh() as first:
+            handle = first.handle
+        assert handle is not None
+        async with store.fresh():  # evicts the first
+            pass
+
+        with pytest.raises(UnknownConversationError):
+            async with store.by_handle(handle):
+                pass
+
+    async def test_a_conversation_is_bound_to_the_principal_that_created_it(self) -> None:
+        store = SessionStore()
+
+        async with store.fresh(principal="alice") as minted:
+            handle = minted.handle
+        assert handle is not None
+
+        async with store.by_handle(handle, principal="alice") as continued:
+            assert continued.handle == handle
+        with pytest.raises(UnknownConversationError):
+            async with store.by_handle(handle, principal="bob"):
+                pass
 
 
 def test_session_store_rejects_bad_config() -> None:

--- a/test/mcp/test_sessions.py
+++ b/test/mcp/test_sessions.py
@@ -220,6 +220,26 @@ class TestHandleNamedConversations:
             async with store.by_handle(handle, principal="bob"):
                 pass
 
+    async def test_acquire_records_the_principal_of_the_handle_it_mints(self) -> None:
+        """A conversation first created through ``acquire`` is reachable by its creator.
+
+        ``acquire`` mints a handle like every other entry point does; recording
+        no principal for it would leave that handle nameable by nobody at all
+        once authentication is configured.
+        """
+        store = SessionStore()
+
+        await store.acquire("s", principal="alice")
+        async with store.session("s", principal="alice") as conversation:
+            handle = conversation.handle
+        assert handle is not None
+
+        async with store.by_handle(handle, principal="alice") as continued:
+            assert continued.handle == handle
+        with pytest.raises(UnknownConversationError):
+            async with store.by_handle(handle, principal="bob"):
+                pass
+
 
 def test_session_store_rejects_bad_config() -> None:
     with pytest.raises(ValueError):

--- a/uv.lock
+++ b/uv.lock
@@ -74,6 +74,7 @@ acp = [
     { name = "agent-client-protocol" },
     { name = "jsonschema" },
     { name = "mcp" },
+    { name = "mcp-types" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
@@ -102,6 +103,7 @@ gemini = [
 mcp = [
     { name = "jsonschema" },
     { name = "mcp" },
+    { name = "mcp-types" },
 ]
 mcp-ui = [
     { name = "mcp" },
@@ -275,6 +277,7 @@ requires-dist = [
     { name = "jsonschema", marker = "extra == 'mcp'", specifier = ">=4.20.0,<5" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2.0.0,<3" },
     { name = "mcp", marker = "extra == 'mcp-ui'", specifier = ">=2.0.0,<3" },
+    { name = "mcp-types", marker = "extra == 'mcp'", specifier = ">=2.0.0,<3" },
     { name = "mcp-ui-server", marker = "extra == 'mcp-ui'", specifier = ">=1.0.0" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.8.0,<3" },
     { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.4.7" },

--- a/website/docs/user-guide/tools/mcp_servers.mdx
+++ b/website/docs/user-guide/tools/mcp_servers.mdx
@@ -11,6 +11,9 @@ It can be thought of as a superset of regular [Tools](/docs/user-guide/tools/too
 1. Each LLM provider had its own tool schema and types, making tools non-portable across providers.
 2. There was no standard way to give an LLM a scoped, context-optimized surface to invoke APIs, RPCs, and similar remote capabilities.
 
+!!! note "Serving, not consuming"
+    This page is about wiring an existing MCP server into an agent. For the inverse — exposing an AG2 `Agent` **as** an MCP server other clients connect to — see [Serving an Agent as an MCP Server](/docs/user-guide/tools/serving_mcp).
+
 ## Two ways to connect an MCP server
 
 Autogen supports both ways MCP servers are typically wired into an agent:

--- a/website/docs/user-guide/tools/mcp_ui.mdx
+++ b/website/docs/user-guide/tools/mcp_ui.mdx
@@ -10,7 +10,7 @@ sidebarTitle: MCP-UI
 AG2 builds these resources and the interactive callbacks (**UI Actions**) in `ag2.mcp_ui`. They are returned from the serving side of `ag2.mcp` — an AG2 `Agent` exposed as an MCP server — so this page starts with the minimum you need to serve one, then focuses on the UI helpers.
 
 !!! note "This is the serving side of MCP"
-    `ag2.mcp.MCPServer` exposes an agent **as** an MCP server. This is the inverse of consuming an MCP server as tools with `MCPToolkit` / `MCPServerTool` — see [MCP Servers](/docs/user-guide/tools/mcp_servers) for that.
+    `ag2.mcp.MCPServer` exposes an agent **as** an MCP server — see [Serving an Agent as an MCP Server](/docs/user-guide/tools/serving_mcp) for transports, conversations and security. This is the inverse of consuming an MCP server as tools with `MCPToolkit` / `MCPServerTool` — see [MCP Servers](/docs/user-guide/tools/mcp_servers) for that.
 
 ## Installation
 

--- a/website/docs/user-guide/tools/serving_mcp.mdx
+++ b/website/docs/user-guide/tools/serving_mcp.mdx
@@ -1,0 +1,245 @@
+---
+title: "Serving an Agent as an MCP Server"
+sidebarTitle: "Serving MCP"
+---
+
+# Serving an Agent as an MCP Server
+
+`ag2.mcp.MCPServer` exposes an AG2 `Agent` **as** an MCP server: any MCP client — Claude Desktop, Cursor, the MCP Inspector, another agent framework — can list its tools and talk to your agent. This is the inverse of [consuming an MCP server as tools](/docs/user-guide/tools/mcp_servers) with `MCPToolkit` / `MCPServerTool`.
+
+## Installation
+
+```bash
+pip install "ag2[mcp]"
+```
+
+## Serving over HTTP
+
+An `MCPServer` **is** an ASGI3 application. It serves MCP over streamable HTTP and manages its own lifespan, so a standalone `uvicorn` run just works:
+
+```python linenums="1"
+import uvicorn
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer
+
+agent = Agent(
+    name="assistant",
+    prompt="You are a helpful assistant.",
+    config=AnthropicConfig(model="claude-haiku-4-5-20251001"),
+)
+app = MCPServer(agent, path="/mcp")
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=8000)
+```
+
+The server is also mountable into a host Starlette/FastAPI app, since it is an ordinary ASGI app.
+
+## Serving over stdio
+
+For a locally-launched client, serve over stdin/stdout instead. The HTTP parameters (`path`, `stateless`, `json_response`, `security`) are ignored on this transport:
+
+```python linenums="1"
+import asyncio
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer
+
+agent = Agent(name="assistant", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+server = MCPServer(agent)
+
+if __name__ == "__main__":
+    asyncio.run(server.run_stdio())
+```
+
+## The conversational tool
+
+The agent is exposed as a single tool — `ask` by default — that runs `Agent.ask()` and returns the reply. It takes a required `message` and an optional `context` string that is prepended to it. Rename it with `tool_name=` and reword its description with `tool_description=`.
+
+If the agent has a `response_schema`, that schema is advertised verbatim as the tool's `outputSchema` and validated replies come back as `structuredContent`.
+
+```python linenums="1"
+from pydantic import BaseModel
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer
+
+class Weather(BaseModel):
+    city: str
+    temp_c: float
+
+agent = Agent(
+    name="weather",
+    config=AnthropicConfig(model="claude-haiku-4-5-20251001"),
+    response_schema=Weather,
+)
+app = MCPServer(agent, tool_name="forecast")
+```
+
+Presentation metadata (`name`, `version`, `title`, `description`, `instructions`, `website_url`, `icons`) is never derived from the agent — `instructions` in particular is client-facing "how to use this server" guidance, not the agent's system prompt. Pass it explicitly when you want it.
+
+## Conversations
+
+By default (`sessions=True`) the server keeps **conversation sessions**: a history that accumulates across `tools/call` invocations, so a caller can hold a multi-turn exchange instead of a series of unrelated questions.
+
+### Starting and continuing one
+
+A caller names the conversation it wants to continue. The tool takes an optional `conversation` argument holding an opaque **conversation handle**:
+
+- **Omit it** and the call starts a new conversation. The server mints a handle and returns it.
+- **Pass a handle back** and that conversation continues.
+
+The handle comes back twice, for two different readers:
+
+- in a **text content block**, so the model driving the tool can read it and carry it into its next call without any help from the host;
+- in the result's **`_meta`**, under the key `ai.ag2/conversation`, for clients threading it programmatically.
+
+`structuredContent` is deliberately left alone: on this tool it is the agent's response schema and is advertised verbatim as `outputSchema`, which MCP requires structured content to conform to.
+
+!!! note "The handle comes back on every reply"
+    Both readers get the handle whether or not the caller ever names a conversation, and in both protocol eras — so a handshake-era client that never touches the `conversation` argument still sees the extra content block and `_meta` key. A client that asserts on the exact shape of a reply will notice; one that reads the first text block, or `structuredContent`, will not.
+
+Threading a handle from the caller's side — here with the `mcp` SDK's own client against the HTTP server above:
+
+```python linenums="1"
+import asyncio
+
+from mcp.client import Client
+
+async def main() -> None:
+    async with Client("http://127.0.0.1:8000/mcp") as client:
+        first = await client.call_tool("ask", {"message": "My name is Ada."})
+        handle = first.meta["ai.ag2/conversation"]
+        second = await client.call_tool(
+            "ask",
+            {"message": "What is my name?", "conversation": handle},
+        )
+        print(second.content[0].text)
+
+asyncio.run(main())
+```
+
+Handles are minted by the server and are version-4 UUIDs — opaque and unguessable. A caller-chosen string is never adopted as a new conversation name; that would let any caller push other callers' conversations out of the bounded registry.
+
+### When a handle is not recognised
+
+A handle the server does not know — expired, evicted, or never minted — comes back as a **tool execution error**: a result flagged `isError`, not a JSON-RPC protocol error. The protocol draws that line so the model can recover by starting a new conversation instead of failing the turn. It is never treated as a fresh conversation, and never falls back to the MCP session.
+
+### What differs between the two protocol eras
+
+MCP has two eras, and each sanctions a different continuity mechanism:
+
+| a `conversation` passed? | handshake era (up to 2025-11-25) | modern era (2026-07-28) |
+|---|---|---|
+| yes | that conversation | that conversation |
+| no  | the caller's **MCP session** keeps its own history (one per process over stdio) | a fresh conversation each call |
+
+A **handshake-era** client negotiates an `initialize` handshake that opens an **MCP session** — the transport's own notion of a connected client — so it gets implicit continuity without passing anything, exactly as before. It may still opt into explicit handles: the handle returned on its first call names the same conversation its MCP session does, so it can migrate ahead of changing protocol revision.
+
+A **modern-era** client has no MCP session. The revision states that connections do not represent conversations, that clients may interleave unrelated requests on one transport, and that servers must not use connection or process identity to establish context — so the handle is the only continuity mechanism available there, on every transport.
+
+### Turning conversations off
+
+`sessions=False` makes every call stateless, and the `conversation` argument disappears from the advertised tool — a client is never offered an argument that cannot work.
+
+### Tuning the registry
+
+`SessionConfig` bounds the registry so a long-lived server cannot leak memory:
+
+```python linenums="1"
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer, SessionConfig
+
+agent = Agent(name="assistant", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+app = MCPServer(
+    agent,
+    sessions=SessionConfig(max_sessions=256, ttl=3600.0),
+)
+```
+
+- `max_sessions` — LRU cap; the least-recently-used conversation's history is dropped once the cap is exceeded.
+- `ttl` — idle expiry in seconds; a conversation untouched for longer has its history dropped (`None`, the default, means no expiry).
+- `storage` — the history backend (see below).
+
+Both bounds are quoted in the `conversation` argument's own description, so a client can judge whether an old handle is still worth presenting.
+
+!!! note "Every unnamed call with no session to fall back on creates a conversation"
+    A call that omits `conversation` and has no MCP session to key on gets a fresh conversation — and a handle for it — on every call. That is every modern-era call, and every handshake-era call on a `stateless=True` transport, so one-shot traffic occupies registry slots too. Size `max_sessions` for your call rate, and set a `ttl` so abandoned one-shot conversations expire instead of pushing real ones out.
+
+## What `stateless` governs
+
+`stateless=True` stops the **HTTP transport** issuing an `mcp-session-id`. That is a *handshake-era* switch: modern-era requests are self-contained single exchanges that never carry a session id in the first place, so the flag does not reach them.
+
+Pairing `stateless=True` with `sessions=True` is a valid configuration, not a contradiction — no transport session, conversations named by handle:
+
+```python linenums="1"
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer
+
+agent = Agent(name="assistant", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+app = MCPServer(agent, stateless=True)
+```
+
+## Where conversations live
+
+A conversation's history is written through the configured `Storage`; the registry that maps a conversation's *name* — a handle, or an MCP session id — to that history is held **in the serving process**.
+
+So a conversation lives in the replica that created it. A handle minted on one replica is unknown on another, and an MCP session id resolves to a different, empty history there. Behind a load balancer, route a caller's calls back to the replica that answered the first one, or run a single replica.
+
+Passing a shared backend keeps the history itself out of process memory, which is what makes a large `max_sessions` affordable:
+
+```python linenums="1"
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer, SessionConfig
+from ag2.streams import RedisStorage
+
+agent = Agent(name="assistant", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+app = MCPServer(
+    agent,
+    sessions=SessionConfig(storage=RedisStorage("redis://localhost:6379")),
+)
+```
+
+!!! warning "A shared backend does not make a handle portable"
+    The registry is per-process, so a shared `Storage` shares the stored history but not the mapping from a name to it. Cross-replica continuity still needs the caller pinned to one replica.
+
+## Authentication and who owns a conversation
+
+`security=` makes the server an OAuth 2.1 Resource Server: it advertises RFC 9728 Protected Resource Metadata at `/.well-known/oauth-protected-resource`, answers a missing or invalid token with `401` (pointing at that metadata) and an insufficient scope with `403`.
+
+```python linenums="1"
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer
+from ag2.mcp.security import oauth2_scheme, require
+
+agent = Agent(name="assistant", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+app = MCPServer(
+    agent,
+    path="/mcp",
+    security=require(
+        oauth2_scheme(url="https://auth.example.com"),
+        resource_url="https://agent.example.com/mcp",
+        verifier=my_token_verifier,  # your TokenVerifier implementation
+        required_scopes=["mcp.read"],
+    ),
+)
+```
+
+With authentication configured, a conversation records the principal that created it — the access token's subject, falling back to its client id — and revalidates that on **every** call, not only at creation. A handle presented under a different principal gets the same error as an unknown one, so the error does not disclose that the handle exists.
+
+!!! warning "Without `security`, the handle is the only credential"
+    With no authentication there is no principal to bind to, so anyone holding a handle can continue the conversation it names. The handle travels through readable content — the model's context, client logs, tracing in between — so decide whether that is acceptable for your deployment before serving unauthenticated.
+
+## Beyond the conversational tool
+
+- **Custom tools** run a handler of yours directly instead of invoking the agent — see [MCP-UI Resources](/docs/user-guide/tools/mcp_ui) for `@mcp_tool` and returning renderable UI. Their state is their own; conversation handles apply only to the conversational tool.
+- **Resources and prompts** are exposed by passing `resources=[Resource(...)]`, `resource_templates=[ResourceTemplate(...)]` and `prompts=[Prompt(...)]` from `ag2.mcp`; the matching capability is advertised only when a non-empty collection is supplied.
+- **Progress and logs** — while the agent runs, its stream events are forwarded to the client as progress notifications and log messages. Turn this off with `stream_progress=False`.

--- a/website/docs/user-guide/tools/serving_mcp.mdx
+++ b/website/docs/user-guide/tools/serving_mcp.mdx
@@ -93,6 +93,8 @@ A caller names the conversation it wants to continue. The tool takes an optional
 - **Omit it** and the call starts a new conversation. The server mints a handle and returns it.
 - **Pass a handle back** and that conversation continues.
 
+A blank handle — `""`, or whitespace — counts as omitting it, because it names nothing. That matters for the reader this channel is built for: a model asked for an optional string argument routinely sends an empty one instead of leaving the key out, and read as an unknown handle that would leave it unable to start a conversation at all. No minted handle is blank, so nothing that could name a conversation is affected.
+
 The handle comes back twice, for two different readers:
 
 - in a **text content block**, so the model driving the tool can read it and carry it into its next call without any help from the host;

--- a/website/docs/user-guide/tools/serving_mcp.mdx
+++ b/website/docs/user-guide/tools/serving_mcp.mdx
@@ -146,7 +146,7 @@ A **modern-era** client has no MCP session. The revision states that connections
 
 ### Turning conversations off
 
-`sessions=False` makes every call stateless, and the `conversation` argument disappears from the advertised tool — a client is never offered an argument that cannot work.
+`sessions=False` makes every call stateless, and the `conversation` argument disappears from the advertised tool — a client is never offered an argument that cannot work. A client that passes one anyway gets a tool error saying the server keeps no conversations, rather than a reply that quietly forgets: this server mints no handles, so continuity is not something omitting the argument would restore either.
 
 ### Tuning the registry
 

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -80,6 +80,7 @@
             "docs/user-guide/tools/toolkits",
             "docs/user-guide/tools/common_toolkits",
             "docs/user-guide/tools/mcp_servers",
+            "docs/user-guide/tools/serving_mcp",
             "docs/user-guide/tools/mcp_ui",
             "docs/user-guide/tools/builtin_tools",
             "docs/user-guide/tools/code_execution",


### PR DESCRIPTION
## Why are these changes needed?

`MCPServer(sessions=True)` promises what its docstring says: each client keeps its own
conversation history, accumulating across `tools/call` invocations. That promise held only
for **handshake-era** clients. A **modern-era** client — protocol revision 2026-07-28 — got
one of two wrong behaviours, and was told about neither:

- **Over HTTP:** the revision has no protocol-level session and issues no session id, so
  every call started from an empty history. Multi-turn silently stopped working — nothing
  logged, nothing errored, the tool still answered.
- **Over stdio:** the conversation fell back to a per-process sentinel, so history was keyed
  on **process identity**. The 2026-07-28 spec states that connections do not represent
  conversations, that clients may interleave unrelated requests on one transport, and that
  servers must not use connection or process identity to establish context. A modern-era
  stdio client doing exactly what the spec permits got its unrelated requests folded into one
  accumulating history.

### What changed

Continuity stops riding on the transport and becomes something the caller names. The
conversational tool gains an optional `conversation` argument holding an opaque handle: omit
it and the call starts fresh (the server mints a handle and returns it), pass it back and the
conversation continues. This is the mechanism 2026-07-28 prescribes for cross-call state, and
it works in both eras on every transport.

| `conversation` passed | handshake era (≤ 2025-11-25) | modern era (2026-07-28) |
|---|---|---|
| yes | history keyed by handle | history keyed by handle |
| no  | history keyed by the MCP session (per-process over stdio) | a fresh conversation each call |

The process-identity fallback is withdrawn from the modern era only — that is the
non-conformance fix. Handshake-era keying is kept, because there the session genuinely exists
at the protocol level and keying on it is what those revisions prescribe.

### What this looks like for the user

`sessions` and `stateless` are two independent knobs, and the names invite conflating them.
`stateless` is about the **transport** — whether the HTTP layer issues an `mcp-session-id`.
`sessions` is about **history** — whether the server keeps conversations at all. Neither
signature changed; the whole surface is still:

```python
app = MCPServer(agent)                                       # default: conversations on
app = MCPServer(agent, stateless=True)                        # no transport session
app = MCPServer(agent, sessions=False)                        # no histories at all
app = MCPServer(agent, sessions=SessionConfig(max_sessions=256, ttl=3600.0))
```

What a caller then observes (`prompts` is the turn list the agent actually received across
three `tools/call`s):

| configuration | era | `conversation` advertised | text blocks in a reply | no handle passed | handle passed |
|---|---|---|---|---|---|
| `sessions=True` (default) | modern | yes | 2 (reply + handle) | `['first'] ['second']` — unrelated | `['first','third']` — continues |
| `sessions=True` | handshake | yes | 2 (reply + handle) | `['first'] ['first','second']` — the MCP session accumulates | the same conversation the session names |
| `stateless=True, sessions=True` | handshake | yes | 2 (reply + handle) | unrelated (there is no session to key on) | continues |
| `sessions=False` | either | no | 1 (reply only) | unrelated | argument silently ignored, not an error |

Three consequences that only this table makes obvious:

- **The shape of a reply follows `sessions`, not the era.** With conversations on, every reply
  carries the handle block and the `_meta` key even if the caller never names a conversation
  (see *Behaviour change to be aware of* below).
- **`sessions=False` is the only switch that removes the argument from the advertised schema.**
  `stateless=True` does not: conversations remain, they just have to be named explicitly.
- **A handle outranks the MCP session, but not the absence of a store.** In the handshake era a
  presented handle always wins over `mcp-session-id`, and an unrecognised one is a tool error
  rather than a silent fall-back to the session — but under `sessions=False` a presented handle
  is a no-op, because there is no registry to consult.

Guidance in the new guide page: a modern-era deployment should set a `ttl`, because there
every unnamed call takes an LRU slot — one-shot traffic included; and the name-to-history
registry is per-process, so a handle minted on one replica is unknown on another even with a
shared `Storage` backend.

Details worth a reviewer's attention:

- **The handle travels back twice, for two readers.** A text content block, because the spec
  puts recovery from an expired handle on the model and the model does not read protocol
  metadata; and the result's `_meta` under `ai.ag2/conversation`, for programmatic clients.
  `structuredContent` is deliberately left alone: on this tool it is the agent's response
  schema, advertised verbatim as `outputSchema`, which MCP requires structured content to
  conform to — a server field mixed in would break the tool's own declared contract.
  `outputSchema` is unchanged.
- **An unknown or expired handle is a tool execution error**, not a JSON-RPC one, so the model
  can start a new conversation instead of failing the turn. It never falls through to the
  transport session: falling through would let any caller name a conversation of their
  choosing and evict other callers' out of the bounded registry.
- **Handles are server-minted v4 UUIDs, never adopted from the caller** — same reason.
- **A conversation is bound to the principal that created it** (the access token's subject,
  falling back to its client id) and that is revalidated on every call, not at creation. A
  mismatched principal gets the same error as an unknown handle, so the error does not
  disclose that the handle exists. With no `security` configured there is no principal to bind
  to and the handle is the only credential — the docstring and the new guide page say so.
- **The `conversation` argument is advertised only when conversations are enabled**, and its
  description states the conversation's lifetime, derived from the configured bound and idle
  expiry rather than hardcoded.
- **`stateless=True` with `sessions=True` is now a coherent configuration** — no transport
  session, conversations by handle. No construction-time validation was added, and no public
  signature on `MCPServer` changed.

Era detection reads the negotiated protocol version off the request context — a
transport-independent fact — and the set of modern revisions comes from the SDK's own
constant, so `mcp-types` is added to the `mcp` extra rather than hardcoding a revision string.

### Behaviour change to be aware of

Every reply now carries the handle text block and the `_meta` key, in **both** eras, whether
or not the caller ever names a conversation. A handshake-era client that reads the first text
block or `structuredContent` is unaffected; one that asserts on the exact shape of a reply
will notice. This is a deliberate trade: it is what lets a handshake-era client migrate to
explicit handles ahead of changing protocol revision.

### Docs

The serving side of `ag2.mcp` had no user-guide page — it appeared in the guide only in
passing, and the MCP-UI page's "the serving side of `ag2.mcp`" reference linked nowhere. This
PR adds `docs/user-guide/tools/serving_mcp`, registers it in the navigation, and points the
two existing MCP pages at it.

### Out of scope

Mirroring the handle into an HTTP header (`x-mcp-header`); retiring transport-keyed
continuity; renaming the `sessions` / `stateless` parameters; the remaining session-manager
knobs. The ACP tool gateway gains **no production code** — only a regression test pinning that
it issues no session id, since it is per-turn and per-request by construction.

## Related issue number

Closes #3185 (sub-issue of #3183).

Note for reviewers: the issue as filed asks for a statelessness flag on the served-agent
surface and reports the embedded tool gateway as stateful. Both claims turned out to be
wrong — the flag has existed since before the issue was opened, and the gateway has run
stateless from the start. What the issue could not have known is that the flag is
**handshake-era only**: the session manager routes modern-era requests to a separate
single-exchange handler that never issues a session id. So the modern era is unconditionally
stateless, the flag is inert there, and the real gap is the absence of any continuity
mechanism for that era — which is what this PR builds. The stdio non-conformance was found
while checking those claims, and confirmed empirically before being fixed.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

**Validation.** `pytest test/mcp` (137 passed) and `pytest test/acp` (410 passed) locally,
plus `ruff check`, `ruff format --check` and `mypy ag2/mcp` (one pre-existing error on
`testing.py`, unchanged from `main`). Tests cover: modern-era calls not sharing a conversation
over both a stream connection and HTTP (the stream case fails against the pre-change code);
handshake-era accumulation and session isolation, pinned against regression; handles threaded
in both eras; handle present in content and `_meta` and the two agreeing; structured content
byte-for-byte the advertised output schema; unrecognised handle as an error-flagged result
that does not fall back to the transport session; principal binding, including a token with no
subject; the argument absent when conversations are disabled; stateless HTTP serving
conversations by handle; registry bound, idle expiry and storage backend applying to
handle-named conversations; custom tools untouched; the gateway issuing no session id.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

