### PR TITLE
feat(tealtiger): add tool_blocklist governance policy

### DIFF
--- a/ag2/extensions/tealtiger/middleware.py
+++ b/ag2/extensions/tealtiger/middleware.py
@@ -332,6 +332,14 @@ class _TealTigerPerTurn(BaseMiddleware):
                     risk_score = max(risk_score, 80)
                     break
 
+            elif policy.type == "tool_blocklist":
+                blocked = policy.config.get("blocked", [])
+                if any(fnmatch.fnmatch(tool_name, p) for p in blocked):
+                    action = "DENY"
+                    reason_codes.append("TOOL_BLOCKED")
+                    risk_score = max(risk_score, 80)
+                    break
+
             elif policy.type == "pii_block":
                 categories = policy.config.get("categories", [])
                 pii_found = self._detect_pii(args_str, categories)

--- a/ag2/extensions/tealtiger/types.py
+++ b/ag2/extensions/tealtiger/types.py
@@ -35,29 +35,37 @@ class GovernancePolicy:
 
     @classmethod
     def tool_allowlist(cls, allowed: list[str]) -> "GovernancePolicy":
-        """Only allow tools matching these patterns (supports glob-style '*' suffix).
+        """Only allow tools whose name matches one of these patterns.
+
+        Patterns are matched with `fnmatch`, so the full glob syntax (`*`, `?`, `[seq]`)
+        applies. Matching follows the host's filename case rules: case-sensitive on
+        Linux/macOS, case-insensitive on Windows.
 
         Args:
-            allowed: List of tool name patterns. Use '*' suffix for prefix matching.
+            allowed: List of tool name patterns, e.g. `["search", "read_*"]`.
         """
-        return cls(type="tool_allowlist", config={"allowed": allowed})
+        return cls(type="tool_allowlist", config={"allowed": list(allowed)})
 
     @classmethod
     def tool_blocklist(cls, blocked: list[str]) -> "GovernancePolicy":
-        """Deny tools matching these patterns (supports glob-style '*' suffix).
+        """Deny tools whose name matches one of these patterns.
 
         The complement of `tool_allowlist`: everything is allowed except the
         tools named here. Use this when you want to permit most tools but block
         a known-dangerous few (e.g. `delete_*`, `shell`), rather than
         enumerating every safe tool.
 
-        A tool is denied if its name matches any pattern via `fnmatch`, so both
-        exact names (`"shell"`) and globs (`"delete_*"`) are supported. When
-        combined with `tool_allowlist`, either policy denying the call results
-        in a DENY.
+        Patterns are matched with `fnmatch`, so the full glob syntax (`*`, `?`,
+        `[seq]`) applies and exact names (`"shell"`) work too. When combined with
+        `tool_allowlist`, either policy denying the call results in a DENY.
+
+        Matching follows the host's filename case rules — case-sensitive on
+        Linux/macOS, case-insensitive on Windows — so `["shell"]` does not block
+        a tool registered as `Shell` on Linux/macOS. List the casings you need to
+        deny explicitly if tool names are not under your control.
 
         Args:
-            blocked: List of tool name patterns to deny. Use '*' for glob matching.
+            blocked: List of tool name patterns to deny, e.g. `["delete_*", "shell"]`.
 
         Raises:
             ValueError: If `blocked` is empty, which would otherwise create a

--- a/ag2/extensions/tealtiger/types.py
+++ b/ag2/extensions/tealtiger/types.py
@@ -43,6 +43,31 @@ class GovernancePolicy:
         return cls(type="tool_allowlist", config={"allowed": allowed})
 
     @classmethod
+    def tool_blocklist(cls, blocked: list[str]) -> "GovernancePolicy":
+        """Deny tools matching these patterns (supports glob-style '*' suffix).
+
+        The complement of `tool_allowlist`: everything is allowed except the
+        tools named here. Use this when you want to permit most tools but block
+        a known-dangerous few (e.g. `delete_*`, `shell`), rather than
+        enumerating every safe tool.
+
+        A tool is denied if its name matches any pattern via `fnmatch`, so both
+        exact names (`"shell"`) and globs (`"delete_*"`) are supported. When
+        combined with `tool_allowlist`, either policy denying the call results
+        in a DENY.
+
+        Args:
+            blocked: List of tool name patterns to deny. Use '*' for glob matching.
+
+        Raises:
+            ValueError: If `blocked` is empty, which would otherwise create a
+                policy that blocks nothing and silently does nothing.
+        """
+        if not blocked:
+            raise ValueError("`blocked` must not be empty; a tool_blocklist with no patterns blocks nothing.")
+        return cls(type="tool_blocklist", config={"blocked": list(blocked)})
+
+    @classmethod
     def pii_block(cls, categories: list[str] | None = None) -> "GovernancePolicy":
         """Block tool calls containing PII in arguments.
 

--- a/test/extensions/tealtiger/test_tool_blocklist.py
+++ b/test/extensions/tealtiger/test_tool_blocklist.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for TealTiger tool blocklist policy.
+
+The blocklist is the complement of the allowlist: every tool is permitted
+except those matching a blocked pattern. Patterns match tool names via
+``fnmatch``, so both exact names and globs (``delete_*``) are supported.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ag2.events import ToolCallEvent, ToolErrorEvent
+from ag2.extensions.tealtiger import GovernanceMode, GovernancePolicy, TealTigerMiddleware
+from ag2.utils import AGENT_CONTEXT_DEPENDENCY_KEY
+
+
+def _make_context(agent_name: str = "assistant") -> MagicMock:
+    """Create a mock Context with agent dependency."""
+    ctx = MagicMock()
+    agent = MagicMock()
+    agent.name = agent_name
+    ctx.dependencies = {AGENT_CONTEXT_DEPENDENCY_KEY: agent}
+    return ctx
+
+
+def _make_tool_event(name: str = "search", arguments: dict | None = None) -> MagicMock:
+    """Create a mock ToolCallEvent with serialized_arguments."""
+    event = MagicMock(spec=ToolCallEvent)
+    event.name = name
+    args = arguments or {}
+    event.serialized_arguments = args
+    event.arguments = json.dumps(args)
+    event.call_id = "call-123"
+    return event
+
+
+@pytest.mark.asyncio
+class TestToolBlocklist:
+    async def test_non_blocked_tool_passes(self):
+        mw = TealTigerMiddleware(
+            policies=[GovernancePolicy.tool_blocklist(["delete_all", "shell"])],
+            mode=GovernanceMode.ENFORCE,
+        )
+        ctx = _make_context()
+        per_turn = mw(MagicMock(), ctx)
+        event = _make_tool_event(name="search")
+        call_next = AsyncMock(return_value=MagicMock())
+
+        result = await per_turn.on_tool_execution(call_next, event, ctx)
+
+        call_next.assert_awaited_once()
+        assert not isinstance(result, ToolErrorEvent)
+
+    async def test_blocked_tool_returns_error(self):
+        mw = TealTigerMiddleware(
+            policies=[GovernancePolicy.tool_blocklist(["delete_all"])],
+            mode=GovernanceMode.ENFORCE,
+        )
+        ctx = _make_context()
+        per_turn = mw(MagicMock(), ctx)
+        event = _make_tool_event(name="delete_all")
+        call_next = AsyncMock()
+
+        result = await per_turn.on_tool_execution(call_next, event, ctx)
+
+        assert isinstance(result, ToolErrorEvent)
+        assert "GOVERNANCE DENIED" in str(result.error)
+        assert "TOOL_BLOCKED" in str(result.error)
+        call_next.assert_not_awaited()
+
+    async def test_glob_pattern_blocks_matching_tools(self):
+        mw = TealTigerMiddleware(
+            policies=[GovernancePolicy.tool_blocklist(["delete_*"])],
+            mode=GovernanceMode.ENFORCE,
+        )
+        ctx = _make_context()
+        per_turn = mw(MagicMock(), ctx)
+        event = _make_tool_event(name="delete_database")
+        call_next = AsyncMock()
+
+        result = await per_turn.on_tool_execution(call_next, event, ctx)
+
+        assert isinstance(result, ToolErrorEvent)
+        assert "TOOL_BLOCKED" in str(result.error)
+        call_next.assert_not_awaited()
+
+    async def test_glob_pattern_allows_non_matching_tools(self):
+        mw = TealTigerMiddleware(
+            policies=[GovernancePolicy.tool_blocklist(["delete_*"])],
+            mode=GovernanceMode.ENFORCE,
+        )
+        ctx = _make_context()
+        per_turn = mw(MagicMock(), ctx)
+        event = _make_tool_event(name="read_file")
+        call_next = AsyncMock(return_value=MagicMock())
+
+        result = await per_turn.on_tool_execution(call_next, event, ctx)
+
+        call_next.assert_awaited_once()
+        assert not isinstance(result, ToolErrorEvent)
+
+    async def test_blocked_decision_recorded(self):
+        mw = TealTigerMiddleware(
+            policies=[GovernancePolicy.tool_blocklist(["shell"])],
+            mode=GovernanceMode.ENFORCE,
+        )
+        ctx = _make_context()
+        per_turn = mw(MagicMock(), ctx)
+        event = _make_tool_event(name="shell")
+        call_next = AsyncMock()
+
+        await per_turn.on_tool_execution(call_next, event, ctx)
+
+        last = mw.decisions[-1]
+        assert last.action == "DENY"
+        assert "TOOL_BLOCKED" in last.reason_codes
+        assert mw.deny_count == 1
+
+    async def test_observe_mode_allows_blocked_tool(self):
+        mw = TealTigerMiddleware(
+            policies=[GovernancePolicy.tool_blocklist(["delete_all"])],
+            mode=GovernanceMode.OBSERVE,
+        )
+        ctx = _make_context()
+        per_turn = mw(MagicMock(), ctx)
+        event = _make_tool_event(name="delete_all")
+        call_next = AsyncMock(return_value=MagicMock())
+
+        result = await per_turn.on_tool_execution(call_next, event, ctx)
+
+        call_next.assert_awaited_once()
+        assert not isinstance(result, ToolErrorEvent)
+
+    async def test_monitor_mode_records_but_allows_blocked_tool(self):
+        mw = TealTigerMiddleware(
+            policies=[GovernancePolicy.tool_blocklist(["delete_all"])],
+            mode=GovernanceMode.MONITOR,
+        )
+        ctx = _make_context()
+        per_turn = mw(MagicMock(), ctx)
+        event = _make_tool_event(name="delete_all")
+        call_next = AsyncMock(return_value=MagicMock())
+
+        result = await per_turn.on_tool_execution(call_next, event, ctx)
+
+        call_next.assert_awaited_once()
+        assert not isinstance(result, ToolErrorEvent)
+        assert mw.decisions[-1].action == "DENY"
+
+    async def test_allowlist_and_blocklist_combine(self):
+        # Allowlist permits read_*, blocklist carves out read_secrets.
+        mw = TealTigerMiddleware(
+            policies=[
+                GovernancePolicy.tool_allowlist(["read_*"]),
+                GovernancePolicy.tool_blocklist(["read_secrets"]),
+            ],
+            mode=GovernanceMode.ENFORCE,
+        )
+        ctx = _make_context()
+
+        allowed = mw(MagicMock(), ctx)
+        allowed_event = _make_tool_event(name="read_file")
+        allowed_next = AsyncMock(return_value=MagicMock())
+        allowed_result = await allowed.on_tool_execution(allowed_next, allowed_event, ctx)
+        allowed_next.assert_awaited_once()
+        assert not isinstance(allowed_result, ToolErrorEvent)
+
+        blocked = mw(MagicMock(), ctx)
+        blocked_event = _make_tool_event(name="read_secrets")
+        blocked_next = AsyncMock()
+        blocked_result = await blocked.on_tool_execution(blocked_next, blocked_event, ctx)
+        assert isinstance(blocked_result, ToolErrorEvent)
+        assert "TOOL_BLOCKED" in str(blocked_result.error)
+        blocked_next.assert_not_awaited()
+
+
+def test_empty_blocklist_raises():
+    with pytest.raises(ValueError, match="must not be empty"):
+        GovernancePolicy.tool_blocklist([])

--- a/test/extensions/tealtiger/test_tool_blocklist.py
+++ b/test/extensions/tealtiger/test_tool_blocklist.py
@@ -6,176 +6,278 @@
 The blocklist is the complement of the allowlist: every tool is permitted
 except those matching a blocked pattern. Patterns match tool names via
 ``fnmatch``, so both exact names and globs (``delete_*``) are supported.
-"""
 
-import json
-from unittest.mock import AsyncMock, MagicMock
+Each case scripts a real agent's turn with ``TestConfig`` so the middleware runs
+where it does in production. Every tool appends to ``ran`` before returning, so
+"the call was blocked" is observed as the tool body never having executed. In
+ENFORCE mode a denial fails the turn, so ``ask`` raises — the same way any tool
+error does.
+"""
 
 import pytest
 
-from ag2.events import ToolCallEvent, ToolErrorEvent
+from ag2 import Agent
+from ag2.events import ToolCallEvent
 from ag2.extensions.tealtiger import GovernanceMode, GovernancePolicy, TealTigerMiddleware
-from ag2.utils import AGENT_CONTEXT_DEPENDENCY_KEY
-
-
-def _make_context(agent_name: str = "assistant") -> MagicMock:
-    """Create a mock Context with agent dependency."""
-    ctx = MagicMock()
-    agent = MagicMock()
-    agent.name = agent_name
-    ctx.dependencies = {AGENT_CONTEXT_DEPENDENCY_KEY: agent}
-    return ctx
-
-
-def _make_tool_event(name: str = "search", arguments: dict | None = None) -> MagicMock:
-    """Create a mock ToolCallEvent with serialized_arguments."""
-    event = MagicMock(spec=ToolCallEvent)
-    event.name = name
-    args = arguments or {}
-    event.serialized_arguments = args
-    event.arguments = json.dumps(args)
-    event.call_id = "call-123"
-    return event
+from ag2.testing import TestConfig
 
 
 @pytest.mark.asyncio
 class TestToolBlocklist:
-    async def test_non_blocked_tool_passes(self):
-        mw = TealTigerMiddleware(
+    async def test_tool_outside_the_blocklist_runs(self):
+        ran: list[str] = []
+
+        def search() -> str:
+            ran.append("search")
+            return "found it"
+
+        governance = TealTigerMiddleware(
             policies=[GovernancePolicy.tool_blocklist(["delete_all", "shell"])],
             mode=GovernanceMode.ENFORCE,
         )
-        ctx = _make_context()
-        per_turn = mw(MagicMock(), ctx)
-        event = _make_tool_event(name="search")
-        call_next = AsyncMock(return_value=MagicMock())
+        agent = Agent(
+            "assistant",
+            config=TestConfig(ToolCallEvent(name="search", arguments="{}"), "Done."),
+            tools=[search],
+            middleware=[governance],
+        )
 
-        result = await per_turn.on_tool_execution(call_next, event, ctx)
+        reply = await agent.ask("look it up")
 
-        call_next.assert_awaited_once()
-        assert not isinstance(result, ToolErrorEvent)
+        assert reply.body == "Done."
+        assert ran == ["search"]
+        assert governance.deny_count == 0
 
-    async def test_blocked_tool_returns_error(self):
-        mw = TealTigerMiddleware(
+    async def test_blocked_tool_never_executes(self):
+        ran: list[str] = []
+
+        def delete_all() -> str:
+            ran.append("delete_all")
+            return "deleted everything"
+
+        governance = TealTigerMiddleware(
             policies=[GovernancePolicy.tool_blocklist(["delete_all"])],
             mode=GovernanceMode.ENFORCE,
         )
-        ctx = _make_context()
-        per_turn = mw(MagicMock(), ctx)
-        event = _make_tool_event(name="delete_all")
-        call_next = AsyncMock()
+        agent = Agent(
+            "assistant",
+            config=TestConfig(ToolCallEvent(name="delete_all", arguments="{}"), "Done."),
+            tools=[delete_all],
+            middleware=[governance],
+        )
 
-        result = await per_turn.on_tool_execution(call_next, event, ctx)
+        with pytest.raises(Exception, match=r"\[GOVERNANCE DENIED\].*TOOL_BLOCKED"):
+            await agent.ask("clean up")
 
-        assert isinstance(result, ToolErrorEvent)
-        assert "GOVERNANCE DENIED" in str(result.error)
-        assert "TOOL_BLOCKED" in str(result.error)
-        call_next.assert_not_awaited()
+        assert ran == []
 
     async def test_glob_pattern_blocks_matching_tools(self):
-        mw = TealTigerMiddleware(
+        ran: list[str] = []
+
+        def delete_database() -> str:
+            ran.append("delete_database")
+            return "dropped"
+
+        governance = TealTigerMiddleware(
             policies=[GovernancePolicy.tool_blocklist(["delete_*"])],
             mode=GovernanceMode.ENFORCE,
         )
-        ctx = _make_context()
-        per_turn = mw(MagicMock(), ctx)
-        event = _make_tool_event(name="delete_database")
-        call_next = AsyncMock()
+        agent = Agent(
+            "assistant",
+            config=TestConfig(ToolCallEvent(name="delete_database", arguments="{}"), "Done."),
+            tools=[delete_database],
+            middleware=[governance],
+        )
 
-        result = await per_turn.on_tool_execution(call_next, event, ctx)
+        with pytest.raises(Exception, match="TOOL_BLOCKED"):
+            await agent.ask("clean up")
 
-        assert isinstance(result, ToolErrorEvent)
-        assert "TOOL_BLOCKED" in str(result.error)
-        call_next.assert_not_awaited()
+        assert ran == []
 
-    async def test_glob_pattern_allows_non_matching_tools(self):
-        mw = TealTigerMiddleware(
+    async def test_glob_pattern_leaves_non_matching_tools_alone(self):
+        ran: list[str] = []
+
+        def read_file() -> str:
+            ran.append("read_file")
+            return "file contents"
+
+        governance = TealTigerMiddleware(
             policies=[GovernancePolicy.tool_blocklist(["delete_*"])],
             mode=GovernanceMode.ENFORCE,
         )
-        ctx = _make_context()
-        per_turn = mw(MagicMock(), ctx)
-        event = _make_tool_event(name="read_file")
-        call_next = AsyncMock(return_value=MagicMock())
+        agent = Agent(
+            "assistant",
+            config=TestConfig(ToolCallEvent(name="read_file", arguments="{}"), "Done."),
+            tools=[read_file],
+            middleware=[governance],
+        )
 
-        result = await per_turn.on_tool_execution(call_next, event, ctx)
+        reply = await agent.ask("read it")
 
-        call_next.assert_awaited_once()
-        assert not isinstance(result, ToolErrorEvent)
+        assert reply.body == "Done."
+        assert ran == ["read_file"]
 
-    async def test_blocked_decision_recorded(self):
-        mw = TealTigerMiddleware(
+    async def test_denial_is_recorded_with_a_receipt(self):
+        def shell() -> str:
+            return "shell output"
+
+        governance = TealTigerMiddleware(
             policies=[GovernancePolicy.tool_blocklist(["shell"])],
             mode=GovernanceMode.ENFORCE,
         )
-        ctx = _make_context()
-        per_turn = mw(MagicMock(), ctx)
-        event = _make_tool_event(name="shell")
-        call_next = AsyncMock()
+        agent = Agent(
+            "assistant",
+            config=TestConfig(ToolCallEvent(name="shell", arguments="{}"), "Done."),
+            tools=[shell],
+            middleware=[governance],
+        )
 
-        await per_turn.on_tool_execution(call_next, event, ctx)
+        with pytest.raises(Exception, match="TOOL_BLOCKED"):
+            await agent.ask("run it")
 
-        last = mw.decisions[-1]
-        assert last.action == "DENY"
-        assert "TOOL_BLOCKED" in last.reason_codes
-        assert mw.deny_count == 1
+        decision = governance.decisions[-1]
+        assert decision.action == "DENY"
+        assert decision.reason_codes == ["TOOL_BLOCKED"]
+        assert decision.risk_score == 80
+        assert decision.tool_name == "shell"
+        assert decision.agent_name == "assistant"
+        assert governance.deny_count == 1
+        assert governance.receipts[-1].execution_outcome == "blocked"
 
-    async def test_observe_mode_allows_blocked_tool(self):
-        mw = TealTigerMiddleware(
+    async def test_observe_mode_skips_evaluation_entirely(self):
+        ran: list[str] = []
+
+        def delete_all() -> str:
+            ran.append("delete_all")
+            return "deleted everything"
+
+        governance = TealTigerMiddleware(
             policies=[GovernancePolicy.tool_blocklist(["delete_all"])],
             mode=GovernanceMode.OBSERVE,
         )
-        ctx = _make_context()
-        per_turn = mw(MagicMock(), ctx)
-        event = _make_tool_event(name="delete_all")
-        call_next = AsyncMock(return_value=MagicMock())
+        agent = Agent(
+            "assistant",
+            config=TestConfig(ToolCallEvent(name="delete_all", arguments="{}"), "Done."),
+            tools=[delete_all],
+            middleware=[governance],
+        )
 
-        result = await per_turn.on_tool_execution(call_next, event, ctx)
+        reply = await agent.ask("clean up")
 
-        call_next.assert_awaited_once()
-        assert not isinstance(result, ToolErrorEvent)
+        assert reply.body == "Done."
+        assert ran == ["delete_all"]
+        # OBSERVE short-circuits before any policy runs, so no TOOL_BLOCKED is ever
+        # recorded — the audit trail shows only the pass-through, as with the allowlist.
+        assert governance.decisions[-1].action == "ALLOW"
+        assert governance.decisions[-1].reason_codes == ["OBSERVE_PASSTHROUGH"]
 
-    async def test_monitor_mode_records_but_allows_blocked_tool(self):
-        mw = TealTigerMiddleware(
+    async def test_monitor_mode_records_the_denial_but_lets_the_call_through(self):
+        ran: list[str] = []
+
+        def delete_all() -> str:
+            ran.append("delete_all")
+            return "deleted everything"
+
+        governance = TealTigerMiddleware(
             policies=[GovernancePolicy.tool_blocklist(["delete_all"])],
             mode=GovernanceMode.MONITOR,
         )
-        ctx = _make_context()
-        per_turn = mw(MagicMock(), ctx)
-        event = _make_tool_event(name="delete_all")
-        call_next = AsyncMock(return_value=MagicMock())
-
-        result = await per_turn.on_tool_execution(call_next, event, ctx)
-
-        call_next.assert_awaited_once()
-        assert not isinstance(result, ToolErrorEvent)
-        assert mw.decisions[-1].action == "DENY"
-
-    async def test_allowlist_and_blocklist_combine(self):
-        # Allowlist permits read_*, blocklist carves out read_secrets.
-        mw = TealTigerMiddleware(
-            policies=[
-                GovernancePolicy.tool_allowlist(["read_*"]),
-                GovernancePolicy.tool_blocklist(["read_secrets"]),
-            ],
-            mode=GovernanceMode.ENFORCE,
+        agent = Agent(
+            "assistant",
+            config=TestConfig(ToolCallEvent(name="delete_all", arguments="{}"), "Done."),
+            tools=[delete_all],
+            middleware=[governance],
         )
-        ctx = _make_context()
 
-        allowed = mw(MagicMock(), ctx)
-        allowed_event = _make_tool_event(name="read_file")
-        allowed_next = AsyncMock(return_value=MagicMock())
-        allowed_result = await allowed.on_tool_execution(allowed_next, allowed_event, ctx)
-        allowed_next.assert_awaited_once()
-        assert not isinstance(allowed_result, ToolErrorEvent)
+        reply = await agent.ask("clean up")
 
-        blocked = mw(MagicMock(), ctx)
-        blocked_event = _make_tool_event(name="read_secrets")
-        blocked_next = AsyncMock()
-        blocked_result = await blocked.on_tool_execution(blocked_next, blocked_event, ctx)
-        assert isinstance(blocked_result, ToolErrorEvent)
-        assert "TOOL_BLOCKED" in str(blocked_result.error)
-        blocked_next.assert_not_awaited()
+        assert reply.body == "Done."
+        assert ran == ["delete_all"]
+        assert governance.decisions[-1].action == "DENY"
+        assert governance.decisions[-1].reason_codes == ["TOOL_BLOCKED"]
+
+
+# The allowlist permits read_*; the blocklist carves out read_secrets. Whichever
+# policy denies is the one reported, whatever its position in the list — so both
+# orderings have to behave identically.
+_COMPOSED_POLICIES = {
+    "allowlist-first": [
+        GovernancePolicy.tool_allowlist(["read_*"]),
+        GovernancePolicy.tool_blocklist(["read_secrets"]),
+    ],
+    "blocklist-first": [
+        GovernancePolicy.tool_blocklist(["read_secrets"]),
+        GovernancePolicy.tool_allowlist(["read_*"]),
+    ],
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("order", list(_COMPOSED_POLICIES))
+class TestAllowlistAndBlocklistCompose:
+    async def test_a_tool_both_policies_accept_runs(self, order: str):
+        ran: list[str] = []
+
+        def read_file() -> str:
+            ran.append("read_file")
+            return "file contents"
+
+        governance = TealTigerMiddleware(policies=_COMPOSED_POLICIES[order], mode=GovernanceMode.ENFORCE)
+        agent = Agent(
+            "assistant",
+            config=TestConfig(ToolCallEvent(name="read_file", arguments="{}"), "Done."),
+            tools=[read_file],
+            middleware=[governance],
+        )
+
+        reply = await agent.ask("read it")
+
+        assert reply.body == "Done."
+        assert ran == ["read_file"]
+
+    async def test_the_blocklist_carve_out_is_denied(self, order: str):
+        ran: list[str] = []
+
+        def read_secrets() -> str:
+            ran.append("read_secrets")
+            return "hunter2"
+
+        governance = TealTigerMiddleware(policies=_COMPOSED_POLICIES[order], mode=GovernanceMode.ENFORCE)
+        agent = Agent(
+            "assistant",
+            config=TestConfig(ToolCallEvent(name="read_secrets", arguments="{}"), "Done."),
+            tools=[read_secrets],
+            middleware=[governance],
+        )
+
+        with pytest.raises(Exception, match="TOOL_BLOCKED"):
+            await agent.ask("read it")
+
+        assert ran == []
+        assert governance.decisions[-1].reason_codes == ["TOOL_BLOCKED"]
+
+    async def test_a_tool_outside_the_allowlist_still_reports_the_allowlist(self, order: str):
+        # Composition must not mask the allowlist: a tool that is neither allowed
+        # nor blocked is denied, under the allowlist's own reason code.
+        ran: list[str] = []
+
+        def shell() -> str:
+            ran.append("shell")
+            return "shell output"
+
+        governance = TealTigerMiddleware(policies=_COMPOSED_POLICIES[order], mode=GovernanceMode.ENFORCE)
+        agent = Agent(
+            "assistant",
+            config=TestConfig(ToolCallEvent(name="shell", arguments="{}"), "Done."),
+            tools=[shell],
+            middleware=[governance],
+        )
+
+        with pytest.raises(Exception, match="TOOL_NOT_ALLOWED"):
+            await agent.ask("run it")
+
+        assert ran == []
+        assert governance.decisions[-1].reason_codes == ["TOOL_NOT_ALLOWED"]
 
 
 def test_empty_blocklist_raises():

--- a/uv.lock
+++ b/uv.lock
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "ag2"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/website/docs/user-guide/extensions/tealtiger.mdx
+++ b/website/docs/user-guide/extensions/tealtiger.mdx
@@ -146,14 +146,28 @@ Any tool matching a pattern is denied with reason code `TOOL_BLOCKED` and risk s
 
 An empty blocklist raises `ValueError` at policy construction, so a policy that blocks nothing cannot be created by mistake.
 
-You can combine an allowlist with a blocklist — for example, permit everything under `read_*` but still deny `read_secrets`. When both are configured, either policy denying the call results in a `DENY` (the first one in your list is the one reported):
+You can combine an allowlist with a blocklist — for example, permit everything under `read_*` but still deny `read_secrets`. When both are configured, every policy is evaluated until one denies, so either one denying results in a `DENY`; the policy that denies is the one reported, whatever its position in the list:
 
 ```python linenums="1"
-policies=[
-    GovernancePolicy.tool_allowlist(["read_*"]),
-    GovernancePolicy.tool_blocklist(["read_secrets"]),
-]
+from ag2.extensions.tealtiger import GovernancePolicy, TealTigerMiddleware
+
+governance = TealTigerMiddleware(
+    policies=[
+        GovernancePolicy.tool_allowlist(["read_*"]),
+        GovernancePolicy.tool_blocklist(["read_secrets"]),
+    ],
+)
 ```
+
+Here `read_file` passes both policies, while `read_secrets` clears the allowlist and is denied by the blocklist — so the reason code is `TOOL_BLOCKED`, from the *second* entry.
+
+!!! warning "Pattern matching is case-sensitive on Linux and macOS"
+
+    `fnmatch` normalizes case the way the host filesystem does, so `["shell"]` blocks `shell`
+    but **not** `Shell` on Linux/macOS, while on Windows it blocks both. For an allowlist that
+    asymmetry denies too much; for a blocklist it lets a call through. If your tool names are
+    not under your control, list the casings you need to block explicitly, or normalize tool
+    names before registering them.
 
 ### PII Detection
 

--- a/website/docs/user-guide/extensions/tealtiger.mdx
+++ b/website/docs/user-guide/extensions/tealtiger.mdx
@@ -3,7 +3,7 @@ title: TealTiger Governance
 sidebarTitle: TealTiger
 ---
 
-The `ag2.extensions.tealtiger` module adds deterministic governance guardrails to AG2 agents. `TealTigerMiddleware` enforces tool allowlists, detects PII and secrets in tool arguments, blocks prompt injection attempts, tracks per-session cost, provides per-agent kill switches, and produces structured TEEC audit receipts — with no LLM in the governance path.
+The `ag2.extensions.tealtiger` module adds deterministic governance guardrails to AG2 agents. `TealTigerMiddleware` enforces tool allowlists and blocklists, detects PII and secrets in tool arguments, blocks prompt injection attempts, tracks per-session cost, provides per-agent kill switches, and produces structured TEEC audit receipts — with no LLM in the governance path.
 
 ## Installation
 
@@ -90,7 +90,7 @@ flowchart LR
 | Hook | Stage | What It Does |
 |------|-------|-------------|
 | `on_turn` | Turn defense | Kill switch enforcement — frozen agents cannot take turns |
-| `on_tool_execution` | Pre-tool defense | Tool allowlist, PII scan, secret scan, cost limit check |
+| `on_tool_execution` | Pre-tool defense | Tool allowlist/blocklist, PII scan, secret scan, cost limit check |
 
 Both stages activate from a single middleware instance. The **middleware factory** pattern keeps state (decisions, receipts, cost, frozen agents) alive across turns.
 
@@ -133,6 +133,27 @@ GovernancePolicy.tool_allowlist(["search", "read_*", "github_*"])
 ```
 
 Any tool not matching the patterns is denied with reason code `TOOL_NOT_ALLOWED` and risk score 80.
+
+### Tool Blocklist
+
+The complement of the allowlist: allow every tool *except* the ones you name. Reach for this when an agent has many safe tools and only a few dangerous ones, so enumerating every safe tool would be tedious. Patterns are matched with `fnmatch`, so the full glob syntax (`*`, `?`, `[seq]`) applies:
+
+```python linenums="1"
+GovernancePolicy.tool_blocklist(["delete_*", "shell", "drop_table"])
+```
+
+Any tool matching a pattern is denied with reason code `TOOL_BLOCKED` and risk score 80.
+
+An empty blocklist raises `ValueError` at policy construction, so a policy that blocks nothing cannot be created by mistake.
+
+You can combine an allowlist with a blocklist — for example, permit everything under `read_*` but still deny `read_secrets`. When both are configured, either policy denying the call results in a `DENY` (the first one in your list is the one reported):
+
+```python linenums="1"
+policies=[
+    GovernancePolicy.tool_allowlist(["read_*"]),
+    GovernancePolicy.tool_blocklist(["read_secrets"]),
+]
+```
 
 ### PII Detection
 
@@ -304,7 +325,7 @@ for decision in governance.decisions:
 | `mode` | `str` | Mode the decision was made under: `OBSERVE`, `MONITOR`, or `ENFORCE` |
 | `agent_name` | `str` | Agent that made the call, or `unknown` |
 | `tool_name` | `str` | Tool that was evaluated (`*` for turn-level denials) |
-| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `BUDGET_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
+| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `TOOL_BLOCKED`, `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `BUDGET_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
 | `risk_score` | `int` | 0 (safe) to 100 (critical) |
 | `evaluation_time_ms` | `float` | Governance latency for this decision |
 | `cost_tracked` | `float` | Cost attributed to this call in USD |
@@ -509,6 +530,7 @@ Each policy type carries its own risk score when it denies:
 | Secret detection | `SECRET_DETECTED` | 95 |
 | PII detection | `PII_DETECTED:{category}` | 90 |
 | Tool allowlist | `TOOL_NOT_ALLOWED` | 80 |
+| Tool blocklist | `TOOL_BLOCKED` | 80 |
 | Cost limit / factory budget | `BUDGET_EXCEEDED` | 70 |
 
 !!! warning "Policy order is yours to choose"


### PR DESCRIPTION
## Why are these changes needed?

The built-in TealTiger governance extension can restrict tools with `tool_allowlist`, but an allowlist forces you to enumerate every safe tool. When an agent has many benign tools and only a few dangerous ones, that is the wrong default — you want to permit everything except a known-bad set.

This adds `GovernancePolicy.tool_blocklist(blocked)`, the complement of `tool_allowlist`:

- Denies any tool whose name matches a blocked pattern; everything else is allowed.
- Patterns match tool names via `fnmatch`, so both exact names (`"shell"`) and globs (`"delete_*"`) work — consistent with how `tool_allowlist` matches.
- A denied call produces a `TOOL_BLOCKED` decision (risk score 80) and, in `ENFORCE` mode, short-circuits execution with a `[GOVERNANCE DENIED]` `ToolErrorEvent`. `OBSERVE`/`MONITOR` modes record the decision without blocking, matching the allowlist's behavior.
- Empty blocklists raise `ValueError` at construction, so a policy that silently blocks nothing cannot be created.
- Allowlist and blocklist compose: if both are configured, either one denying results in a DENY (useful for "allow `read_*` but not `read_secrets`").

No new dependencies — evaluation stays deterministic and inline (`fnmatch` from stdlib, no LLM in the governance path). This is part of the extension's Phase 2 detection expansion, alongside the recently added prompt injection detection.

## Related issue number

<!-- Fill in if there is a tracking issue, e.g. "Closes #NNNN". Otherwise remove. -->

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

### Validation

- Added `test/extensions/tealtiger/test_tool_blocklist.py` (9 tests): non-blocked pass-through, exact + glob deny, decision recording, OBSERVE/MONITOR pass-through, allowlist+blocklist composition, and the empty-list `ValueError`.
- `python -m pytest test/extensions/tealtiger/` — 117 passed (existing extension tests + the new ones).
- `ruff check` and `ruff format --check` pass on all changed files.
- Documented the policy in `website/docs/user-guide/extensions/tealtiger.mdx`: new **Tool Blocklist** section, `TOOL_BLOCKED` added to the decision-contract and evaluation-order tables, and a note on allowlist/blocklist composition.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
