### PR TITLE
fix(middleware): stop retries after streaming chunks

### DIFF
--- a/ag2/middleware/builtin/llm_retry.py
+++ b/ag2/middleware/builtin/llm_retry.py
@@ -5,7 +5,7 @@
 from collections.abc import Sequence
 
 from ag2.annotations import Context
-from ag2.events import BaseEvent, ModelResponse
+from ag2.events import BaseEvent, ModelMessageChunk, ModelResponse
 from ag2.middleware.base import BaseMiddleware, LLMCall, MiddlewareFactory
 from ag2.middleware.describe import MiddlewareDescription
 
@@ -59,9 +59,25 @@ class _RetryMiddleware(BaseMiddleware):
         context: Context,
     ) -> ModelResponse:
         for _ in range(self._max_retries):
-            try:
-                return await call_next(events, context)
-            except self._retry_on:
-                pass
+            attempt = _RetryAttempt()
+            with context.stream.where(ModelMessageChunk).sub_scope(
+                attempt.on_message_chunk,
+                interrupt=True,
+                sync_to_thread=False,
+            ):
+                try:
+                    return await call_next(events, context)
+                except self._retry_on:
+                    if attempt.message_chunk_emitted:
+                        raise
         # Final attempt — let the original exception propagate.
         return await call_next(events, context)
+
+
+class _RetryAttempt:
+    def __init__(self) -> None:
+        self.message_chunk_emitted = False
+
+    def on_message_chunk(self, event: ModelMessageChunk) -> ModelMessageChunk:
+        self.message_chunk_emitted = True
+        return event

--- a/ag2/middleware/builtin/llm_retry.py
+++ b/ag2/middleware/builtin/llm_retry.py
@@ -37,35 +37,6 @@ class RetryMiddleware(MiddlewareFactory):
         )
 
 
-class _RetryAttempt:
-    """Records whether one attempt has already put an event on the stream.
-
-    No event type is named here on purpose. An ``on_llm_call`` scope bottoms out
-    at the provider client, and the agent loop publishes its own events —
-    ``ModelRequest``, ``ToolCallsEvent``, ``UsageEvent`` — outside the middleware
-    chain. So everything reaching this hook is the client's own output: streamed
-    chunks and reasoning, the message, server-side tool calls and results, provider
-    replay carriers. All of it is equally unrecallable once sent, and a list of
-    types would only be a copy of the clients' send sites, going stale the first
-    time one of them learns a new event.
-
-    Registered as an *interrupter* rather than a plain subscriber, because
-    interrupters run first in ``Stream.send`` and may drop an event: whatever an
-    earlier interrupter filtered out never reaches a subscriber, so it must not
-    count as published here either. Returning the event unchanged is what hands it
-    on — returning ``None`` would swallow it for every consumer.
-    """
-
-    __slots__ = ("published",)
-
-    def __init__(self) -> None:
-        self.published = False
-
-    def on_published(self, event: BaseEvent) -> BaseEvent:
-        self.published = True
-        return event
-
-
 class _RetryMiddleware(BaseMiddleware):
     """Retry LLM calls on transient failures."""
 
@@ -88,12 +59,12 @@ class _RetryMiddleware(BaseMiddleware):
         context: Context,
     ) -> ModelResponse:
         for _ in range(self._max_retries):
-            attempt = _RetryAttempt()
-            with context.stream.sub_scope(
-                attempt.on_published,
-                interrupt=True,
-                sync_to_thread=False,
-            ):
+            # Watch for *any* event: an ``on_llm_call`` scope bottoms out at the
+            # provider client, and the agent loop publishes its own events —
+            # ``ModelRequest``, ``ToolCallsEvent``, ``UsageEvent`` — outside the
+            # middleware chain, so whatever lands here is the client's own output:
+            # streamed chunks and reasoning, the message, server-side tool calls.
+            async with context.stream.get(BaseEvent) as published:
                 try:
                     return await call_next(events, context)
                 except self._retry_on:
@@ -101,7 +72,7 @@ class _RetryMiddleware(BaseMiddleware):
                     # so it is safely repeatable. One that published is not: the
                     # retry's output would be concatenated onto it by every live
                     # consumer, while the reply carries only the retry's.
-                    if attempt.published:
+                    if published.done():
                         raise
         # Final attempt — let the original exception propagate.
         return await call_next(events, context)

--- a/ag2/middleware/builtin/llm_retry.py
+++ b/ag2/middleware/builtin/llm_retry.py
@@ -5,7 +5,7 @@
 from collections.abc import Sequence
 
 from ag2.annotations import Context
-from ag2.events import BaseEvent, ModelMessageChunk, ModelResponse
+from ag2.events import BaseEvent, ModelResponse
 from ag2.middleware.base import BaseMiddleware, LLMCall, MiddlewareFactory
 from ag2.middleware.describe import MiddlewareDescription
 
@@ -37,6 +37,35 @@ class RetryMiddleware(MiddlewareFactory):
         )
 
 
+class _RetryAttempt:
+    """Records whether one attempt has already put an event on the stream.
+
+    No event type is named here on purpose. An ``on_llm_call`` scope bottoms out
+    at the provider client, and the agent loop publishes its own events —
+    ``ModelRequest``, ``ToolCallsEvent``, ``UsageEvent`` — outside the middleware
+    chain. So everything reaching this hook is the client's own output: streamed
+    chunks and reasoning, the message, server-side tool calls and results, provider
+    replay carriers. All of it is equally unrecallable once sent, and a list of
+    types would only be a copy of the clients' send sites, going stale the first
+    time one of them learns a new event.
+
+    Registered as an *interrupter* rather than a plain subscriber, because
+    interrupters run first in ``Stream.send`` and may drop an event: whatever an
+    earlier interrupter filtered out never reaches a subscriber, so it must not
+    count as published here either. Returning the event unchanged is what hands it
+    on — returning ``None`` would swallow it for every consumer.
+    """
+
+    __slots__ = ("published",)
+
+    def __init__(self) -> None:
+        self.published = False
+
+    def on_published(self, event: BaseEvent) -> BaseEvent:
+        self.published = True
+        return event
+
+
 class _RetryMiddleware(BaseMiddleware):
     """Retry LLM calls on transient failures."""
 
@@ -60,24 +89,19 @@ class _RetryMiddleware(BaseMiddleware):
     ) -> ModelResponse:
         for _ in range(self._max_retries):
             attempt = _RetryAttempt()
-            with context.stream.where(ModelMessageChunk).sub_scope(
-                attempt.on_message_chunk,
+            with context.stream.sub_scope(
+                attempt.on_published,
                 interrupt=True,
                 sync_to_thread=False,
             ):
                 try:
                     return await call_next(events, context)
                 except self._retry_on:
-                    if attempt.message_chunk_emitted:
+                    # An attempt that published nothing left no trace to contradict,
+                    # so it is safely repeatable. One that published is not: the
+                    # retry's output would be concatenated onto it by every live
+                    # consumer, while the reply carries only the retry's.
+                    if attempt.published:
                         raise
         # Final attempt — let the original exception propagate.
         return await call_next(events, context)
-
-
-class _RetryAttempt:
-    def __init__(self) -> None:
-        self.message_chunk_emitted = False
-
-    def on_message_chunk(self, event: ModelMessageChunk) -> ModelMessageChunk:
-        self.message_chunk_emitted = True
-        return event

--- a/ag2/testing.py
+++ b/ag2/testing.py
@@ -3,14 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 from unittest.mock import MagicMock
 
 from typing_extensions import Self
 
 from ag2 import Context
 from ag2.config import LLMClient, ModelConfig, ModelProvider
-from ag2.events import BaseEvent, ModelMessage, ModelResponse, ToolCallEvent, ToolCallsEvent, ToolErrorEvent
+from ag2.events import (
+    BaseEvent,
+    BuiltinToolCallEvent,
+    ModelMessage,
+    ModelResponse,
+    ToolCallEvent,
+    ToolCallsEvent,
+    ToolErrorEvent,
+)
 
 if TYPE_CHECKING:
     from ag2.files.protocol import FilesClient
@@ -18,7 +26,20 @@ if TYPE_CHECKING:
 __all__ = (
     "TestConfig",
     "TrackingConfig",
+    "Turn",
 )
+
+Turn: TypeAlias = "str | ModelResponse | ToolCallEvent | Iterable[ToolCallEvent] | BaseEvent | BaseException"
+"""One scripted LLM turn.
+
+* ``str`` — the model replies with that text.
+* ``ToolCallEvent`` (or an iterable of them) — the model calls tools.
+* ``ModelResponse`` — the response, spelled out in full.
+* ``BaseException`` — the call fails with it, the way a provider client would.
+* any other ``BaseEvent`` — published to the stream *during* the turn, exactly as
+  a provider client streams chunks or reasoning, then the script is read on for
+  whatever ends the turn.
+"""
 
 
 class TestClient(LLMClient):
@@ -26,7 +47,7 @@ class TestClient(LLMClient):
 
     def __init__(
         self,
-        *events: str | ModelResponse | ToolCallEvent | Iterable[ToolCallEvent],
+        *events: "Turn",
         raise_tool_errors: bool = True,
     ) -> None:
         self.events = iter(events)
@@ -43,20 +64,34 @@ class TestClient(LLMClient):
                 if isinstance(m, ToolErrorEvent):
                     raise m.error
 
-        next_msg = next(self.events)
+        while True:
+            scripted = next(self.events)
 
-        if isinstance(next_msg, str):
-            message = ModelMessage(next_msg)
-            await context.send(message)
-            next_msg = ModelResponse(message)
+            if isinstance(scripted, BaseException):
+                raise scripted
 
-        elif isinstance(next_msg, Iterable):
-            next_msg = ModelResponse(tool_calls=ToolCallsEvent(list(next_msg)))
+            if isinstance(scripted, str):
+                message = ModelMessage(scripted)
+                await context.send(message)
+                return ModelResponse(message)
 
-        elif isinstance(next_msg, ToolCallEvent):
-            next_msg = ModelResponse(tool_calls=ToolCallsEvent([next_msg]))
+            if isinstance(scripted, ModelResponse):
+                return scripted
 
-        return next_msg
+            # A builtin call is not a request for the agent to run a tool: the
+            # provider ran it, and the client only publishes it. It falls through
+            # to the branch below.
+            if isinstance(scripted, ToolCallEvent) and not isinstance(scripted, BuiltinToolCallEvent):
+                return ModelResponse(tool_calls=ToolCallsEvent([scripted]))
+
+            if isinstance(scripted, BaseEvent):
+                # Anything else a provider publishes mid-turn — a streamed chunk,
+                # reasoning, server-side tool activity. It does not end the turn,
+                # so keep reading the script for what does.
+                await context.send(scripted)
+                continue
+
+            return ModelResponse(tool_calls=ToolCallsEvent(list(scripted)))
 
 
 class TrackingClient(LLMClient):
@@ -102,12 +137,18 @@ class TestConfig(ModelConfig):
 
     def __init__(
         self,
-        *events: ModelResponse | ToolCallEvent | Iterable[ToolCallEvent] | str,
+        *events: "Turn",
         provider: ModelProvider | None = None,
         model: str | None = None,
         raise_tool_errors: bool = True,
     ) -> None:
-        """Script one LLM turn per positional event.
+        """Script the LLM, one :data:`Turn` per positional event.
+
+        Events that only *publish* (chunks, reasoning, builtin tool activity) do
+        not consume a turn — they are sent to the stream and the next scripted
+        event is read straight away, so a single turn can stream and then fail::
+
+            TestConfig(ModelMessageChunk("Tok"), TimeoutError("dropped"), "Recovered")
 
         ``raise_tool_errors`` (default ``True``) re-raises any ``ToolErrorEvent``
         it finds in the history, which is the convenient way to assert that a

--- a/test/middleware/builtins/test_llm_retry.py
+++ b/test/middleware/builtins/test_llm_retry.py
@@ -1,14 +1,9 @@
 # Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Sequence
-from typing import Any
-from unittest.mock import MagicMock
-
 import pytest
 
-from ag2 import Agent, Context, MemoryStream
-from ag2.config import LLMClient
+from ag2 import Agent, MemoryStream
 from ag2.events import (
     BaseEvent,
     BuiltinToolCallEvent,
@@ -16,12 +11,10 @@ from ag2.events import (
     ModelMessage,
     ModelMessageChunk,
     ModelReasoning,
-    ModelResponse,
-    TextInput,
     ToolCallEvent,
 )
 from ag2.middleware import RetryMiddleware
-from ag2.testing import TestConfig
+from ag2.testing import TestConfig, TrackingConfig, Turn
 from ag2.tools import ToolResult, tool
 
 
@@ -33,73 +26,72 @@ class PermanentError(Exception):
     pass
 
 
-@pytest.mark.asyncio()
-async def test_llm_retry_calls_next_once_when_successful(mock: MagicMock) -> None:
-    context = Context(stream=MemoryStream())
-    retry_middleware = RetryMiddleware(max_retries=3)
-
-    async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
-        mock.llm_call(events)
-        return ModelResponse(ModelMessage("result"))
-
-    middleware = retry_middleware(TextInput("Hi!"), context)
-    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
-
-    assert response == ModelResponse(ModelMessage("result"))
-    mock.llm_call.assert_called_once_with([TextInput("Hi!")])
+@tool
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
 
 
-@pytest.mark.asyncio()
-async def test_llm_retry_retries_matching_errors_until_success(mock: MagicMock) -> None:
-    context = Context(stream=MemoryStream())
-    retry_middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))
-    attempts = 0
+def retrying_agent(*script: Turn, max_retries: int = 3) -> tuple[Agent, TrackingConfig]:
+    """An agent that retries ``TransientError`` and nothing else.
 
-    async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
-        nonlocal attempts
-        attempts += 1
-        mock.llm_call(events)
-        if attempts < 3:
-            raise TransientError(f"transient failure {attempts}")
-        return ModelResponse(ModelMessage("result"))
-
-    middleware = retry_middleware(TextInput("Hi!"), context)
-    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
-
-    assert response == ModelResponse(ModelMessage("result"))
-    assert mock.llm_call.call_count == attempts == 3
+    The returned config counts LLM calls, failed attempts included, so a test can
+    say how many times the model was asked.
+    """
+    config = TrackingConfig(TestConfig(*script))
+    agent = Agent(
+        "retrying",
+        config=config,
+        tools=[add],
+        middleware=[RetryMiddleware(max_retries=max_retries, retry_on=(TransientError,))],
+    )
+    return agent, config
 
 
 @pytest.mark.asyncio()
-async def test_llm_retry_raises_after_exhausting_retries(mock: MagicMock) -> None:
-    context = Context(stream=MemoryStream())
-    retry_middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))
+async def test_a_call_that_succeeds_is_made_once() -> None:
+    agent, config = retrying_agent("Hello!")
 
-    async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
-        mock.llm_call(events)
-        raise TransientError("still failing")
+    reply = await agent.ask("Hi!")
 
-    middleware = retry_middleware(TextInput("Hi!"), context)
+    assert reply.body == "Hello!"
+    assert config.mock.call_count == 1
+
+
+@pytest.mark.asyncio()
+async def test_a_failing_call_is_retried_until_it_succeeds() -> None:
+    agent, config = retrying_agent(
+        TransientError("transient failure 1"),
+        TransientError("transient failure 2"),
+        "Hello!",
+    )
+
+    reply = await agent.ask("Hi!")
+
+    assert reply.body == "Hello!"
+    assert config.mock.call_count == 3
+
+
+@pytest.mark.asyncio()
+async def test_the_error_surfaces_once_the_retries_run_out() -> None:
+    # ``max_retries`` counts the retries, so the model is asked one more time
+    # than that before the failure is allowed through.
+    agent, config = retrying_agent(*(TransientError("still failing") for _ in range(4)), max_retries=3)
+
     with pytest.raises(TransientError, match="still failing"):
-        await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
+        await agent.ask("Hi!")
 
-    assert mock.llm_call.call_count == 3
+    assert config.mock.call_count == 4
 
 
 @pytest.mark.asyncio()
-async def test_llm_retry_does_not_retry_non_matching_errors(mock: MagicMock) -> None:
-    context = Context(stream=MemoryStream())
-    retry_middleware = RetryMiddleware(max_retries=3, retry_on=(TransientError,))
-    middleware = retry_middleware(TextInput("Hi!"), context)
-
-    async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
-        mock.llm_call(events)
-        raise PermanentError("do not retry")
+async def test_an_error_outside_retry_on_is_not_retried() -> None:
+    agent, config = retrying_agent(PermanentError("do not retry"), "never reached")
 
     with pytest.raises(PermanentError, match="do not retry"):
-        await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
+        await agent.ask("Hi!")
 
-    mock.llm_call.assert_called_once_with([TextInput("Hi!")])
+    assert config.mock.call_count == 1
 
 
 @pytest.mark.parametrize(
@@ -114,115 +106,49 @@ async def test_llm_retry_does_not_retry_non_matching_errors(mock: MagicMock) -> 
     ids=["chunk", "reasoning", "message", "builtin_call", "builtin_result"],
 )
 @pytest.mark.asyncio()
-async def test_llm_retry_stops_once_the_attempt_published_output(published: BaseEvent) -> None:
+async def test_a_call_that_published_output_is_not_retried(published: BaseEvent) -> None:
     """A retry cannot take back what consumers already have, so it must not happen.
 
     The cases are what a provider client publishes mid-call — streamed content,
     the message, server-side tool activity — but the middleware names no types:
     anything reaching the stream inside the call counts.
     """
-    stream = MemoryStream()
-    context = Context(stream=stream)
-    middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))(TextInput("Hi!"), context)
-    attempts = 0
+    agent, config = retrying_agent(published, TransientError("stream disconnected"), "would be a second copy")
+
     seen: list[BaseEvent] = []
+    stream = MemoryStream()
 
     async def collect(event: BaseEvent) -> None:
         seen.append(event)
 
-    async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
-        nonlocal attempts
-        attempts += 1
-        await ctx.send(published)
-        raise TransientError("stream disconnected")
-
     stream.subscribe(collect, sync_to_thread=False)
 
     with pytest.raises(TransientError, match="stream disconnected"):
-        await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
+        await agent.ask("Hi!", stream=stream)
 
-    assert attempts == 1
-    # Watching must not disturb delivery: the subscriber downstream still gets the
-    # one event, unchanged.
-    assert seen == [published]
-    assert seen[0] is published
+    assert config.mock.call_count == 1
+    # Consumers keep the partial output — exactly once. A retry would have made it two.
+    assert seen.count(published) == 1
 
 
 @pytest.mark.asyncio()
-async def test_llm_retry_scopes_published_output_to_a_single_call() -> None:
-    """A chunk published by an earlier call must not disarm a later call's retries."""
-    stream = MemoryStream()
-    context = Context(stream=stream)
-    middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))(TextInput("Hi!"), context)
-    attempts = 0
+async def test_output_from_an_earlier_turn_does_not_disarm_the_next_one() -> None:
+    """The guard is scoped to one call, and the loop's own events stay outside it.
 
-    async def streaming_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
-        await ctx.send(ModelMessageChunk("first turn"))
-        return ModelResponse(ModelMessage("first turn"))
-
-    async def failing_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
-        nonlocal attempts
-        attempts += 1
-        if attempts < 2:
-            raise TransientError("transient failure")
-        return ModelResponse(ModelMessage("second turn"))
-
-    await middleware.on_llm_call(streaming_call, [TextInput("Hi!")], context)
-    response = await middleware.on_llm_call(failing_call, [TextInput("Hi!")], context)
-
-    assert response == ModelResponse(ModelMessage("second turn"))
-    assert attempts == 2
-
-
-@tool
-def add(a: int, b: int) -> int:
-    """Add two numbers."""
-    return a + b
-
-
-class _FlakyClient(LLMClient):
-    """Wraps a scripted client and fails the nth call with a transient error."""
-
-    def __init__(self, client: LLMClient, fail_on: int) -> None:
-        self.client = client
-        self.fail_on = fail_on
-        self.calls = 0
-
-    async def __call__(self, messages: Sequence[BaseEvent], context: Context, **kwargs: Any) -> ModelResponse:
-        self.calls += 1
-        if self.calls == self.fail_on:
-            raise TransientError("transient failure")
-        return await self.client(messages, context=context, **kwargs)
-
-
-class _FlakyConfig(TestConfig):
-    """``TestConfig`` whose single per-turn client fails one call."""
-
-    def create(self) -> _FlakyClient:
-        self.client = _FlakyClient(super().create(), fail_on=2)
-        return self.client
-
-
-@pytest.mark.asyncio()
-async def test_llm_retry_survives_the_agent_loops_own_events() -> None:
-    """The agent loop's events must not read as the attempt's own output.
-
-    The guard counts *any* event published inside ``on_llm_call`` rather than a
-    list of types, which holds only because the loop publishes its own events —
-    ``ModelRequest``, ``ToolCallsEvent``, ``ToolResultEvent``, ``UsageEvent`` —
-    outside the middleware chain. Were one to move inside it, every retry after
-    the first tool call would silently stop happening; this pins that down.
+    Turn one streams a chunk and asks for a tool; the loop then publishes the
+    tool call and its result. None of that is turn two's output, so turn two is
+    still free to retry. Were the scope wider — or were the loop to publish from
+    inside the middleware chain — every retry after a tool call would silently
+    stop happening.
     """
-    config = _FlakyConfig(ToolCallEvent(name="add", arguments='{"a": 1, "b": 2}'), "done")
-    agent = Agent(
-        "retrying",
-        config=config,
-        tools=[add],
-        middleware=[RetryMiddleware(max_retries=2, retry_on=(TransientError,))],
+    agent, config = retrying_agent(
+        ModelMessageChunk("Let me add those"),  # turn 1 streams...
+        ToolCallEvent(name="add", arguments='{"a": 1, "b": 2}'),  # ...then calls the tool
+        TransientError("transient failure"),  # turn 2 fails...
+        "The answer is 3.",  # ...and its retry succeeds
     )
 
-    reply = await agent.ask("go")
+    reply = await agent.ask("What is 1 + 2?")
 
-    # Three client calls: the tool call, the failure, the retry that succeeds.
-    assert config.client.calls == 3
-    assert reply.body == "done"
+    assert reply.body == "The answer is 3."
+    assert config.mock.call_count == 3

--- a/test/middleware/builtins/test_llm_retry.py
+++ b/test/middleware/builtins/test_llm_retry.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from ag2 import Context
-from ag2.events import BaseEvent, ModelMessage, ModelResponse, TextInput
+from ag2 import Context, MemoryStream
+from ag2.events import BaseEvent, ModelMessage, ModelMessageChunk, ModelResponse, TextInput
 from ag2.middleware import RetryMiddleware
 
 
@@ -82,3 +82,30 @@ async def test_llm_retry_does_not_retry_non_matching_errors(mock: MagicMock) -> 
         await middleware.on_llm_call(llm_call, [TextInput("Hi!")], mock)
 
     mock.llm_call.assert_called_once_with([TextInput("Hi!")])
+
+
+@pytest.mark.asyncio()
+async def test_llm_retry_does_not_retry_after_streaming_a_message_chunk() -> None:
+    stream = MemoryStream()
+    context = Context(stream=stream)
+    retry_middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))
+    middleware = retry_middleware(TextInput("Hi!"), context)
+    attempts = 0
+    chunks: list[str] = []
+
+    async def collect(event: ModelMessageChunk) -> None:
+        chunks.append(event.content)
+
+    async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
+        nonlocal attempts
+        attempts += 1
+        await ctx.send(ModelMessageChunk("partial"))
+        raise TransientError("stream disconnected")
+
+    stream.where(ModelMessageChunk).subscribe(collect, sync_to_thread=False)
+
+    with pytest.raises(TransientError, match="stream disconnected"):
+        await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
+
+    assert attempts == 1
+    assert chunks == ["partial"]

--- a/test/middleware/builtins/test_llm_retry.py
+++ b/test/middleware/builtins/test_llm_retry.py
@@ -35,14 +35,15 @@ class PermanentError(Exception):
 
 @pytest.mark.asyncio()
 async def test_llm_retry_calls_next_once_when_successful(mock: MagicMock) -> None:
+    context = Context(stream=MemoryStream())
     retry_middleware = RetryMiddleware(max_retries=3)
 
     async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
         mock.llm_call(events)
         return ModelResponse(ModelMessage("result"))
 
-    middleware = retry_middleware(TextInput("Hi!"), mock)
-    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], mock)
+    middleware = retry_middleware(TextInput("Hi!"), context)
+    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
 
     assert response == ModelResponse(ModelMessage("result"))
     mock.llm_call.assert_called_once_with([TextInput("Hi!")])
@@ -50,6 +51,7 @@ async def test_llm_retry_calls_next_once_when_successful(mock: MagicMock) -> Non
 
 @pytest.mark.asyncio()
 async def test_llm_retry_retries_matching_errors_until_success(mock: MagicMock) -> None:
+    context = Context(stream=MemoryStream())
     retry_middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))
     attempts = 0
 
@@ -61,8 +63,8 @@ async def test_llm_retry_retries_matching_errors_until_success(mock: MagicMock) 
             raise TransientError(f"transient failure {attempts}")
         return ModelResponse(ModelMessage("result"))
 
-    middleware = retry_middleware(TextInput("Hi!"), mock)
-    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], mock)
+    middleware = retry_middleware(TextInput("Hi!"), context)
+    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
 
     assert response == ModelResponse(ModelMessage("result"))
     assert mock.llm_call.call_count == attempts == 3
@@ -70,30 +72,32 @@ async def test_llm_retry_retries_matching_errors_until_success(mock: MagicMock) 
 
 @pytest.mark.asyncio()
 async def test_llm_retry_raises_after_exhausting_retries(mock: MagicMock) -> None:
+    context = Context(stream=MemoryStream())
     retry_middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))
 
     async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
         mock.llm_call(events)
         raise TransientError("still failing")
 
-    middleware = retry_middleware(TextInput("Hi!"), mock)
+    middleware = retry_middleware(TextInput("Hi!"), context)
     with pytest.raises(TransientError, match="still failing"):
-        await middleware.on_llm_call(llm_call, [TextInput("Hi!")], mock)
+        await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
 
     assert mock.llm_call.call_count == 3
 
 
 @pytest.mark.asyncio()
 async def test_llm_retry_does_not_retry_non_matching_errors(mock: MagicMock) -> None:
+    context = Context(stream=MemoryStream())
     retry_middleware = RetryMiddleware(max_retries=3, retry_on=(TransientError,))
-    middleware = retry_middleware(TextInput("Hi!"), mock)
+    middleware = retry_middleware(TextInput("Hi!"), context)
 
     async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
         mock.llm_call(events)
         raise PermanentError("do not retry")
 
     with pytest.raises(PermanentError, match="do not retry"):
-        await middleware.on_llm_call(llm_call, [TextInput("Hi!")], mock)
+        await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
 
     mock.llm_call.assert_called_once_with([TextInput("Hi!")])
 
@@ -138,36 +142,10 @@ async def test_llm_retry_stops_once_the_attempt_published_output(published: Base
         await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
 
     assert attempts == 1
-    # The middleware observes through an interrupter, which is allowed to drop or
-    # replace an event — this one must do neither.
+    # Watching must not disturb delivery: the subscriber downstream still gets the
+    # one event, unchanged.
     assert seen == [published]
     assert seen[0] is published
-
-
-@pytest.mark.asyncio()
-async def test_llm_retry_retries_on_a_real_stream_when_nothing_was_published() -> None:
-    """The control for the test above: the guard must not disarm retries wholesale.
-
-    The other retry tests pass a ``MagicMock`` context, which makes the stream
-    subscription a no-op — only a real stream exercises the guard's False branch.
-    """
-    stream = MemoryStream()
-    context = Context(stream=stream)
-    middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))(TextInput("Hi!"), context)
-    attempts = 0
-
-    async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
-        nonlocal attempts
-        attempts += 1
-        if attempts < 3:
-            raise TransientError(f"transient failure {attempts}")
-        await ctx.send(ModelMessageChunk("complete"))
-        return ModelResponse(ModelMessage("complete"))
-
-    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
-
-    assert response == ModelResponse(ModelMessage("complete"))
-    assert attempts == 3
 
 
 @pytest.mark.asyncio()

--- a/test/middleware/builtins/test_llm_retry.py
+++ b/test/middleware/builtins/test_llm_retry.py
@@ -2,13 +2,27 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Sequence
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
-from ag2 import Context, MemoryStream
-from ag2.events import BaseEvent, ModelMessage, ModelMessageChunk, ModelResponse, TextInput
+from ag2 import Agent, Context, MemoryStream
+from ag2.config import LLMClient
+from ag2.events import (
+    BaseEvent,
+    BuiltinToolCallEvent,
+    BuiltinToolResultEvent,
+    ModelMessage,
+    ModelMessageChunk,
+    ModelReasoning,
+    ModelResponse,
+    TextInput,
+    ToolCallEvent,
+)
 from ag2.middleware import RetryMiddleware
+from ag2.testing import TestConfig
+from ag2.tools import ToolResult, tool
 
 
 class TransientError(Exception):
@@ -84,28 +98,153 @@ async def test_llm_retry_does_not_retry_non_matching_errors(mock: MagicMock) -> 
     mock.llm_call.assert_called_once_with([TextInput("Hi!")])
 
 
+@pytest.mark.parametrize(
+    "published",
+    [
+        ModelMessageChunk("stale "),
+        ModelReasoning("half a thought"),
+        ModelMessage("stale"),
+        BuiltinToolCallEvent("web_search"),
+        BuiltinToolResultEvent(parent_id="call-1", result=ToolResult("stale")),
+    ],
+    ids=["chunk", "reasoning", "message", "builtin_call", "builtin_result"],
+)
 @pytest.mark.asyncio()
-async def test_llm_retry_does_not_retry_after_streaming_a_message_chunk() -> None:
+async def test_llm_retry_stops_once_the_attempt_published_output(published: BaseEvent) -> None:
+    """A retry cannot take back what consumers already have, so it must not happen.
+
+    The cases are what a provider client publishes mid-call — streamed content,
+    the message, server-side tool activity — but the middleware names no types:
+    anything reaching the stream inside the call counts.
+    """
     stream = MemoryStream()
     context = Context(stream=stream)
-    retry_middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))
-    middleware = retry_middleware(TextInput("Hi!"), context)
+    middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))(TextInput("Hi!"), context)
     attempts = 0
-    chunks: list[str] = []
+    seen: list[BaseEvent] = []
 
-    async def collect(event: ModelMessageChunk) -> None:
-        chunks.append(event.content)
+    async def collect(event: BaseEvent) -> None:
+        seen.append(event)
 
     async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
         nonlocal attempts
         attempts += 1
-        await ctx.send(ModelMessageChunk("partial"))
+        await ctx.send(published)
         raise TransientError("stream disconnected")
 
-    stream.where(ModelMessageChunk).subscribe(collect, sync_to_thread=False)
+    stream.subscribe(collect, sync_to_thread=False)
 
     with pytest.raises(TransientError, match="stream disconnected"):
         await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
 
     assert attempts == 1
-    assert chunks == ["partial"]
+    # The middleware observes through an interrupter, which is allowed to drop or
+    # replace an event — this one must do neither.
+    assert seen == [published]
+    assert seen[0] is published
+
+
+@pytest.mark.asyncio()
+async def test_llm_retry_retries_on_a_real_stream_when_nothing_was_published() -> None:
+    """The control for the test above: the guard must not disarm retries wholesale.
+
+    The other retry tests pass a ``MagicMock`` context, which makes the stream
+    subscription a no-op — only a real stream exercises the guard's False branch.
+    """
+    stream = MemoryStream()
+    context = Context(stream=stream)
+    middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))(TextInput("Hi!"), context)
+    attempts = 0
+
+    async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise TransientError(f"transient failure {attempts}")
+        await ctx.send(ModelMessageChunk("complete"))
+        return ModelResponse(ModelMessage("complete"))
+
+    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
+
+    assert response == ModelResponse(ModelMessage("complete"))
+    assert attempts == 3
+
+
+@pytest.mark.asyncio()
+async def test_llm_retry_scopes_published_output_to_a_single_call() -> None:
+    """A chunk published by an earlier call must not disarm a later call's retries."""
+    stream = MemoryStream()
+    context = Context(stream=stream)
+    middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))(TextInput("Hi!"), context)
+    attempts = 0
+
+    async def streaming_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
+        await ctx.send(ModelMessageChunk("first turn"))
+        return ModelResponse(ModelMessage("first turn"))
+
+    async def failing_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 2:
+            raise TransientError("transient failure")
+        return ModelResponse(ModelMessage("second turn"))
+
+    await middleware.on_llm_call(streaming_call, [TextInput("Hi!")], context)
+    response = await middleware.on_llm_call(failing_call, [TextInput("Hi!")], context)
+
+    assert response == ModelResponse(ModelMessage("second turn"))
+    assert attempts == 2
+
+
+@tool
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+class _FlakyClient(LLMClient):
+    """Wraps a scripted client and fails the nth call with a transient error."""
+
+    def __init__(self, client: LLMClient, fail_on: int) -> None:
+        self.client = client
+        self.fail_on = fail_on
+        self.calls = 0
+
+    async def __call__(self, messages: Sequence[BaseEvent], context: Context, **kwargs: Any) -> ModelResponse:
+        self.calls += 1
+        if self.calls == self.fail_on:
+            raise TransientError("transient failure")
+        return await self.client(messages, context=context, **kwargs)
+
+
+class _FlakyConfig(TestConfig):
+    """``TestConfig`` whose single per-turn client fails one call."""
+
+    def create(self) -> _FlakyClient:
+        self.client = _FlakyClient(super().create(), fail_on=2)
+        return self.client
+
+
+@pytest.mark.asyncio()
+async def test_llm_retry_survives_the_agent_loops_own_events() -> None:
+    """The agent loop's events must not read as the attempt's own output.
+
+    The guard counts *any* event published inside ``on_llm_call`` rather than a
+    list of types, which holds only because the loop publishes its own events —
+    ``ModelRequest``, ``ToolCallsEvent``, ``ToolResultEvent``, ``UsageEvent`` —
+    outside the middleware chain. Were one to move inside it, every retry after
+    the first tool call would silently stop happening; this pins that down.
+    """
+    config = _FlakyConfig(ToolCallEvent(name="add", arguments='{"a": 1, "b": 2}'), "done")
+    agent = Agent(
+        "retrying",
+        config=config,
+        tools=[add],
+        middleware=[RetryMiddleware(max_retries=2, retry_on=(TransientError,))],
+    )
+
+    reply = await agent.ask("go")
+
+    # Three client calls: the tool call, the failure, the retry that succeeds.
+    assert config.client.calls == 3
+    assert reply.body == "done"

--- a/website/docs/user-guide/middleware.mdx
+++ b/website/docs/user-guide/middleware.mdx
@@ -364,6 +364,18 @@ By default it retries any `Exception`, but you can narrow that with `retry_on=..
 
 Use it for transient failures such as provider timeouts or flaky network issues.
 
+An attempt that already published output stops being retryable.
+Streaming clients emit `ModelMessageChunk` and `ModelReasoning` while the response
+is still arriving, and publish server-side tool calls and results as they walk it —
+subscribers have those the moment they are sent, and a retry cannot take them back.
+Retrying anyway would leave every live consumer holding the failed attempt's output
+concatenated with the retry's, while the final reply carries only the retry's.
+So if a call fails after publishing anything, `RetryMiddleware` propagates the
+exception instead of starting another attempt. A call that fails before publishing —
+a connection error, a rate limit, a `5xx` — retries as usual, which covers most
+transient failures. Non-streaming calls publish nothing until they return and are
+therefore unaffected.
+
 ### `HistoryLimiter`
 
 ```python linenums="1"

--- a/website/docs/user-guide/middleware.mdx
+++ b/website/docs/user-guide/middleware.mdx
@@ -364,11 +364,11 @@ By default it retries any `Exception`, but you can narrow that with `retry_on=..
 
 Use it for transient failures such as provider timeouts or flaky network issues.
 
-A call that already streamed part of its response is not retried: the exception
-propagates instead, because a retry would leave live consumers holding both attempts'
-output while the reply carries only the second.
-Failures arriving before anything is streamed — connection errors, rate limits, `5xx` —
-retry as usual, as do non-streaming calls.
+A call that already published something to the stream — a chunk, reasoning, or a
+server-side tool call — is not retried; the exception propagates instead.
+Retrying would leave anyone watching the stream with both attempts' output, while the
+reply carries only the second.
+Failures that arrive before anything is published — connection errors, rate limits, `5xx` — retry as usual.
 
 ### `HistoryLimiter`
 

--- a/website/docs/user-guide/middleware.mdx
+++ b/website/docs/user-guide/middleware.mdx
@@ -364,17 +364,11 @@ By default it retries any `Exception`, but you can narrow that with `retry_on=..
 
 Use it for transient failures such as provider timeouts or flaky network issues.
 
-An attempt that already published output stops being retryable.
-Streaming clients emit `ModelMessageChunk` and `ModelReasoning` while the response
-is still arriving, and publish server-side tool calls and results as they walk it —
-subscribers have those the moment they are sent, and a retry cannot take them back.
-Retrying anyway would leave every live consumer holding the failed attempt's output
-concatenated with the retry's, while the final reply carries only the retry's.
-So if a call fails after publishing anything, `RetryMiddleware` propagates the
-exception instead of starting another attempt. A call that fails before publishing —
-a connection error, a rate limit, a `5xx` — retries as usual, which covers most
-transient failures. Non-streaming calls publish nothing until they return and are
-therefore unaffected.
+A call that already streamed part of its response is not retried: the exception
+propagates instead, because a retry would leave live consumers holding both attempts'
+output while the reply carries only the second.
+Failures arriving before anything is streamed — connection errors, rate limits, `5xx` —
+retry as usual, as do non-streaming calls.
 
 ### `HistoryLimiter`
 


### PR DESCRIPTION
## Why are these changes needed?

`RetryMiddleware` currently retries a failed LLM call even when that attempt has already published `ModelMessageChunk` events. Live consumers then see partial content from the failed attempt followed by content from the successful retry, while the final response contains only the successful attempt.

This change tracks message chunks during each retryable attempt. If an attempt has published a chunk, a subsequent retryable exception is propagated instead of starting another attempt on the same stream. Failures that occur before any message chunk is published keep the existing retry behavior.

A regression test verifies that a streaming failure is not retried after its partial chunk becomes visible.

## Related issue number

Closes #3215

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. No documentation changes are needed for this bug fix.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed. CI is pending; local checks are listed below.

Local validation:

- `pytest -q test/middleware`: 98 passed, 2 skipped
- `ruff check ag2/middleware/builtin/llm_retry.py test/middleware/builtins/test_llm_retry.py`: passed
- `ruff format --check ag2/middleware/builtin/llm_retry.py test/middleware/builtins/test_llm_retry.py`: passed
- `mypy ag2/middleware/builtin/llm_retry.py`: passed
- `git diff --check`: passed

## AI assistance

Codex assisted with diagnosing the event-ordering bug and drafting the implementation, regression test, and PR text. The resulting diff was reviewed against the repository instructions and validated with the local checks above.

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
