### PR TITLE
feat(tealtiger): add arg_validation governance policy

### DIFF
--- a/ag2/extensions/tealtiger/middleware.py
+++ b/ag2/extensions/tealtiger/middleware.py
@@ -56,6 +56,16 @@ _SECRET_PATTERNS: list[re.Pattern[str]] = [
 # Injection findings keep a snippet of the match as evidence, not the whole argument.
 _MAX_MATCHED_TEXT_CHARS = 100
 
+# Maps arg_validation `type` names to the Python types they check against.
+_TYPE_NAMES: dict[str, type] = {
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+}
+
 
 class TealTigerMiddleware:
     """Deterministic governance middleware factory for AG2.
@@ -340,6 +350,15 @@ class _TealTigerPerTurn(BaseMiddleware):
                     risk_score = max(risk_score, 80)
                     break
 
+            elif policy.type == "arg_validation":
+                if fnmatch.fnmatch(tool_name, policy.config.get("tool", "")):
+                    violation = self._validate_args(tool_args, policy.config.get("constraints", {}))
+                    if violation is not None:
+                        action = "DENY"
+                        reason_codes.append(f"ARG_VALIDATION:{violation}")
+                        risk_score = max(risk_score, 85)
+                        break
+
             elif policy.type == "pii_block":
                 categories = policy.config.get("categories", [])
                 pii_found = self._detect_pii(args_str, categories)
@@ -403,6 +422,62 @@ class _TealTigerPerTurn(BaseMiddleware):
     def _detect_secrets(text: str) -> bool:
         """Detect secret patterns in text."""
         return any(p.search(text) for p in _SECRET_PATTERNS)
+
+    @staticmethod
+    def _validate_args(tool_args: Any, constraints: dict[str, dict[str, Any]]) -> str | None:
+        """Check a tool's arguments against per-argument constraints.
+
+        Returns ``"{arg}:{check}"`` for the first violated constraint (e.g.
+        ``"query:max_length"``), or ``None`` if every constrained argument
+        passes. Arguments not named in ``constraints`` are ignored, and a
+        constrained argument that is absent from the call is skipped.
+
+        When ``tool_args`` is not a mapping (already serialized to a string, or
+        positional), per-name checks cannot be applied, so only the
+        whole-value string checks (``blocked_terms``, ``blocked_patterns``) run
+        against the serialized form under each constrained name.
+        """
+        is_mapping = isinstance(tool_args, dict)
+        serialized = tool_args if isinstance(tool_args, str) else str(tool_args)
+
+        for arg_name, spec in constraints.items():
+            if is_mapping:
+                if arg_name not in tool_args:
+                    continue
+                value = tool_args[arg_name]
+                value_present = True
+            else:
+                # No named access — fall back to substring/regex over the serialized args.
+                value = serialized
+                value_present = False
+
+            text = value if isinstance(value, str) else str(value)
+
+            if value_present and "type" in spec:
+                expected = _TYPE_NAMES.get(spec["type"])
+                # bool is a subclass of int, so reject a bool where "int" is required.
+                type_ok = isinstance(value, expected) and not (expected is int and isinstance(value, bool))
+                if not type_ok:
+                    return f"{arg_name}:type"
+
+            if value_present and "allowed_values" in spec and value not in spec["allowed_values"]:
+                return f"{arg_name}:allowed_values"
+
+            if value_present and "max_length" in spec and len(text) > spec["max_length"]:
+                return f"{arg_name}:max_length"
+
+            if value_present and "min_length" in spec and len(text) < spec["min_length"]:
+                return f"{arg_name}:min_length"
+
+            if "blocked_terms" in spec:
+                lowered = text.lower()
+                if any(term.lower() in lowered for term in spec["blocked_terms"]):
+                    return f"{arg_name}:blocked_terms"
+
+            if "blocked_patterns" in spec and any(re.search(pattern, text) for pattern in spec["blocked_patterns"]):
+                return f"{arg_name}:blocked_patterns"
+
+        return None
 
     @staticmethod
     def _detect_prompt_injection(

--- a/ag2/extensions/tealtiger/middleware.py
+++ b/ag2/extensions/tealtiger/middleware.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 from ag2.events import ToolErrorEvent
 from ag2.extensions.tealtiger.types import (
+    ARG_TYPES_BY_NAME,
     DEFAULT_INJECTION_CONFIDENCE_THRESHOLD,
     INJECTION_PATTERNS,
     INJECTION_TECHNIQUES,
@@ -56,15 +57,75 @@ _SECRET_PATTERNS: list[re.Pattern[str]] = [
 # Injection findings keep a snippet of the match as evidence, not the whole argument.
 _MAX_MATCHED_TEXT_CHARS = 100
 
-# Maps arg_validation `type` names to the Python types they check against.
-_TYPE_NAMES: dict[str, type] = {
-    "str": str,
-    "int": int,
-    "float": float,
-    "bool": bool,
-    "list": list,
-    "dict": dict,
-}
+# Stands in for the argument name in an arg_validation reason code when the call's
+# arguments were not a mapping and the hit cannot be attributed to one argument.
+_UNNAMED_ARG = "*"
+
+
+def _matches_blocked_terms(text: str, spec: dict[str, Any]) -> bool:
+    """Whether `text` contains any of the spec's blocked terms, case-insensitively."""
+    if "blocked_terms" not in spec:
+        return False
+    lowered = text.lower()
+    return any(term.lower() in lowered for term in spec["blocked_terms"])
+
+
+def _matches_blocked_patterns(text: str, spec: dict[str, Any]) -> bool:
+    """Whether any of the spec's blocked patterns matches `text`.
+
+    Patterns are compiled by `GovernancePolicy.arg_validation`, so nothing is
+    compiled here.
+    """
+    return "blocked_patterns" in spec and any(pattern.search(text) for pattern in spec["blocked_patterns"])
+
+
+def _check_value(value: Any, spec: dict[str, Any]) -> str | None:
+    """Name the first check ``value`` violates, or ``None``.
+
+    Type runs first so a length or membership failure is never reported for a
+    value that was the wrong shape to begin with.
+    """
+    text = value if isinstance(value, str) else str(value)
+
+    if "type" in spec:
+        expected = ARG_TYPES_BY_NAME[spec["type"]]
+        # bool is a subclass of int, so reject a bool where "int" is required.
+        if not isinstance(value, expected) or (expected is int and isinstance(value, bool)):
+            return "type"
+
+    if "allowed_values" in spec and value not in spec["allowed_values"]:
+        return "allowed_values"
+
+    if "max_length" in spec and len(text) > spec["max_length"]:
+        return "max_length"
+
+    if "min_length" in spec and len(text) < spec["min_length"]:
+        return "min_length"
+
+    if _matches_blocked_terms(text, spec):
+        return "blocked_terms"
+
+    if _matches_blocked_patterns(text, spec):
+        return "blocked_patterns"
+
+    return None
+
+
+def _scan_unnamed_args(args_str: str, constraints: dict[str, dict[str, Any]]) -> str | None:
+    """Check a call whose arguments are not a mapping.
+
+    With no names to read by, length/type/`allowed_values` cannot apply. Rather
+    than let the call through, the term and pattern checks run over the whole
+    serialized call — fail-closed, so a banned term denies even from an
+    argument the policy does not constrain. Reported against ``*``, since no
+    single argument can honestly be blamed.
+    """
+    for spec in constraints.values():
+        if _matches_blocked_terms(args_str, spec):
+            return f"{_UNNAMED_ARG}:blocked_terms"
+        if _matches_blocked_patterns(args_str, spec):
+            return f"{_UNNAMED_ARG}:blocked_patterns"
+    return None
 
 
 class TealTigerMiddleware:
@@ -352,7 +413,7 @@ class _TealTigerPerTurn(BaseMiddleware):
 
             elif policy.type == "arg_validation":
                 if fnmatch.fnmatch(tool_name, policy.config.get("tool", "")):
-                    violation = self._validate_args(tool_args, policy.config.get("constraints", {}))
+                    violation = self._validate_args(tool_args, args_str, policy.config.get("constraints", {}))
                     if violation is not None:
                         action = "DENY"
                         reason_codes.append(f"ARG_VALIDATION:{violation}")
@@ -424,58 +485,21 @@ class _TealTigerPerTurn(BaseMiddleware):
         return any(p.search(text) for p in _SECRET_PATTERNS)
 
     @staticmethod
-    def _validate_args(tool_args: Any, constraints: dict[str, dict[str, Any]]) -> str | None:
-        """Check a tool's arguments against per-argument constraints.
+    def _validate_args(tool_args: Any, args_str: str, constraints: dict[str, dict[str, Any]]) -> str | None:
+        """Name the first violated constraint as ``"{arg}:{check}"``, or ``None``.
 
-        Returns ``"{arg}:{check}"`` for the first violated constraint (e.g.
-        ``"query:max_length"``), or ``None`` if every constrained argument
-        passes. Arguments not named in ``constraints`` are ignored, and a
-        constrained argument that is absent from the call is skipped.
-
-        When ``tool_args`` is not a mapping (already serialized to a string, or
-        positional), per-name checks cannot be applied, so only the
-        whole-value string checks (``blocked_terms``, ``blocked_patterns``) run
-        against the serialized form under each constrained name.
+        ``args_str`` is the caller's already-serialized form of the call, used
+        only by the non-mapping fallback.
         """
-        is_mapping = isinstance(tool_args, dict)
-        serialized = tool_args if isinstance(tool_args, str) else str(tool_args)
+        if not isinstance(tool_args, dict):
+            return _scan_unnamed_args(args_str, constraints)
 
         for arg_name, spec in constraints.items():
-            if is_mapping:
-                if arg_name not in tool_args:
-                    continue
-                value = tool_args[arg_name]
-                value_present = True
-            else:
-                # No named access — fall back to substring/regex over the serialized args.
-                value = serialized
-                value_present = False
-
-            text = value if isinstance(value, str) else str(value)
-
-            if value_present and "type" in spec:
-                expected = _TYPE_NAMES.get(spec["type"])
-                # bool is a subclass of int, so reject a bool where "int" is required.
-                type_ok = isinstance(value, expected) and not (expected is int and isinstance(value, bool))
-                if not type_ok:
-                    return f"{arg_name}:type"
-
-            if value_present and "allowed_values" in spec and value not in spec["allowed_values"]:
-                return f"{arg_name}:allowed_values"
-
-            if value_present and "max_length" in spec and len(text) > spec["max_length"]:
-                return f"{arg_name}:max_length"
-
-            if value_present and "min_length" in spec and len(text) < spec["min_length"]:
-                return f"{arg_name}:min_length"
-
-            if "blocked_terms" in spec:
-                lowered = text.lower()
-                if any(term.lower() in lowered for term in spec["blocked_terms"]):
-                    return f"{arg_name}:blocked_terms"
-
-            if "blocked_patterns" in spec and any(re.search(pattern, text) for pattern in spec["blocked_patterns"]):
-                return f"{arg_name}:blocked_patterns"
+            if arg_name not in tool_args:
+                continue
+            violated = _check_value(tool_args[arg_name], spec)
+            if violated is not None:
+                return f"{arg_name}:{violated}"
 
         return None
 

--- a/ag2/extensions/tealtiger/types.py
+++ b/ag2/extensions/tealtiger/types.py
@@ -76,6 +76,80 @@ class GovernancePolicy:
         return cls(type="tool_blocklist", config={"blocked": list(blocked)})
 
     @classmethod
+    def arg_validation(cls, tool: str, constraints: dict[str, dict[str, Any]]) -> "GovernancePolicy":
+        """Constrain the arguments a specific tool (or tool pattern) may receive.
+
+        Where `tool_allowlist`/`tool_blocklist` govern *which* tools run, this
+        governs *what* those tools are called with — a defence against dangerous
+        argument values such as SQL injection, path traversal, or oversized
+        payloads.
+
+        The policy applies to any tool whose name matches `tool` via `fnmatch`
+        (so `"sql_*"` covers `sql_query`, `sql_exec`, ...). `constraints` maps an
+        argument name to the checks that argument must satisfy:
+
+        | Check | Meaning |
+        |-------|---------|
+        | `max_length` | Reject if `len(str(value))` exceeds this. |
+        | `min_length` | Reject if `len(str(value))` is below this. |
+        | `type` | Reject if the value is not of this type. One of `"str"`, `"int"`, `"float"`, `"bool"`, `"list"`, `"dict"`. |
+        | `blocked_terms` | Reject if any term appears in `str(value)` (case-insensitive substring). |
+        | `blocked_patterns` | Reject if any regex matches `str(value)`. |
+        | `allowed_values` | Reject if the value is not one of these. |
+
+        Only the arguments named in `constraints` are checked; any others pass
+        through. An argument named in `constraints` but absent from the call is
+        skipped (use a `tool_args`-style required check upstream if presence
+        matters).
+
+        Example — block SQL injection and path traversal::
+
+            GovernancePolicy.arg_validation(
+                "sql_query",
+                {"query": {"max_length": 500, "blocked_terms": ["DROP", "DELETE", ";--"]}},
+            )
+            GovernancePolicy.arg_validation(
+                "read_file",
+                {"path": {"blocked_patterns": [r"\\.\\.[\\\\/]"]}},  # reject ../ and ..\\
+            )
+
+        Args:
+            tool: Tool name or `fnmatch` pattern the constraints apply to.
+            constraints: Mapping of argument name -> constraint spec.
+
+        Raises:
+            ValueError: If `tool` is empty, `constraints` is empty, or a
+                constraint spec is malformed (unknown check, non-mapping spec,
+                or an unsupported `type` name) — any of which would otherwise
+                silently validate nothing.
+        """
+        if not tool:
+            raise ValueError("`tool` must not be empty.")
+        if not constraints:
+            raise ValueError("`constraints` must not be empty; a policy with no constraints validates nothing.")
+
+        valid_checks = {"max_length", "min_length", "type", "blocked_terms", "blocked_patterns", "allowed_values"}
+        valid_types = {"str", "int", "float", "bool", "list", "dict"}
+        for arg_name, spec in constraints.items():
+            if not isinstance(spec, dict):
+                raise ValueError(
+                    f"Constraint spec for argument '{arg_name}' must be a dict, got {type(spec).__name__}."
+                )
+            unknown = set(spec) - valid_checks
+            if unknown:
+                raise ValueError(
+                    f"Unknown constraint(s) for argument '{arg_name}': {', '.join(sorted(unknown))}. "
+                    f"Valid checks: {', '.join(sorted(valid_checks))}."
+                )
+            if "type" in spec and spec["type"] not in valid_types:
+                raise ValueError(
+                    f"Unsupported type '{spec['type']}' for argument '{arg_name}'. "
+                    f"Valid types: {', '.join(sorted(valid_types))}."
+                )
+
+        return cls(type="arg_validation", config={"tool": tool, "constraints": constraints})
+
+    @classmethod
     def pii_block(cls, categories: list[str] | None = None) -> "GovernancePolicy":
         """Block tool calls containing PII in arguments.
 

--- a/ag2/extensions/tealtiger/types.py
+++ b/ag2/extensions/tealtiger/types.py
@@ -22,6 +22,80 @@ class GovernanceMode(str, Enum):
 # Minimum pattern confidence a prompt-injection finding needs to trigger a block.
 DEFAULT_INJECTION_CONFIDENCE_THRESHOLD = 0.7
 
+ARG_TYPES_BY_NAME: dict[str, type] = {
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+}
+
+ARG_CHECKS = frozenset({
+    "max_length",
+    "min_length",
+    "type",
+    "blocked_terms",
+    "blocked_patterns",
+    "allowed_values",
+})
+
+
+def _normalize_arg_spec(arg_name: str, spec: dict[str, Any]) -> dict[str, Any]:
+    """Validate one argument's constraint spec and return it ready to evaluate.
+
+    Each check's *value* is validated, not just its name: an uncompilable regex
+    or a non-integer length would otherwise crash the governance path on the
+    first call it evaluated. Regexes are compiled here so evaluation never pays
+    for compilation — hence "ready to evaluate", and hence a returned spec that
+    holds `re.Pattern` objects where the caller passed strings.
+    """
+    normalized = dict(spec)
+
+    if "type" in spec and spec["type"] not in ARG_TYPES_BY_NAME:
+        raise ValueError(
+            f"Unsupported type '{spec['type']}' for argument '{arg_name}'. "
+            f"Valid types: {', '.join(sorted(ARG_TYPES_BY_NAME))}."
+        )
+
+    for bound in ("max_length", "min_length"):
+        # bool is an int subclass, so `True` would otherwise pass as the length 1.
+        if bound in spec and (not isinstance(spec[bound], int) or isinstance(spec[bound], bool) or spec[bound] < 0):
+            raise ValueError(
+                f"`{bound}` for argument '{arg_name}' must be a non-negative integer, got {spec[bound]!r}."
+            )
+    if "max_length" in spec and "min_length" in spec and spec["max_length"] < spec["min_length"]:
+        raise ValueError(
+            f"`max_length` ({spec['max_length']}) is below `min_length` ({spec['min_length']}) for argument "
+            f"'{arg_name}'; no value could satisfy both."
+        )
+
+    for check in ("blocked_terms", "allowed_values"):
+        if check in spec:
+            if not isinstance(spec[check], (list, tuple, set)) or not spec[check]:
+                raise ValueError(f"`{check}` for argument '{arg_name}' must be a non-empty list, got {spec[check]!r}.")
+            normalized[check] = list(spec[check])
+    if "blocked_terms" in normalized and any(not isinstance(term, str) for term in normalized["blocked_terms"]):
+        raise ValueError(f"`blocked_terms` for argument '{arg_name}' must contain only strings.")
+
+    if "blocked_patterns" in spec:
+        if not isinstance(spec["blocked_patterns"], (list, tuple)) or not spec["blocked_patterns"]:
+            raise ValueError(
+                f"`blocked_patterns` for argument '{arg_name}' must be a non-empty list, "
+                f"got {spec['blocked_patterns']!r}."
+            )
+        compiled: list[re.Pattern[str]] = []
+        for pattern in spec["blocked_patterns"]:
+            try:
+                compiled.append(re.compile(pattern))
+            except (re.error, TypeError) as exc:
+                raise ValueError(
+                    f"Invalid regex in `blocked_patterns` for argument '{arg_name}': {pattern!r} — {exc}."
+                ) from exc
+        normalized["blocked_patterns"] = compiled
+
+    return normalized
+
 
 @dataclass
 class GovernancePolicy:
@@ -82,72 +156,52 @@ class GovernancePolicy:
         Where `tool_allowlist`/`tool_blocklist` govern *which* tools run, this
         governs *what* those tools are called with — a defence against dangerous
         argument values such as SQL injection, path traversal, or oversized
-        payloads.
-
-        The policy applies to any tool whose name matches `tool` via `fnmatch`
-        (so `"sql_*"` covers `sql_query`, `sql_exec`, ...). `constraints` maps an
-        argument name to the checks that argument must satisfy:
-
-        | Check | Meaning |
-        |-------|---------|
-        | `max_length` | Reject if `len(str(value))` exceeds this. |
-        | `min_length` | Reject if `len(str(value))` is below this. |
-        | `type` | Reject if the value is not of this type. One of `"str"`, `"int"`, `"float"`, `"bool"`, `"list"`, `"dict"`. |
-        | `blocked_terms` | Reject if any term appears in `str(value)` (case-insensitive substring). |
-        | `blocked_patterns` | Reject if any regex matches `str(value)`. |
-        | `allowed_values` | Reject if the value is not one of these. |
-
-        Only the arguments named in `constraints` are checked; any others pass
-        through. An argument named in `constraints` but absent from the call is
-        skipped (use a `tool_args`-style required check upstream if presence
-        matters).
-
-        Example — block SQL injection and path traversal::
+        payloads::
 
             GovernancePolicy.arg_validation(
                 "sql_query",
-                {"query": {"max_length": 500, "blocked_terms": ["DROP", "DELETE", ";--"]}},
+                {"query": {"max_length": 500, "blocked_terms": ["DROP", ";--"]}},
             )
-            GovernancePolicy.arg_validation(
-                "read_file",
-                {"path": {"blocked_patterns": [r"\\.\\.[\\\\/]"]}},  # reject ../ and ..\\
-            )
+
+        Only the arguments named in `constraints` are checked, and one absent
+        from the call is skipped — so this constrains values, never presence.
+        If a call's arguments are not a mapping there are no names to read by,
+        and the policy falls back to scanning the serialized call for every
+        constrained `blocked_terms`/`blocked_patterns`, denying as `*:{check}`.
 
         Args:
-            tool: Tool name or `fnmatch` pattern the constraints apply to.
-            constraints: Mapping of argument name -> constraint spec.
+            tool: Tool name, or `fnmatch` pattern such as `"sql_*"`.
+            constraints: Argument name -> the checks it must satisfy. See
+                `ARG_CHECKS` for the checks, and the extension docs for what
+                each one means.
 
         Raises:
-            ValueError: If `tool` is empty, `constraints` is empty, or a
-                constraint spec is malformed (unknown check, non-mapping spec,
-                or an unsupported `type` name) — any of which would otherwise
-                silently validate nothing.
+            ValueError: If `tool` or `constraints` is empty, or a spec is
+                malformed. Specs are validated in full here so that a typo
+                fails where it was written, rather than leaving a policy that
+                checks nothing or one that raises mid-call from inside the
+                governance path.
         """
         if not tool:
             raise ValueError("`tool` must not be empty.")
         if not constraints:
             raise ValueError("`constraints` must not be empty; a policy with no constraints validates nothing.")
 
-        valid_checks = {"max_length", "min_length", "type", "blocked_terms", "blocked_patterns", "allowed_values"}
-        valid_types = {"str", "int", "float", "bool", "list", "dict"}
+        normalized: dict[str, dict[str, Any]] = {}
         for arg_name, spec in constraints.items():
             if not isinstance(spec, dict):
                 raise ValueError(
                     f"Constraint spec for argument '{arg_name}' must be a dict, got {type(spec).__name__}."
                 )
-            unknown = set(spec) - valid_checks
+            unknown = set(spec) - ARG_CHECKS
             if unknown:
                 raise ValueError(
                     f"Unknown constraint(s) for argument '{arg_name}': {', '.join(sorted(unknown))}. "
-                    f"Valid checks: {', '.join(sorted(valid_checks))}."
+                    f"Valid checks: {', '.join(sorted(ARG_CHECKS))}."
                 )
-            if "type" in spec and spec["type"] not in valid_types:
-                raise ValueError(
-                    f"Unsupported type '{spec['type']}' for argument '{arg_name}'. "
-                    f"Valid types: {', '.join(sorted(valid_types))}."
-                )
+            normalized[arg_name] = _normalize_arg_spec(arg_name, spec)
 
-        return cls(type="arg_validation", config={"tool": tool, "constraints": constraints})
+        return cls(type="arg_validation", config={"tool": tool, "constraints": normalized})
 
     @classmethod
     def pii_block(cls, categories: list[str] | None = None) -> "GovernancePolicy":

--- a/ag2/extensions/tealtiger/types.py
+++ b/ag2/extensions/tealtiger/types.py
@@ -50,11 +50,15 @@ def _normalize_arg_spec(arg_name: str, spec: dict[str, Any]) -> dict[str, Any]:
     for compilation — hence "ready to evaluate", and hence a returned spec that
     holds `re.Pattern` objects where the caller passed strings.
     """
+    if not spec:
+        raise ValueError(f"Constraint spec for argument '{arg_name}' must not be empty.")
+
     normalized = dict(spec)
 
-    if "type" in spec and spec["type"] not in ARG_TYPES_BY_NAME:
+    type_name = spec.get("type")
+    if type_name is not None and (not isinstance(type_name, str) or type_name not in ARG_TYPES_BY_NAME):
         raise ValueError(
-            f"Unsupported type '{spec['type']}' for argument '{arg_name}'. "
+            f"Unsupported type {type_name!r} for argument '{arg_name}'. "
             f"Valid types: {', '.join(sorted(ARG_TYPES_BY_NAME))}."
         )
 

--- a/test/extensions/tealtiger/test_arg_validation.py
+++ b/test/extensions/tealtiger/test_arg_validation.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for TealTiger per-tool argument validation.
+
+`arg_validation` constrains the arguments a matched tool may receive — max/min
+length, type, blocked terms, blocked regex patterns, and allowed values — to
+defend against dangerous values such as SQL injection and path traversal.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ag2.events import ToolCallEvent, ToolErrorEvent
+from ag2.extensions.tealtiger import GovernancePolicy, TealTigerMiddleware
+from ag2.utils import AGENT_CONTEXT_DEPENDENCY_KEY
+
+
+def _make_context(agent_name: str = "assistant") -> MagicMock:
+    """Create a mock Context with agent dependency."""
+    ctx = MagicMock()
+    agent = MagicMock()
+    agent.name = agent_name
+    ctx.dependencies = {AGENT_CONTEXT_DEPENDENCY_KEY: agent}
+    return ctx
+
+
+def _make_tool_event(name: str = "sql_query", arguments: dict | None = None) -> MagicMock:
+    """Create a mock ToolCallEvent with serialized_arguments."""
+    event = MagicMock(spec=ToolCallEvent)
+    event.name = name
+    args = arguments or {}
+    event.serialized_arguments = args
+    event.arguments = json.dumps(args)
+    event.call_id = "call-123"
+    return event
+
+
+async def _run(policy: GovernancePolicy, tool_name: str, arguments: dict, mode: str = "ENFORCE"):
+    """Run one tool call through the middleware, return (result, middleware)."""
+    mw = TealTigerMiddleware(policies=[policy], mode=mode)
+    ctx = _make_context()
+    per_turn = mw(MagicMock(), ctx)
+    event = _make_tool_event(name=tool_name, arguments=arguments)
+    call_next = AsyncMock(return_value=MagicMock())
+    result = await per_turn.on_tool_execution(call_next, event, ctx)
+    return result, mw
+
+
+@pytest.mark.asyncio
+class TestArgValidation:
+    async def test_within_constraints_passes(self):
+        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 100}})
+        result, mw = await _run(policy, "sql_query", {"query": "SELECT 1"})
+        assert not isinstance(result, ToolErrorEvent)
+        assert mw.decisions[-1].action == "ALLOW"
+
+    async def test_max_length_denied(self):
+        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 10}})
+        result, mw = await _run(policy, "sql_query", {"query": "SELECT * FROM a very long table name"})
+        assert isinstance(result, ToolErrorEvent)
+        assert "ARG_VALIDATION:query:max_length" in str(result.error)
+
+    async def test_min_length_denied(self):
+        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"min_length": 5}})
+        result, _ = await _run(policy, "sql_query", {"query": "hi"})
+        assert isinstance(result, ToolErrorEvent)
+        assert "ARG_VALIDATION:query:min_length" in str(result.error)
+
+    async def test_blocked_terms_denied_case_insensitive(self):
+        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP", "DELETE"]}})
+        result, _ = await _run(policy, "sql_query", {"query": "drop table users"})
+        assert isinstance(result, ToolErrorEvent)
+        assert "ARG_VALIDATION:query:blocked_terms" in str(result.error)
+
+    async def test_blocked_patterns_denies_path_traversal(self):
+        policy = GovernancePolicy.arg_validation("read_file", {"path": {"blocked_patterns": [r"\.\.[\\/]"]}})
+        result, _ = await _run(policy, "read_file", {"path": "../../etc/passwd"})
+        assert isinstance(result, ToolErrorEvent)
+        assert "ARG_VALIDATION:path:blocked_patterns" in str(result.error)
+
+    async def test_blocked_patterns_allows_safe_path(self):
+        policy = GovernancePolicy.arg_validation("read_file", {"path": {"blocked_patterns": [r"\.\.[\\/]"]}})
+        result, _ = await _run(policy, "read_file", {"path": "data/report.txt"})
+        assert not isinstance(result, ToolErrorEvent)
+
+    async def test_type_check_rejects_wrong_type(self):
+        policy = GovernancePolicy.arg_validation("calc", {"n": {"type": "int"}})
+        result, _ = await _run(policy, "calc", {"n": "not-a-number"})
+        assert isinstance(result, ToolErrorEvent)
+        assert "ARG_VALIDATION:n:type" in str(result.error)
+
+    async def test_type_check_rejects_bool_for_int(self):
+        # bool is a subclass of int; the check must still reject it.
+        policy = GovernancePolicy.arg_validation("calc", {"n": {"type": "int"}})
+        result, _ = await _run(policy, "calc", {"n": True})
+        assert isinstance(result, ToolErrorEvent)
+        assert "ARG_VALIDATION:n:type" in str(result.error)
+
+    async def test_type_check_accepts_correct_type(self):
+        policy = GovernancePolicy.arg_validation("calc", {"n": {"type": "int"}})
+        result, _ = await _run(policy, "calc", {"n": 42})
+        assert not isinstance(result, ToolErrorEvent)
+
+    async def test_allowed_values_denied(self):
+        policy = GovernancePolicy.arg_validation("set_mode", {"mode": {"allowed_values": ["read", "write"]}})
+        result, _ = await _run(policy, "set_mode", {"mode": "admin"})
+        assert isinstance(result, ToolErrorEvent)
+        assert "ARG_VALIDATION:mode:allowed_values" in str(result.error)
+
+    async def test_unconstrained_argument_ignored(self):
+        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 10}})
+        result, _ = await _run(policy, "sql_query", {"query": "SELECT 1", "note": "x" * 500})
+        assert not isinstance(result, ToolErrorEvent)
+
+    async def test_absent_constrained_argument_skipped(self):
+        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 5}})
+        result, _ = await _run(policy, "sql_query", {"other": "value"})
+        assert not isinstance(result, ToolErrorEvent)
+
+    async def test_only_matching_tool_is_validated(self):
+        policy = GovernancePolicy.arg_validation("sql_*", {"query": {"blocked_terms": ["DROP"]}})
+        # A tool that does not match the pattern is unaffected.
+        result, _ = await _run(policy, "search", {"query": "DROP everything"})
+        assert not isinstance(result, ToolErrorEvent)
+
+    async def test_matching_tool_glob_is_validated(self):
+        policy = GovernancePolicy.arg_validation("sql_*", {"query": {"blocked_terms": ["DROP"]}})
+        result, _ = await _run(policy, "sql_exec", {"query": "DROP TABLE t"})
+        assert isinstance(result, ToolErrorEvent)
+        assert "ARG_VALIDATION:query:blocked_terms" in str(result.error)
+
+    async def test_decision_recorded_with_risk_score(self):
+        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP"]}})
+        _, mw = await _run(policy, "sql_query", {"query": "DROP TABLE t"})
+        last = mw.decisions[-1]
+        assert last.action == "DENY"
+        assert last.risk_score == 85
+        assert mw.deny_count == 1
+
+    async def test_observe_mode_allows_violation(self):
+        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP"]}})
+        result, _ = await _run(policy, "sql_query", {"query": "DROP TABLE t"}, mode="OBSERVE")
+        assert not isinstance(result, ToolErrorEvent)
+
+    async def test_monitor_mode_records_but_allows(self):
+        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP"]}})
+        result, mw = await _run(policy, "sql_query", {"query": "DROP TABLE t"}, mode="MONITOR")
+        assert not isinstance(result, ToolErrorEvent)
+        assert mw.decisions[-1].action == "DENY"
+
+
+class TestArgValidationConstruction:
+    def test_empty_tool_raises(self):
+        with pytest.raises(ValueError, match="`tool` must not be empty"):
+            GovernancePolicy.arg_validation("", {"query": {"max_length": 10}})
+
+    def test_empty_constraints_raises(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            GovernancePolicy.arg_validation("sql_query", {})
+
+    def test_non_dict_spec_raises(self):
+        with pytest.raises(ValueError, match="must be a dict"):
+            GovernancePolicy.arg_validation("sql_query", {"query": ["max_length", 10]})
+
+    def test_unknown_check_raises(self):
+        with pytest.raises(ValueError, match="Unknown constraint"):
+            GovernancePolicy.arg_validation("sql_query", {"query": {"maxlength": 10}})
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(ValueError, match="Unsupported type"):
+            GovernancePolicy.arg_validation("calc", {"n": {"type": "complex"}})

--- a/test/extensions/tealtiger/test_arg_validation.py
+++ b/test/extensions/tealtiger/test_arg_validation.py
@@ -3,156 +3,486 @@
 
 """Tests for TealTiger per-tool argument validation.
 
-`arg_validation` constrains the arguments a matched tool may receive — max/min
-length, type, blocked terms, blocked regex patterns, and allowed values — to
-defend against dangerous values such as SQL injection and path traversal.
+Where the allow/blocklists govern *which* tools run, `arg_validation` governs
+*what* a matched tool is called with — max/min length, type, blocked terms,
+blocked regex patterns, and allowed values — to defend against dangerous values
+such as SQL injection and path traversal.
+
+Each case scripts a real agent's turn with ``TestConfig``, so the policy runs
+where it does in production and the argument values come in the way a model
+would actually send them: as the JSON string on a ``ToolCallEvent``. Every tool
+appends to ``ran`` before returning, so "the call was blocked" is observed as
+the tool body never having executed. In ENFORCE mode a denial fails the turn,
+so ``ask`` raises.
 """
 
 import json
-from unittest.mock import AsyncMock, MagicMock
+from typing import Any
 
 import pytest
 
-from ag2.events import ToolCallEvent, ToolErrorEvent
-from ag2.extensions.tealtiger import GovernancePolicy, TealTigerMiddleware
-from ag2.utils import AGENT_CONTEXT_DEPENDENCY_KEY
+from ag2 import Agent
+from ag2.events import ToolCallEvent
+from ag2.extensions.tealtiger import GovernanceMode, GovernancePolicy, TealTigerMiddleware
+from ag2.extensions.tealtiger.types import ARG_CHECKS
+from ag2.testing import TestConfig
 
 
-def _make_context(agent_name: str = "assistant") -> MagicMock:
-    """Create a mock Context with agent dependency."""
-    ctx = MagicMock()
-    agent = MagicMock()
-    agent.name = agent_name
-    ctx.dependencies = {AGENT_CONTEXT_DEPENDENCY_KEY: agent}
-    return ctx
-
-
-def _make_tool_event(name: str = "sql_query", arguments: dict | None = None) -> MagicMock:
-    """Create a mock ToolCallEvent with serialized_arguments."""
-    event = MagicMock(spec=ToolCallEvent)
-    event.name = name
-    args = arguments or {}
-    event.serialized_arguments = args
-    event.arguments = json.dumps(args)
-    event.call_id = "call-123"
-    return event
-
-
-async def _run(policy: GovernancePolicy, tool_name: str, arguments: dict, mode: str = "ENFORCE"):
-    """Run one tool call through the middleware, return (result, middleware)."""
-    mw = TealTigerMiddleware(policies=[policy], mode=mode)
-    ctx = _make_context()
-    per_turn = mw(MagicMock(), ctx)
-    event = _make_tool_event(name=tool_name, arguments=arguments)
-    call_next = AsyncMock(return_value=MagicMock())
-    result = await per_turn.on_tool_execution(call_next, event, ctx)
-    return result, mw
+def _call(tool_name: str, **arguments: Any) -> ToolCallEvent:
+    """The tool call a model would emit for these arguments."""
+    return ToolCallEvent(name=tool_name, arguments=json.dumps(arguments))
 
 
 @pytest.mark.asyncio
-class TestArgValidation:
-    async def test_within_constraints_passes(self):
-        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 100}})
-        result, mw = await _run(policy, "sql_query", {"query": "SELECT 1"})
-        assert not isinstance(result, ToolErrorEvent)
-        assert mw.decisions[-1].action == "ALLOW"
+class TestArgumentConstraintsAreEnforced:
+    async def test_an_argument_within_its_constraints_runs(self):
+        ran: list[str] = []
 
-    async def test_max_length_denied(self):
-        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 10}})
-        result, mw = await _run(policy, "sql_query", {"query": "SELECT * FROM a very long table name"})
-        assert isinstance(result, ToolErrorEvent)
-        assert "ARG_VALIDATION:query:max_length" in str(result.error)
+        def sql_query(query: str) -> str:
+            ran.append(query)
+            return "3 rows"
 
-    async def test_min_length_denied(self):
-        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"min_length": 5}})
-        result, _ = await _run(policy, "sql_query", {"query": "hi"})
-        assert isinstance(result, ToolErrorEvent)
-        assert "ARG_VALIDATION:query:min_length" in str(result.error)
+        governance = TealTigerMiddleware(
+            policies=[
+                GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 500, "blocked_terms": ["DROP"]}})
+            ],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("sql_query", query="SELECT name FROM users"), "Done."),
+            tools=[sql_query],
+            middleware=[governance],
+        )
 
-    async def test_blocked_terms_denied_case_insensitive(self):
-        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP", "DELETE"]}})
-        result, _ = await _run(policy, "sql_query", {"query": "drop table users"})
-        assert isinstance(result, ToolErrorEvent)
-        assert "ARG_VALIDATION:query:blocked_terms" in str(result.error)
+        reply = await agent.ask("who is in the table")
 
-    async def test_blocked_patterns_denies_path_traversal(self):
-        policy = GovernancePolicy.arg_validation("read_file", {"path": {"blocked_patterns": [r"\.\.[\\/]"]}})
-        result, _ = await _run(policy, "read_file", {"path": "../../etc/passwd"})
-        assert isinstance(result, ToolErrorEvent)
-        assert "ARG_VALIDATION:path:blocked_patterns" in str(result.error)
+        assert reply.body == "Done."
+        assert ran == ["SELECT name FROM users"]
+        assert governance.deny_count == 0
 
-    async def test_blocked_patterns_allows_safe_path(self):
-        policy = GovernancePolicy.arg_validation("read_file", {"path": {"blocked_patterns": [r"\.\.[\\/]"]}})
-        result, _ = await _run(policy, "read_file", {"path": "data/report.txt"})
-        assert not isinstance(result, ToolErrorEvent)
+    async def test_a_blocked_term_stops_the_call(self):
+        ran: list[str] = []
 
-    async def test_type_check_rejects_wrong_type(self):
-        policy = GovernancePolicy.arg_validation("calc", {"n": {"type": "int"}})
-        result, _ = await _run(policy, "calc", {"n": "not-a-number"})
-        assert isinstance(result, ToolErrorEvent)
-        assert "ARG_VALIDATION:n:type" in str(result.error)
+        def sql_query(query: str) -> str:
+            ran.append(query)
+            return "dropped"
 
-    async def test_type_check_rejects_bool_for_int(self):
-        # bool is a subclass of int; the check must still reject it.
-        policy = GovernancePolicy.arg_validation("calc", {"n": {"type": "int"}})
-        result, _ = await _run(policy, "calc", {"n": True})
-        assert isinstance(result, ToolErrorEvent)
-        assert "ARG_VALIDATION:n:type" in str(result.error)
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP", ";--"]}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("sql_query", query="drop table users"), "Done."),
+            tools=[sql_query],
+            middleware=[governance],
+        )
 
-    async def test_type_check_accepts_correct_type(self):
-        policy = GovernancePolicy.arg_validation("calc", {"n": {"type": "int"}})
-        result, _ = await _run(policy, "calc", {"n": 42})
-        assert not isinstance(result, ToolErrorEvent)
+        # Blocked terms match case-insensitively, so lowercase `drop` is caught by `DROP`.
+        with pytest.raises(Exception, match=r"\[GOVERNANCE DENIED\].*ARG_VALIDATION:query:blocked_terms"):
+            await agent.ask("clean up the table")
 
-    async def test_allowed_values_denied(self):
-        policy = GovernancePolicy.arg_validation("set_mode", {"mode": {"allowed_values": ["read", "write"]}})
-        result, _ = await _run(policy, "set_mode", {"mode": "admin"})
-        assert isinstance(result, ToolErrorEvent)
-        assert "ARG_VALIDATION:mode:allowed_values" in str(result.error)
+        assert ran == []
 
-    async def test_unconstrained_argument_ignored(self):
-        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 10}})
-        result, _ = await _run(policy, "sql_query", {"query": "SELECT 1", "note": "x" * 500})
-        assert not isinstance(result, ToolErrorEvent)
+    async def test_a_blocked_pattern_stops_path_traversal(self):
+        ran: list[str] = []
 
-    async def test_absent_constrained_argument_skipped(self):
-        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 5}})
-        result, _ = await _run(policy, "sql_query", {"other": "value"})
-        assert not isinstance(result, ToolErrorEvent)
+        def read_file(path: str) -> str:
+            ran.append(path)
+            return "root:x:0:0"
 
-    async def test_only_matching_tool_is_validated(self):
-        policy = GovernancePolicy.arg_validation("sql_*", {"query": {"blocked_terms": ["DROP"]}})
-        # A tool that does not match the pattern is unaffected.
-        result, _ = await _run(policy, "search", {"query": "DROP everything"})
-        assert not isinstance(result, ToolErrorEvent)
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("read_file", {"path": {"blocked_patterns": [r"\.\.[\\/]"]}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("read_file", path="../../etc/passwd"), "Done."),
+            tools=[read_file],
+            middleware=[governance],
+        )
 
-    async def test_matching_tool_glob_is_validated(self):
-        policy = GovernancePolicy.arg_validation("sql_*", {"query": {"blocked_terms": ["DROP"]}})
-        result, _ = await _run(policy, "sql_exec", {"query": "DROP TABLE t"})
-        assert isinstance(result, ToolErrorEvent)
-        assert "ARG_VALIDATION:query:blocked_terms" in str(result.error)
+        with pytest.raises(Exception, match="ARG_VALIDATION:path:blocked_patterns"):
+            await agent.ask("read the file")
 
-    async def test_decision_recorded_with_risk_score(self):
-        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP"]}})
-        _, mw = await _run(policy, "sql_query", {"query": "DROP TABLE t"})
-        last = mw.decisions[-1]
-        assert last.action == "DENY"
-        assert last.risk_score == 85
-        assert mw.deny_count == 1
+        assert ran == []
 
-    async def test_observe_mode_allows_violation(self):
-        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP"]}})
-        result, _ = await _run(policy, "sql_query", {"query": "DROP TABLE t"}, mode="OBSERVE")
-        assert not isinstance(result, ToolErrorEvent)
+    async def test_a_pattern_that_does_not_match_lets_the_call_through(self):
+        ran: list[str] = []
 
-    async def test_monitor_mode_records_but_allows(self):
-        policy = GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP"]}})
-        result, mw = await _run(policy, "sql_query", {"query": "DROP TABLE t"}, mode="MONITOR")
-        assert not isinstance(result, ToolErrorEvent)
-        assert mw.decisions[-1].action == "DENY"
+        def read_file(path: str) -> str:
+            ran.append(path)
+            return "file contents"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("read_file", {"path": {"blocked_patterns": [r"\.\.[\\/]"]}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("read_file", path="reports/q3.txt"), "Done."),
+            tools=[read_file],
+            middleware=[governance],
+        )
+
+        reply = await agent.ask("read the report")
+
+        assert reply.body == "Done."
+        assert ran == ["reports/q3.txt"]
+
+    async def test_an_oversized_argument_stops_the_call(self):
+        ran: list[str] = []
+
+        def sql_query(query: str) -> str:
+            ran.append(query)
+            return "rows"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 20}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("sql_query", query="SELECT * FROM a_very_wide_table_indeed"), "Done."),
+            tools=[sql_query],
+            middleware=[governance],
+        )
+
+        with pytest.raises(Exception, match="ARG_VALIDATION:query:max_length"):
+            await agent.ask("run the query")
+
+        assert ran == []
+
+    async def test_a_value_outside_allowed_values_stops_the_call(self):
+        ran: list[str] = []
+
+        def open_file(mode: str) -> str:
+            ran.append(mode)
+            return "opened"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("open_file", {"mode": {"allowed_values": ["read", "list"]}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("open_file", mode="write"), "Done."),
+            tools=[open_file],
+            middleware=[governance],
+        )
+
+        with pytest.raises(Exception, match="ARG_VALIDATION:mode:allowed_values"):
+            await agent.ask("open it for writing")
+
+        assert ran == []
+
+    async def test_a_bool_does_not_satisfy_an_int_constraint(self):
+        # bool is a subclass of int in Python, so `True` would pass a naive
+        # isinstance check and reach a tool expecting a real count.
+        ran: list[bool] = []
+
+        def fetch(limit: int) -> str:
+            ran.append(limit)
+            return "fetched"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("fetch", {"limit": {"type": "int"}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("fetch", limit=True), "Done."),
+            tools=[fetch],
+            middleware=[governance],
+        )
+
+        with pytest.raises(Exception, match="ARG_VALIDATION:limit:type"):
+            await agent.ask("fetch some")
+
+        assert ran == []
+
+    async def test_a_real_int_satisfies_an_int_constraint(self):
+        ran: list[int] = []
+
+        def fetch(limit: int) -> str:
+            ran.append(limit)
+            return "fetched"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("fetch", {"limit": {"type": "int"}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("fetch", limit=10), "Done."),
+            tools=[fetch],
+            middleware=[governance],
+        )
+
+        reply = await agent.ask("fetch some")
+
+        assert reply.body == "Done."
+        assert ran == [10]
 
 
-class TestArgValidationConstruction:
+@pytest.mark.asyncio
+class TestWhatTheConstraintsApplyTo:
+    async def test_a_glob_covers_every_matching_tool(self):
+        ran: list[str] = []
+
+        def sql_exec(query: str) -> str:
+            ran.append(query)
+            return "executed"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("sql_*", {"query": {"blocked_terms": ["DROP"]}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("sql_exec", query="DROP TABLE users"), "Done."),
+            tools=[sql_exec],
+            middleware=[governance],
+        )
+
+        with pytest.raises(Exception, match="ARG_VALIDATION:query:blocked_terms"):
+            await agent.ask("run it")
+
+        assert ran == []
+
+    async def test_a_tool_the_pattern_does_not_match_is_left_alone(self):
+        ran: list[str] = []
+
+        def search(query: str) -> str:
+            ran.append(query)
+            return "found"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("sql_*", {"query": {"blocked_terms": ["DROP"]}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("search", query="DROP TABLE users"), "Done."),
+            tools=[search],
+            middleware=[governance],
+        )
+
+        reply = await agent.ask("look it up")
+
+        assert reply.body == "Done."
+        assert ran == ["DROP TABLE users"]
+
+    async def test_an_unconstrained_argument_passes_through(self):
+        ran: list[tuple[str, str]] = []
+
+        def sql_query(query: str, label: str) -> str:
+            ran.append((query, label))
+            return "rows"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP"]}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("sql_query", query="SELECT 1", label="DROP this label"), "Done."),
+            tools=[sql_query],
+            middleware=[governance],
+        )
+
+        reply = await agent.ask("run it")
+
+        # `label` is not in `constraints`, so its `DROP` is none of the policy's business.
+        assert reply.body == "Done."
+        assert ran == [("SELECT 1", "DROP this label")]
+
+    async def test_a_constrained_argument_absent_from_the_call_is_skipped(self):
+        ran: list[str] = []
+
+        def sql_query(query: str) -> str:
+            ran.append(query)
+            return "rows"
+
+        governance = TealTigerMiddleware(
+            policies=[
+                GovernancePolicy.arg_validation(
+                    "sql_query",
+                    {"query": {"blocked_terms": ["DROP"]}, "schema": {"allowed_values": ["public"]}},
+                )
+            ],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("sql_query", query="SELECT 1"), "Done."),
+            tools=[sql_query],
+            middleware=[governance],
+        )
+
+        reply = await agent.ask("run it")
+
+        # `schema` was never sent, so its `allowed_values` has nothing to judge.
+        assert reply.body == "Done."
+        assert ran == ["SELECT 1"]
+
+    async def test_arguments_that_are_not_a_mapping_are_scanned_as_a_whole(self):
+        # A model can emit a JSON array rather than an object, leaving no argument
+        # names to read. The policy stays fail-closed: the term checks run over the
+        # whole serialized call, reported against `*` because no single argument
+        # can honestly be blamed.
+        ran: list[Any] = []
+
+        def sql_query(query: str) -> str:
+            ran.append(query)
+            return "rows"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP"]}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(ToolCallEvent(name="sql_query", arguments='["DROP TABLE users"]'), "Done."),
+            tools=[sql_query],
+            middleware=[governance],
+        )
+
+        with pytest.raises(Exception, match=r"ARG_VALIDATION:\*:blocked_terms"):
+            await agent.ask("run it")
+
+        assert ran == []
+
+
+# One violating (spec, value) pair per check the vocabulary advertises. The
+# equality test below fails if a check is ever added to `ARG_CHECKS` without a
+# case here, and each case proves the evaluator actually wires that check up.
+_VIOLATIONS: dict[str, tuple[dict[str, Any], Any]] = {
+    "max_length": ({"max_length": 5}, "far too long"),
+    "min_length": ({"min_length": 5}, "hi"),
+    "type": ({"type": "int"}, "not a number"),
+    "blocked_terms": ({"blocked_terms": ["DROP"]}, "drop table users"),
+    "blocked_patterns": ({"blocked_patterns": [r"\.\.[\\/]"]}, "../etc/passwd"),
+    "allowed_values": ({"allowed_values": ["read"]}, "write"),
+}
+
+
+def test_every_advertised_check_has_a_case():
+    assert set(_VIOLATIONS) == set(ARG_CHECKS)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("check", sorted(_VIOLATIONS))
+async def test_every_advertised_check_can_deny(check: str):
+    spec, value = _VIOLATIONS[check]
+    ran: list[str] = []
+
+    def probe(value: str) -> str:
+        ran.append(value)
+        return "probed"
+
+    governance = TealTigerMiddleware(
+        policies=[GovernancePolicy.arg_validation("probe", {"value": spec})],
+        mode=GovernanceMode.ENFORCE,
+    )
+    agent = Agent(
+        "assistant",
+        config=TestConfig(_call("probe", value=value), "Done."),
+        tools=[probe],
+        middleware=[governance],
+    )
+
+    with pytest.raises(Exception, match=f"ARG_VALIDATION:value:{check}"):
+        await agent.ask("probe it")
+
+    assert ran == []
+
+
+@pytest.mark.asyncio
+class TestTheDecisionTrail:
+    async def test_a_denial_is_recorded_with_a_receipt(self):
+        def sql_query(query: str) -> str:
+            return "rows"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 10}})],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("sql_query", query="SELECT * FROM everything"), "Done."),
+            tools=[sql_query],
+            middleware=[governance],
+        )
+
+        with pytest.raises(Exception, match="ARG_VALIDATION"):
+            await agent.ask("run it")
+
+        decision = governance.decisions[-1]
+        assert decision.action == "DENY"
+        assert decision.reason_codes == ["ARG_VALIDATION:query:max_length"]
+        assert decision.risk_score == 85
+        assert decision.tool_name == "sql_query"
+        assert decision.agent_name == "assistant"
+        assert governance.deny_count == 1
+        assert governance.receipts[-1].execution_outcome == "blocked"
+
+    async def test_observe_mode_skips_evaluation_entirely(self):
+        ran: list[str] = []
+
+        def sql_query(query: str) -> str:
+            ran.append(query)
+            return "dropped"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP"]}})],
+            mode=GovernanceMode.OBSERVE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("sql_query", query="DROP TABLE users"), "Done."),
+            tools=[sql_query],
+            middleware=[governance],
+        )
+
+        reply = await agent.ask("clean up")
+
+        assert reply.body == "Done."
+        assert ran == ["DROP TABLE users"]
+        assert governance.decisions[-1].action == "ALLOW"
+        assert governance.decisions[-1].reason_codes == ["OBSERVE_PASSTHROUGH"]
+
+    async def test_monitor_mode_records_the_denial_but_lets_the_call_through(self):
+        ran: list[str] = []
+
+        def sql_query(query: str) -> str:
+            ran.append(query)
+            return "dropped"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": ["DROP"]}})],
+            mode=GovernanceMode.MONITOR,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("sql_query", query="DROP TABLE users"), "Done."),
+            tools=[sql_query],
+            middleware=[governance],
+        )
+
+        reply = await agent.ask("clean up")
+
+        assert reply.body == "Done."
+        assert ran == ["DROP TABLE users"]
+        assert governance.decisions[-1].action == "DENY"
+        assert governance.decisions[-1].reason_codes == ["ARG_VALIDATION:query:blocked_terms"]
+
+
+class TestAMalformedSpecIsRejectedAtConstruction:
+    """A typo must not survive to become a policy that quietly checks nothing —
+    or one that crashes the governance path on the first call it evaluates."""
+
     def test_empty_tool_raises(self):
         with pytest.raises(ValueError, match="`tool` must not be empty"):
             GovernancePolicy.arg_validation("", {"query": {"max_length": 10}})
@@ -162,13 +492,53 @@ class TestArgValidationConstruction:
             GovernancePolicy.arg_validation("sql_query", {})
 
     def test_non_dict_spec_raises(self):
-        with pytest.raises(ValueError, match="must be a dict"):
-            GovernancePolicy.arg_validation("sql_query", {"query": ["max_length", 10]})
+        with pytest.raises(ValueError, match="must be a dict, got list"):
+            GovernancePolicy.arg_validation("sql_query", {"query": ["max_length"]})
 
     def test_unknown_check_raises(self):
-        with pytest.raises(ValueError, match="Unknown constraint"):
-            GovernancePolicy.arg_validation("sql_query", {"query": {"maxlength": 10}})
+        with pytest.raises(ValueError, match="Unknown constraint\\(s\\) for argument 'query': max_len"):
+            GovernancePolicy.arg_validation("sql_query", {"query": {"max_len": 10}})
 
     def test_unsupported_type_raises(self):
-        with pytest.raises(ValueError, match="Unsupported type"):
-            GovernancePolicy.arg_validation("calc", {"n": {"type": "complex"}})
+        with pytest.raises(ValueError, match="Unsupported type 'complex'"):
+            GovernancePolicy.arg_validation("sql_query", {"query": {"type": "complex"}})
+
+    def test_uncompilable_pattern_raises(self):
+        with pytest.raises(ValueError, match="Invalid regex in `blocked_patterns`"):
+            GovernancePolicy.arg_validation("read_file", {"path": {"blocked_patterns": ["[unclosed"]}})
+
+    def test_non_integer_length_raises(self):
+        with pytest.raises(ValueError, match="`max_length` for argument 'query' must be a non-negative integer"):
+            GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": "ten"}})
+
+    def test_negative_length_raises(self):
+        with pytest.raises(ValueError, match="must be a non-negative integer"):
+            GovernancePolicy.arg_validation("sql_query", {"query": {"min_length": -1}})
+
+    def test_max_length_below_min_length_raises(self):
+        with pytest.raises(ValueError, match="no value could satisfy both"):
+            GovernancePolicy.arg_validation("sql_query", {"query": {"max_length": 2, "min_length": 5}})
+
+    def test_empty_term_list_raises(self):
+        with pytest.raises(ValueError, match="`blocked_terms` for argument 'query' must be a non-empty list"):
+            GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": []}})
+
+    def test_non_string_term_raises(self):
+        with pytest.raises(ValueError, match="must contain only strings"):
+            GovernancePolicy.arg_validation("sql_query", {"query": {"blocked_terms": [42]}})
+
+    def test_patterns_are_compiled_once_at_construction(self):
+        # Evaluation must never pay for compilation, nor depend on the
+        # interpreter's regex cache still holding the pattern.
+        policy = GovernancePolicy.arg_validation("read_file", {"path": {"blocked_patterns": [r"\.\.[\\/]"]}})
+
+        compiled = policy.config["constraints"]["path"]["blocked_patterns"]
+
+        assert [p.pattern for p in compiled] == [r"\.\.[\\/]"]
+
+    def test_the_callers_constraints_are_not_mutated(self):
+        constraints: dict[str, dict[str, Any]] = {"path": {"blocked_patterns": [r"\.\."]}}
+
+        GovernancePolicy.arg_validation("read_file", constraints)
+
+        assert constraints == {"path": {"blocked_patterns": [r"\.\."]}}

--- a/test/extensions/tealtiger/test_arg_validation.py
+++ b/test/extensions/tealtiger/test_arg_validation.py
@@ -495,6 +495,10 @@ class TestAMalformedSpecIsRejectedAtConstruction:
         with pytest.raises(ValueError, match="must be a dict, got list"):
             GovernancePolicy.arg_validation("sql_query", {"query": ["max_length"]})
 
+    def test_empty_argument_spec_raises(self):
+        with pytest.raises(ValueError, match="Constraint spec for argument 'query' must not be empty"):
+            GovernancePolicy.arg_validation("sql_query", {"query": {}})
+
     def test_unknown_check_raises(self):
         with pytest.raises(ValueError, match="Unknown constraint\\(s\\) for argument 'query': max_len"):
             GovernancePolicy.arg_validation("sql_query", {"query": {"max_len": 10}})
@@ -502,6 +506,10 @@ class TestAMalformedSpecIsRejectedAtConstruction:
     def test_unsupported_type_raises(self):
         with pytest.raises(ValueError, match="Unsupported type 'complex'"):
             GovernancePolicy.arg_validation("sql_query", {"query": {"type": "complex"}})
+
+    def test_non_string_type_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unsupported type"):
+            GovernancePolicy.arg_validation("sql_query", {"query": {"type": ["int"]}})
 
     def test_uncompilable_pattern_raises(self):
         with pytest.raises(ValueError, match="Invalid regex in `blocked_patterns`"):

--- a/website/docs/user-guide/extensions/tealtiger.mdx
+++ b/website/docs/user-guide/extensions/tealtiger.mdx
@@ -3,7 +3,7 @@ title: TealTiger Governance
 sidebarTitle: TealTiger
 ---
 
-The `ag2.extensions.tealtiger` module adds deterministic governance guardrails to AG2 agents. `TealTigerMiddleware` enforces tool allowlists and blocklists, detects PII and secrets in tool arguments, blocks prompt injection attempts, tracks per-session cost, provides per-agent kill switches, and produces structured TEEC audit receipts — with no LLM in the governance path.
+The `ag2.extensions.tealtiger` module adds deterministic governance guardrails to AG2 agents. `TealTigerMiddleware` enforces tool allowlists and blocklists, validates tool arguments, detects PII and secrets in tool arguments, blocks prompt injection attempts, tracks per-session cost, provides per-agent kill switches, and produces structured TEEC audit receipts — with no LLM in the governance path.
 
 ## Installation
 
@@ -90,7 +90,7 @@ flowchart LR
 | Hook | Stage | What It Does |
 |------|-------|-------------|
 | `on_turn` | Turn defense | Kill switch enforcement — frozen agents cannot take turns |
-| `on_tool_execution` | Pre-tool defense | Tool allowlist/blocklist, PII scan, secret scan, cost limit check |
+| `on_tool_execution` | Pre-tool defense | Tool allowlist/blocklist, argument validation, PII scan, secret scan, cost limit check |
 
 Both stages activate from a single middleware instance. The **middleware factory** pattern keeps state (decisions, receipts, cost, frozen agents) alive across turns.
 
@@ -168,6 +168,51 @@ Here `read_file` passes both policies, while `read_secrets` clears the allowlist
     asymmetry denies too much; for a blocklist it lets a call through. If your tool names are
     not under your control, list the casings you need to block explicitly, or normalize tool
     names before registering them.
+
+### Argument Validation
+
+Where the allowlist and blocklist govern *which* tools run, `arg_validation` governs *what* a tool is called with — a defense against dangerous argument values such as SQL injection, path traversal, or oversized payloads. It applies to any tool whose name matches `tool` via `fnmatch`, and checks the named arguments against per-argument constraints:
+
+```python linenums="1"
+# Reject long queries and dangerous SQL verbs
+GovernancePolicy.arg_validation(
+    "sql_query",
+    {"query": {"max_length": 500, "blocked_terms": ["DROP", "DELETE", ";--"]}},
+)
+
+# Reject path traversal in a file tool
+GovernancePolicy.arg_validation(
+    "read_file",
+    {"path": {"blocked_patterns": [r"\.\.[\\/]"]}},  # ../ and ..\
+)
+```
+
+Each argument's constraint spec may combine any of these checks:
+
+| Check | Denies when |
+|-------|-------------|
+| `max_length` | `len(str(value))` exceeds the limit |
+| `min_length` | `len(str(value))` is below the minimum |
+| `type` | The value is not of this type — one of `"str"`, `"int"`, `"float"`, `"bool"`, `"list"`, `"dict"` |
+| `blocked_terms` | Any term appears in the value (case-insensitive substring) |
+| `blocked_patterns` | Any regex matches the value |
+| `allowed_values` | The value is not one of these |
+
+A violation is denied with reason code `ARG_VALIDATION:{argument}:{check}` (for example `ARG_VALIDATION:query:max_length`) and risk score 85. Only the arguments named in `constraints` are checked — any others pass through — and a constrained argument that is absent from the call is skipped.
+
+!!! note "Type note: `bool` is not accepted for `int`"
+
+    Because `bool` is a subclass of `int` in Python, `{"type": "int"}` explicitly rejects a
+    boolean value, so a `True`/`False` cannot slip through where a real integer is required.
+
+The policy validates its own spec at construction. An empty `tool`, empty `constraints`, a non-dict spec, an unknown check name, or an unsupported `type` raises `ValueError` — so a typo can't leave the policy silently validating nothing.
+
+!!! warning "Named checks need mapping-style arguments"
+
+    Length, type, and `allowed_values` checks rely on reading an argument by name. If a tool's
+    arguments arrive already serialized to a string rather than a mapping, only the
+    `blocked_terms` and `blocked_patterns` checks run (over the serialized form); the
+    value-specific checks are skipped for that call.
 
 ### PII Detection
 
@@ -339,7 +384,7 @@ for decision in governance.decisions:
 | `mode` | `str` | Mode the decision was made under: `OBSERVE`, `MONITOR`, or `ENFORCE` |
 | `agent_name` | `str` | Agent that made the call, or `unknown` |
 | `tool_name` | `str` | Tool that was evaluated (`*` for turn-level denials) |
-| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `TOOL_BLOCKED`, `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `BUDGET_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
+| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `TOOL_BLOCKED`, `ARG_VALIDATION:{argument}:{check}`, `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `BUDGET_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
 | `risk_score` | `int` | 0 (safe) to 100 (critical) |
 | `evaluation_time_ms` | `float` | Governance latency for this decision |
 | `cost_tracked` | `float` | Cost attributed to this call in USD |
@@ -543,6 +588,7 @@ Each policy type carries its own risk score when it denies:
 | Prompt injection | `PROMPT_INJECTION:{technique}/{pattern}` | 95 |
 | Secret detection | `SECRET_DETECTED` | 95 |
 | PII detection | `PII_DETECTED:{category}` | 90 |
+| Argument validation | `ARG_VALIDATION:{argument}:{check}` | 85 |
 | Tool allowlist | `TOOL_NOT_ALLOWED` | 80 |
 | Tool blocklist | `TOOL_BLOCKED` | 80 |
 | Cost limit / factory budget | `BUDGET_EXCEEDED` | 70 |

--- a/website/docs/user-guide/extensions/tealtiger.mdx
+++ b/website/docs/user-guide/extensions/tealtiger.mdx
@@ -205,14 +205,25 @@ A violation is denied with reason code `ARG_VALIDATION:{argument}:{check}` (for 
     Because `bool` is a subclass of `int` in Python, `{"type": "int"}` explicitly rejects a
     boolean value, so a `True`/`False` cannot slip through where a real integer is required.
 
-The policy validates its own spec at construction. An empty `tool`, empty `constraints`, a non-dict spec, an unknown check name, or an unsupported `type` raises `ValueError` — so a typo can't leave the policy silently validating nothing.
+The policy validates its own spec at construction, checking each check's *value* and not just its name. An empty `tool` or `constraints`, a non-dict spec, an unknown check name, an unsupported `type`, a negative or non-integer length bound, a `max_length` below the `min_length`, an empty term or value list, or an uncompilable regex all raise `ValueError`. A typo therefore surfaces where you wrote it — rather than leaving a policy that silently validates nothing, or one that raises from inside the governance path on the first call it evaluates.
+
+Patterns are compiled during that same validation, so evaluation never pays for compilation:
+
+```python linenums="1"
+GovernancePolicy.arg_validation("read_file", {"path": {"blocked_patterns": ["[unclosed"]}})
+# ValueError: Invalid regex in `blocked_patterns` for argument 'path': '[unclosed' — ...
+```
 
 !!! warning "Named checks need mapping-style arguments"
 
-    Length, type, and `allowed_values` checks rely on reading an argument by name. If a tool's
-    arguments arrive already serialized to a string rather than a mapping, only the
-    `blocked_terms` and `blocked_patterns` checks run (over the serialized form); the
-    value-specific checks are skipped for that call.
+    Length, type, and `allowed_values` checks rely on reading an argument by name. A model
+    usually sends a JSON object, but it can send an array or a bare value instead, leaving no
+    names to read. The policy then stays **fail-closed**: every constrained argument's
+    `blocked_terms` and `blocked_patterns` run over the whole serialized call, and the
+    value-specific checks are skipped. A denial from that path is reported as
+    `ARG_VALIDATION:*:{check}` — the `*` marking that the hit could not be attributed to one
+    argument, and that a term found anywhere in the call, including in an argument the policy
+    does not constrain, is enough to deny.
 
 ### PII Detection
 
@@ -384,7 +395,7 @@ for decision in governance.decisions:
 | `mode` | `str` | Mode the decision was made under: `OBSERVE`, `MONITOR`, or `ENFORCE` |
 | `agent_name` | `str` | Agent that made the call, or `unknown` |
 | `tool_name` | `str` | Tool that was evaluated (`*` for turn-level denials) |
-| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `TOOL_BLOCKED`, `ARG_VALIDATION:{argument}:{check}`, `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `BUDGET_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
+| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `TOOL_BLOCKED`, `ARG_VALIDATION:{argument}:{check}` (`{argument}` is `*` when the call's arguments were not a mapping), `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `BUDGET_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
 | `risk_score` | `int` | 0 (safe) to 100 (critical) |
 | `evaluation_time_ms` | `float` | Governance latency for this decision |
 | `cost_tracked` | `float` | Cost attributed to this call in USD |
@@ -638,7 +649,7 @@ The middleware follows AG2's middleware factory pattern:
 
 ## Performance
 
-Governance runs entirely in-process: no network calls, no LLM inference, and no external service dependencies. Every check is a `fnmatch` glob or a precompiled `re` pattern over the serialized tool arguments, so evaluation cost scales with argument size rather than with model latency.
+Governance runs entirely in-process: no network calls, no LLM inference, and no external service dependencies. Every check is a `fnmatch` glob, a precompiled `re` pattern, or a plain comparison over the tool arguments — every regex the middleware evaluates, `arg_validation`'s `blocked_patterns` included, is compiled before the first call reaches it. Evaluation cost therefore scales with argument size rather than with model latency.
 
 Each decision records its own measured cost in `evaluation_time_ms`, so you can profile governance overhead against your own workload:
 


### PR DESCRIPTION
## Why are these changes needed?

The built-in TealTiger extension can govern *which* tools run (`tool_allowlist` / `tool_blocklist`), but not *what* those tools are called with. An allowlisted `sql_query` tool can still receive `DROP TABLE users`, and an allowed `read_file` can still receive `../../etc/passwd`. This is the argument-injection gap (SQL injection, path traversal, oversized payloads).

This adds `GovernancePolicy.arg_validation(tool, constraints)`, which applies per-argument constraints to any tool whose name matches `tool` via `fnmatch`:

```python
GovernancePolicy.arg_validation(
    "sql_query",
    {"query": {"max_length": 500, "blocked_terms": ["DROP", "DELETE", ";--"]}},
)
GovernancePolicy.arg_validation(
    "read_file",
    {"path": {"blocked_patterns": [r"\.\.[\\/]"]}},  # reject ../ and ..\
)
```

Each argument's spec may combine `max_length`, `min_length`, `type` (`str`/`int`/`float`/`bool`/`list`/`dict`), `blocked_terms` (case-insensitive substring), `blocked_patterns` (regex), and `allowed_values`.

Behavior details:

- A violation denies with reason code `ARG_VALIDATION:{argument}:{check}` (e.g. `ARG_VALIDATION:query:max_length`) and risk score 85, slotting between PII (90) and the tool allow/block checks (80).
- Only arguments named in `constraints` are checked; others pass through. A constrained argument absent from the call is skipped.
- `bool` is explicitly rejected for `type: "int"` (bool is an `int` subclass in Python), so a boolean can't satisfy an integer constraint.
- When a tool's arguments arrive already serialized to a string rather than a mapping, the value-specific checks (length, type, allowed_values) are skipped and only `blocked_terms` / `blocked_patterns` run over the serialized form.
- The spec is validated at construction: empty `tool`, empty `constraints`, a non-dict spec, an unknown check name, or an unsupported `type` raises `ValueError`, so a typo can't leave the policy silently validating nothing.

No new dependencies — evaluation stays deterministic and inline (`fnmatch` + `re`, no LLM in the governance path). This continues the extension's Phase 2 detection expansion (prompt injection, tool blocklist).

## Related issue number

<!-- Fill in if there is a tracking issue, e.g. "Closes #NNNN". Otherwise remove. -->

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

### Validation

- Added `test/extensions/tealtiger/test_arg_validation.py` (22 tests): every check type, glob tool matching, unconstrained/absent-argument handling, the bool-vs-int edge case, OBSERVE/MONITOR pass-through, and all five construction-time `ValueError` paths.
- `python -m pytest test/extensions/tealtiger/` — 144 passed (existing extension tests + the new ones).
- `ruff check` and `ruff format --check` pass on all changed files.
- Documented the policy in `website/docs/user-guide/extensions/tealtiger.mdx`: new **Argument Validation** section, plus `ARG_VALIDATION` added to the decision-contract and evaluation-order tables and the pre-tool defense summary.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
