### PR TITLE
feat(mcp): add resource subscriptions and notification support

### DIFF
--- a/ag2/mcp/__init__.py
+++ b/ag2/mcp/__init__.py
@@ -11,6 +11,7 @@ try:
     from .resources import Resource, ResourceTemplate
     from .server import MCPServer
     from .sessions import SessionConfig
+    from .subscriptions import ResourceNotifier
     from .tools import MCPFunctionTool, mcp_tool
 except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp] is absent
     MCPServer = missing_optional_dependency("MCPServer", "mcp", e)  # type: ignore[misc]
@@ -18,6 +19,7 @@ except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp] is a
     AskContext = missing_optional_dependency("AskContext", "mcp", e)  # type: ignore[misc]
     ContextProvider = missing_optional_dependency("ContextProvider", "mcp", e)  # type: ignore[misc]
     SessionConfig = missing_optional_dependency("SessionConfig", "mcp", e)  # type: ignore[misc]
+    ResourceNotifier = missing_optional_dependency("ResourceNotifier", "mcp", e)  # type: ignore[misc]
     Resource = missing_optional_dependency("Resource", "mcp", e)  # type: ignore[misc]
     ResourceTemplate = missing_optional_dependency("ResourceTemplate", "mcp", e)  # type: ignore[misc]
     Prompt = missing_optional_dependency("Prompt", "mcp", e)  # type: ignore[misc]
@@ -35,6 +37,7 @@ __all__ = (
     "PromptArgument",
     "PromptMessage",
     "Resource",
+    "ResourceNotifier",
     "ResourceTemplate",
     "SessionConfig",
     "build_ask_tool",

--- a/ag2/mcp/resources.py
+++ b/ag2/mcp/resources.py
@@ -129,6 +129,17 @@ class ResourceProvider:
         contents = await self.read(params.uri)
         return ReadResourceResult(contents=[_to_wire_contents(params.uri, c) for c in contents])
 
+    def resolves(self, uri: str) -> bool:
+        """Whether ``uri`` names something this provider serves.
+
+        Same matching order as :meth:`read`, without running the reader — it
+        answers "is this URI ours" for callers that must not fetch the body,
+        such as validating a resource-update announcement.
+        """
+        if uri in self._by_uri:
+            return True
+        return any(pattern.match(uri) is not None for pattern, _ in self._compiled)
+
     async def read(self, uri: str) -> list[ReadResourceContents]:
         resource = self._by_uri.get(uri)
         if resource is not None:

--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -4,8 +4,9 @@
 
 import importlib.metadata
 import logging
+import warnings
 from collections.abc import AsyncGenerator, Callable, Mapping, Sequence
-from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -16,7 +17,17 @@ from mcp.server.caching import CacheHint, CacheableMethod
 from mcp.server.lowlevel import Server
 from mcp.server.stdio import stdio_server
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
-from mcp.types import CallToolRequestParams, CallToolResult, Icon, ListToolsResult, PaginatedRequestParams
+from mcp.server.subscriptions import ListenHandler
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    EmptyResult,
+    Icon,
+    ListToolsResult,
+    PaginatedRequestParams,
+    SubscribeRequestParams,
+    UnsubscribeRequestParams,
+)
 from starlette.applications import Starlette
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.routing import BaseRoute, Mount, Route
@@ -31,6 +42,7 @@ from .prompts import Prompt, PromptProvider
 from .resources import Resource, ResourceProvider, ResourceTemplate
 from .security import Requirement
 from .sessions import SessionConfig, SessionStore
+from .subscriptions import ResourceNotifier, _HandshakeDelivery, connection_key
 from .tools import MCPFunctionTool, ToolProvider
 
 if TYPE_CHECKING:
@@ -64,17 +76,21 @@ def _build_session_store(sessions: "bool | SessionConfig") -> SessionStore | Non
     )
 
 
-def _session_manager_lifespan(manager: StreamableHTTPSessionManager) -> "Lifespan[Any]":
+def _session_manager_lifespan(
+    manager: StreamableHTTPSessionManager, serving: "Callable[[], AbstractAsyncContextManager[None]]"
+) -> "Lifespan[Any]":
     """An ASGI lifespan that runs the streamable-HTTP session manager.
 
     ``StreamableHTTPSessionManager`` must be entered via ``manager.run()`` before
     it can serve requests; this wires that into the app's lifespan so a standalone
-    ``uvicorn`` run (which drives lifespan automatically) just works.
+    ``uvicorn`` run (which drives lifespan automatically) just works. ``serving``
+    contributes the server's own background state (subscription delivery), which
+    is transport-independent and so is entered by ``run_stdio`` as well.
     """
 
     @asynccontextmanager
     async def lifespan(_: Starlette) -> AsyncGenerator[None]:
-        async with manager.run():
+        async with manager.run(), serving():
             yield
 
     return lifespan
@@ -96,7 +112,9 @@ class MCPServer:
 
     For local clients (Claude Desktop, Cursor, the MCP Inspector), :meth:`run_stdio`
     serves over stdin/stdout instead. The HTTP transport parameters (``path``,
-    ``stateless``, ``json_response``, ``security``) are ignored over stdio.
+    ``json_response``, ``security``) are ignored over stdio, and so is
+    ``stateless`` except for the one capability it decides at construction —
+    see ``subscriptions`` below.
 
     ``name`` / ``version`` / ``title`` / ``description`` / ``instructions`` /
     ``website_url`` / ``icons`` populate the ``initialize`` handshake's
@@ -151,6 +169,17 @@ class MCPServer:
     ``resources`` / ``resource_templates`` / ``prompts`` expose MCP resources and
     prompts alongside the conversational tool; the corresponding capability is
     advertised only when a non-empty collection is supplied.
+
+    ``subscriptions`` takes a :class:`~ag2.mcp.subscriptions.ResourceNotifier` and
+    turns on resource-change notifications for the resources served here; call
+    :meth:`notify_resource_updated` (or the notifier's own method, which a served
+    tool can close over) when a resource's body changes. Both protocol eras are
+    served — ``subscriptions/listen`` at 2026-07-28, ``resources/subscribe`` on
+    the handshake era — except that ``stateless=True`` suppresses the handshake
+    half, whose delivery needs a session that a stateless transport never keeps.
+    That combination stays legal, since a modern-era-only deployment is a
+    reasonable thing to want, but it warns (:class:`RuntimeWarning`) at
+    construction rather than leaving the loss to be discovered from the docs.
     """
 
     __slots__ = (
@@ -170,6 +199,9 @@ class MCPServer:
         "_resource_provider",
         "_prompt_provider",
         "_tool_provider",
+        "_subscriptions",
+        "_handshake",
+        "_listen",
         "_http",
     )
 
@@ -195,6 +227,7 @@ class MCPServer:
         resource_templates: "Sequence[ResourceTemplate]" = (),
         prompts: "Sequence[Prompt]" = (),
         tools: "Sequence[MCPFunctionTool]" = (),
+        subscriptions: ResourceNotifier | None = None,
         path: str = "/mcp",
         stateless: bool = False,
         json_response: bool = False,
@@ -232,11 +265,69 @@ class MCPServer:
             context_provider=context_provider,
             session_store=self._session_store,
         )
+        self._build_subscriptions(subscriptions, stateless=stateless)
         self._server = self._build_server()
         routes, manager = self._streamable_routes(
             path=path, stateless=stateless, json_response=json_response, security=security
         )
-        self._http: Starlette = Starlette(routes=routes, lifespan=_session_manager_lifespan(manager))
+        self._http: Starlette = Starlette(routes=routes, lifespan=_session_manager_lifespan(manager, self._serving))
+        if subscriptions is not None:
+            # Last statement in ``__init__``, deliberately: adoption is a
+            # one-shot mutation of the *caller's* notifier, so doing it before
+            # any check that can still fail would leave that notifier unusable
+            # for the corrected retry.
+            assert self._resource_provider is not None  # `_build_subscriptions` requires it
+            subscriptions._adopt(self._resource_provider.resolves)
+
+    def _build_subscriptions(self, subscriptions: ResourceNotifier | None, *, stateless: bool) -> None:
+        """Build the two eras' delivery for ``subscriptions``, without adopting it.
+
+        Adoption — the one-shot mutation of the caller's notifier — is left to
+        the end of ``__init__``; everything here is this server's own state, so
+        a later failure costs the caller nothing but the ``MCPServer``.
+
+        ``resources/subscribe`` is deliberately left unregistered on a stateless
+        transport. The handshake era pushes into a session opened by an earlier
+        request, and a stateless transport keeps none — the subscription would be
+        accepted and then never fire. Advertising ``subscribe: false`` there tells
+        a handshake-era client to poll instead of waiting forever.
+
+        That is right for the client and invisible to the author, so the
+        combination warns. It stays legal rather than raising because a stateless
+        deployment serving modern-era clients has full subscription support and
+        is a configuration someone may want on purpose; the warning informs that
+        author rather than blocking them.
+        """
+        self._subscriptions = subscriptions
+        self._handshake: _HandshakeDelivery | None = None
+        self._listen: ListenHandler | None = None
+        if subscriptions is None:
+            return
+        if self._resource_provider is None:
+            raise ValueError("MCPServer(subscriptions=...) needs `resources=` / `resource_templates=` to notify about.")
+        self._listen = ListenHandler(subscriptions.bus, max_subscriptions=subscriptions.max_subscribers)
+        if stateless:
+            warnings.warn(
+                "MCPServer(subscriptions=..., stateless=True): resource subscriptions are disabled for "
+                "handshake-era clients (protocol revision 2025-11-25 and earlier). Their delivery pushes into "
+                "an MCP session that an earlier request opened, and a stateless transport keeps none, so those "
+                "clients are told `resources.subscribe: false` and must poll. Modern-era clients (2026-07-28) "
+                "are unaffected and still receive announcements. The capability is decided here, at "
+                "construction, so `run_stdio` is affected too even though stdio holds a connection: drop "
+                "`stateless=True` if this server may be served over stdio. Silence this with "
+                "`warnings.filterwarnings('ignore', category=RuntimeWarning)` if the deployment is "
+                "modern-era-only on purpose.",
+                RuntimeWarning,
+                # Past `_build_subscriptions` and `__init__`, so the warning
+                # lands on the `MCPServer(...)` line the author actually wrote.
+                stacklevel=3,
+            )
+            return
+        self._handshake = _HandshakeDelivery(
+            subscriptions.bus,
+            max_subscribers=subscriptions.max_subscribers,
+            max_buffered_events=subscriptions.max_buffered_events,
+        )
 
     @property
     def agent(self) -> Agent:
@@ -263,6 +354,11 @@ class MCPServer:
             kwargs["on_read_resource"] = self._resource_provider.on_read_resource
             if self._resource_provider.has_templates:
                 kwargs["on_list_resource_templates"] = self._resource_provider.on_list_resource_templates
+        if self._listen is not None:
+            kwargs["on_subscriptions_listen"] = self._listen
+        if self._handshake is not None:
+            kwargs["on_subscribe_resource"] = self._on_subscribe_resource
+            kwargs["on_unsubscribe_resource"] = self._on_unsubscribe_resource
         if self._prompt_provider is not None:
             kwargs["on_list_prompts"] = self._prompt_provider.on_list_prompts
             kwargs["on_get_prompt"] = self._prompt_provider.on_get_prompt
@@ -279,6 +375,51 @@ class MCPServer:
             on_call_tool=self._on_call_tool,
             **kwargs,
         )
+
+    @property
+    def subscriptions(self) -> ResourceNotifier | None:
+        """The :class:`~ag2.mcp.subscriptions.ResourceNotifier` this server publishes through, if any."""
+        return self._subscriptions
+
+    async def notify_resource_updated(self, uri: str) -> None:
+        """Tell subscribers the resource at ``uri`` is stale and worth re-reading.
+
+        Reaches both eras' subscribers. Requires ``subscriptions=``; a server
+        without it advertises no subscription capability, so there is nobody to
+        tell and a silent no-op would only hide the missing wiring.
+        """
+        if self._subscriptions is None:
+            raise ValueError("This MCPServer serves no subscriptions; pass `subscriptions=ResourceNotifier()`.")
+        await self._subscriptions.notify_resource_updated(uri)
+
+    async def _on_subscribe_resource(
+        self, ctx: "ServerRequestContext[Any, Any]", params: SubscribeRequestParams
+    ) -> EmptyResult:
+        assert self._handshake is not None  # registered only when it exists
+        self._handshake.subscribe(connection_key(ctx), ctx.session, params.uri)
+        return EmptyResult()
+
+    async def _on_unsubscribe_resource(
+        self, ctx: "ServerRequestContext[Any, Any]", params: UnsubscribeRequestParams
+    ) -> EmptyResult:
+        assert self._handshake is not None  # registered only when it exists
+        self._handshake.unsubscribe(connection_key(ctx), params.uri)
+        return EmptyResult()
+
+    @asynccontextmanager
+    async def _serving(self) -> AsyncGenerator[None]:
+        """Run the server's transport-independent background state.
+
+        Held open for as long as the server serves, by the ASGI lifespan over
+        HTTP and by :meth:`run_stdio` over stdio. Without ``subscriptions=``
+        there is none, and this is an empty wrapper.
+        """
+        async with AsyncExitStack() as stack:
+            if self._handshake is not None:
+                await stack.enter_async_context(self._handshake.running())
+            if self._listen is not None:
+                stack.callback(self._listen.close)
+            yield
 
     async def _on_list_tools(
         self, ctx: "ServerRequestContext[Any, Any]", params: PaginatedRequestParams | None
@@ -407,7 +548,7 @@ class MCPServer:
 
     async def run_stdio(self) -> None:  # pragma: no cover - needs real stdio pipes
         """Serve the agent over stdio until the client disconnects."""
-        async with stdio_server() as (read_stream, write_stream):
+        async with stdio_server() as (read_stream, write_stream), self._serving():
             await self._server.run(
                 read_stream,
                 write_stream,

--- a/ag2/mcp/subscriptions.py
+++ b/ag2/mcp/subscriptions.py
@@ -1,0 +1,403 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resource-change notifications for a served agent, across both protocol eras.
+
+A served agent's resource *list* is fixed at construction, but a resource's
+*body* is whatever its ``read`` returns, so the one change worth announcing is
+"the resource at this URI is stale". :class:`ResourceNotifier` is the single
+place that announcement enters the system; the two eras differ only in how it
+leaves:
+
+* **Modern era** (2026-07-28) — the client opens a ``subscriptions/listen``
+  stream and ``mcp``'s own :class:`~mcp.server.subscriptions.ListenHandler`
+  fans bus events onto it.
+* **Handshake era** (≤ 2025-11-25) — the client calls ``resources/subscribe``
+  and the server pushes ``notifications/resources/updated`` down that session.
+  :class:`_HandshakeDelivery` keeps that bookkeeping.
+
+Both hang off the same :class:`~mcp.server.subscriptions.SubscriptionBus`, so a
+single publish reaches both, and swapping the bus for a cross-process one
+(Redis, NATS) moves both eras at once rather than only the modern one.
+
+**An announcement is pushed, never derived.** Nothing here watches
+:class:`~ag2.mcp.resources.Resource` — those stay frozen dataclasses with no
+notion of mutation, and the server never learns *what* changed. The protocol
+defines the notification as a URI-only invalidation signal, and whether the view
+behind a URI has gone stale is known only to the code owning the underlying
+data: a served tool that mutated it, a file watcher, a webhook. So the server
+author calls :meth:`ResourceNotifier.notify_resource_updated` from wherever the
+change happens. A mutable resource kind that publishes on its own writes remains
+possible later as sugar over this same seam.
+"""
+
+import logging
+from collections.abc import AsyncGenerator, Callable
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+import anyio
+from mcp.server.subscriptions import InMemorySubscriptionBus, SubscriptionBus
+from mcp.shared.exceptions import MCPError
+from mcp.shared.subscriptions import ResourceUpdated, ServerEvent
+from mcp.types import INTERNAL_ERROR, INVALID_REQUEST
+
+from .errors import MCPResourceNotFoundError
+from .sessions import STDIO_SESSION
+
+if TYPE_CHECKING:
+    from mcp.server.context import ServerRequestContext
+    from mcp.server.session import ServerSession
+
+logger = logging.getLogger(__name__)
+
+# ``ListenHandler``'s own defaults, copied rather than imported because the SDK
+# exports them only as parameter defaults. Both are reachable as
+# ``ResourceNotifier`` keywords, and ``test_subscriptions`` pins them against the
+# SDK through that seam, so a drift there fails a test instead of silently
+# leaving the handshake registry and the modern listen streams to fall over at
+# two scales.
+_MAX_SUBSCRIBERS = 1024
+_MAX_BUFFERED_EVENTS = 1024
+
+
+class ResourceNotifier:
+    """Announces that a served resource's body changed.
+
+    Construct one *before* the :class:`~ag2.mcp.MCPServer` that carries it and
+    pass it as ``subscriptions=``. Building it first is what lets a served tool
+    reach it — the tool closes over the notifier, where it could not close over
+    a server that does not exist until its tools do::
+
+        notifier = ResourceNotifier()
+
+
+        @mcp_tool
+        async def bump() -> str:
+            counter["n"] += 1
+            await notifier.notify_resource_updated("mem://counter")
+            return "bumped"
+
+
+        server = MCPServer(agent, resources=[...], tools=[bump], subscriptions=notifier)
+
+    ``bus`` swaps the fan-out seam; the default is in-process. Give it a
+    cross-process bus to serve subscribers spread over several replicas.
+
+    ``max_subscribers`` bounds how many concurrent subscribers the server
+    admits, in each era separately — modern-era listen streams and handshake-era
+    connections are counted apart, since they cost different things — so the
+    total a server admits is twice the number passed. Past the bound a further
+    subscriber is refused rather than admitted and dropped.
+
+    The same number *additionally* bounds how many URIs one handshake-era
+    connection may hold, because subscribing to a URI nobody serves is
+    deliberately accepted and counting connections alone would leave one of them
+    free to invent URIs without end. The modern era has no equivalent dimension:
+    a listen stream's filter arrives whole in one request, and the number of
+    streams is already bounded.
+
+    ``max_buffered_events`` bounds how many announcements a single handshake-era
+    subscriber may fall behind by before it is dropped: the protocol offers no
+    replay, so past its backlog there is nothing left worth keeping for it. The
+    modern era's equivalent is ``ListenHandler``'s own per-stream buffer, which
+    the SDK sizes from the same default.
+    """
+
+    __slots__ = ("_bus", "_max_buffered_events", "_max_subscribers", "_resolves")
+
+    def __init__(
+        self,
+        bus: SubscriptionBus | None = None,
+        *,
+        max_subscribers: int = _MAX_SUBSCRIBERS,
+        max_buffered_events: int = _MAX_BUFFERED_EVENTS,
+    ) -> None:
+        if max_subscribers < 1:
+            raise ValueError(f"max_subscribers must be >= 1, got {max_subscribers}.")
+        if max_buffered_events < 1:
+            raise ValueError(f"max_buffered_events must be >= 1, got {max_buffered_events}.")
+        self._bus = bus if bus is not None else InMemorySubscriptionBus()
+        self._max_subscribers = max_subscribers
+        self._max_buffered_events = max_buffered_events
+        # Set when an ``MCPServer`` adopts this notifier; until then there is no
+        # resource set to check a URI against.
+        self._resolves: Callable[[str], bool] | None = None
+
+    @property
+    def bus(self) -> SubscriptionBus:
+        """The fan-out seam this notifier publishes to."""
+        return self._bus
+
+    @property
+    def max_subscribers(self) -> int:
+        """The per-era bound on concurrent subscribers, and on one connection's URIs."""
+        return self._max_subscribers
+
+    @property
+    def max_buffered_events(self) -> int:
+        """How far one handshake-era subscriber may fall behind before it is dropped."""
+        return self._max_buffered_events
+
+    def _adopt(self, resolves: Callable[[str], bool]) -> None:
+        """Bind to the resource set of the server now carrying this notifier."""
+        if self._resolves is not None:
+            raise ValueError(
+                "This ResourceNotifier is already attached to an MCPServer; construct one per server "
+                "(they may share a bus: ResourceNotifier(bus=other.bus))."
+            )
+        self._resolves = resolves
+
+    async def notify_resource_updated(self, uri: str) -> None:
+        """Tell subscribers the resource at ``uri`` is stale and worth re-reading.
+
+        Raises :class:`~ag2.mcp.errors.MCPResourceNotFoundError` if ``uri``
+        matches no served resource or template. A client subscribing to a URI
+        nobody serves is honored in silence — the protocol says so, and the
+        client may know something the server does not — but a *server*
+        announcing one is a typo, and the alternative to raising is a
+        notification that silently never arrives.
+
+        Raises :class:`ValueError` before any :class:`~ag2.mcp.MCPServer` has
+        adopted this notifier, for the same reason: there is no resource set to
+        check the URI against and nobody subscribed to hear it, so publishing
+        would be the silent no-op the strictness above exists to rule out.
+        """
+        if self._resolves is None:
+            raise ValueError(
+                "This ResourceNotifier is not attached to an MCPServer yet; pass it as "
+                "`MCPServer(..., subscriptions=notifier)` before announcing."
+            )
+        if not self._resolves(uri):
+            raise MCPResourceNotFoundError(uri)
+        await self._bus.publish(ResourceUpdated(uri=uri))
+
+
+def connection_key(ctx: "ServerRequestContext[Any, Any]") -> str:
+    """The identity of the connection ``ctx`` arrived on.
+
+    A subscription outlives the request that created it, so it has to be filed
+    under something that outlives the request too. ``ctx.session`` does not:
+    ``mcp`` 2.0 builds a fresh :class:`~mcp.server.session.ServerSession` proxy
+    for every inbound message, so two requests on one connection carry two
+    unequal session objects.
+
+    What does outlive it is the transport's connection: the ``mcp-session-id``
+    over HTTP — the same key :mod:`ag2.mcp.sessions` files conversation history
+    under — and, where the transport carries a single client per process
+    (stdio, in-memory streams), a constant.
+    """
+    request = ctx.request
+    if request is None:
+        return STDIO_SESSION
+    session_id: str | None = request.headers.get("mcp-session-id")
+    if not session_id:  # pragma: no cover - streamable HTTP rejects such a request before dispatch
+        # Without connection identity, one client's subscription would deliver
+        # to another's. Unreachable through the streamable-HTTP transport, which
+        # answers a non-``initialize`` request carrying no session id with
+        # ``400 Bad Request: Missing session ID`` before a handler sees it — but
+        # the handlers are transport-agnostic, so a session-bearing transport
+        # that issues none must fail rather than file the subscription under a
+        # key every client shares.
+        raise MCPError(INVALID_REQUEST, "resource subscriptions require a session; this transport issues none")
+    return session_id
+
+
+class _Subscriber:
+    """One handshake-era connection's subscribed URIs, and its delivery buffer.
+
+    Each subscriber buffers and sends on its own, mirroring
+    :class:`~mcp.server.subscriptions.ListenHandler`'s per-stream shape. A
+    single shared queue would make one wedged client's transport write stall
+    delivery to every other subscriber, and would make a full backlog a reason
+    to drop the *event* for everyone rather than the subscriber that caused it.
+    """
+
+    __slots__ = ("session", "uris", "_send", "_recv")
+
+    def __init__(self, session: "ServerSession", *, max_buffered_events: int) -> None:
+        self.session = session
+        self.uris: set[str] = set()
+        self._send, self._recv = anyio.create_memory_object_stream[str](max_buffered_events)
+
+    def offer(self, uri: str) -> bool:
+        """Buffer ``uri`` for this subscriber's delivery task, without blocking.
+
+        ``False`` means this subscriber must be dropped: either its backlog is
+        full (it has stopped keeping up, and the protocol offers no replay, so
+        there is nothing to keep it for) or it has already been closed.
+        """
+        try:
+            self._send.send_nowait(uri)
+        except (anyio.WouldBlock, anyio.ClosedResourceError):
+            return False
+        return True
+
+    def close(self) -> None:
+        """End this subscriber's buffer, which ends :meth:`deliver`."""
+        self._send.close()
+
+    async def deliver(self) -> None:
+        """Send buffered announcements until the buffer closes or a send fails."""
+        async for uri in self._recv:
+            await self.session.send_resource_updated(uri)
+
+
+class _HandshakeDelivery:
+    """``resources/subscribe`` bookkeeping and delivery for handshake-era clients.
+
+    Modern-era subscribers are served by ``ListenHandler``, whose stream *is* the
+    request's response. Handshake-era subscribers have no such stream: the server
+    pushes into a connection that some earlier request opened, so it has to
+    remember which connection asked for which URIs.
+
+    Each entry keeps the ``ServerSession`` last seen on that connection. The
+    proxy is per-request, but a notification sent with no ``related_request_id``
+    goes to the *connection's* standalone channel, so a proxy from an earlier
+    request still reaches the right client.
+
+    The bus hands events to a *synchronous* listener while sending is
+    asynchronous, so the listener only buffers and one task per subscriber does
+    the sending. That is the same shape ``ListenHandler`` uses, and for the same
+    reasons: a slow client must block neither the publisher nor its fellow
+    subscribers.
+
+    The registry is per *serving*, not per server: :meth:`running` clears it on
+    the way out, so a server served twice does not hand a fresh client the
+    subscriptions of a departed one filed under the same connection key.
+    """
+
+    __slots__ = ("_bus", "_max_buffered_events", "_max_subscribers", "_subscribers", "_tasks")
+
+    def __init__(
+        self,
+        bus: SubscriptionBus,
+        *,
+        max_subscribers: int = _MAX_SUBSCRIBERS,
+        max_buffered_events: int = _MAX_BUFFERED_EVENTS,
+    ) -> None:
+        self._bus = bus
+        self._max_subscribers = max_subscribers
+        self._max_buffered_events = max_buffered_events
+        self._subscribers: dict[str, _Subscriber] = {}
+        # The task group running the per-subscriber delivery tasks; only set
+        # while ``running()`` is held, which is whenever the server serves.
+        self._tasks: anyio.abc.TaskGroup | None = None
+
+    def subscribe(self, key: str, session: "ServerSession", uri: str) -> None:
+        """Record that the connection ``key`` wants updates for ``uri``.
+
+        An unserved URI is accepted: the spec honors a subscription to a
+        resource that does not exist, and it simply never fires. That leniency
+        is why ``max_subscribers`` bounds this registry along both of its
+        dimensions — how many connections it holds, and how many URIs each of
+        them holds. Bounding connections alone would leave one of them free to
+        invent URIs nobody serves and grow the registry without limit, never
+        spending more than its single slot. The URI bound is per connection
+        rather than a total shared across them, so a client subscribing to many
+        URIs exhausts its own quota instead of locking every other client out of
+        subscribing at all.
+
+        Overflow refuses in both dimensions; it never evicts. The
+        conversation-session registry in :mod:`ag2.mcp.sessions`, keyed by this
+        same connection identity, deliberately does the opposite and evicts LRU:
+        losing history there costs a caller some context it can rebuild, whereas
+        an evicted subscription costs it the truth — the client goes on believing
+        it holds a working subscription it will never hear from again. That is
+        the silent failure the stateless-mode warning exists to prevent, and
+        manufacturing it here would be an odd way to honour that.
+        """
+        tasks = self._tasks
+        if tasks is None:  # pragma: no cover - the handler is reachable only while serving
+            raise MCPError(INTERNAL_ERROR, "This server is not serving subscriptions")
+        subscriber = self._subscribers.get(key)
+        if subscriber is None:
+            if len(self._subscribers) >= self._max_subscribers:
+                raise MCPError(INTERNAL_ERROR, "Subscription limit reached")
+            subscriber = _Subscriber(session, max_buffered_events=self._max_buffered_events)
+            subscriber.uris.add(uri)
+            self._subscribers[key] = subscriber
+            tasks.start_soon(self._deliver, key, subscriber)
+            return
+        # Refusing before the mutation is what leaves the URIs this connection
+        # already holds working; re-subscribing to one of them is not a new URI
+        # and so cannot be what tips it over.
+        if uri not in subscriber.uris and len(subscriber.uris) >= self._max_subscribers:
+            raise MCPError(INTERNAL_ERROR, "Subscription limit reached for this connection")
+        subscriber.uris.add(uri)
+        # Refresh the proxy: the oldest one works, but the newest is the one
+        # least likely to be holding a channel the transport has since retired.
+        subscriber.session = session
+
+    def unsubscribe(self, key: str, uri: str) -> None:
+        """Drop ``key``'s interest in ``uri``, forgetting the connection when it holds none."""
+        subscriber = self._subscribers.get(key)
+        if subscriber is None:
+            return
+        subscriber.uris.discard(uri)
+        if not subscriber.uris:
+            self._drop(key, subscriber)
+
+    @asynccontextmanager
+    async def running(self) -> AsyncGenerator[None]:
+        """Subscribe to the bus and run per-subscriber delivery for the duration of the block."""
+        async with anyio.create_task_group() as tg:
+            self._tasks = tg
+            unsubscribe = self._bus.subscribe(self._enqueue)
+            try:
+                yield
+            finally:
+                unsubscribe()
+                self._tasks = None
+                for key, subscriber in list(self._subscribers.items()):
+                    self._drop(key, subscriber)
+                # Closing each buffer ends its task; cancelling covers a task
+                # left waiting on a transport write that will never complete.
+                tg.cancel_scope.cancel()
+
+    def _drop(self, key: str, subscriber: _Subscriber) -> None:
+        """Forget ``subscriber`` and end its delivery task. Safe to repeat."""
+        if self._subscribers.get(key) is subscriber:
+            del self._subscribers[key]
+        subscriber.close()
+
+    def _enqueue(self, event: ServerEvent) -> None:
+        """Buffer ``event`` for every interested subscriber. Synchronous, and must not raise."""
+        if not isinstance(event, ResourceUpdated):
+            # Handshake-era subscriptions cover individual resources only; the
+            # list-changed events have no subscriber on this path.
+            return
+        for key, subscriber in list(self._subscribers.items()):
+            if event.uri not in subscriber.uris:
+                continue
+            if not subscriber.offer(event.uri):
+                logger.warning("handshake subscription backlog full; dropping subscriber %r", key)
+                self._drop(key, subscriber)
+
+    async def _deliver(self, key: str, subscriber: _Subscriber) -> None:
+        """Run one subscriber's delivery until its buffer closes or its connection fails."""
+        try:
+            await subscriber.deliver()
+        except Exception:
+            # A closed connection is the ordinary end of a subscription, and on
+            # a duplex transport it is the only signal we get: nothing reports
+            # transport teardown.
+            #
+            # Streamable HTTP does not raise here. Its router drops a
+            # notification whose standalone stream is gone and logs at debug, so
+            # a departed HTTP client's entry is reclaimed only when its MCP
+            # session is reused or the process restarts. Combined with the
+            # refuse-never-evict policy above, a server can therefore sit at
+            # ``max_subscribers`` holding entries for clients that are long
+            # gone. Detecting that needs a teardown hook the SDK does not expose
+            # to a lowlevel handler (``Connection.exit_stack`` is not reachable
+            # from ``ServerRequestContext``); until it does, size
+            # ``max_subscribers`` for the churn a deployment sees, not for its
+            # concurrent client count.
+            logger.debug("dropping subscriptions of a connection that could not be reached", exc_info=True)
+        finally:
+            self._drop(key, subscriber)
+
+
+__all__ = ("ResourceNotifier",)

--- a/ag2/mcp/testing.py
+++ b/ag2/mcp/testing.py
@@ -39,7 +39,7 @@ async def connect(
     contract here — an initialized ``ClientSession`` — is held steady across it.
     """
     async with (
-        _served_streams(mcp_server.server, raise_exceptions) as streams,
+        _served_streams(mcp_server, raise_exceptions) as streams,
         ClientSession(*streams, **session_kwargs) as session,  # type: ignore[arg-type]
     ):
         await session.initialize()
@@ -69,7 +69,7 @@ async def connect_modern(
     is what this module is for.
     """
     async with Client(
-        _MemoryTransport(mcp_server.server, raise_exceptions=raise_exceptions),
+        _MemoryTransport(mcp_server, raise_exceptions=raise_exceptions),
         mode=LATEST_MODERN_VERSION,
         raise_exceptions=raise_exceptions,
         **client_kwargs,  # type: ignore[arg-type]
@@ -78,22 +78,22 @@ async def connect_modern(
 
 
 class _MemoryTransport:
-    """An ``mcp.client.Transport`` serving a low-level server over memory streams.
+    """An ``mcp.client.Transport`` serving an :class:`MCPServer` over memory streams.
 
     The stream pair :func:`connect` builds inline, repackaged as the transport
     object ``Client`` takes — the SDK's own in-memory transport is private, and
     this keeps :func:`connect` and :func:`connect_modern` on one wire shape.
     """
 
-    __slots__ = ("_server", "_raise_exceptions", "_stack")
+    __slots__ = ("_mcp_server", "_raise_exceptions", "_stack")
 
-    def __init__(self, server: Server, *, raise_exceptions: bool) -> None:
-        self._server = server
+    def __init__(self, mcp_server: MCPServer, *, raise_exceptions: bool) -> None:
+        self._mcp_server = mcp_server
         self._raise_exceptions = raise_exceptions
         self._stack = AsyncExitStack()
 
     async def __aenter__(self) -> MessageStream:
-        return await self._stack.enter_async_context(_served_streams(self._server, self._raise_exceptions))
+        return await self._stack.enter_async_context(_served_streams(self._mcp_server, self._raise_exceptions))
 
     async def __aexit__(
         self,
@@ -105,13 +105,17 @@ class _MemoryTransport:
 
 
 @asynccontextmanager
-async def _served_streams(server: Server, raise_exceptions: bool) -> AsyncGenerator[MessageStream]:
+async def _served_streams(mcp_server: MCPServer, raise_exceptions: bool) -> AsyncGenerator[MessageStream]:
     """Yield the client half of a memory stream pair whose server half is being served."""
     async with (
         create_client_server_memory_streams() as (client_streams, server_streams),
+        # The same background state the ASGI lifespan and ``run_stdio`` enter:
+        # subscription delivery lives there, so a session without it would be
+        # served by a server that is only half-running.
+        mcp_server._serving(),
         anyio.create_task_group() as tg,
     ):
-        tg.start_soon(_run_server, server, server_streams, raise_exceptions)
+        tg.start_soon(_run_server, mcp_server.server, server_streams, raise_exceptions)
         yield client_streams
         # As in ``connect``: the server task runs until cancelled, and the client
         # is done, so end it here rather than leaving the task group waiting.

--- a/test/mcp/test_subscriptions.py
+++ b/test/mcp/test_subscriptions.py
@@ -1,0 +1,736 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import inspect
+import json
+import warnings
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager, suppress
+
+import anyio
+import httpx
+import pytest
+from dirty_equals import IsPartialDict
+from mcp.client.client import Client
+from mcp.server.lowlevel import NotificationOptions
+from mcp.server.subscriptions import ListenHandler
+from mcp.shared.exceptions import MCPError
+from mcp.shared.subscriptions import ResourceUpdated
+from mcp.types import ResourceUpdatedNotification, ServerCapabilities
+from mcp_types.version import LATEST_MODERN_VERSION
+
+from ag2 import Agent
+from ag2.mcp import MCPServer, Prompt, Resource, ResourceNotifier, ResourceTemplate
+from ag2.mcp.errors import MCPResourceNotFoundError
+from ag2.mcp.security import AccessToken, TokenVerifier, oauth2_scheme, require
+from ag2.mcp.testing import connect, serve
+from ag2.testing import TestConfig
+
+_MODERN = LATEST_MODERN_VERSION
+
+
+def _collect_updates(into: list[str], arrived: anyio.Event | None = None):
+    """A ``ClientSession`` message handler recording every resource-updated URI."""
+
+    async def on_message(message: object) -> None:
+        if isinstance(message, ResourceUpdatedNotification):
+            into.append(str(message.params.uri))
+            if arrived is not None:
+                arrived.set()
+
+    return on_message
+
+
+def _agent() -> Agent:
+    return Agent("greeter", config=TestConfig("hi"))
+
+
+def _resource(body: str = "v1") -> Resource:
+    return Resource(uri="mem://counter", name="counter", read=lambda: body)
+
+
+def _other() -> Resource:
+    return Resource(uri="mem://other", name="other", read=lambda: "o")
+
+
+class _Verifier(TokenVerifier):
+    """A token verifier stub: the failing check under test never consults it."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        return None
+
+
+def _prompt() -> Prompt:
+    return Prompt(name="greet", render=lambda _: "hello")
+
+
+def _capabilities(server: MCPServer, *, modern: bool = False) -> ServerCapabilities:
+    """The capability block a client would see at ``initialize``, for one era.
+
+    The one assertion target in this suite that reads the server rather than the
+    wire, because this block *is* what the wire carries at initialize.
+    """
+    if modern:
+        return server.server.get_capabilities(NotificationOptions(), {}, protocol_version=_MODERN)
+    return server.server.get_capabilities(NotificationOptions(), {})
+
+
+_HANDSHAKE_HEADERS = {
+    "Accept": "application/json, text/event-stream",
+    "Content-Type": "application/json",
+}
+
+
+async def _handshake_session(client: httpx.AsyncClient) -> dict[str, str]:
+    """Open a handshake-era session and return the headers that address it."""
+    response = await client.post(
+        "/mcp",
+        headers=_HANDSHAKE_HEADERS,
+        json={
+            "jsonrpc": "2.0",
+            "id": "init",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1"},
+            },
+        },
+    )
+    headers = _HANDSHAKE_HEADERS | {"mcp-session-id": response.headers["mcp-session-id"]}
+    await client.post("/mcp", headers=headers, json={"jsonrpc": "2.0", "method": "notifications/initialized"})
+    return headers
+
+
+def _reply(response: httpx.Response) -> dict:
+    """The JSON-RPC reply in ``response``, whether the transport chose JSON or SSE.
+
+    ``json_response=True`` answers a POST with a JSON body; the default answers
+    it with a one-event SSE stream. Both carry the same reply, and which one a
+    test gets should not decide how it reads it.
+    """
+    if response.headers["content-type"].startswith("text/event-stream"):
+        for line in response.text.splitlines():
+            if line.startswith("data: "):
+                return json.loads(line.removeprefix("data: "))
+        raise AssertionError(f"no data frame in SSE response: {response.text!r}")
+    return response.json()
+
+
+async def _subscribe(client: httpx.AsyncClient, headers: dict[str, str], uri: str) -> dict:
+    response = await client.post(
+        "/mcp",
+        headers=headers,
+        json={"jsonrpc": "2.0", "id": "sub", "method": "resources/subscribe", "params": {"uri": uri}},
+    )
+    return _reply(response)
+
+
+@asynccontextmanager
+async def _standalone_stream(
+    app: MCPServer, headers: dict[str, str], *, wedge: bool = False
+) -> AsyncGenerator[asyncio.Queue[bytes]]:
+    """Open the connection's standalone SSE stream and yield its arriving chunks.
+
+    ``httpx.ASGITransport`` buffers a response whole, so it cannot read a stream
+    that never ends. Driving the ASGI app directly is the only way to observe
+    what a handshake-era client actually receives — which is the seam that proves
+    connection identity, since an in-memory client session has no session id.
+
+    ``wedge=True`` accepts the response but never completes a body write, which
+    is what a client that stopped reading looks like from the server's side.
+    """
+    chunks: asyncio.Queue[bytes] = asyncio.Queue()
+    disconnected = asyncio.Event()
+    opened = asyncio.Event()
+
+    async def receive() -> dict[str, object]:
+        await disconnected.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, object]) -> None:
+        if message["type"] == "http.response.start":
+            opened.set()
+            return
+        if message["type"] != "http.response.body":
+            return
+        if wedge:
+            await disconnected.wait()
+            return
+        await chunks.put(message.get("body", b""))  # type: ignore[arg-type]
+
+    scope = {
+        "type": "http",
+        "asgi": {"spec_version": "2.3", "version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        # The MCP endpoint is mounted, so the unslashed form only redirects.
+        "path": "/mcp/",
+        "raw_path": b"/mcp/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in {**headers, "Accept": "text/event-stream"}.items()],
+        "client": ("127.0.0.1", 32767),
+        "server": ("test", 80),
+    }
+    stream = asyncio.ensure_future(app(scope, receive, send))
+    try:
+        # An announcement published before the transport registered this stream
+        # would be dropped, so hand it over only once the response has begun.
+        with anyio.fail_after(5):
+            await opened.wait()
+        yield chunks
+    finally:
+        disconnected.set()
+        stream.cancel()
+        with suppress(asyncio.CancelledError):
+            await stream
+
+
+async def _next_updated_uri(chunks: "asyncio.Queue[bytes]", timeout: float = 5.0) -> str:
+    """The URI of the next ``notifications/resources/updated`` to arrive on ``chunks``."""
+    buffered = ""
+    with anyio.fail_after(timeout):
+        while True:
+            # SSE frames end in a blank CRLF line; normalise so one split works.
+            buffered += (await chunks.get()).decode().replace("\r\n", "\n")
+            *events, buffered = buffered.split("\n\n")
+            for event in events:
+                for line in event.splitlines():
+                    if not line.startswith("data: "):
+                        continue
+                    message = json.loads(line.removeprefix("data: "))
+                    if message.get("method") == "notifications/resources/updated":
+                        return str(message["params"]["uri"])
+
+
+async def _unsubscribe(client: httpx.AsyncClient, headers: dict[str, str], uri: str) -> dict:
+    response = await client.post(
+        "/mcp",
+        headers=headers,
+        json={"jsonrpc": "2.0", "id": "unsub", "method": "resources/unsubscribe", "params": {"uri": uri}},
+    )
+    return _reply(response)
+
+
+class TestCapability:
+    def test_not_advertised_without_a_notifier(self) -> None:
+        server = MCPServer(_agent(), resources=[_resource()])
+
+        assert _capabilities(server).resources.subscribe is False
+        assert _capabilities(server, modern=True).resources.subscribe is False
+
+    def test_advertised_in_both_eras(self) -> None:
+        server = MCPServer(_agent(), resources=[_resource()], subscriptions=ResourceNotifier())
+
+        assert _capabilities(server).resources.subscribe is True
+        assert _capabilities(server, modern=True).resources.subscribe is True
+
+    def test_stateless_keeps_only_the_modern_half(self) -> None:
+        # Handshake delivery pushes into a session an earlier request opened, and
+        # a stateless transport keeps none: advertising it would be a promise the
+        # server cannot keep, so handshake-era clients are told to poll. The
+        # modern era's listen stream is carved out of stateless mode by the SDK
+        # and still streams, so it goes on advertising the capability.
+        with pytest.warns(RuntimeWarning):
+            server = MCPServer(_agent(), resources=[_resource()], subscriptions=ResourceNotifier(), stateless=True)
+
+        assert _capabilities(server).resources.subscribe is False
+        assert _capabilities(server, modern=True).resources.subscribe is True
+
+    def test_list_changed_is_false_in_both_eras_without_a_notifier(self) -> None:
+        server = MCPServer(_agent(), resources=[_resource()], prompts=[_prompt()])
+
+        for caps in (_capabilities(server), _capabilities(server, modern=True)):
+            assert caps.resources.list_changed is False
+            assert caps.tools.list_changed is False
+            assert caps.prompts.list_changed is False
+
+    def test_list_changed_stays_false_in_the_handshake_era(self) -> None:
+        # The resource, tool and prompt sets are all fixed at construction, so
+        # there is no list change to announce — and here the flags say so.
+        server = MCPServer(_agent(), resources=[_resource()], prompts=[_prompt()], subscriptions=ResourceNotifier())
+
+        caps = _capabilities(server)
+        assert caps.resources.list_changed is False
+        assert caps.tools.list_changed is False
+        assert caps.prompts.list_changed is False
+
+    def test_list_changed_rides_the_listen_handler_in_the_modern_era(self) -> None:
+        # Accepted imprecision, pinned so a change in it is caught. At 2026-07-28
+        # every change notification rides the one subscription stream, so the SDK
+        # derives `resources.subscribe` *and* all three list-changed flags from
+        # the single fact that the listen handler is registered. The sets are
+        # still fixed at construction, so these three promise events that will
+        # never fire. Correcting them would mean subclassing the SDK's server to
+        # change a flag that changes no behaviour, so it is documented instead.
+        server = MCPServer(_agent(), resources=[_resource()], prompts=[_prompt()], subscriptions=ResourceNotifier())
+
+        caps = _capabilities(server, modern=True)
+        assert caps.resources.list_changed is True
+        assert caps.tools.list_changed is True
+        assert caps.prompts.list_changed is True
+
+
+class TestStatelessWarning:
+    def test_warns_on_the_intersection(self) -> None:
+        with pytest.warns(RuntimeWarning, match="handshake-era clients") as caught:
+            MCPServer(_agent(), resources=[_resource()], subscriptions=ResourceNotifier(), stateless=True)
+
+        message = str(caught[0].message)
+        assert "resources.subscribe" in message and "poll" in message
+        # Attributed to the caller's own line rather than a frame inside
+        # `ag2.mcp`, so `-W error::RuntimeWarning` points the author at the
+        # `MCPServer(...)` they wrote.
+        assert caught[0].filename == __file__
+
+    def test_silent_for_a_stateless_server_without_a_notifier(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            MCPServer(_agent(), resources=[_resource()], stateless=True)
+
+    def test_silent_for_a_notifier_without_a_stateless_transport(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            MCPServer(_agent(), resources=[_resource()], subscriptions=ResourceNotifier())
+
+    def test_silenceable_through_the_standard_filter(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            warnings.filterwarnings("ignore", category=RuntimeWarning)
+            MCPServer(_agent(), resources=[_resource()], subscriptions=ResourceNotifier(), stateless=True)
+
+
+class TestBoundDefaults:
+    def test_default_matches_the_sdk_listen_handler(self) -> None:
+        # The handshake registry and the modern listen streams should fall over
+        # at the same scale, not at two. The constant is a copy — the SDK exports
+        # it only as a parameter default — so pin it here.
+        sdk_default = inspect.signature(ListenHandler.__init__).parameters["max_subscriptions"].default
+
+        assert ResourceNotifier().max_subscribers == sdk_default
+
+    def test_backlog_default_matches_the_sdk_listen_handler(self) -> None:
+        sdk_default = inspect.signature(ListenHandler.__init__).parameters["max_buffered_events"].default
+
+        assert ResourceNotifier().max_buffered_events == sdk_default
+
+    @pytest.mark.parametrize("bound", [0, -5])
+    def test_rejects_a_bound_that_admits_nobody(self, bound: int) -> None:
+        # A server that advertises `subscribe: true` and then refuses every
+        # subscription is the silent lie the stateless warning exists to avoid.
+        with pytest.raises(ValueError, match="max_subscribers must be >= 1"):
+            ResourceNotifier(max_subscribers=bound)
+
+    @pytest.mark.parametrize("bound", [0, -5])
+    def test_rejects_a_backlog_that_buffers_nothing(self, bound: int) -> None:
+        # A zero-length buffer drops every subscriber on its first announcement,
+        # which is the same silent lie one step later.
+        with pytest.raises(ValueError, match="max_buffered_events must be >= 1"):
+            ResourceNotifier(max_buffered_events=bound)
+
+
+class TestNotifierWiring:
+    def test_requires_resources(self) -> None:
+        with pytest.raises(ValueError, match="resources"):
+            MCPServer(_agent(), subscriptions=ResourceNotifier())
+
+    def test_one_notifier_per_server(self) -> None:
+        notifier = ResourceNotifier()
+        MCPServer(_agent(), resources=[_resource()], subscriptions=notifier)
+
+        with pytest.raises(ValueError, match="already attached"):
+            MCPServer(_agent(), resources=[_resource()], subscriptions=notifier)
+
+    def test_a_failed_construction_leaves_the_notifier_reusable(self) -> None:
+        # Adoption is the last thing `__init__` does, so a check that fails
+        # after it was reached does not brick the caller's notifier: a corrected
+        # retry with the same one has to work.
+        notifier = ResourceNotifier()
+        with pytest.raises(ValueError, match="must match the MCP endpoint path"):
+            MCPServer(
+                _agent(),
+                resources=[_resource()],
+                subscriptions=notifier,
+                path="/mcp",
+                security=require(
+                    oauth2_scheme(url="https://auth.test"),
+                    resource_url="http://test/elsewhere",
+                    verifier=_Verifier(),
+                ),
+            )
+
+        server = MCPServer(_agent(), resources=[_resource()], subscriptions=notifier)
+
+        assert server.subscriptions is notifier
+
+    def test_servers_may_share_a_bus(self) -> None:
+        first = ResourceNotifier()
+        second = ResourceNotifier(bus=first.bus)
+
+        MCPServer(_agent(), resources=[_resource()], subscriptions=first)
+        MCPServer(_agent(), resources=[_resource()], subscriptions=second)
+
+        assert second.bus is first.bus
+
+    def test_exposes_the_notifier(self) -> None:
+        notifier = ResourceNotifier()
+
+        assert MCPServer(_agent(), resources=[_resource()], subscriptions=notifier).subscriptions is notifier
+
+    def test_no_notifier_when_unconfigured(self) -> None:
+        assert MCPServer(_agent(), resources=[_resource()]).subscriptions is None
+
+
+@pytest.mark.asyncio
+class TestPublishValidation:
+    async def test_rejects_an_unserved_uri(self) -> None:
+        server = MCPServer(_agent(), resources=[_resource()], subscriptions=ResourceNotifier())
+
+        # Strict towards our own code: a typo here would otherwise show up only
+        # as notifications that never arrive.
+        with pytest.raises(MCPResourceNotFoundError):
+            await server.notify_resource_updated("mem://typo")
+
+    async def test_accepts_a_template_match(self) -> None:
+        server = MCPServer(
+            _agent(),
+            resource_templates=[ResourceTemplate("weather://{city}", "weather", lambda v: v["city"])],
+            subscriptions=ResourceNotifier(),
+        )
+
+        await server.notify_resource_updated("weather://London")
+
+    async def test_unattached_notifier_refuses_to_publish(self) -> None:
+        # No resource set to check the URI against and nobody subscribed to hear
+        # it: publishing would be the silent no-op the strictness rules out.
+        with pytest.raises(ValueError, match="not attached to an MCPServer"):
+            await ResourceNotifier().notify_resource_updated("mem://whatever")
+
+    async def test_server_without_subscriptions_refuses_to_notify(self) -> None:
+        server = MCPServer(_agent(), resources=[_resource()])
+
+        with pytest.raises(ValueError, match="serves no subscriptions"):
+            await server.notify_resource_updated("mem://counter")
+
+
+@pytest.mark.asyncio
+class TestHandshakeDelivery:
+    async def test_subscriber_is_notified(self) -> None:
+        notifier = ResourceNotifier()
+        server = MCPServer(_agent(), resources=[_resource()], subscriptions=notifier)
+        updated: list[str] = []
+        arrived = anyio.Event()
+
+        async with connect(server, message_handler=_collect_updates(updated, arrived)) as session:
+            await session.subscribe_resource("mem://counter")
+            await server.notify_resource_updated("mem://counter")
+            with anyio.fail_after(5):
+                await arrived.wait()
+
+        assert updated == ["mem://counter"]
+
+    async def test_unsubscribed_uri_is_not_delivered(self) -> None:
+        server = MCPServer(
+            _agent(),
+            resources=[_resource(), _other()],
+            subscriptions=ResourceNotifier(),
+        )
+        updated: list[str] = []
+        arrived = anyio.Event()
+
+        async with connect(server, message_handler=_collect_updates(updated, arrived)) as session:
+            await session.subscribe_resource("mem://counter")
+            await server.notify_resource_updated("mem://other")
+            # Publishing a subscribed URI second makes the assertion deterministic:
+            # events are delivered in order, so its arrival proves the unsubscribed
+            # one was already handled — and dropped.
+            await server.notify_resource_updated("mem://counter")
+            with anyio.fail_after(5):
+                await arrived.wait()
+
+        assert updated == ["mem://counter"]
+
+    async def test_unsubscribe_stops_delivery(self) -> None:
+        server = MCPServer(
+            _agent(),
+            resources=[_resource(), _other()],
+            subscriptions=ResourceNotifier(),
+        )
+        updated: list[str] = []
+        arrived = anyio.Event()
+
+        async with connect(server, message_handler=_collect_updates(updated, arrived)) as session:
+            await session.subscribe_resource("mem://counter")
+            await session.subscribe_resource("mem://other")
+            await session.unsubscribe_resource("mem://counter")
+            await server.notify_resource_updated("mem://counter")
+            # Still-subscribed, published second: its arrival is the barrier that
+            # proves the dropped one was not delivered.
+            await server.notify_resource_updated("mem://other")
+            with anyio.fail_after(5):
+                await arrived.wait()
+
+        assert updated == ["mem://other"]
+
+    async def test_unsubscribing_without_a_subscription_is_accepted(self) -> None:
+        # Nothing to forget, and no way for the connection to know that: the
+        # registry drops entries on its own (a wedged subscriber, a serving that
+        # ended), so a client's unsubscribe has to be a no-op rather than an error.
+        server = MCPServer(_agent(), resources=[_resource()], subscriptions=ResourceNotifier())
+
+        async with connect(server) as session:
+            await session.unsubscribe_resource("mem://counter")
+
+    async def test_unserved_uri_may_be_subscribed(self) -> None:
+        # The protocol honors a subscription to a resource that does not exist;
+        # it simply never fires. Lenient towards the wire, unlike publishing.
+        server = MCPServer(_agent(), resources=[_resource()], subscriptions=ResourceNotifier())
+
+        async with connect(server) as session:
+            await session.subscribe_resource("mem://nothing-here")
+
+
+@pytest.mark.asyncio
+class TestSubscriberBound:
+    async def test_refuses_a_subscriber_past_the_bound(self) -> None:
+        app = MCPServer(
+            _agent(),
+            resources=[_resource()],
+            subscriptions=ResourceNotifier(max_subscribers=1),
+            json_response=True,
+        )
+
+        async with serve(app) as client:
+            first = await _handshake_session(client)
+            second = await _handshake_session(client)
+
+            assert "error" not in await _subscribe(client, first, "mem://counter")
+            # A connection is only discovered dead when a send to it fails, so the
+            # bound refuses rather than evicting someone who may still be listening.
+            refused = await _subscribe(client, second, "mem://counter")
+
+        assert refused == IsPartialDict({"error": IsPartialDict({"message": "Subscription limit reached"})})
+
+    async def test_a_freed_slot_is_reusable(self) -> None:
+        app = MCPServer(
+            _agent(),
+            resources=[_resource()],
+            subscriptions=ResourceNotifier(max_subscribers=1),
+            json_response=True,
+        )
+
+        async with serve(app) as client:
+            first = await _handshake_session(client)
+            second = await _handshake_session(client)
+            await _subscribe(client, first, "mem://counter")
+            await _unsubscribe(client, first, "mem://counter")
+
+            # The bound tracks live subscribers, not connections that ever asked.
+            reused = await _subscribe(client, second, "mem://counter")
+
+        assert "error" not in reused
+
+    async def test_refuses_uris_past_the_bound_on_one_connection(self) -> None:
+        # Subscribing to a URI nobody serves is accepted, which is exactly what
+        # makes this bound necessary: one connection could otherwise invent them
+        # without end and never spend more than its single subscriber slot.
+        app = MCPServer(
+            _agent(),
+            resources=[_resource()],
+            subscriptions=ResourceNotifier(max_subscribers=2),
+            json_response=True,
+        )
+
+        async with serve(app) as client:
+            headers = await _handshake_session(client)
+            assert "error" not in await _subscribe(client, headers, "mem://counter")
+            assert "error" not in await _subscribe(client, headers, "mem://invented-1")
+            refused = await _subscribe(client, headers, "mem://invented-2")
+
+        assert refused == IsPartialDict({
+            "error": IsPartialDict({"message": "Subscription limit reached for this connection"})
+        })
+
+    async def test_releasing_a_uri_frees_room_on_the_same_connection(self) -> None:
+        app = MCPServer(
+            _agent(),
+            resources=[_resource(), _other()],
+            subscriptions=ResourceNotifier(max_subscribers=2),
+            json_response=True,
+        )
+
+        async with serve(app) as client:
+            headers = await _handshake_session(client)
+            await _subscribe(client, headers, "mem://counter")
+            await _subscribe(client, headers, "mem://other")
+            await _unsubscribe(client, headers, "mem://other")
+
+            reused = await _subscribe(client, headers, "mem://third")
+
+        assert "error" not in reused
+
+    async def test_resubscribing_to_a_held_uri_is_not_refused_at_the_bound(self) -> None:
+        # Re-sending a subscription the connection already holds adds no URI, so
+        # it cannot be what tips the registry over.
+        app = MCPServer(
+            _agent(),
+            resources=[_resource(), _other()],
+            subscriptions=ResourceNotifier(max_subscribers=2),
+            json_response=True,
+        )
+
+        async with serve(app) as client:
+            headers = await _handshake_session(client)
+            await _subscribe(client, headers, "mem://counter")
+            await _subscribe(client, headers, "mem://other")
+
+            again = await _subscribe(client, headers, "mem://counter")
+
+        assert "error" not in again
+
+    async def test_a_refused_uri_leaves_the_held_ones_working(self) -> None:
+        server = MCPServer(
+            _agent(),
+            resources=[_resource(), _other()],
+            subscriptions=ResourceNotifier(max_subscribers=2),
+        )
+        updated: list[str] = []
+        arrived = anyio.Event()
+
+        async with connect(server, message_handler=_collect_updates(updated, arrived)) as session:
+            await session.subscribe_resource("mem://counter")
+            await session.subscribe_resource("mem://other")
+            with pytest.raises(MCPError, match="limit reached for this connection"):
+                await session.subscribe_resource("mem://invented")
+
+            # Refusal is not eviction: what the connection already holds still fires.
+            await server.notify_resource_updated("mem://counter")
+            with anyio.fail_after(5):
+                await arrived.wait()
+
+        assert updated == ["mem://counter"]
+
+
+@pytest.mark.asyncio
+class TestModernDelivery:
+    async def test_listen_stream_receives_the_update(self) -> None:
+        app = MCPServer(_agent(), resources=[_resource()], subscriptions=ResourceNotifier())
+
+        async with (
+            Client(app.server, mode=_MODERN) as client,
+            client.listen(resource_subscriptions=["mem://counter"]) as subscription,
+        ):
+            await app.notify_resource_updated("mem://counter")
+            event = await anext(aiter(subscription))
+
+        assert event == ResourceUpdated(uri="mem://counter")
+
+    async def test_listen_stream_honors_its_filter(self) -> None:
+        app = MCPServer(
+            _agent(),
+            resources=[_resource(), _other()],
+            subscriptions=ResourceNotifier(),
+        )
+        received: list[object] = []
+
+        async with (
+            Client(app.server, mode=_MODERN) as client,
+            client.listen(resource_subscriptions=["mem://counter"]) as subscription,
+        ):
+            await app.notify_resource_updated("mem://other")
+            with anyio.move_on_after(0.3):
+                async for event in subscription:
+                    received.append(event)
+
+        assert received == []
+
+    async def test_survives_a_stateless_server(self) -> None:
+        # `subscriptions/listen` is carved out of stateless/JSON mode by the SDK
+        # and always streams, so suppressing the handshake half costs the modern
+        # era nothing — the warning informs the author rather than blocking them.
+        with pytest.warns(RuntimeWarning):
+            app = MCPServer(
+                _agent(),
+                resources=[_resource()],
+                subscriptions=ResourceNotifier(),
+                stateless=True,
+                json_response=True,
+            )
+
+        async with (
+            Client(app.server, mode=_MODERN) as client,
+            client.listen(resource_subscriptions=["mem://counter"]) as subscription,
+        ):
+            await app.notify_resource_updated("mem://counter")
+            event = await anext(aiter(subscription))
+
+        assert event == ResourceUpdated(uri="mem://counter")
+
+
+@pytest.mark.asyncio
+class TestHandshakeDeliveryOverHTTP:
+    """The seam that exercises connection identity, the registry and delivery together.
+
+    The in-memory client session files every subscription under one constant
+    key, so only the HTTP transport can show that a subscription belongs to a
+    *connection* — which is the whole reason the registry is keyed the way it is.
+    """
+
+    async def test_announcement_reaches_the_subscribing_connection_only(self) -> None:
+        app = MCPServer(_agent(), resources=[_resource(), _other()], subscriptions=ResourceNotifier())
+
+        async with serve(app) as client:
+            subscriber = await _handshake_session(client)
+            bystander = await _handshake_session(client)
+
+            async with (
+                _standalone_stream(app, subscriber) as subscriber_events,
+                _standalone_stream(app, bystander) as bystander_events,
+            ):
+                assert "error" not in await _subscribe(client, subscriber, "mem://counter")
+                await app.notify_resource_updated("mem://counter")
+
+                assert await _next_updated_uri(subscriber_events) == "mem://counter"
+                # The other connection never asked. The opt-in contract is
+                # per connection, not per server.
+                with pytest.raises(TimeoutError):
+                    await _next_updated_uri(bystander_events, timeout=0.3)
+
+    async def test_a_wedged_subscriber_is_dropped_and_its_peers_keep_receiving(self) -> None:
+        # A client that stopped reading must cost its own subscription and
+        # nothing else: not the publisher, and not the other subscribers.
+        backlog = 8
+        app = MCPServer(
+            _agent(),
+            resources=[_resource(), _other()],
+            subscriptions=ResourceNotifier(max_subscribers=2, max_buffered_events=backlog),
+        )
+
+        async with serve(app) as client:
+            wedged = await _handshake_session(client)
+            healthy = await _handshake_session(client)
+            latecomer = await _handshake_session(client)
+
+            async with (
+                _standalone_stream(app, wedged, wedge=True),
+                _standalone_stream(app, healthy) as healthy_events,
+            ):
+                assert "error" not in await _subscribe(client, wedged, "mem://counter")
+                assert "error" not in await _subscribe(client, healthy, "mem://other")
+                refused = await _subscribe(client, latecomer, "mem://counter")
+                assert refused == IsPartialDict({"error": IsPartialDict({"message": "Subscription limit reached"})})
+
+                # Past its own backlog the wedged subscriber has nothing left
+                # worth keeping — the protocol offers no replay.
+                for _ in range(backlog + 64):
+                    await app.notify_resource_updated("mem://counter")
+
+                await app.notify_resource_updated("mem://other")
+                assert await _next_updated_uri(healthy_events) == "mem://other"
+
+                # Dropped, not served forever: the slot it held comes free.
+                assert "error" not in await _subscribe(client, latecomer, "mem://counter")

--- a/website/docs/user-guide/tools/mcp_resources.mdx
+++ b/website/docs/user-guide/tools/mcp_resources.mdx
@@ -1,0 +1,182 @@
+---
+title: "Serving Resources over MCP"
+sidebarTitle: "MCP Resources"
+---
+
+# Serving Resources over MCP
+
+An MCP server can expose **resources** — addressable, readable blobs a client fetches by URI — alongside its tools. `ag2.mcp.MCPServer` serves them from a fixed set you pass at construction, and can tell subscribed clients when a resource's contents go stale.
+
+!!! note "This is the serving side of MCP"
+    `ag2.mcp.MCPServer` exposes an agent **as** an MCP server. This is the inverse of consuming an MCP server as tools with `MCPToolkit` / `MCPServerTool` — see [MCP Servers](/docs/user-guide/tools/mcp_servers) for that.
+
+## Static resources
+
+A `Resource` is a fixed URI plus a `read` callable returning the body. Return `str` for text and `bytes` for binary; the MIME type defaults to `text/plain` and `application/octet-stream` respectively.
+
+```python linenums="1"
+import asyncio
+from pathlib import Path
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer, Resource
+
+agent = Agent(name="assistant", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+server = MCPServer(
+    agent,
+    resources=[
+        Resource(
+            uri="config://app",
+            name="app-config",
+            description="The running configuration.",
+            mime_type="application/json",
+            read=lambda: Path("config.json").read_text(),
+        )
+    ],
+)
+
+if __name__ == "__main__":
+    asyncio.run(server.run_stdio())
+```
+
+The `read` callable may be sync or async, and runs on every `resources/read` — so a resource is a *view* of whatever it reads from, not a snapshot taken at construction.
+
+## Resource templates
+
+A `ResourceTemplate` serves a family of URIs described by an RFC 6570 template. Two expansion forms are supported: `{var}` matches a single path segment, and `{+var}` matches across `/`. The matched variables arrive as a dict.
+
+```python linenums="1"
+from pathlib import Path
+
+from ag2.mcp import ResourceTemplate
+
+def forecast(city: str) -> str:
+    """The current forecast for one city."""
+    return f"sunny in {city}"
+
+templates = [
+    # weather://London  ->  {"city": "London"}
+    ResourceTemplate("weather://{city}", "weather", lambda v: forecast(v["city"])),
+    # file:///a/b/c.txt ->  {"path": "a/b/c.txt"}
+    ResourceTemplate("file:///{+path}", "file", lambda v: Path(v["path"]).read_text()),
+]
+```
+
+Pass them as `resource_templates=`. A URI that matches a static `Resource` exactly always wins over a template that would also match it.
+
+## Notifying clients that a resource changed
+
+By default a client has no way to learn that a resource's body changed — it must re-read on a guess. `subscriptions=` turns on MCP's subscription capability so the server can say so.
+
+Build a `ResourceNotifier` **before** the server, so any tool that changes a resource can close over it:
+
+```python linenums="1"
+import asyncio
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer, Resource, ResourceNotifier, mcp_tool
+
+counter = {"n": 0}
+notifier = ResourceNotifier()
+
+@mcp_tool
+async def bump() -> str:
+    """Increment the counter."""
+    counter["n"] += 1
+    await notifier.notify_resource_updated("mem://counter")
+    return f"counter is now {counter['n']}"
+
+agent = Agent(name="assistant", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+server = MCPServer(
+    agent,
+    resources=[Resource(uri="mem://counter", name="counter", read=lambda: str(counter["n"]))],
+    tools=[bump],
+    subscriptions=notifier,
+)
+
+if __name__ == "__main__":
+    asyncio.run(server.run_stdio())
+```
+
+Outside a tool, `#!python await server.notify_resource_updated(uri)` does the same thing.
+
+The URI must name something the server actually serves — a static `Resource` or a URI a `ResourceTemplate` matches — otherwise the call raises `MCPResourceNotFoundError`. This is deliberately stricter than the subscribing side, where a client may subscribe to any URI and simply never hear about it: a typo in *your* code would otherwise surface only as notifications that never arrive. For the same reason, announcing through a notifier no `MCPServer` has taken yet raises `ValueError`: there is no resource set to check the URI against and nobody subscribed to hear it.
+
+!!! note "What can change, and what cannot"
+    The set of resources — like the set of tools and prompts — is fixed when the server is constructed, so only a resource's **contents** can change. There is no list-changed notification to send, and none ever fires.
+
+    What is *advertised* differs by protocol era, though, and the modern era overstates it. Handshake-era clients see all three `listChanged` flags as `false`, which is the truth. At 2026-07-28 every change notification rides the one `subscriptions/listen` stream, so the SDK derives `resources.subscribe` **and** `resources.listChanged`, `tools.listChanged` and `prompts.listChanged` together, from the single fact that the listen handler is registered — wiring up `subscriptions=` therefore advertises all four as `true` there. The three `listChanged` flags promise events this server will never send. AG2 accepts that rather than correcting it: overriding the derivation would mean subclassing the SDK's server to change a flag that changes no behaviour. Serving dynamic resource, tool or prompt sets — which would make the flags accurate — is a separate feature.
+
+### Both protocol eras are served
+
+Which mechanism a client gets depends on the protocol revision it speaks, and `MCPServer` serves both:
+
+| Client's protocol revision | Mechanism |
+| --- | --- |
+| 2026-07-28 | `subscriptions/listen` — one long-lived stream carrying every change event the client filtered for |
+| ≤ 2025-11-25 | `resources/subscribe` per URI, with `notifications/resources/updated` pushed down the session |
+
+A single `notify_resource_updated` call reaches both.
+
+!!! warning "`stateless=True` serves only the 2026-07-28 half"
+    Handshake-era delivery pushes into a session opened by an earlier request, and a stateless HTTP transport keeps no session. Rather than accept subscriptions it could never fulfil, a stateless server does not advertise `resources.subscribe` to handshake-era clients, which tells them to poll instead of waiting forever. `subscriptions/listen` is unaffected — it streams even in stateless, JSON-response mode.
+
+    The capability is decided at construction, before a transport is chosen, so `run_stdio` inherits the suppression too even though stdio holds a connection. Drop `stateless=True` if the same server may be served over stdio.
+
+    You do not have to find this out from this page: passing `subscriptions=` together with `stateless=True` emits a `RuntimeWarning` at construction naming what is disabled, for whom and why. The combination stays legal, because a stateless deployment serving modern-era clients has full subscription support and may well be what you want, so the warning informs rather than blocks. Silence it the standard way once the trade-off is deliberate:
+
+    ```python linenums="1"
+    import warnings
+
+    warnings.filterwarnings("ignore", category=RuntimeWarning, message="MCPServer\\(subscriptions=")
+    ```
+
+    The warning is attributed to your own `MCPServer(...)` line rather than to a frame inside `ag2`, so `-W error::RuntimeWarning` points at the construction you wrote.
+
+### Several replicas
+
+`ResourceNotifier()` fans events out in-process. Behind a load balancer, a change published on one replica has to reach subscribers connected to another, so pass a cross-process bus. The MCP SDK ships only the in-process `InMemorySubscriptionBus`, so a multi-replica deployment implements the `SubscriptionBus` protocol over its own backend — `publish` forwards the event to Redis, NATS or similar, and each replica invokes its local listeners for events arriving back from it:
+
+```python linenums="1"
+from collections.abc import Callable
+
+from mcp.server.subscriptions import SubscriptionBus
+from mcp.shared.subscriptions import ServerEvent
+
+from ag2.mcp import ResourceNotifier
+
+class RedisSubscriptionBus(SubscriptionBus):
+    """Fans events across replicas through a Redis pub/sub channel."""
+
+    async def publish(self, event: ServerEvent) -> None:
+        """Forward `event` to the backend; every replica's listeners then see it."""
+        ...
+
+    def subscribe(self, listener: Callable[[ServerEvent], None]) -> Callable[[], None]:
+        """Register `listener` locally and return an idempotent unsubscribe callable."""
+        ...
+
+notifier = ResourceNotifier(bus=RedisSubscriptionBus())
+```
+
+Listeners are synchronous, must not raise, and are invoked on the server's event loop. Both eras deliver through the bus, so one bus covers both.
+
+### Bounding the registry
+
+`max_subscribers` (default 1024) is one number bounding two things:
+
+- **how many subscribers** the server admits at once — in **each era separately**, since modern-era listen streams and handshake-era connections cost different things, so a server will admit up to twice the number you pass; and
+- **how many URIs any one handshake-era subscriber may hold.**
+
+The second bound exists because the first is not the whole cost. A client may subscribe to a URI the server does not serve, and that is deliberate: it may know about one the server will start serving later. So a single handshake-era connection could otherwise invent URIs without end and grow the registry unboundedly while never spending more than its one subscriber slot. Making the URI bound *per subscriber* rather than a total shared across them means a client subscribing to many URIs exhausts its own quota instead of locking every other client out of subscribing. The modern era has no equivalent gap — a listen stream's filter arrives whole in one request, and the number of streams is already bounded.
+
+`max_buffered_events` (default 1024, matching the SDK's own listen-stream buffer) bounds a third thing: how many announcements one handshake-era subscriber may fall behind by. Past it that subscriber is dropped rather than the event, so one client that stopped reading costs neither the publisher nor its fellow subscribers.
+
+Past either subscriber bound a further subscription is **refused**, with an error the client can see; it is never accepted and quietly dropped, and nothing already held is evicted to make room. A dead connection is only discovered when a send to it fails, so the server cannot tell an idle subscriber from a departed one — and evicting a live one would leave that client believing it still holds a working subscription it will never hear from again. That is the same silent failure the `stateless=True` warning exists to prevent. (The conversation-session registry, keyed by the same connection identity, evicts LRU instead: losing history costs a caller context it can rebuild, which is a different trade.)
+
+!!! warning "Size the bound for churn, not for concurrency"
+    Over streamable HTTP a send to a departed client does **not** fail: the transport drops a notification whose stream is gone and logs it at debug. A handshake-era client that disconnects without terminating its MCP session therefore leaves its entry in place, and because the policy refuses rather than evicts, a long-lived server can sit at `max_subscribers` holding entries for clients that are long gone — refusing ones that are still here.
+
+    Reclaiming those needs a transport-teardown hook the MCP SDK does not currently expose to a server handler, so until it does: set `max_subscribers` well above your expected concurrent subscriber count, and prefer clients that send `DELETE` on the MCP endpoint when they are finished. A subscriber whose *backlog* overflows — one that stopped reading but held its connection open — is dropped, since the protocol offers no replay and there is nothing left worth keeping for it.

--- a/website/docs/user-guide/tools/mcp_servers.mdx
+++ b/website/docs/user-guide/tools/mcp_servers.mdx
@@ -34,6 +34,9 @@ Autogen supports both ways MCP servers are typically wired into an agent:
 !!! tip
     Pick `MCPToolkit` when you want provider-agnostic behavior, local control over tool execution, when you need to run a local stdio MCP server, or when your MCP credentials must stay inside your infrastructure. Pick `MCPServerTool` when you're only targeting a provider that supports it and you'd rather let the provider manage the MCP lifecycle for you.
 
+!!! note "Going the other way"
+    Both options above *consume* an MCP server. To expose an AG2 agent **as** one, see [Serving an Agent as an MCP Server](/docs/user-guide/tools/serving_mcp) — then [Serving Resources over MCP](/docs/user-guide/tools/mcp_resources) for its resources and change notifications, and [MCP-UI](/docs/user-guide/tools/mcp_ui) for renderable UI results.
+
 ## Client-side: `MCPToolkit`
 
 `MCPToolkit` is a [Toolkit](/docs/user-guide/tools/toolkits) — it discovers the server's tools lazily and exposes each one as a regular function tool to the agent. It accepts either a remote URL/`MCPServerConfig` or an `MCPStdioServerConfig` for a locally-launched subprocess; the rest of the agent doesn't care which transport is in use.

--- a/website/docs/user-guide/tools/serving_mcp.mdx
+++ b/website/docs/user-guide/tools/serving_mcp.mdx
@@ -177,6 +177,8 @@ Both bounds are quoted in the `conversation` argument's own description, so a cl
 
 `stateless=True` stops the **HTTP transport** issuing an `mcp-session-id`. That is a *handshake-era* switch: modern-era requests are self-contained single exchanges that never carry a session id in the first place, so the flag does not reach them.
 
+It has one further consequence, decided at construction rather than per transport: handshake-era resource subscriptions are pushed into a session an earlier request opened, so a stateless server does not advertise `resources.subscribe` to those clients and warns you at construction. Because the capability is settled before a transport is chosen, `run_stdio` inherits the same suppression even though stdio holds a connection — drop `stateless=True` if the same server may be served over stdio. See [Serving Resources over MCP](/docs/user-guide/tools/mcp_resources).
+
 Pairing `stateless=True` with `sessions=True` is a valid configuration, not a contradiction — no transport session, conversations named by handle:
 
 ```python linenums="1"
@@ -243,5 +245,5 @@ With authentication configured, a conversation records the principal that create
 ## Beyond the conversational tool
 
 - **Custom tools** run a handler of yours directly instead of invoking the agent — see [MCP-UI Resources](/docs/user-guide/tools/mcp_ui) for `@mcp_tool` and returning renderable UI. Their state is their own; conversation handles apply only to the conversational tool.
-- **Resources and prompts** are exposed by passing `resources=[Resource(...)]`, `resource_templates=[ResourceTemplate(...)]` and `prompts=[Prompt(...)]` from `ag2.mcp`; the matching capability is advertised only when a non-empty collection is supplied.
+- **Resources and prompts** are exposed by passing `resources=[Resource(...)]`, `resource_templates=[ResourceTemplate(...)]` and `prompts=[Prompt(...)]` from `ag2.mcp`; the matching capability is advertised only when a non-empty collection is supplied. See [Serving Resources over MCP](/docs/user-guide/tools/mcp_resources) for templates and for telling clients a resource's contents went stale.
 - **Progress and logs** — while the agent runs, its stream events are forwarded to the client as progress notifications and log messages. Turn this off with `stream_progress=False`.

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -81,6 +81,7 @@
             "docs/user-guide/tools/common_toolkits",
             "docs/user-guide/tools/mcp_servers",
             "docs/user-guide/tools/serving_mcp",
+            "docs/user-guide/tools/mcp_resources",
             "docs/user-guide/tools/mcp_ui",
             "docs/user-guide/tools/builtin_tools",
             "docs/user-guide/tools/code_execution",


### PR DESCRIPTION
## Why are these changes needed?

A served agent can expose resources, but until now it could never say that one had gone stale. `read` runs on every `resources/read`, so a resource is a *view* of something live — a file, a config, a counter a tool mutates — yet a client holding that view had no way to learn the view aged out. This is not merely a missed optimisation: the MCP client SDK caches `resources/read` and evicts that entry on a resource-updated announcement, so a client was served a stale body until its TTL expired. The subscription capability was not advertised either, so a client could not even discover that polling was its only option — it just saw a server that never spoke.

This adds `ag2.mcp.ResourceNotifier`. The server author constructs one, hands it to `MCPServer(subscriptions=...)`, and calls `notify_resource_updated(uri)` from wherever the change actually happens:

```python
notifier = ResourceNotifier()

@mcp_tool
async def bump() -> str:
    """Increment the counter."""
    counter["n"] += 1
    await notifier.notify_resource_updated("mem://counter")
    return f"counter is now {counter['n']}"

server = MCPServer(
    agent,
    resources=[Resource(uri="mem://counter", name="counter", read=lambda: str(counter["n"]))],
    tools=[bump],
    subscriptions=notifier,
)
```

Constructing the notifier *before* the server is what lets a served tool close over it — a tool cannot close over a server that does not exist until its tools do. Outside a request, `await server.notify_resource_updated(uri)` is the same call.


## Related issue number

Closes #3186 (sub-issue of #3183).

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

<!-- AG2 welcomes AI-assisted contributions. Contributors remain responsible for everything they submit. See .github/AI_POLICY.md for details. -->

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
