### PR TITLE
fix(eval): count suite tasks with no trace instead of dropping them

### DIFF
--- a/ag2/eval/__init__.py
+++ b/ag2/eval/__init__.py
@@ -9,7 +9,7 @@ with prebuilt scorers, deterministic runs via ``TestConfig`` cassettes,
 and persisted run JSON suitable for run-vs-run diffing.
 """
 
-from ._types import Feedback, ScorerReturnTypeError
+from ._types import Feedback, MissingTraceError, ScorerReturnTypeError
 from .dataset import Suite, Task
 from .pairwise import (
     Agreement,
@@ -64,6 +64,7 @@ __all__ = (
     "Feedback",
     "InMemoryTraceSource",
     "LeaderboardRow",
+    "MissingTraceError",
     "OpenInferenceConvention",
     "PairwiseCase",
     "PairwiseComparator",

--- a/ag2/eval/_types.py
+++ b/ag2/eval/_types.py
@@ -12,11 +12,13 @@ decorator; a scorer can also return a :class:`Feedback` (or list of them)
 directly to set the key explicitly or attach a comment.
 """
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, TypeAlias
 
 __all__ = (
     "Feedback",
+    "MissingTraceError",
     "ScoreValue",
     "ScorerReturnTypeError",
     "ValueLabel",
@@ -69,3 +71,17 @@ class ScorerReturnTypeError(TypeError):
     Supported return types: ``bool``, ``int``, ``float``, ``str``,
     :class:`Feedback`, ``list[Feedback]``, ``None``.
     """
+
+
+class MissingTraceError(LookupError):
+    """A suite task has no trace in the source.
+
+    Recorded on the task's ``Trace.exception`` under
+    ``evaluate_traces(on_missing_task="error")``, raised for the whole run under
+    ``"raise"``. ``task_ids`` holds every uncovered task id.
+    """
+
+    def __init__(self, task_ids: str | Iterable[str]) -> None:
+        ids = (task_ids,) if isinstance(task_ids, str) else tuple(task_ids)
+        self.task_ids: tuple[str, ...] = ids
+        super().__init__(f"no trace in the source for task(s): {', '.join(ids)}")

--- a/ag2/eval/runtime/evaluate.py
+++ b/ag2/eval/runtime/evaluate.py
@@ -16,6 +16,8 @@ so reference-based scorers like ``final_answer_matches`` work against a
 reconstructed trace. ``reference_outputs``
 come from the paired :class:`~ag2.eval.Suite` task (via
 ``TraceRef.task_id``); traces with no paired task are graded reference-free.
+The reverse — a suite task with no trace — is governed by ``on_missing_task``
+and counts as an error by default.
 """
 
 import asyncio
@@ -26,14 +28,14 @@ import time
 from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime, timezone
 from functools import partial
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from ag2.context import ConversationContext
 from ag2.events import ModelResponse
 from ag2.stream import Stream
 
-from .._types import Feedback
+from .._types import Feedback, MissingTraceError
 from ..dataset import Suite, Task
 from ..events import EvalCompleted, EvalStarted, TaskEvaluated
 from ..results import BudgetThresholds, RunResult, TaskResult
@@ -45,6 +47,9 @@ from ._settle import reraise_if_not_exception
 __all__ = ("evaluate_traces",)
 
 logger = logging.getLogger(__name__)
+
+OnMissingTask = Literal["error", "ignore", "raise"]
+"""What to do with a suite task the source has no trace for."""
 
 
 async def evaluate_traces(
@@ -58,6 +63,7 @@ async def evaluate_traces(
     run_id: str | None = None,
     label: str | None = None,
     stream: Stream | None = None,
+    on_missing_task: OnMissingTask = "error",
 ) -> RunResult:
     """Grade every trace from ``source`` and persist a :class:`RunResult`.
 
@@ -78,6 +84,15 @@ async def evaluate_traces(
         stream: Optional :class:`~ag2.stream.Stream` to publish eval
             lifecycle events to (``EvalStarted`` / ``TaskEvaluated`` /
             ``EvalCompleted``) — observe a grading pass like you observe an agent.
+        on_missing_task: How to treat a ``suite`` task that no ``TraceRef``
+            carries the ``task_id`` of. ``"error"`` (default) grades it with an
+            empty :class:`~ag2.eval.Trace` carrying a
+            :class:`~ag2.eval.MissingTraceError`, so it counts in
+            ``aggregates.errors`` and in the pass-rate denominator; ``"ignore"``
+            leaves it out of the result and logs a warning; ``"raise"`` raises
+            :class:`~ag2.eval.MissingTraceError` before anything is graded.
+            Ignored when ``suite`` is ``None``. Missing tasks are appended in
+            suite order after the graded traces.
     """
     started = time.perf_counter()
     return await _grade(
@@ -92,6 +107,7 @@ async def evaluate_traces(
         stream=stream,
         target_path=f"trace-source:{type(source).__name__}",
         started_at=started,
+        on_missing_task=on_missing_task,
     )
 
 
@@ -109,6 +125,7 @@ async def _grade(
     target_path: str,
     started_at: float,
     variant: str | None = None,
+    on_missing_task: OnMissingTask = "error",
 ) -> RunResult:
     """Grade every trace from ``source`` into a persisted :class:`RunResult`.
 
@@ -118,11 +135,14 @@ async def _grade(
     when ``stream`` is set — publishes the lifecycle events. ``target_path`` records
     provenance (the agent for ``run_agent``; the trace source for ``evaluate_traces``);
     ``started_at`` is the caller's ``perf_counter`` start so the run-level duration
-    spans the caller's whole operation.
+    spans the caller's whole operation. ``on_missing_task`` decides what a suite task
+    with no matching ref becomes; missing tasks are graded after the refs, in suite order.
     """
     refs = [ref async for ref in source.list()]
     tasks_by_id = {task.task_id: task for task in suite} if suite is not None else {}
     resolved_suite = suite if suite is not None else _suite_from_refs(refs)
+    missing = _uncovered_tasks(suite, refs, on_missing_task)
+    missing_refs = [TraceRef(trace_id=f"missing:{task.task_id}", task_id=task.task_id) for task in missing]
     semaphore = asyncio.Semaphore(max(1, concurrency))
 
     actual_run_id = run_id if run_id is not None else uuid4().hex
@@ -132,7 +152,7 @@ async def _grade(
         eval_ctx = ConversationContext(stream=stream) if stream is not None else None
 
         await eval_ctx.send(
-            EvalStarted(run_id=actual_run_id, label=label, suite=resolved_suite.name, total=len(refs)),
+            EvalStarted(run_id=actual_run_id, label=label, suite=resolved_suite.name, total=len(refs) + len(missing)),
         )
 
         on_result = partial(_publish_task_evaluated, eval_ctx, actual_run_id, label, variant)
@@ -146,9 +166,13 @@ async def _grade(
         )
         for ref in refs
     ]
+    coros += [
+        _evaluate_missing(semaphore, task, ref, scorers=scorers, budgets=budgets, on_result=on_result)
+        for task, ref in zip(missing, missing_refs)
+    ]
     gathered = await asyncio.gather(*coros, return_exceptions=True)
     task_results: list[TaskResult] = []
-    for ref, outcome in zip(refs, gathered):
+    for ref, outcome in zip(refs + missing_refs, gathered):
         if isinstance(outcome, BaseException):
             reraise_if_not_exception(outcome)
             logger.error("eval ref failed: %s", getattr(ref, "task_id", ref), exc_info=outcome)
@@ -179,6 +203,26 @@ async def _grade(
     return result
 
 
+def _uncovered_tasks(suite: Suite | None, refs: list[TraceRef], on_missing_task: OnMissingTask) -> list[Task]:
+    """Suite tasks no ref carries the ``task_id`` of, per ``on_missing_task``.
+
+    Empty for ``"ignore"`` (warned instead) and when no suite was given.
+    """
+    if suite is None:
+        return []
+    covered = {ref.task_id for ref in refs}
+    missing = [task for task in suite if task.task_id not in covered]
+    if not missing:
+        return []
+    task_ids = [task.task_id for task in missing]
+    if on_missing_task == "raise":
+        raise MissingTraceError(task_ids)
+    if on_missing_task == "ignore":
+        logger.warning("%d suite task(s) have no trace and were not graded: %s", len(task_ids), task_ids)
+        return []
+    return missing
+
+
 def _error_task_result(ref: TraceRef, exc: BaseException) -> TaskResult:
     """Build a failed :class:`TaskResult` when ``_evaluate_ref`` raises.
 
@@ -206,27 +250,54 @@ async def _evaluate_ref(
         task = tasks_by_id.get(ref.task_id) if ref.task_id is not None else None
         if task is None:
             task = Task(task_id=ref.task_id or ref.trace_id, inputs={}, reference_outputs=None)
+        return await _score(task, trace, ref, scorers=scorers, budgets=budgets, on_result=on_result)
 
-        outputs = _outputs_from_trace(trace)
-        feedback: list[Feedback] = []
-        for scorer in scorers:
-            feedback.extend(
-                await scorer(
-                    inputs=task.inputs,
-                    outputs=outputs,
-                    reference_outputs=task.reference_outputs,
-                    trace=trace,
-                    task=task,
-                )
+
+async def _evaluate_missing(
+    semaphore: asyncio.Semaphore,
+    task: Task,
+    ref: TraceRef,
+    *,
+    scorers: tuple[Scorer, ...],
+    budgets: BudgetThresholds | None,
+    on_result: Callable[[Task, TaskResult], Awaitable[None]] | None = None,
+) -> TaskResult:
+    """Grade a suite task with no trace, through the same scorer path as a ref."""
+    async with semaphore:
+        trace = Trace(events=(), exception=MissingTraceError(task.task_id), duration_ms=0)
+        return await _score(task, trace, ref, scorers=scorers, budgets=budgets, on_result=on_result)
+
+
+async def _score(
+    task: Task,
+    trace: Trace,
+    ref: TraceRef,
+    *,
+    scorers: tuple[Scorer, ...],
+    budgets: BudgetThresholds | None,
+    on_result: Callable[[Task, TaskResult], Awaitable[None]] | None,
+) -> TaskResult:
+    """Run every scorer over one ``(task, trace)`` pair and build its :class:`TaskResult`."""
+    outputs = _outputs_from_trace(trace)
+    feedback: list[Feedback] = []
+    for scorer in scorers:
+        feedback.extend(
+            await scorer(
+                inputs=task.inputs,
+                outputs=outputs,
+                reference_outputs=task.reference_outputs,
+                trace=trace,
+                task=task,
             )
-
-        budget_violation = budgets.exceeded_by(trace) if budgets is not None else False
-        result = TaskResult(
-            task=task, trace=trace, feedback=tuple(feedback), budget_violation=budget_violation, trace_ref=ref
         )
-        if on_result is not None:
-            await on_result(task, result)
-        return result
+
+    budget_violation = budgets.exceeded_by(trace) if budgets is not None else False
+    result = TaskResult(
+        task=task, trace=trace, feedback=tuple(feedback), budget_violation=budget_violation, trace_ref=ref
+    )
+    if on_result is not None:
+        await on_result(task, result)
+    return result
 
 
 async def _publish_task_evaluated(

--- a/docs/adr/0016-evaluate-traces-counts-uncovered-tasks.md
+++ b/docs/adr/0016-evaluate-traces-counts-uncovered-tasks.md
@@ -1,0 +1,63 @@
+---
+status: accepted
+date: 2026-09-02
+---
+
+# `evaluate_traces` counts a suite task with no trace, rather than dropping it
+
+## Context
+
+`evaluate_traces(source, suite=…)` graded whatever the source listed: one
+`TaskResult` per `TraceRef`, joined back to a `Suite` task by `task_id` for
+reference-based scorers. The join was one-directional. A trace with no matching
+task was tolerated — graded reference-free against a synthesized `Task` — but a
+*task* with no matching trace contributed nothing at all.
+
+`Aggregates` is computed over the graded tasks, so an uncovered task shrank the
+pass-rate denominator instead of registering a failure. The failure mode is
+backwards for the thing evals exist to do: an agent that crashed before emitting
+any span, or a run whose export never landed, made the suite score *higher*. A CI
+gate on `pass_rate(...) >= 0.9` reads green precisely when the run went worst.
+
+The producing side already had the right shape. `run_agent` catches a task that
+raised and records it as `Trace(events=(), exception=…)` (`_error_trace_pair`),
+so the task is graded and counted as an error. Only the trace-source path could
+lose a task silently, and it does so for every `TraceSource` implementation.
+
+## Decision
+
+`evaluate_traces` takes a keyword-only `on_missing_task: Literal["error",
+"ignore", "raise"]`, applied to every suite task no `TraceRef` carries the
+`task_id` of. `"raise"` aborts before grading anything; `"ignore"` is the old
+behaviour plus a warning naming the uncovered ids; `"error"` — the default —
+materializes the task as a `TaskResult` whose trace is
+`Trace(events=(), exception=MissingTraceError(task_id), duration_ms=0)`, graded
+through the same scorer path as any other trace, so it lands in
+`aggregates.errors` and in the pass-rate denominator. It mirrors what
+`run_agent` already does for a task that raised.
+
+The asymmetry stays deliberate in the other direction: a trace whose `task_id`
+is not in the suite is still graded reference-free. A source may legitimately
+carry more than the suite describes (captured production traffic); a suite
+describes exactly what was meant to run.
+
+## Consequences
+
+- **This changes existing numbers.** A run where the source did not cover the
+  whole suite now reports more tasks, more errors, and usually a lower pass rate.
+  That is the point — but a `RunResult` graded before this change is not
+  comparable with one graded after if any task was uncovered, and `diff()` will
+  see tasks that "appeared". Nothing in the docs, tests, or an earlier ADR
+  promised that uncovered tasks were skipped, so no behaviour contract is being
+  broken; callers who want the old numbers pass `on_missing_task="ignore"`.
+- Ordering is the simplest deterministic rule: graded traces first in source
+  order, then missing tasks in suite order. Callers keying off positional index
+  should key off `task_id`.
+- A scorer now sees an empty `Trace` for such a task. That is not a new shape —
+  it is exactly what `run_agent` hands a scorer when `ask` raised — so scorers
+  need no change, and one that raises on it is captured as
+  `Feedback(score=None)` as always.
+- `MissingTraceError` is public (`ag2.eval`), so a caller can distinguish "no
+  trace" from a real agent failure recorded on the trace.
+- `run_agent` is unaffected in practice: it produces one trace per task,
+  including for tasks that raised, so its suite is always fully covered.

--- a/test/eval/runtime/test_evaluate.py
+++ b/test/eval/runtime/test_evaluate.py
@@ -5,6 +5,7 @@
 """Tests for evaluate_traces() — grading traces from a TraceSource."""
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator, Sequence
 
 import pytest
@@ -12,9 +13,11 @@ import pytest
 from ag2.eval import (
     BudgetThresholds,
     InMemoryTraceSource,
+    MissingTraceError,
     Suite,
     TraceRef,
     evaluate_traces,
+    load_run,
     scorer,
 )
 from ag2.eval.scorers import final_answer_matches, tool_called
@@ -224,3 +227,94 @@ async def test_evaluate_propagates_cancellation(tmp_path) -> None:
 
     with pytest.raises(asyncio.CancelledError):
         await evaluate_traces(source, scorers=[cancels], suite=suite, store_dir=tmp_path)
+
+
+def _two_of_three() -> tuple[InMemoryTraceSource, Suite]:
+    """A 3-task suite whose source only covers ``task-1`` and ``task-2``."""
+    source = InMemoryTraceSource([
+        (TraceRef("t1", task_id="task-1"), _trace("Paris")),
+        (TraceRef("t2", task_id="task-2"), _trace("London")),
+    ])
+    suite = Suite.from_list([
+        {"task_id": "task-1", "inputs": {"input": "capital of France?"}},
+        {"task_id": "task-2", "inputs": {"input": "capital of UK?"}},
+        {"task_id": "task-3", "inputs": {"input": "capital of Japan?"}},
+    ])
+    return source, suite
+
+
+@pytest.mark.asyncio()
+class TestOnMissingTask:
+    """A suite task the source has no trace for — the CI-gate failure mode."""
+
+    async def test_default_counts_the_uncovered_task_as_an_error(self, tmp_path) -> None:
+        source, suite = _two_of_three()
+
+        result = await evaluate_traces(source, scorers=[has_one_response], suite=suite, store_dir=tmp_path)
+
+        assert [tr.task.task_id for tr in result.tasks] == ["task-1", "task-2", "task-3"]
+        assert result.aggregates.errors == 1
+        # denominator is 3, not 2: the uncovered task scores as a failure
+        assert result.pass_rate("has_one_response") == pytest.approx(2 / 3)
+        missing = result.tasks[-1]
+        assert isinstance(missing.trace.exception, MissingTraceError)
+        assert missing.trace.exception.task_ids == ("task-3",)
+        assert "task-3" in str(missing.trace.exception)
+
+    async def test_ignore_drops_the_uncovered_task_and_warns(self, tmp_path, caplog) -> None:
+        source, suite = _two_of_three()
+
+        with caplog.at_level(logging.WARNING, logger="ag2.eval.runtime.evaluate"):
+            result = await evaluate_traces(
+                source, scorers=[has_one_response], suite=suite, store_dir=tmp_path, on_missing_task="ignore"
+            )
+
+        assert [tr.task.task_id for tr in result.tasks] == ["task-1", "task-2"]
+        assert result.aggregates.errors == 0
+        assert result.pass_rate("has_one_response") == 1.0
+        [record] = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert "1 suite task(s) have no trace" in record.getMessage()
+        assert "task-3" in record.getMessage()
+
+    async def test_raise_aborts_before_anything_is_graded(self, tmp_path) -> None:
+        source, suite = _two_of_three()
+        graded: list[str] = []
+
+        @scorer
+        def record(task) -> bool:
+            graded.append(task.task_id)
+            return True
+
+        with pytest.raises(MissingTraceError, match="task-3"):
+            await evaluate_traces(source, scorers=[record], suite=suite, store_dir=tmp_path, on_missing_task="raise")
+
+        assert graded == []
+
+    async def test_ref_outside_the_suite_is_still_graded_reference_free(self, tmp_path) -> None:
+        """The tolerated asymmetry: an extra trace is graded, never dropped."""
+        source = InMemoryTraceSource([
+            (TraceRef("t1", task_id="task-1"), _trace("Paris")),
+            (TraceRef("t9", task_id="not-in-suite"), _trace("Tokyo")),
+        ])
+        suite = Suite.from_list([{"task_id": "task-1", "inputs": {"input": "capital of France?"}}])
+
+        result = await evaluate_traces(source, scorers=[has_one_response], suite=suite, store_dir=tmp_path)
+
+        assert [tr.task.task_id for tr in result.tasks] == ["task-1", "not-in-suite"]
+        assert result.aggregates.errors == 0
+        extra = result.tasks[-1]
+        assert extra.task.reference_outputs is None
+        assert extra.feedback[0].score is True
+
+    async def test_missing_task_error_survives_save_and_load(self, tmp_path) -> None:
+        source, suite = _two_of_three()
+
+        result = await evaluate_traces(source, scorers=[has_one_response], suite=suite, store_dir=tmp_path)
+        loaded = load_run(result.save())
+
+        assert loaded.aggregates.errors == 1
+        assert loaded.pass_rate("has_one_response") == pytest.approx(2 / 3)
+        # store.py keeps only the exception's type + message
+        restored = loaded.tasks[-1].trace.exception
+        assert restored is not None
+        assert str(restored) == "MissingTraceError: no trace in the source for task(s): task-3"

--- a/website/docs/user-guide/evaluation/runs.mdx
+++ b/website/docs/user-guide/evaluation/runs.mdx
@@ -267,6 +267,22 @@ A **`TraceSource`** is anything that yields traces. Three ship:
 
 Because grading depends only on the reconstructed `Trace`, the **same scorers** work whether the trace came from `run_agent`, a directory, or production.
 
+### Suite tasks with no trace — `on_missing_task`
+
+A trace whose `task_id` isn't in the suite is graded reference-free. The reverse — a **suite task no trace covers**, because the run crashed before emitting spans, or the export never landed — is controlled by `on_missing_task`:
+
+| Value | Behaviour |
+|---|---|
+| `"error"` *(default)* | The task is graded with an empty `Trace` carrying a `MissingTraceError`, so it counts in `aggregates.errors` **and** in the pass-rate denominator. |
+| `"ignore"` | The task is left out of the result and a warning is logged with the uncovered ids. |
+| `"raise"` | `MissingTraceError` is raised, listing the uncovered ids, before anything is graded. |
+
+The default is `"error"` so a missing trace can never make a suite look *better*: a task that produced nothing is a failure, not a smaller denominator. Missing tasks are appended in suite order after the graded traces.
+
+```python linenums="1"
+result = await evaluate_traces(source, scorers=[...], suite=suite, store_dir="runs", on_missing_task="raise")
+```
+
 Reconstruction understands **two span dialects**, auto-detected per trace, so traces from a range of tools and frameworks grade unchanged:
 
 - the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/){.external-link target="_blank"} — `gen_ai.*` spans, what AG2's own `TelemetryMiddleware` emits, and


### PR DESCRIPTION
## Why are these changes needed?

`evaluate_traces` graded whatever the `TraceSource` listed: `_grade` did `refs = [ref async for ref in source.list()]` and built one `TaskResult` per ref. A suite `Task` with no matching `TraceRef` contributed **nothing** to the result. `Aggregates` is computed over the graded tasks, so an uncovered task shrank the pass-rate denominator instead of registering a failure.

For a CI gate that is the worst possible direction: a run that crashed before producing a trace, or whose span export never landed, makes the suite look *better*. A gate on `pass_rate(...) >= 0.9` reads green precisely when the run went worst. This affected every `TraceSource` (`InMemoryTraceSource`, `DirectoryTraceSource`, `TempoTraceSource`).

The producing side already had the right shape: `run_agent` catches a task whose `ask` raised and records it as `Trace(events=(), exception=…)` (`_error_trace_pair` in `runtime/runner.py`), so it is graded and counted. Only the trace-source path could lose a task silently.

### The three modes

`evaluate_traces` gains a keyword-only `on_missing_task: Literal["error", "ignore", "raise"]`, applied to every suite task no ref carries the `task_id` of (ignored when `suite is None`):

| Value | Behaviour |
|---|---|
| `"error"` *(default)* | The task is materialized as a `TaskResult` whose trace is `Trace(events=(), exception=MissingTraceError(task_id), duration_ms=0)` with a synthetic `TraceRef(trace_id=f"missing:{task_id}", task_id=task_id)`, graded through the **normal scorer path**, so it lands in `aggregates.errors` *and* in the pass-rate denominator. |
| `"ignore"` | Today's behaviour — the task is left out — plus a `logger.warning` naming the count and the uncovered ids. |
| `"raise"` | `MissingTraceError` is raised listing the uncovered ids, **before anything is graded** (no `source.load`, no scorer call). |

`MissingTraceError` is a new small public exception in `ag2/eval/_types.py` (next to `ScorerReturnTypeError`), exported from `ag2.eval`, carrying `task_ids: tuple[str, ...]` so a caller can tell "no trace" apart from a real agent failure recorded on the trace.

### Why the default is `"error"`

I checked before choosing: nothing in `test/eval/`, `website/docs/user-guide/evaluation/*.mdx`, or any ADR (including `0003-eval-run-api-takes-agent-instances.md`) promises that uncovered tasks are skipped. Every existing test that passes a `suite=` to `evaluate_traces` supplies a source that covers it fully, so no existing test changes behaviour. With no contract to preserve, the default fixes the bug for everyone rather than leaving it opt-in.

This *is* a deliberate behaviour change: a run where the source did not cover the whole suite now reports more tasks, more errors, and usually a lower pass rate. Callers who want the old numbers pass `on_missing_task="ignore"`. `run_agent` is unaffected in practice — it produces one trace per task, including for tasks that raised, so its suite is always fully covered (this includes `repeats=`, which expands task ids to `"<id>#N"` *before* production, so refs and suite tasks carry the same suffixed ids; `evaluate_traces` itself does no `#N` handling and this change adds none).

### The asymmetry stays

A ref whose `task_id` is not in the suite is still tolerated and graded reference-free (`_evaluate_ref` synthesizes a `Task`). A source may legitimately carry more than the suite describes (captured production traffic); a suite describes exactly what was meant to run. There is a regression test guarding this.

### Ordering

Simplest deterministic rule: graded traces first in source order, then missing tasks in suite order, appended. Stated in the docstring and the ADR.

### Scorer path unchanged

Missing tasks go through the same `_score` helper (extracted from `_evaluate_ref`, no behaviour change) as any other trace. A scorer sees an empty `Trace` — exactly the shape `run_agent` already hands it for a task whose `ask` raised — so a scorer that raises on it is captured as `Feedback(score=None)` by the `Scorer` wrapper as always.

### Also

- ADR `docs/adr/0016-evaluate-traces-counts-uncovered-tasks.md` (0016 was free; note `0010` is duplicated in `docs/adr/`, so the highest number was 0015).
- `website/docs/user-guide/evaluation/runs.mdx` — a short `on_missing_task` subsection under "Grading existing traces".

### Validation

```
$ uv run ruff check ag2/eval/. test/eval/.
All checks passed!

$ uv run ruff format ag2/eval/. test/eval/.
2 files reformatted, 66 files left unchanged

$ uv run mypy
Success: no issues found in 1 source file

$ uv run mypy ag2/eval/runtime/evaluate.py ag2/eval/_types.py
Success: no issues found in 2 source files

$ uv run pytest test/eval/. -q
278 passed, 6 skipped, 1 warning in 2.67s
```

(Bare `uv run mypy` is how CI runs it; `[tool.mypy] files` is currently scoped to `ag2/_import_utils.py`, so I also ran it explicitly over the two changed modules.)

Five new tests in `test/eval/runtime/test_evaluate.py` (`TestOnMissingTask`), all built from `InMemoryTraceSource` with hand-built `Trace` objects, no monkeypatching: default mode counts the uncovered task (3 results, `errors == 1`, pass rate `2/3` proving the denominator is 3, `MissingTraceError` naming the task id); `"ignore"` yields 2 results and logs the warning (`caplog`); `"raise"` aborts with the task id in the message and no scorer having run; an out-of-suite ref is still graded reference-free; and a `save()` / `load_run` round-trip preserves the error (`store.py` keeps only type + message, so the assertion is on `"MissingTraceError: no trace in the source for task(s): task-3"`).

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

This change was drafted with AI assistance and is pending the author's own review before the boxes above are ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
