### PR TITLE
test(acp): wait for parked turns instead of a fixed sleep in connection-limit tests

### DIFF
--- a/test/acp/test_agent_cancel.py
+++ b/test/acp/test_agent_cancel.py
@@ -519,6 +519,14 @@ class _ConcurrencyProbeConfig(ModelConfig):
         self.peak = 0
         self.release = asyncio.Event()
 
+    async def wait_until_running(self, n: int, *, timeout: float = 5.0) -> None:
+        """Poll until ``n`` turns are parked; the fixed sleep it replaces raced CI."""
+        deadline = asyncio.get_running_loop().time() + timeout
+        while self.running < n:
+            if asyncio.get_running_loop().time() > deadline:
+                raise TimeoutError(f"only {self.running} of {n} turns parked within {timeout}s")
+            await asyncio.sleep(0.01)
+
     def copy(self) -> Self:
         return self
 
@@ -562,11 +570,13 @@ class TestConnectionWideLimits:
         async with connect(server) as (conn, _):
             ids = [(await conn.new_session(cwd="/tmp")).session_id for _ in range(6)]
             turns = [asyncio.create_task(conn.prompt(session_id=sid, prompt=[acp.text_block("go")])) for sid in ids]
-            await asyncio.sleep(0.1)
+            try:
+                await probe.wait_until_running(3)
+                await asyncio.sleep(0.1)
 
-            assert probe.peak == 3
-
-            probe.release.set()
+                assert probe.peak == 3
+            finally:
+                probe.release.set()
             responses = await asyncio.gather(*turns)
 
         assert [r.stop_reason for r in responses] == ["end_turn"] * 6
@@ -582,11 +592,13 @@ class TestConnectionWideLimits:
         async with connect(server) as (conn, _):
             ids = [(await conn.new_session(cwd="/tmp")).session_id for _ in range(5)]
             turns = [asyncio.create_task(conn.prompt(session_id=sid, prompt=[acp.text_block("go")])) for sid in ids]
-            await asyncio.sleep(0.1)
+            try:
+                await probe.wait_until_running(2)
+                await asyncio.sleep(0.1)
 
-            assert not any(t.done() for t in turns)
-
-            probe.release.set()
+                assert not any(t.done() for t in turns)
+            finally:
+                probe.release.set()
             responses = await asyncio.gather(*turns)
 
         assert all(r.stop_reason == "end_turn" for r in responses)
@@ -601,12 +613,13 @@ class TestConnectionWideLimits:
         async with connect(server) as (conn, _):
             ids = [(await conn.new_session(cwd="/tmp")).session_id for _ in range(5)]
             turns = [asyncio.create_task(conn.prompt(session_id=sid, prompt=[acp.text_block("go")])) for sid in ids[:4]]
-            await asyncio.sleep(0.1)
+            try:
+                await probe.wait_until_running(2)
 
-            with pytest.raises(acp.RequestError):
-                await conn.prompt(session_id=ids[4], prompt=[acp.text_block("go")])
-
-            probe.release.set()
+                with pytest.raises(acp.RequestError):
+                    await conn.prompt(session_id=ids[4], prompt=[acp.text_block("go")])
+            finally:
+                probe.release.set()
             await asyncio.gather(*turns)
 
     async def test_a_slot_frees_up_once_a_turn_finishes(self) -> None:


### PR DESCRIPTION
## Why are these changes needed?

`TestConnectionWideLimits` in `test/acp/test_agent_cancel.py` is failing on CI for branches cut from current `main`, including `main`'s own run at 702b56132a4 (Python 3.10) and #3225 twice (Python 3.11). Failure: `test_concurrent_turns_are_capped_across_sessions` hits the 45s pytest-timeout.

Two causes, both in the test:

1. **Timing assumption.** The test fired six prompts, slept 100 ms, then asserted that exactly three turns were parked inside the LLM call. On a loaded runner with coverage enabled, the session handshakes and turn startup take longer than that, so the probe had seen zero turns (`assert 0 == 3` in the captured log).
2. **Hang on failure.** The assertion ran before the probe's release event was set. When it failed, the six parked turns were never released, connection teardown waited on them, and the test ran until pytest-timeout instead of failing fast.

Fix:

- `_ConcurrencyProbeConfig.wait_until_running(n)` polls until `n` turns are parked (5 s deadline, 10 ms tick), following the `asyncio.wait_for(..., timeout=5)` pattern already used in `test_agent_lifecycle.py` and `test_agent_load.py`.
- The three tests that used the fixed sleep now wait for the expected number of parked turns first. `test_concurrent_turns_are_capped_across_sessions` still settles 100 ms after reaching three before asserting the peak, so an over-admitted fourth turn would be caught.
- Each test releases the probe in a `finally`, so an assertion failure surfaces as a failure rather than a hang.

No production code changes. Locally the file passes three consecutive runs; the two changed tests complete in under 0.25 s each.

Validation:

```
uv run ruff check test/acp/test_agent_cancel.py    -> All checks passed
uv run ruff format test/acp/test_agent_cancel.py   -> 1 file left unchanged
uv run pytest test/acp/test_agent_cancel.py -q     -> 24 passed (x3)
```

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.

This change was drafted with AI assistance and is pending the author's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
