### PR TITLE
fix(middleware): prevent RetryMiddleware mixing chunks from failed streaming attempts (#3215)

### DIFF
--- a/ag2/middleware/builtin/llm_retry.py
+++ b/ag2/middleware/builtin/llm_retry.py
@@ -3,11 +3,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Sequence
+from typing import Any
 
 from ag2.annotations import Context
 from ag2.events import BaseEvent, ModelResponse
 from ag2.middleware.base import BaseMiddleware, LLMCall, MiddlewareFactory
 from ag2.middleware.describe import MiddlewareDescription
+
+
+class _AttemptContext:
+    """Context wrapper that tracks whether any event was published during an attempt."""
+
+    __slots__ = ("_inner", "has_emitted")
+
+    def __init__(self, inner: Context) -> None:
+        self._inner = inner
+        self.has_emitted: bool = False
+
+    async def send(self, event: BaseEvent) -> None:
+        self.has_emitted = True
+        await self._inner.send(event)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
 
 
 class RetryMiddleware(MiddlewareFactory):
@@ -59,9 +77,11 @@ class _RetryMiddleware(BaseMiddleware):
         context: Context,
     ) -> ModelResponse:
         for _ in range(self._max_retries):
+            attempt_context = _AttemptContext(context)
             try:
-                return await call_next(events, context)
+                return await call_next(events, attempt_context)  # type: ignore[arg-type]
             except self._retry_on:
-                pass
+                if attempt_context.has_emitted:
+                    raise
         # Final attempt — let the original exception propagate.
         return await call_next(events, context)

--- a/ag2/middleware/builtin/llm_retry.py
+++ b/ag2/middleware/builtin/llm_retry.py
@@ -3,26 +3,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, cast
 
 from ag2.annotations import Context
+from ag2.context import Stream
 from ag2.events import BaseEvent, ModelResponse
 from ag2.middleware.base import BaseMiddleware, LLMCall, MiddlewareFactory
 from ag2.middleware.describe import MiddlewareDescription
 
 
-class _AttemptContext:
-    """Context wrapper that tracks whether any event was published during an attempt."""
+class _AttemptStream:
+    """Stream proxy that records whether an attempt published an event."""
 
     __slots__ = ("_inner", "has_emitted")
 
-    def __init__(self, inner: Context) -> None:
+    def __init__(self, inner: Stream) -> None:
         self._inner = inner
-        self.has_emitted: bool = False
+        self.has_emitted = False
 
-    async def send(self, event: BaseEvent) -> None:
+    async def send(self, event: BaseEvent, context: Context) -> None:
         self.has_emitted = True
-        await self._inner.send(event)
+        await self._inner.send(event, context)
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
@@ -77,11 +78,16 @@ class _RetryMiddleware(BaseMiddleware):
         context: Context,
     ) -> ModelResponse:
         for _ in range(self._max_retries):
-            attempt_context = _AttemptContext(context)
+            original_stream = context.stream
+            attempt_stream = _AttemptStream(original_stream)
+            context.stream = cast(Stream, attempt_stream)
             try:
-                return await call_next(events, attempt_context)  # type: ignore[arg-type]
+                return await call_next(events, context)
             except self._retry_on:
-                if attempt_context.has_emitted:
+                if attempt_stream.has_emitted:
                     raise
+            finally:
+                if context.stream is attempt_stream:
+                    context.stream = original_stream
         # Final attempt — let the original exception propagate.
         return await call_next(events, context)

--- a/test/middleware/builtins/test_llm_retry.py
+++ b/test/middleware/builtins/test_llm_retry.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from ag2 import Context
-from ag2.events import BaseEvent, ModelMessage, ModelResponse, TextInput
+from ag2.events import BaseEvent, ModelMessage, ModelMessageChunk, ModelResponse, TextInput
 from ag2.middleware import RetryMiddleware
 
 
@@ -82,3 +82,57 @@ async def test_llm_retry_does_not_retry_non_matching_errors(mock: MagicMock) -> 
         await middleware.on_llm_call(llm_call, [TextInput("Hi!")], mock)
 
     mock.llm_call.assert_called_once_with([TextInput("Hi!")])
+
+
+@pytest.mark.asyncio()
+async def test_llm_retry_propagates_when_chunks_emitted_before_error(mock: MagicMock) -> None:
+    retry_middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))
+    emitted_chunks: list[str] = []
+
+    async def fake_send(event: BaseEvent) -> None:
+        if isinstance(event, ModelMessageChunk):
+            emitted_chunks.append(event.content)
+
+    mock.send = fake_send
+
+    async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
+        mock.llm_call(events)
+        await ctx.send(ModelMessageChunk("stale "))
+        raise TransientError("network dropped mid-stream")
+
+    middleware = retry_middleware(TextInput("Hi!"), mock)
+    with pytest.raises(TransientError, match="network dropped mid-stream"):
+        await middleware.on_llm_call(llm_call, [TextInput("Hi!")], mock)
+
+    mock.llm_call.assert_called_once_with([TextInput("Hi!")])
+    assert emitted_chunks == ["stale "]
+
+
+@pytest.mark.asyncio()
+async def test_llm_retry_retries_when_error_before_any_emission(mock: MagicMock) -> None:
+    retry_middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))
+    attempts = 0
+    emitted_chunks: list[str] = []
+
+    async def fake_send(event: BaseEvent) -> None:
+        if isinstance(event, ModelMessageChunk):
+            emitted_chunks.append(event.content)
+
+    mock.send = fake_send
+
+    async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
+        nonlocal attempts
+        attempts += 1
+        mock.llm_call(events)
+        if attempts == 1:
+            # Error occurs before any chunk is emitted (e.g. rate limit, DNS)
+            raise TransientError("rate limited on handshake")
+        await ctx.send(ModelMessageChunk("clean stream"))
+        return ModelResponse(ModelMessage("clean stream"))
+
+    middleware = retry_middleware(TextInput("Hi!"), mock)
+    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], mock)
+
+    assert response == ModelResponse(ModelMessage("clean stream"))
+    assert mock.llm_call.call_count == attempts == 2
+    assert emitted_chunks == ["clean stream"]

--- a/test/middleware/builtins/test_llm_retry.py
+++ b/test/middleware/builtins/test_llm_retry.py
@@ -7,8 +7,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from ag2 import Context
+from ag2.context import ConversationContext
 from ag2.events import BaseEvent, ModelMessage, ModelMessageChunk, ModelResponse, TextInput
 from ag2.middleware import RetryMiddleware
+from ag2.stream import MemoryStream
 
 
 class TransientError(Exception):
@@ -85,40 +87,55 @@ async def test_llm_retry_does_not_retry_non_matching_errors(mock: MagicMock) -> 
 
 
 @pytest.mark.asyncio()
+async def test_llm_retry_preserves_context_contract() -> None:
+    stream = MemoryStream()
+    context = ConversationContext(stream=stream)
+    retry_middleware = RetryMiddleware(max_retries=1, retry_on=(TransientError,))
+
+    async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
+        assert ctx is context
+        assert isinstance(ctx, ConversationContext)
+        ctx.prompt = ["updated"]
+        return ModelResponse(ModelMessage("result"))
+
+    middleware = retry_middleware(TextInput("Hi!"), context)
+    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
+
+    assert response == ModelResponse(ModelMessage("result"))
+    assert context.prompt == ["updated"]
+    assert context.stream is stream
+
+
+@pytest.mark.asyncio()
 async def test_llm_retry_propagates_when_chunks_emitted_before_error(mock: MagicMock) -> None:
     retry_middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))
+    stream = MemoryStream()
+    context = ConversationContext(stream=stream)
     emitted_chunks: list[str] = []
-
-    async def fake_send(event: BaseEvent) -> None:
-        if isinstance(event, ModelMessageChunk):
-            emitted_chunks.append(event.content)
-
-    mock.send = fake_send
+    stream.where(ModelMessageChunk).subscribe(lambda event: emitted_chunks.append(event.content))
 
     async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
         mock.llm_call(events)
         await ctx.send(ModelMessageChunk("stale "))
         raise TransientError("network dropped mid-stream")
 
-    middleware = retry_middleware(TextInput("Hi!"), mock)
+    middleware = retry_middleware(TextInput("Hi!"), context)
     with pytest.raises(TransientError, match="network dropped mid-stream"):
-        await middleware.on_llm_call(llm_call, [TextInput("Hi!")], mock)
+        await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
 
     mock.llm_call.assert_called_once_with([TextInput("Hi!")])
     assert emitted_chunks == ["stale "]
+    assert context.stream is stream
 
 
 @pytest.mark.asyncio()
 async def test_llm_retry_retries_when_error_before_any_emission(mock: MagicMock) -> None:
     retry_middleware = RetryMiddleware(max_retries=2, retry_on=(TransientError,))
+    stream = MemoryStream()
+    context = ConversationContext(stream=stream)
     attempts = 0
     emitted_chunks: list[str] = []
-
-    async def fake_send(event: BaseEvent) -> None:
-        if isinstance(event, ModelMessageChunk):
-            emitted_chunks.append(event.content)
-
-    mock.send = fake_send
+    stream.where(ModelMessageChunk).subscribe(lambda event: emitted_chunks.append(event.content))
 
     async def llm_call(events: Sequence[BaseEvent], ctx: Context) -> ModelResponse:
         nonlocal attempts
@@ -130,9 +147,10 @@ async def test_llm_retry_retries_when_error_before_any_emission(mock: MagicMock)
         await ctx.send(ModelMessageChunk("clean stream"))
         return ModelResponse(ModelMessage("clean stream"))
 
-    middleware = retry_middleware(TextInput("Hi!"), mock)
-    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], mock)
+    middleware = retry_middleware(TextInput("Hi!"), context)
+    response = await middleware.on_llm_call(llm_call, [TextInput("Hi!")], context)
 
     assert response == ModelResponse(ModelMessage("clean stream"))
     assert mock.llm_call.call_count == attempts == 2
     assert emitted_chunks == ["clean stream"]
+    assert context.stream is stream


### PR DESCRIPTION
## Why are these changes needed?

When using `RetryMiddleware` in streaming mode, provider clients (OpenAI, Anthropic, Gemini, Bedrock, etc.) emit `ModelMessageChunk` events onto the conversation stream via `await context.send(...)` while streaming.

If an exception matching `retry_on` occurred after one or more chunks had already been published, `RetryMiddleware` previously re-executed the LLM call on the same stream. Consumers could receive chunks from both attempts concatenated together (for example, `"stale complete"`), while the final `AgentReply.body` contained only the successful attempt.

This change temporarily wraps the context's `Stream` for each retryable attempt while passing the original `ConversationContext` object through unchanged.

- If an attempt publishes any event before raising a retryable exception, the exception is propagated immediately so a later attempt cannot contaminate the same stream.
- If an attempt fails before publishing an event, retry behavior remains unchanged.
- The original stream is restored on success and failure, preserving the Context contract for provider clients and nested middleware.

## Related issue number

Closes #3215

## Checks

- [ ] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

Local validation:

- `pytest -q test/middleware` — 158 passed
- Public `Agent + MemoryStream` reproduction from #3215 — passed
- Ruff check and format check — passed
- Mypy on `ag2/middleware/builtin/llm_retry.py` — passed

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
