### PR TITLE
feat(extensions): add WebzioNewsSearchToolkit for Webz.io news search

### DIFF
--- a/ag2/extensions/tools/search/__init__.py
+++ b/ag2/extensions/tools/search/__init__.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ag2.exceptions import missing_additional_dependency
+from ag2.exceptions import missing_additional_dependency, missing_optional_dependency
 
 try:
     from .exa import ExaToolkit
@@ -15,11 +15,18 @@ except ImportError as e:
     TinyFishSearchToolkit = missing_additional_dependency("TinyFishSearchToolkit", "tinyfish>=0.2.3", e)  # type: ignore[misc]
 
 from .serply import SerplySearchToolkit
+
+try:
+    from .webzio import WebzioNewsSearchToolkit
+except ImportError as e:
+    WebzioNewsSearchToolkit = missing_optional_dependency("WebzioNewsSearchToolkit", "mcp", e)  # type: ignore[misc]
+
 from .xquik import XquikSearchToolkit
 
 __all__ = (
     "ExaToolkit",
     "SerplySearchToolkit",
     "TinyFishSearchToolkit",
+    "WebzioNewsSearchToolkit",
     "XquikSearchToolkit",
 )

--- a/ag2/extensions/tools/search/webzio.py
+++ b/ag2/extensions/tools/search/webzio.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Webz.io contextual news search Extension for AG2.
+
+Wraps the hosted News Search MCP server so agents can search global news
+in natural language. Filter schemas come from MCP ``tools/list`` at runtime
+and are not hardcoded in this module.
+
+Maintainer: Webz.io (ShakedDegani)
+Docs: https://docs.ag2.ai/docs/user-guide/extensions/tools/search/webzio/
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+
+from ag2.middleware import ToolMiddleware
+from ag2.tools import MCPServerConfig, MCPToolkit
+
+DEFAULT_MCP_URL = "https://news-search-mcp.webz.io/mcp"
+TOKEN_ENV_NAME = "WEBZ_API_TOKEN"
+MCP_URL_ENV_NAME = "WEBZ_MCP_URL"
+PREFERRED_TOOL_NAME = "news_search_by_webz"
+SERVER_LABEL = "webzio-news-search"
+
+
+class WebzioConfigError(ValueError):
+    """Raised when the Webzio MCP client cannot be configured."""
+
+
+def resolve_api_token(api_token: str | None = None) -> str:
+    """Return a Webz API token from the argument or ``WEBZ_API_TOKEN``.
+
+    Args:
+        api_token: Explicit token. When omitted, ``WEBZ_API_TOKEN`` is used.
+
+    Returns:
+        The stripped API token.
+
+    Raises:
+        WebzioConfigError: If neither the argument nor the environment is set.
+    """
+    token = (api_token or os.getenv(TOKEN_ENV_NAME) or "").strip()
+    if not token:
+        raise WebzioConfigError(f"missing Webz API token. set {TOKEN_ENV_NAME} or pass api_token.")
+    return token
+
+
+def resolve_mcp_url(mcp_url: str | None = None) -> str:
+    """Return the MCP endpoint from the argument, env, or the production default.
+
+    Args:
+        mcp_url: Explicit MCP URL. When omitted, ``WEBZ_MCP_URL`` or the
+            hosted production endpoint is used.
+
+    Returns:
+        The MCP URL without a trailing slash.
+
+    Raises:
+        WebzioConfigError: If the resolved value is empty.
+    """
+    url = (mcp_url or os.getenv(MCP_URL_ENV_NAME) or DEFAULT_MCP_URL).strip()
+    if not url:
+        raise WebzioConfigError("missing MCP url.")
+    return url.rstrip("/")
+
+
+def build_mcp_server_config(
+    api_token: str | None = None,
+    *,
+    mcp_url: str | None = None,
+) -> MCPServerConfig:
+    """Build the MCP client config for the hosted Webz News Search server.
+
+    Args:
+        api_token: Webz API token. Defaults to ``WEBZ_API_TOKEN``.
+        mcp_url: MCP endpoint. Defaults to the hosted production URL.
+
+    Returns:
+        An ``MCPServerConfig`` that authenticates with a Bearer token and
+        registers ``news_search_by_webz``.
+    """
+    return MCPServerConfig(
+        server_url=resolve_mcp_url(mcp_url),
+        authorization_token=resolve_api_token(api_token),
+        allowed_tools=[PREFERRED_TOOL_NAME],
+        server_label=SERVER_LABEL,
+    )
+
+
+class WebzioNewsSearchToolkit(MCPToolkit):
+    """Toolkit that exposes Webz.io contextual news search to AG2 agents.
+
+    Connects to the hosted News Search MCP server and registers
+    ``news_search_by_webz`` with its live input schema from ``tools/list``.
+    Filter fields are not hardcoded — new server filters appear at runtime.
+
+    Pass the toolkit to an agent to register news search::
+
+        toolkit = WebzioNewsSearchToolkit(api_token=...)
+        agent = Agent("researcher", config=config, tools=[toolkit])
+
+    Call ``search()`` when you want to register only the news search tool::
+
+        agent = Agent("researcher", config=config, tools=[toolkit.search()])
+
+    Reads ``WEBZ_API_TOKEN`` from the environment when ``api_token`` is omitted.
+    """
+
+    def __init__(
+        self,
+        api_token: str | None = None,
+        *,
+        mcp_url: str | None = None,
+        middleware: Iterable[ToolMiddleware] = (),
+    ) -> None:
+        """Connect to the hosted Webz News Search MCP server.
+
+        Args:
+            api_token: Webz API token. Defaults to ``WEBZ_API_TOKEN``.
+            mcp_url: MCP endpoint override. Defaults to the hosted production URL.
+            middleware: Middleware applied to every tool in the toolkit.
+        """
+        super().__init__(
+            build_mcp_server_config(api_token, mcp_url=mcp_url),
+            middleware=middleware,
+        )
+
+    def search(self) -> WebzioNewsSearchToolkit:
+        """Return this toolkit, registering only the news search tool.
+
+        Returns:
+            This toolkit instance.
+        """
+        return self

--- a/ag2/extensions/tools/search/webzio.py
+++ b/ag2/extensions/tools/search/webzio.py
@@ -10,6 +10,7 @@ schemas come from MCP ``tools/list`` at runtime and are not hardcoded here.
 
 Maintainer: ShakedDegani
 Docs: https://docs.ag2.ai/docs/user-guide/extensions/tools/search/webzio/
+Examples: https://github.com/ag2ai/build-with-ag2/tree/main/webzio-news-search
 """
 
 from __future__ import annotations

--- a/ag2/extensions/tools/search/webzio.py
+++ b/ag2/extensions/tools/search/webzio.py
@@ -4,11 +4,11 @@
 
 """Webz.io contextual news search Extension for AG2.
 
-Wraps the hosted News Search MCP server so agents can search global news
-in natural language. Filter schemas come from MCP ``tools/list`` at runtime
-and are not hardcoded in this module.
+Provides a toolkit that lets agents query the hosted News Search MCP server
+and receive ranked article excerpts with titles, URLs, and metadata. Filter
+schemas come from MCP ``tools/list`` at runtime and are not hardcoded here.
 
-Maintainer: Webz.io (ShakedDegani)
+Maintainer: ShakedDegani
 Docs: https://docs.ag2.ai/docs/user-guide/extensions/tools/search/webzio/
 """
 
@@ -108,6 +108,10 @@ class WebzioNewsSearchToolkit(MCPToolkit):
         agent = Agent("researcher", config=config, tools=[toolkit.search()])
 
     Reads ``WEBZ_API_TOKEN`` from the environment when ``api_token`` is omitted.
+
+    Attributes:
+        config: MCP server configuration. Includes the hosted URL, Bearer
+            token, ``allowed_tools``, and ``server_label``.
     """
 
     def __init__(

--- a/test/extensions/tools/search/test_webzio.py
+++ b/test/extensions/tools/search/test_webzio.py
@@ -3,12 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+from collections.abc import Callable
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
+from dirty_equals import IsPartialDict
 
 pytest.importorskip("mcp")
+from mcp.types import CallToolResult, ListToolsResult, TextContent
+from mcp.types import Tool as MCPTool
 
+from ag2 import Agent, Context
+from ag2.events import ToolCallEvent
 from ag2.extensions.tools.search import webzio as webzio_module
 from ag2.extensions.tools.search.webzio import (
     DEFAULT_MCP_URL,
@@ -21,6 +28,8 @@ from ag2.extensions.tools.search.webzio import (
     resolve_api_token,
     resolve_mcp_url,
 )
+from ag2.testing import TestConfig
+from ag2.tools.toolkits.mcp_server import toolkit as _toolkit_module
 
 WEBZIO_SOURCE = Path(inspect.getfile(webzio_module)).read_text(encoding="utf-8")
 
@@ -34,6 +43,64 @@ FILTER_NAMES_OWNED_BY_MCP = (
     "min_similarity",
     "allow_multiple_chunks_per_article",
 )
+
+NEWS_SEARCH_TOOL = MCPTool(
+    name=PREFERRED_TOOL_NAME,
+    description="Semantic news search.",
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Natural language search query"},
+            "k": {"type": "integer", "description": "Articles to return"},
+        },
+        "required": ["query"],
+    },
+)
+
+MCPSessionPatch = Callable[[list[MCPTool], dict[str, CallToolResult] | None], "_FakeMCPSession"]
+
+
+class _FakeMCPSession:
+    """In-memory stand-in for ``mcp.ClientSession`` used by the toolkit."""
+
+    def __init__(
+        self,
+        tools: list[MCPTool],
+        call_results: dict[str, CallToolResult] | None = None,
+    ) -> None:
+        self._tools = tools
+        self._call_results = call_results or {}
+        self.calls: list[tuple[str, dict]] = []
+
+    async def list_tools(self) -> ListToolsResult:
+        return ListToolsResult(tools=self._tools)
+
+    async def call_tool(self, name: str, arguments: dict) -> CallToolResult:
+        self.calls.append((name, arguments))
+        return self._call_results.get(
+            name,
+            CallToolResult(content=[TextContent(type="text", text="ok")]),
+        )
+
+
+@pytest.fixture
+def patch_mcp_session(monkeypatch: pytest.MonkeyPatch) -> MCPSessionPatch:
+    """Replace ``_mcp_session`` with a fake that yields a controllable session."""
+
+    def _install(
+        tools: list[MCPTool],
+        call_results: dict[str, CallToolResult] | None = None,
+    ) -> _FakeMCPSession:
+        session = _FakeMCPSession(tools, call_results)
+
+        @asynccontextmanager
+        async def fake(_):
+            yield session
+
+        monkeypatch.setattr(_toolkit_module, "_mcp_session", fake)
+        return session
+
+    return _install
 
 
 def test_resolve_api_token_requires_value(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -79,3 +146,55 @@ def test_public_export() -> None:
     from ag2.extensions.tools.search import WebzioNewsSearchToolkit as Exported
 
     assert Exported is WebzioNewsSearchToolkit
+
+
+@pytest.mark.asyncio
+async def test_discovers_news_search_schema(
+    patch_mcp_session: MCPSessionPatch,
+    context: Context,
+) -> None:
+    patch_mcp_session([
+        NEWS_SEARCH_TOOL,
+        MCPTool(name="other_tool", description="", inputSchema={"type": "object"}),
+    ])
+    toolkit = WebzioNewsSearchToolkit(api_token="tok")
+
+    [schema] = list(await toolkit.schemas(context))
+
+    assert schema.function.name == PREFERRED_TOOL_NAME
+    assert schema.function.parameters == IsPartialDict({
+        "type": "object",
+        "required": ["query"],
+        "properties": IsPartialDict({
+            "query": IsPartialDict({"type": "string"}),
+            "k": IsPartialDict({"type": "integer"}),
+        }),
+    })
+
+
+@pytest.mark.asyncio
+async def test_search_result_is_returned_to_agent(patch_mcp_session: MCPSessionPatch) -> None:
+    session = patch_mcp_session(
+        [NEWS_SEARCH_TOOL],
+        call_results={
+            PREFERRED_TOOL_NAME: CallToolResult(
+                content=[TextContent(type="text", text="Query: AI regulation\nTitle: Example")]
+            ),
+        },
+    )
+    agent = Agent(
+        name="researcher",
+        tools=[WebzioNewsSearchToolkit(api_token="tok")],
+        config=TestConfig(
+            ToolCallEvent(
+                name=PREFERRED_TOOL_NAME,
+                arguments='{"query": "AI regulation", "k": 3}',
+            ),
+            "done",
+        ),
+    )
+
+    result = await agent.ask("search")
+
+    assert result.body == "done"
+    assert session.calls == [(PREFERRED_TOOL_NAME, {"query": "AI regulation", "k": 3})]

--- a/test/extensions/tools/search/test_webzio.py
+++ b/test/extensions/tools/search/test_webzio.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from ag2.extensions.tools.search import webzio as webzio_module
+from ag2.extensions.tools.search.webzio import (
+    DEFAULT_MCP_URL,
+    PREFERRED_TOOL_NAME,
+    SERVER_LABEL,
+    TOKEN_ENV_NAME,
+    WebzioConfigError,
+    WebzioNewsSearchToolkit,
+    build_mcp_server_config,
+    resolve_api_token,
+    resolve_mcp_url,
+)
+
+WEBZIO_SOURCE = Path(inspect.getfile(webzio_module)).read_text(encoding="utf-8")
+
+FILTER_NAMES_OWNED_BY_MCP = (
+    "allow_all_dates",
+    "exclude_domain",
+    "domain_rank_gte",
+    "domain_rank_lte",
+    "trust_category",
+    "political_bias",
+    "min_similarity",
+    "allow_multiple_chunks_per_article",
+)
+
+
+def test_resolve_api_token_requires_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(TOKEN_ENV_NAME, raising=False)
+    with pytest.raises(WebzioConfigError, match="missing Webz API token"):
+        resolve_api_token()
+
+
+def test_resolve_api_token_prefers_argument(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TOKEN_ENV_NAME, "from-env")
+    assert resolve_api_token(" from-arg ") == "from-arg"
+
+
+def test_resolve_mcp_url_default_and_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WEBZ_MCP_URL", raising=False)
+    assert resolve_mcp_url() == DEFAULT_MCP_URL
+    assert resolve_mcp_url("https://localhost:8765/mcp/") == "https://localhost:8765/mcp"
+
+
+def test_build_mcp_server_config_uses_bearer_and_allowed_tools() -> None:
+    config = build_mcp_server_config("secret-token", mcp_url="https://example.test/mcp")
+    assert config.server_url == "https://example.test/mcp"
+    assert config.authorization_token == "secret-token"
+    assert config.allowed_tools == [PREFERRED_TOOL_NAME]
+    assert config.server_label == SERVER_LABEL
+
+
+def test_toolkit_wraps_mcp_server_config() -> None:
+    toolkit = WebzioNewsSearchToolkit(api_token="tok", mcp_url="https://example.test/mcp")
+    assert isinstance(toolkit, WebzioNewsSearchToolkit)
+    assert toolkit.search() is toolkit
+    assert toolkit.config.server_url == "https://example.test/mcp"
+    assert toolkit.config.authorization_token == "tok"
+    assert toolkit.config.allowed_tools == [PREFERRED_TOOL_NAME]
+
+
+def test_toolkit_source_does_not_hardcode_mcp_filters() -> None:
+    for name in FILTER_NAMES_OWNED_BY_MCP:
+        assert name not in WEBZIO_SOURCE, f"wrapper must not hardcode MCP filter {name}"
+
+
+def test_public_export() -> None:
+    from ag2.extensions.tools.search import WebzioNewsSearchToolkit as Exported
+
+    assert Exported is WebzioNewsSearchToolkit

--- a/website/docs/user-guide/extensions/tools/search/webzio.mdx
+++ b/website/docs/user-guide/extensions/tools/search/webzio.mdx
@@ -1,0 +1,59 @@
+---
+title: Webzio News Search
+sidebarTitle: Webzio News Search
+---
+
+`WebzioNewsSearchToolkit` gives an AG2 agent semantic news search powered by [Webz.io](https://webz.io){.external-link target="_blank"}. Ask a question in plain language, optionally steer filters in the prompt, and get back ranked article excerpts with titles, URLs, and metadata.
+
+!!! note
+    Requires AG2 with MCP support and a Webz.io API token: `pip install "ag2[mcp]"`
+
+```python linenums="1"
+import os
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.extensions.tools.search import WebzioNewsSearchToolkit
+
+agent = Agent(
+    "researcher",
+    config=AnthropicConfig(model="claude-sonnet-5"),
+    tools=[WebzioNewsSearchToolkit(api_token=os.environ["WEBZ_API_TOKEN"])],
+)
+```
+
+If `api_token` is omitted, the toolkit reads `WEBZ_API_TOKEN` from the environment.
+
+## Tool
+
+| Tool | Description |
+| :--- | :--- |
+| `news_search_by_webz` | Semantic news search with filters (language, country, days, sentiment, domain, ticker, and more) |
+
+Filter names and schemas are loaded live from the hosted [News Search MCP server](https://docs.webz.io/docs/webz/news-search-api-mcp){.external-link target="_blank"} (`tools/list`). New filters on the server appear without an AG2 release.
+
+## Register only news search
+
+Call `search()` to register the news search tool:
+
+```python linenums="1"
+toolkit = WebzioNewsSearchToolkit(api_token=...)
+
+agent = Agent(
+    "researcher",
+    config=config,
+    tools=[toolkit.search()],
+)
+```
+
+Today the MCP server exposes a single tool, so `toolkit` and `toolkit.search()` are equivalent.
+
+## Configuration
+
+| Name | Default | Description |
+| :--- | :--- | :--- |
+| `WEBZ_API_TOKEN` | required | API token from the [Webz.io dashboard](https://webz.io){.external-link target="_blank"} |
+| `WEBZ_MCP_URL` | `https://news-search-mcp.webz.io/mcp` | Override for testing against another MCP endpoint |
+
+You can also pass `api_token=` and `mcp_url=` to `WebzioNewsSearchToolkit()`. Each search uses the same News Search API credits and rate limits as other Webz.io clients.
+
+See the [MCP tool reference](https://docs.webz.io/docs/webz/news-search-api-mcp#tool-reference){.external-link target="_blank"} for current filters.

--- a/website/docs/user-guide/extensions/tools/search/webzio.mdx
+++ b/website/docs/user-guide/extensions/tools/search/webzio.mdx
@@ -57,3 +57,7 @@ Today the MCP server exposes a single tool, so `toolkit` and `toolkit.search()` 
 You can also pass `api_token=` and `mcp_url=` to `WebzioNewsSearchToolkit()`. Each search uses the same News Search API credits and rate limits as other Webz.io clients.
 
 See the [MCP tool reference](https://docs.webz.io/docs/webz/news-search-api-mcp#tool-reference){.external-link target="_blank"} for current filters.
+
+## Runnable example
+
+A complete news-researcher agent is in [build-with-ag2/webzio-news-search](https://github.com/ag2ai/build-with-ag2/tree/main/webzio-news-search){.external-link target="_blank"}.


### PR DESCRIPTION
## Summary
- Add `WebzioNewsSearchToolkit` under `ag2.extensions.tools.search`, wrapping AG2's client-side `MCPToolkit` around the hosted Webz.io News Search MCP server (`https://news-search-mcp.webz.io/mcp`).
- Filter schemas come from MCP `tools/list` at runtime; this extension does not hardcode filter fields and does not add a new third-party SDK (only `ag2[mcp]`, already in the `optionals` group).
- Document the toolkit at `website/docs/user-guide/extensions/tools/search/webzio.mdx`.

## Maintainer
I (`ShakedDegani`, Webz.io) will maintain this Extension: respond to issues and PRs, keep it working with current Core releases, and tell AG2 if I can no longer maintain it.

## Test plan
- [x] `pytest test/extensions/tools/search/test_webzio.py` (no network; skipped only if `mcp` is not installed)
- [x] Mocked MCP session: discovers `news_search_by_webz`, filters extra tools, returns a search result through `agent.ask`
- [ ] `just test` on CI
- [ ] Confirm docs page renders at `/docs/user-guide/extensions/tools/search/webzio/`
