### PR TITLE
feat(anthropic): add AnthropicBashTool and improve event handling

### DIFF
--- a/ag2/config/anthropic/anthropic_client.py
+++ b/ag2/config/anthropic/anthropic_client.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import logging
 from collections.abc import Iterable, Sequence
 from itertools import chain
 from typing import Any, TypedDict
@@ -10,7 +11,9 @@ from typing import Any, TypedDict
 import httpx2
 from anthropic import NOT_GIVEN, AsyncAnthropic
 from anthropic.types import (
+    ContainerUploadBlock,
     Message,
+    RedactedThinkingBlock,
     ServerToolUseBlock,
     TextBlock,
     ThinkingBlock,
@@ -34,7 +37,27 @@ from ag2.tools.builtin.code_execution import CodeExecutionToolSchema
 from ag2.tools.builtin.skills import SkillsToolSchema
 from ag2.tools.schemas import ToolSchema
 
-from .events import AnthropicServerToolCallEvent, AnthropicServerToolResultBlockType, AnthropicServerToolResultEvent
+from .events import (
+    AnthropicContainerUploadEvent,
+    AnthropicRedactedThinkingEvent,
+    AnthropicServerToolCallEvent,
+    AnthropicServerToolResultBlockType,
+    AnthropicServerToolResultEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _tool_use_vendor_metadata(block: ToolUseBlock) -> dict[str, Any]:
+    """Provider fields ``ToolCallEvent`` has no column for but must replay."""
+    meta: dict[str, Any] = {}
+    if (caller := getattr(block, "caller", None)) is not None:
+        meta["caller"] = caller.model_dump(mode="json") if hasattr(caller, "model_dump") else caller
+    if (toolset := getattr(block, "toolset_name", None)) is not None:
+        meta["toolset_name"] = toolset
+    return meta
+
+
 from .mappers import (
     convert_messages,
     extract_mcp_servers,
@@ -253,6 +276,7 @@ class AnthropicClient(LLMClient):
                         id=block.id,
                         name=block.name,
                         arguments=json.dumps(block.input),
+                        vendor_metadata=_tool_use_vendor_metadata(block),
                     )
                 )
 
@@ -260,10 +284,25 @@ class AnthropicClient(LLMClient):
                 if call_event := AnthropicServerToolCallEvent.from_block(block):
                     await context.send(call_event)
 
+            elif isinstance(block, RedactedThinkingBlock):
+                await context.send(AnthropicRedactedThinkingEvent(block=block))
+
+            elif isinstance(block, ContainerUploadBlock):
+                await context.send(AnthropicContainerUploadEvent(block=block))
+
             elif isinstance(block, AnthropicServerToolResultBlockType) and (
                 result_event := AnthropicServerToolResultEvent.from_block(block)
             ):
                 await context.send(result_event)
+
+            else:
+                # Without this the next block type Anthropic adds disappears with
+                # no event, no warning and no trace in history.
+                logger.warning(
+                    "Dropping unhandled Anthropic content block type=%r (%s)",
+                    getattr(block, "type", None),
+                    type(block).__name__,
+                )
 
         usage = normalize_usage(response.usage.model_dump() if response.usage else {})
 
@@ -285,6 +324,7 @@ class AnthropicClient(LLMClient):
         calls: list[ToolCallEvent] = []
 
         current_tool: dict[str, Any] | None = None
+        current_server: dict[str, Any] | None = None
 
         async for event in stream:
             event_type = getattr(event, "type", None)
@@ -297,14 +337,26 @@ class AnthropicClient(LLMClient):
                         "id": block.id,
                         "name": block.name,
                         "arguments": "",
+                        "vendor_metadata": _tool_use_vendor_metadata(block),
                     }
                 elif block_type == "server_tool_use":
-                    if call_event := AnthropicServerToolCallEvent.from_block(block):
-                        await context.send(call_event)
-                elif isinstance(block, AnthropicServerToolResultBlockType) and (
-                    result_event := AnthropicServerToolResultEvent.from_block(block)
-                ):
-                    await context.send(result_event)
+                    # ``input`` is empty here and arrives as input_json_delta; the
+                    # event is built at content_block_stop so it carries the whole
+                    # thing. Building it now replays an empty input.
+                    current_server = {"block": block, "arguments": ""}
+                elif isinstance(block, RedactedThinkingBlock):
+                    await context.send(AnthropicRedactedThinkingEvent(block=block))
+                elif isinstance(block, ContainerUploadBlock):
+                    await context.send(AnthropicContainerUploadEvent(block=block))
+                elif isinstance(block, AnthropicServerToolResultBlockType):
+                    if result_event := AnthropicServerToolResultEvent.from_block(block):
+                        await context.send(result_event)
+                elif block_type not in ("text", "thinking"):
+                    logger.warning(
+                        "Dropping unhandled Anthropic content block type=%r (%s)",
+                        block_type,
+                        type(block).__name__,
+                    )
 
             elif event_type == "content_block_delta":
                 delta = event.delta
@@ -317,8 +369,11 @@ class AnthropicClient(LLMClient):
                 elif delta_type == "thinking_delta":
                     await context.send(ModelReasoning(delta.thinking))
 
-                elif delta_type == "input_json_delta" and current_tool is not None:
-                    current_tool["arguments"] += delta.partial_json
+                elif delta_type == "input_json_delta":
+                    if current_tool is not None:
+                        current_tool["arguments"] += delta.partial_json
+                    elif current_server is not None:
+                        current_server["arguments"] += delta.partial_json
 
             elif event_type == "content_block_stop":
                 if current_tool is not None:
@@ -327,9 +382,26 @@ class AnthropicClient(LLMClient):
                             id=current_tool["id"],
                             name=current_tool["name"],
                             arguments=current_tool["arguments"],
+                            vendor_metadata=current_tool["vendor_metadata"],
                         )
                     )
                     current_tool = None
+                elif current_server is not None:
+                    block = current_server["block"]
+                    raw = current_server["arguments"]
+                    try:
+                        # ``max_tokens`` can cut a block mid-JSON; keep the block
+                        # rather than fail the turn on a partial input.
+                        block = block.model_copy(update={"input": json.loads(raw)}) if raw else block
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "Incomplete server_tool_use input for id=%s; keeping %r",
+                            block.id,
+                            block.input,
+                        )
+                    if call_event := AnthropicServerToolCallEvent.from_block(block):
+                        await context.send(call_event)
+                    current_server = None
 
         message: ModelMessage | None = None
         if full_content:

--- a/ag2/config/anthropic/events.py
+++ b/ag2/config/anthropic/events.py
@@ -14,8 +14,10 @@ from anthropic.types import (
     CodeExecutionResultBlock,
     CodeExecutionToolResultBlock,
     CodeExecutionToolResultError,
+    ContainerUploadBlock,
     EncryptedCodeExecutionResultBlock,
     PlainTextSource,
+    RedactedThinkingBlock,
     ServerToolUseBlock,
     TextEditorCodeExecutionCreateResultBlock,
     TextEditorCodeExecutionStrReplaceResultBlock,
@@ -34,6 +36,7 @@ from anthropic.types import (
 )
 
 from ag2.events import (
+    BaseEvent,
     BinaryInput,
     BinaryType,
     BuiltinToolCallEvent,
@@ -41,6 +44,7 @@ from ag2.events import (
     Field,
     FileIdInput,
     Input,
+    ProviderReplay,
     TextInput,
     ToolResult,
     UrlInput,
@@ -58,6 +62,32 @@ AnthropicServerToolResultBlockType: TypeAlias = (
     | TextEditorCodeExecutionToolResultBlock
     | ToolSearchToolResultBlock
 )
+
+
+class AnthropicRedactedThinkingEvent(BaseEvent, ProviderReplay):
+    """Safety-redacted thinking, opaque and encrypted.
+
+    Anthropic requires the block echoed back unchanged on the next turn, so it is
+    a replay anchor rather than a transient reasoning event.
+    """
+
+    __replay_role__ = "anchor"
+
+    block: RedactedThinkingBlock = Field(repr=False)
+
+
+class AnthropicContainerUploadEvent(BaseEvent):
+    """A file the code-execution container produced.
+
+    Recorded so the ``file_id`` survives, never replayed: the API answers 400
+    "'container_upload' blocks are not permitted within assistant turns".
+    """
+
+    block: ContainerUploadBlock = Field(repr=False)
+
+    @property
+    def file_id(self) -> str:
+        return self.block.file_id
 
 
 class AnthropicServerToolCallEvent(BuiltinToolCallEvent):

--- a/ag2/config/anthropic/mappers.py
+++ b/ag2/config/anthropic/mappers.py
@@ -11,7 +11,11 @@ from typing import Any
 from fast_depends.library.serializer import SerializerProto
 
 from ag2.compact import CompactionSummary
-from ag2.config.anthropic.events import AnthropicServerToolCallEvent, AnthropicServerToolResultEvent
+from ag2.config.anthropic.events import (
+    AnthropicRedactedThinkingEvent,
+    AnthropicServerToolCallEvent,
+    AnthropicServerToolResultEvent,
+)
 from ag2.events import (
     BaseEvent,
     BinaryInput,
@@ -33,6 +37,7 @@ logger = logging.getLogger(__name__)
 from ag2.exceptions import UnsupportedInputError, UnsupportedToolError
 from ag2.files import FileProvider
 from ag2.response import ResponseProto
+from ag2.tools.builtin.anthropic_bash import ANTHROPIC_BASH_TOOL_NAME, AnthropicBashToolSchema
 from ag2.tools.builtin.code_execution import CodeExecutionToolSchema
 from ag2.tools.builtin.mcp_server import MCPServerToolSchema
 from ag2.tools.builtin.memory import MemoryToolSchema
@@ -155,6 +160,13 @@ def tool_to_api(t: ToolSchema) -> dict[str, Any]:
         # https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool
         return {"type": t.version, "name": "memory"}
 
+    elif isinstance(t, AnthropicBashToolSchema):
+        # https://platform.claude.com/docs/en/agents-and-tools/tool-use/bash-tool
+        # Client-executed: Anthropic returns a plain tool_use block and waits for
+        # a tool_result. AnthropicBashTool registers the executor under the same
+        # name, so the call is answered instead of raising ToolNotFound.
+        return {"type": t.version, "name": ANTHROPIC_BASH_TOOL_NAME}
+
     elif isinstance(t, ShellToolSchema):
         # Anthropic's bash tool is client-side — it ships a typed schema but the
         # application must execute the command itself and return a tool_result.
@@ -258,6 +270,67 @@ def _file_id_block_type(filename: str | None) -> str:
     return "document"
 
 
+def _tool_result_block(
+    result: "ToolResultEvent",
+    serializer: Any,
+    toolset_name: str | None = None,
+) -> dict[str, Any]:
+    """Render one tool result as an Anthropic ``tool_result`` block.
+
+    Shared by the wrapped (``ToolResultsEvent``) and loose paths so a result
+    renders identically whichever one carries it.
+    """
+    parts: list[dict[str, Any]] = []
+    for part in result.result.parts:
+        if isinstance(part, TextInput):
+            parts.append({"type": "text", "text": part.content})
+        elif isinstance(part, DataInput):
+            parts.append({"type": "text", "text": serializer.encode(part.data).decode()})
+        elif isinstance(part, BinaryInput):
+            if part.kind is BinaryType.IMAGE:
+                b64 = base64.b64encode(part.data).decode()
+                parts.append({
+                    "type": "image",
+                    "source": {"type": "base64", "media_type": part.media_type, "data": b64},
+                })
+            elif part.kind is BinaryType.DOCUMENT:
+                b64 = base64.b64encode(part.data).decode()
+                parts.append({
+                    "type": "document",
+                    "source": {"type": "base64", "media_type": part.media_type, "data": b64},
+                })
+            else:
+                raise UnsupportedInputError(f"BinaryInput({part.kind.value})", "anthropic")
+        elif isinstance(part, UrlInput):
+            if part.kind is BinaryType.IMAGE:
+                parts.append({"type": "image", "source": {"type": "url", "url": part.url}})
+            elif part.kind in (BinaryType.DOCUMENT, BinaryType.BINARY):
+                parts.append({"type": "document", "source": {"type": "url", "url": part.url}})
+            else:
+                raise UnsupportedInputError(f"UrlInput({part.kind.value})", "anthropic")
+        elif isinstance(part, FileIdInput):
+            parts.append({
+                "type": _file_id_block_type(part.filename),
+                "source": {"type": "file", "file_id": part.file_id},
+            })
+        else:
+            raise UnsupportedInputError(type(part).__name__, "anthropic")
+
+    if len(parts) == 1 and (only := parts[0])["type"] == "text":
+        content: str | list[dict[str, Any]] = only["text"]
+    else:
+        content = parts
+    block: dict[str, Any] = {"type": "tool_result", "tool_use_id": result.parent_id, "content": content}
+    if isinstance(result, ToolErrorEvent):
+        # Without this the model reads a traceback as a successful result.
+        block["is_error"] = True
+    if toolset_name is not None:
+        # The API refuses a tool_result answering a member tool_use that does not
+        # repeat the paired tool_use's toolset_name.
+        block["toolset_name"] = toolset_name
+    return block
+
+
 def has_file_id_references(messages: Iterable[BaseEvent]) -> bool:
     """True if any message (user turn or tool result) references a file_id.
 
@@ -284,10 +357,14 @@ def convert_messages(
     # drop orphaned tool_result blocks whose matching tool_use was
     # trimmed by a reduction policy (SlidingWindow, TokenBudget, etc.).
     valid_tool_ids: set[str] = set()
+    # A member tool_use's toolset_name has to be repeated on its tool_result.
+    toolset_names: dict[str, str] = {}
     for message in event_list:
         if isinstance(message, ModelResponse):
             for call in message.tool_calls.calls:
                 valid_tool_ids.add(call.id)
+                if name := call.vendor_metadata.get("toolset_name"):
+                    toolset_names[call.id] = name
 
     # Collect all parent_ids referenced by ToolResultsEvent blocks so we
     # can also drop orphaned tool_use blocks — the mirror case of the
@@ -351,16 +428,26 @@ def convert_messages(
                         call.name,
                     )
                     continue
-                content.append({
+                use_block: dict[str, Any] = {
                     "type": "tool_use",
                     "id": call.id,
                     "name": call.name,
                     "input": json.loads(call.arguments or "{}"),
-                })
+                }
+                for key in ("caller", "toolset_name"):
+                    if (value := call.vendor_metadata.get(key)) is not None:
+                        use_block[key] = value
+                content.append(use_block)
             if content:
                 result.append({"role": "assistant", "content": content})
 
-        elif isinstance(message, (AnthropicServerToolCallEvent, AnthropicServerToolResultEvent)):
+        # AnthropicRedactedThinkingEvent rides along: Anthropic requires the block
+        # echoed back unchanged. AnthropicContainerUploadEvent deliberately has no
+        # branch — the API refuses container_upload inside an assistant turn.
+        elif isinstance(
+            message,
+            (AnthropicServerToolCallEvent, AnthropicServerToolResultEvent, AnthropicRedactedThinkingEvent),
+        ):
             block = message.block.model_dump(exclude_none=True, mode="json")
             if result and result[-1]["role"] == "assistant":
                 result[-1]["content"].append(block)
@@ -377,52 +464,7 @@ def convert_messages(
                 # (e.g. unit-testing the rendering in isolation).
                 if valid_tool_ids and r.parent_id not in valid_tool_ids:
                     continue
-                parts: list[dict[str, Any]] = []
-                for part in r.result.parts:
-                    if isinstance(part, TextInput):
-                        parts.append({"type": "text", "text": part.content})
-                    elif isinstance(part, DataInput):
-                        parts.append({"type": "text", "text": serializer.encode(part.data).decode()})
-                    elif isinstance(part, BinaryInput):
-                        if part.kind is BinaryType.IMAGE:
-                            b64 = base64.b64encode(part.data).decode()
-                            parts.append({
-                                "type": "image",
-                                "source": {"type": "base64", "media_type": part.media_type, "data": b64},
-                            })
-                        elif part.kind is BinaryType.DOCUMENT:
-                            b64 = base64.b64encode(part.data).decode()
-                            parts.append({
-                                "type": "document",
-                                "source": {"type": "base64", "media_type": part.media_type, "data": b64},
-                            })
-                        else:
-                            raise UnsupportedInputError(f"BinaryInput({part.kind.value})", "anthropic")
-                    elif isinstance(part, UrlInput):
-                        if part.kind is BinaryType.IMAGE:
-                            parts.append({"type": "image", "source": {"type": "url", "url": part.url}})
-                        elif part.kind in (BinaryType.DOCUMENT, BinaryType.BINARY):
-                            parts.append({"type": "document", "source": {"type": "url", "url": part.url}})
-                        else:
-                            raise UnsupportedInputError(f"UrlInput({part.kind.value})", "anthropic")
-                    elif isinstance(part, FileIdInput):
-                        block_type = _file_id_block_type(part.filename)
-                        parts.append({
-                            "type": block_type,
-                            "source": {"type": "file", "file_id": part.file_id},
-                        })
-                    else:
-                        raise UnsupportedInputError(type(part).__name__, "anthropic")
-
-                if len(parts) == 1 and (part := parts[0])["type"] == "text":
-                    tool_content: str | list[dict[str, Any]] = part["text"]
-                else:
-                    tool_content = parts
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": r.parent_id,
-                    "content": tool_content,
-                })
+                tool_results.append(_tool_result_block(r, serializer, toolset_names.get(r.parent_id)))
             if tool_results:
                 emitted_result_ids.update(r["tool_use_id"] for r in tool_results)
                 result.append({"role": "user", "content": tool_results})
@@ -504,13 +546,7 @@ def convert_messages(
                 emitted_result_ids.add(parent)
                 result.append({
                     "role": "user",
-                    "content": [
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": parent,
-                            "content": message.content,
-                        }
-                    ],
+                    "content": [_tool_result_block(message, serializer, toolset_names.get(parent))],
                 })
 
     return result

--- a/ag2/events/tool_events.py
+++ b/ag2/events/tool_events.py
@@ -68,6 +68,10 @@ class ToolCallEvent(ToolEvent):
     id: str = Field(default_factory=lambda: str(uuid4()))
     name: str = Field(kw_only=False)
     arguments: str = "{}"
+    # Provider-native fields with no home on this event that the provider needs
+    # back verbatim (Anthropic's ``caller`` / ``toolset_name``). Same role as
+    # ``BinaryInput.vendor_metadata``.
+    vendor_metadata: dict[str, Any] = Field(default_factory=dict)
 
     _serialized_arguments: dict[str, Any] | None = Field(default=None, init=False, compare=False)
 

--- a/ag2/tools/__init__.py
+++ b/ag2/tools/__init__.py
@@ -5,6 +5,7 @@
 from ag2.events import ToolResult
 
 from .builtin import (
+    AnthropicBashTool,
     CodeExecutionTool,
     ContainerAutoEnvironment,
     ContainerReferenceEnvironment,
@@ -31,6 +32,7 @@ from .skills import MemorySkill, SkillPlugin, SkillSearchToolkit, SkillsToolkit
 from .toolkits import FilesystemToolkit, MCPServerConfig, MCPStdioServerConfig, MCPToolkit
 
 __all__ = (
+    "AnthropicBashTool",
     "CodeExecutionTool",
     "ContainerAutoEnvironment",
     "ContainerReferenceEnvironment",

--- a/ag2/tools/builtin/__init__.py
+++ b/ag2/tools/builtin/__init__.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from .anthropic_bash import AnthropicBashTool
 from .code_execution import CodeExecutionTool
 from .file_search import FileSearchTool
 from .google_maps import GoogleMapsTool
@@ -17,6 +18,7 @@ from .web_search import UserLocation, WebSearchTool
 from .x_search import XSearchTool
 
 __all__ = (
+    "AnthropicBashTool",
     "CodeExecutionTool",
     "ContainerAutoEnvironment",
     "ContainerReferenceEnvironment",

--- a/ag2/tools/builtin/anthropic_bash.py
+++ b/ag2/tools/builtin/anthropic_bash.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterable
+from contextlib import AsyncExitStack, ExitStack
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from ag2.annotations import Context
+from ag2.events import ToolCallEvent, ToolErrorEvent, ToolResultEvent
+from ag2.middleware import BaseMiddleware, ToolExecution, ToolMiddleware, ToolResultType
+from ag2.tools.schemas import ToolSchema
+from ag2.tools.tool import Tool
+
+if TYPE_CHECKING:
+    from ag2.tools.sandbox import SandboxFactory
+
+# The name Anthropic puts on the wire for ``bash_20250124``. It is also the
+# schema ``type``, so ``known_tools`` (which stores ``schema.type`` for
+# non-function schemas) matches the incoming ``ToolCallEvent.name`` and the
+# executor below is reached instead of the not-found guard.
+ANTHROPIC_BASH_TOOL_NAME = "bash"
+
+
+@dataclass(slots=True)
+class AnthropicBashToolSchema(ToolSchema):
+    """Anthropic's client-executed bash tool.
+
+    Unlike the other entries under ``ag2/tools/builtin/``, this is not a
+    provider-executed capability flag: Anthropic sends a plain ``tool_use``
+    block and waits for a ``tool_result``.
+    """
+
+    type: str = field(default=ANTHROPIC_BASH_TOOL_NAME, init=False)
+    version: Literal["bash_20250124"] = "bash_20250124"
+
+
+class AnthropicBashTool(Tool):
+    """Anthropic's ``bash_20250124`` tool, executed by ag2.
+
+    Declares Anthropic's typed schema and runs the commands it asks for through
+    the same :class:`~ag2.tools.sandbox.adapter.ShellAdapter` that backs
+    :class:`~ag2.tools.SandboxShellTool`, so the backend choice and the
+    ``allowed`` / ``blocked`` / ``readonly`` policy are unchanged.
+
+    Anthropic-only: every other provider's mapper rejects this schema.
+
+    Args:
+        environment: Execution backend; ``None`` means a local subprocess.
+        allowed / blocked / ignore / readonly: command filter set, as on
+            :class:`~ag2.tools.SandboxShellTool`.
+    """
+
+    __slots__ = ("name", "_adapter", "_schema")
+
+    def __init__(
+        self,
+        environment: "SandboxFactory | None" = None,
+        *,
+        allowed: list[str] | None = None,
+        blocked: list[str] | None = None,
+        ignore: list[str] | None = None,
+        readonly: bool = False,
+    ) -> None:
+        # Imported here, not at module scope: ``ag2/tools/builtin`` is pulled in
+        # early (ag2.config -> client -> tools/__init__ -> builtin) while
+        # ``ag2.tools.sandbox`` imports ``ag2.tools.code``, which imports
+        # ``ag2.tools.sandbox`` back. A module-level import deadlocks that cycle.
+        from ag2.tools.sandbox import LocalEnvironment
+        from ag2.tools.sandbox.adapter import ShellAdapter
+
+        backend: SandboxFactory = environment if environment is not None else LocalEnvironment()
+        self._adapter = ShellAdapter(
+            backend,
+            allowed=allowed,
+            blocked=blocked,
+            ignore=ignore,
+            readonly=readonly,
+        )
+        self._schema = AnthropicBashToolSchema()
+        self.name = ANTHROPIC_BASH_TOOL_NAME
+
+    async def schemas(self, context: "Context") -> list[ToolSchema]:
+        return [self._schema]
+
+    async def __call__(self, event: "ToolCallEvent", context: "Context") -> "ToolResultEvent":
+        args = event.serialized_arguments
+        try:
+            if args.get("restart"):
+                # The adapter opens a sandbox per ``run``, so there is no session
+                # to restart. Say so rather than claim a restart that never happened.
+                result = "No persistent bash session to restart; each command runs in a fresh sandbox."
+            else:
+                result = await self._adapter.run(args.get("command", ""), context=context)
+            return ToolResultEvent.from_call(event, result=result)
+        except Exception as e:
+            return ToolErrorEvent.from_call(event, error=e)
+
+    def register(
+        self,
+        stack: "ExitStack | AsyncExitStack",
+        context: "Context",
+        *,
+        middleware: Iterable["BaseMiddleware"] = (),
+    ) -> None:
+        def wrap(hook: "ToolMiddleware", inner: "ToolExecution") -> "ToolExecution":
+            async def call(event: "ToolCallEvent", context: "Context") -> "ToolResultType":
+                return await hook(inner, event, context)
+
+            return call
+
+        # This tool runs model-authored shell commands, so the agent's governance
+        # and telemetry hooks have to wrap it like any other executing tool.
+        execution: ToolExecution = self
+        for mw in middleware:
+            execution = wrap(mw.on_tool_execution, execution)
+
+        async def execute(event: "ToolCallEvent", context: "Context") -> None:
+            await context.send(await execution(event, context))
+
+        stack.enter_context(
+            context.stream.where(ToolCallEvent.name == ANTHROPIC_BASH_TOOL_NAME).sub_scope(execute),
+        )

--- a/test/config/anthropic/_helpers.py
+++ b/test/config/anthropic/_helpers.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from anthropic.types import Message, Usage
+
+
+class FakeStream:
+    """Stand-in for Anthropic's streaming context manager.
+
+    Yields the given raw stream events, then answers ``get_final_message`` with an
+    empty assistant message — the client reads the blocks off the events, not off
+    the final message.
+    """
+
+    def __init__(self, events: list[Any], *, stop_reason: str = "end_turn") -> None:
+        self._events = events
+        self._stop_reason = stop_reason
+
+    def __aiter__(self) -> Any:
+        async def gen() -> Any:
+            for e in self._events:
+                yield e
+
+        return gen()
+
+    async def get_final_message(self) -> Message:
+        return Message.model_construct(
+            id="m1",
+            type="message",
+            role="assistant",
+            model="claude-sonnet-5",
+            content=[],
+            usage=Usage(input_tokens=1, output_tokens=1),
+            stop_reason=self._stop_reason,
+        )

--- a/test/config/anthropic/test_convert_messages.py
+++ b/test/config/anthropic/test_convert_messages.py
@@ -35,6 +35,7 @@ from ag2.events import (
     TextInput,
     ToolCallEvent,
     ToolCallsEvent,
+    ToolErrorEvent,
     ToolNotFoundEvent,
     ToolResultEvent,
     ToolResultsEvent,
@@ -868,6 +869,8 @@ def test_hallucinated_tool_call_maps_with_error_text() -> None:
                     "type": "tool_result",
                     "tool_use_id": "tc_1",
                     "content": "ag2.exceptions.ToolNotFoundError: Tool `ghost_tool` not found\n",
+                    # ToolNotFoundEvent is a ToolErrorEvent: the model must see a failure.
+                    "is_error": True,
                 }
             ],
         }
@@ -880,3 +883,151 @@ def test_compaction_summary_renders_as_user_turn() -> None:
     result = convert_messages([summary], SerializerCls)
 
     assert result == [{"role": "user", "content": "[Summary of earlier conversation]\nLooked up Paris and Tokyo."}]
+
+
+class TestLooseToolResultEvent:
+    """A ToolResultEvent that arrives without its ToolResultsEvent wrapper.
+
+    mappers.py handles this because the wrapper can fail to persist; the
+    fallback must render the same block the wrapped path does.
+    """
+
+    PNG = b"\x89PNG\r\n"
+
+    def test_text_result_renders(self) -> None:
+        events = [
+            _model_response_with_tool_call('{"n": 1}'),
+            ToolResultEvent(parent_id="tc_1", result=ToolResult("ok")),
+        ]
+
+        assert convert_messages(events, SerializerCls)[-1] == {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "tc_1", "content": "ok"}],
+        }
+
+    def test_non_text_parts_render_like_the_wrapped_path(self) -> None:
+        image = ImageInput(data=self.PNG, media_type="image/png")
+        wrapped = convert_messages(
+            [
+                _model_response_with_tool_call(None),
+                ToolResultsEvent(results=[ToolResultEvent(parent_id="tc_1", result=ToolResult(image))]),
+            ],
+            SerializerCls,
+        )
+        loose = convert_messages(
+            [_model_response_with_tool_call(None), ToolResultEvent(parent_id="tc_1", result=ToolResult(image))],
+            SerializerCls,
+        )
+
+        assert loose == wrapped
+
+    def test_tool_error_event_renders(self) -> None:
+        error = ToolErrorEvent.from_call(ToolCallEvent(id="tc_1", name="list_items"), ValueError("boom"))
+        events = [_model_response_with_tool_call(None), error]
+
+        assert convert_messages(events, SerializerCls)[-1] == {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "tc_1", "content": "ValueError: boom\n", "is_error": True}
+            ],
+        }
+
+    def test_wrapper_still_wins_when_both_are_present(self) -> None:
+        loose = ToolResultEvent(parent_id="tc_1", result=ToolResult("ok"))
+        events = [_model_response_with_tool_call(None), loose, _matching_tool_result()]
+
+        results = [m for m in convert_messages(events, SerializerCls) if m["role"] == "user"]
+        assert len(results) == 1
+
+
+class TestToolErrorIsError:
+    """A failed tool must reach the model as ``is_error``, not as a successful result."""
+
+    def test_error_sets_is_error(self) -> None:
+        error = ToolErrorEvent.from_call(ToolCallEvent(id="tc_1", name="t"), ValueError("boom"))
+
+        assert convert_messages([ToolResultsEvent(results=[error])], SerializerCls) == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tc_1", "content": "ValueError: boom\n", "is_error": True}
+                ],
+            }
+        ]
+
+    def test_success_has_no_is_error(self) -> None:
+        ok = ToolResultEvent(parent_id="tc_1", name="t", result=ToolResult("fine"))
+
+        assert convert_messages([ToolResultsEvent(results=[ok])], SerializerCls) == [
+            {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tc_1", "content": "fine"}]}
+        ]
+
+    def test_loose_error_sets_is_error(self) -> None:
+        error = ToolErrorEvent.from_call(ToolCallEvent(id="tc_1", name="list_items"), ValueError("boom"))
+
+        assert convert_messages([_model_response_with_tool_call(None), error], SerializerCls)[-1] == {
+            "role": "user",
+            "content": [IsPartialDict({"tool_use_id": "tc_1", "is_error": True})],
+        }
+
+
+class TestToolUseVendorMetadata:
+    """``caller`` and ``toolset_name`` ride on ToolCallEvent.vendor_metadata.
+
+    ``caller`` says whether the model asked directly or a server tool did (the
+    ``allowed_callers`` feature of ``bash_20250124``). ``toolset_name`` is
+    mandatory on the way back for a browser/computer member tool: the API answers
+    400 "a tool_result answering a member tool_use must carry the paired
+    tool_use's toolset_name". Both round-trip cleanly (verified live).
+    """
+
+    def _response(self, **vendor: object) -> ModelResponse:
+        return ModelResponse(
+            message=None,
+            tool_calls=ToolCallsEvent(
+                calls=[ToolCallEvent(id="tc_1", name="navigate", arguments="{}", vendor_metadata=dict(vendor))],
+            ),
+        )
+
+    def test_caller_replays_on_the_tool_use(self) -> None:
+        events = [
+            self._response(caller={"type": "code_execution_20250825", "tool_id": "srvtoolu_1"}),
+            _matching_tool_result(),
+        ]
+
+        assert convert_messages(events, SerializerCls)[0] == {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tc_1",
+                    "name": "navigate",
+                    "input": {},
+                    "caller": {"type": "code_execution_20250825", "tool_id": "srvtoolu_1"},
+                }
+            ],
+        }
+
+    def test_toolset_name_replays_on_both_sides(self) -> None:
+        events = [self._response(toolset_name="browser"), _matching_tool_result()]
+
+        assert convert_messages(events, SerializerCls) == [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "tc_1", "name": "navigate", "input": {}, "toolset_name": "browser"}
+                ],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "tc_1", "content": "ok", "toolset_name": "browser"}],
+            },
+        ]
+
+    def test_nothing_added_when_absent(self) -> None:
+        events = [self._response(), _matching_tool_result()]
+
+        assert convert_messages(events, SerializerCls) == [
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "tc_1", "name": "navigate", "input": {}}]},
+            {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tc_1", "content": "ok"}]},
+        ]

--- a/test/config/anthropic/test_dropped_blocks.py
+++ b/test/config/anthropic/test_dropped_blocks.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Block types the response loop used to drop without a trace.
+
+The loop had no ``else``, so an unrecognized block produced no event, no warning
+and no history entry. Two stable ``ContentBlock`` arms fell through it.
+
+Replay behaviour was measured against the live API:
+
+- ``redacted_thinking`` is permitted in an assistant turn (a bogus ``data`` is
+  rejected as ``Invalid `data` in `redacted_thinking` block``, i.e. the shape is
+  accepted) and Anthropic's own docs require it echoed back unchanged.
+- ``container_upload`` is refused: ``'container_upload' blocks are not permitted
+  within assistant turns``. It must be recorded but never replayed.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+import pytest
+from anthropic.types import ContainerUploadBlock, Message, RedactedThinkingBlock, TextBlock, Usage
+from fast_depends.use import SerializerCls
+
+from ag2 import Context, MemoryStream
+from ag2.config.anthropic import AnthropicClient
+from ag2.config.anthropic.events import AnthropicContainerUploadEvent, AnthropicRedactedThinkingEvent
+from ag2.config.anthropic.mappers import convert_messages
+from ag2.events import BaseEvent, ModelResponse
+
+REDACTED = RedactedThinkingBlock(data="EroBCkYIBBgCKkA...", type="redacted_thinking")
+UPLOAD = ContainerUploadBlock(file_id="file_011CQ7", type="container_upload")
+
+
+async def _process(content: Iterable[Any]) -> tuple[ModelResponse, list[BaseEvent]]:
+    client = AnthropicClient(api_key="test", prompt_caching=False)
+    message = Message.model_construct(
+        id="m1",
+        type="message",
+        role="assistant",
+        model="claude-sonnet-5",
+        content=list(content),
+        usage=Usage(input_tokens=10, output_tokens=20),
+        stop_reason="end_turn",
+    )
+    stream = MemoryStream()
+    response = await client._process_response(message, Context(stream=stream))
+    return response, list(await stream.history.get_events())
+
+
+@pytest.mark.asyncio
+async def test_redacted_thinking_is_recorded() -> None:
+    _, events = await _process([REDACTED, TextBlock(text="ok", type="text")])
+
+    assert AnthropicRedactedThinkingEvent(block=REDACTED) in events
+
+
+@pytest.mark.asyncio
+async def test_container_upload_is_recorded() -> None:
+    _, events = await _process([UPLOAD, TextBlock(text="ok", type="text")])
+
+    [event] = [e for e in events if isinstance(e, AnthropicContainerUploadEvent)]
+    assert event.file_id == "file_011CQ7"
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_block_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    class FutureBlock:
+        type = "something_anthropic_adds_next"
+
+    with caplog.at_level("WARNING"):
+        await _process([FutureBlock()])
+
+    assert "something_anthropic_adds_next" in caplog.text
+
+
+def test_redacted_thinking_replays_verbatim() -> None:
+    result = convert_messages([AnthropicRedactedThinkingEvent(block=REDACTED)], SerializerCls)
+
+    assert result == [{"role": "assistant", "content": [{"data": "EroBCkYIBBgCKkA...", "type": "redacted_thinking"}]}]
+
+
+def test_container_upload_is_never_replayed() -> None:
+    # The API refuses it inside an assistant turn; replaying would 400 the next request.
+    assert convert_messages([AnthropicContainerUploadEvent(block=UPLOAD)], SerializerCls) == []

--- a/test/config/anthropic/test_streaming_blocks.py
+++ b/test/config/anthropic/test_streaming_blocks.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The streaming path must record what the non-streaming path records.
+
+``server_tool_use`` input arrives as ``input_json_delta`` chunks. Building the
+event at ``content_block_start`` captures ``input={}``, and that empty block is
+what gets replayed. Measured live on the same prompt: ``streaming=True`` replayed
+``{"input": {}, "name": "web_search"}`` where ``streaming=False`` replayed
+``{"input": {"query": "capital of Iceland"}}``.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from anthropic.types import ContainerUploadBlock, RedactedThinkingBlock, ServerToolUseBlock
+
+from ag2 import Context, MemoryStream
+from ag2.config.anthropic import AnthropicClient
+from ag2.config.anthropic.events import (
+    AnthropicContainerUploadEvent,
+    AnthropicRedactedThinkingEvent,
+    AnthropicServerToolCallEvent,
+)
+from ag2.events import BaseEvent
+from test.config.anthropic._helpers import FakeStream
+
+
+def _start(block: Any) -> Any:
+    return SimpleNamespace(type="content_block_start", content_block=block)
+
+
+def _json_delta(partial: str) -> Any:
+    return SimpleNamespace(
+        type="content_block_delta", delta=SimpleNamespace(type="input_json_delta", partial_json=partial)
+    )
+
+
+def _stop() -> Any:
+    return SimpleNamespace(type="content_block_stop")
+
+
+async def _stream(events: list[Any]) -> list[BaseEvent]:
+    client = AnthropicClient(api_key="test", prompt_caching=False)
+    stream = MemoryStream()
+    await client._process_stream(FakeStream(events), Context(stream=stream))
+    return list(await stream.history.get_events())
+
+
+@pytest.mark.asyncio
+async def test_server_tool_use_input_is_accumulated() -> None:
+    block = ServerToolUseBlock(id="srvtoolu_1", name="web_search", input={}, type="server_tool_use")
+
+    events = await _stream([
+        _start(block),
+        _json_delta('{"query": "capital '),
+        _json_delta('of Iceland"}'),
+        _stop(),
+    ])
+
+    [call] = [e for e in events if isinstance(e, AnthropicServerToolCallEvent)]
+    assert call.block.input == {"query": "capital of Iceland"}
+    assert call.arguments == '{"query": "capital of Iceland"}'
+
+
+@pytest.mark.asyncio
+async def test_redacted_thinking_is_recorded() -> None:
+    block = RedactedThinkingBlock(data="EroBCkYIBBgCKkA...", type="redacted_thinking")
+
+    events = await _stream([_start(block), _stop()])
+
+    assert AnthropicRedactedThinkingEvent(block=block) in events
+
+
+@pytest.mark.asyncio
+async def test_container_upload_is_recorded() -> None:
+    block = ContainerUploadBlock(file_id="file_011CQ7", type="container_upload")
+
+    events = await _stream([_start(block), _stop()])
+
+    [event] = [e for e in events if isinstance(e, AnthropicContainerUploadEvent)]
+    assert event.file_id == "file_011CQ7"
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_block_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("WARNING"):
+        await _stream([_start(SimpleNamespace(type="something_anthropic_adds_next")), _stop()])
+
+    assert "something_anthropic_adds_next" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_truncated_server_tool_input_does_not_fail_the_turn(caplog: pytest.LogCaptureFixture) -> None:
+    # max_tokens can cut a block mid-JSON. Accumulating the input must not turn
+    # that into a JSONDecodeError escaping the whole stream.
+    block = ServerToolUseBlock(id="srvtoolu_1", name="web_search", input={}, type="server_tool_use")
+
+    with caplog.at_level("WARNING"):
+        events = await _stream([_start(block), _json_delta('{"query": "capi'), _stop()])
+
+    [call] = [e for e in events if isinstance(e, AnthropicServerToolCallEvent)]
+    assert call.block.input == {}
+    assert "srvtoolu_1" in caplog.text

--- a/test/config/anthropic/test_text_blocks.py
+++ b/test/config/anthropic/test_text_blocks.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Anthropic splits one answer across several ``TextBlock``s whenever citations
+are on, which web search always is. ``ModelResponse.message`` holds a single
+``ModelMessage``, so only the last block survives and ``reply.body`` returns a
+trailing fragment instead of the answer.
+
+Measured against the live API: asked for the capital of Iceland with
+``WebSearchTool``, Anthropic returned 5 text blocks totalling 350 characters
+starting "The capital of Iceland is Reykjavík"; ``reply.body`` was the 84-character
+block "The city and its suburbs account for about two-thirds of Iceland's total
+population."
+
+The assertion below states the requirement, not a fix: no text the provider sent
+may be missing from the durable record. How to satisfy it is open — it needs a
+representation for a multi-block answer, which no model event currently has
+(``ModelMessage.content`` is a single ``str``). The same defect is in
+``openai_responses_client.py`` (last ``part`` wins) while ``gemini_client.py``
+and ``mistral_client.py`` concatenate in the client instead.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+import pytest
+from anthropic.types import Message, TextBlock, Usage
+
+from ag2 import Context, MemoryStream
+from ag2.config.anthropic import AnthropicClient
+from ag2.events import ModelResponse
+
+
+async def _process(content: Iterable[Any]) -> ModelResponse:
+    client = AnthropicClient(api_key="test", prompt_caching=False)
+    message = Message.model_construct(
+        id="m1",
+        type="message",
+        role="assistant",
+        model="claude-sonnet-5",
+        content=list(content),
+        usage=Usage(input_tokens=10, output_tokens=20),
+        stop_reason="end_turn",
+    )
+    return await client._process_response(message, Context(stream=MemoryStream()))
+
+
+@pytest.mark.asyncio
+async def test_single_text_block() -> None:
+    response = await _process([TextBlock(text="Reykjavík.", type="text")])
+
+    assert response.content == "Reykjavík."
+
+
+@pytest.mark.xfail(reason="no representation for a multi-block answer; see module docstring", strict=True)
+@pytest.mark.asyncio
+async def test_no_text_the_provider_sent_is_lost() -> None:
+    blocks = [
+        TextBlock(text="The capital of Iceland is Reykjavík.", type="text"),
+        TextBlock(text=" ", type="text"),
+        TextBlock(text="It sits on Faxa Bay.", type="text"),
+    ]
+
+    response = await _process(blocks)
+
+    assert response.content is not None
+    for block in blocks:
+        assert block.text.strip() in response.content

--- a/test/config/anthropic/test_tool_use_fidelity.py
+++ b/test/config/anthropic/test_tool_use_fidelity.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``ToolUseBlock`` carries more than id/name/input.
+
+``caller`` distinguishes a call the model made directly from one a server tool
+made (``bash_20250124`` accepts ``allowed_callers``), and ``toolset_name`` is
+mandatory on the tool_result of a browser/computer member tool. Both must survive
+the round trip, so both paths park them on ``vendor_metadata``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from anthropic.types import Message, ToolUseBlock, Usage
+
+from ag2 import Context, MemoryStream
+from ag2.config.anthropic import AnthropicClient
+from ag2.events import ModelResponse
+from test.config.anthropic._helpers import FakeStream
+
+BLOCK = ToolUseBlock.model_construct(
+    id="toolu_1",
+    name="navigate",
+    input={"url": "https://example.com"},
+    type="tool_use",
+    caller={"type": "direct"},
+    toolset_name="browser",
+)
+
+
+async def _non_streaming() -> ModelResponse:
+    client = AnthropicClient(api_key="test", prompt_caching=False)
+    message = Message.model_construct(
+        id="m1",
+        type="message",
+        role="assistant",
+        model="claude-sonnet-5",
+        content=[BLOCK],
+        usage=Usage(input_tokens=1, output_tokens=1),
+        stop_reason="tool_use",
+    )
+    return await client._process_response(message, Context(stream=MemoryStream()))
+
+
+async def _streaming() -> ModelResponse:
+    client = AnthropicClient(api_key="test", prompt_caching=False)
+    events = [
+        SimpleNamespace(type="content_block_start", content_block=BLOCK),
+        SimpleNamespace(
+            type="content_block_delta",
+            delta=SimpleNamespace(type="input_json_delta", partial_json='{"url": "https://example.com"}'),
+        ),
+        SimpleNamespace(type="content_block_stop"),
+    ]
+    return await client._process_stream(FakeStream(events, stop_reason="tool_use"), Context(stream=MemoryStream()))
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_keeps_caller_and_toolset_name() -> None:
+    [call] = (await _non_streaming()).tool_calls.calls
+
+    assert call.vendor_metadata == {"caller": {"type": "direct"}, "toolset_name": "browser"}
+
+
+@pytest.mark.asyncio
+async def test_streaming_keeps_caller_and_toolset_name() -> None:
+    [call] = (await _streaming()).tool_calls.calls
+
+    assert call.vendor_metadata == {"caller": {"type": "direct"}, "toolset_name": "browser"}
+
+
+@pytest.mark.asyncio
+async def test_plain_tool_use_stays_empty() -> None:
+    client = AnthropicClient(api_key="test", prompt_caching=False)
+    plain = ToolUseBlock(id="toolu_2", name="my_func", input={"x": 1}, type="tool_use")
+    message = Message.model_construct(
+        id="m1",
+        type="message",
+        role="assistant",
+        model="claude-sonnet-5",
+        content=[plain],
+        usage=Usage(input_tokens=1, output_tokens=1),
+        stop_reason="tool_use",
+    )
+
+    [call] = (await client._process_response(message, Context(stream=MemoryStream()))).tool_calls.calls
+    assert call.vendor_metadata == {}

--- a/test/config/anthropic/tools/test_anthropic_bash.py
+++ b/test/config/anthropic/tools/test_anthropic_bash.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import ExitStack
+
+import pytest
+
+from ag2 import Context, MemoryStream, ToolResult
+from ag2.config.anthropic.mappers import tool_to_api
+from ag2.events import ToolCallEvent, ToolResultEvent
+from ag2.exceptions import UnsupportedToolError
+from ag2.middleware import BaseMiddleware, ToolExecution
+from ag2.tools.builtin.anthropic_bash import AnthropicBashTool
+from ag2.tools.builtin.shell import ShellTool
+from ag2.tools.sandbox import LocalEnvironment
+
+
+@pytest.mark.asyncio
+async def test_defaults(context: Context) -> None:
+    tool = AnthropicBashTool()
+
+    [schema] = await tool.schemas(context)
+
+    assert tool_to_api(schema) == {"type": "bash_20250124", "name": "bash"}
+
+
+@pytest.mark.asyncio
+async def test_schema_type_matches_the_wire_name(context: Context) -> None:
+    # ``known_tools`` stores ``schema.type`` for non-function schemas, and the
+    # incoming ToolCallEvent carries Anthropic's wire name. They must be equal
+    # or every call trips the not-found guard instead of reaching the executor.
+    tool = AnthropicBashTool()
+
+    [schema] = await tool.schemas(context)
+
+    assert schema.type == tool_to_api(schema)["name"] == tool.name
+
+
+@pytest.mark.asyncio
+async def test_shell_tool_is_still_rejected(context: Context) -> None:
+    # ShellTool is the provider-executed capability flag; Anthropic's bash is
+    # client-executed. Adding the latter must not make the former mappable.
+    [schema] = await ShellTool().schemas(context)
+
+    with pytest.raises(UnsupportedToolError):
+        tool_to_api(schema)
+
+
+@pytest.mark.asyncio
+async def test_middleware_wraps_execution(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # The tool runs model-authored shell commands, so a governance/telemetry
+    # middleware must see the call. Ignoring the argument silently bypassed it.
+    seen: list[str] = []
+
+    class Deny(BaseMiddleware):
+        async def on_tool_execution(
+            self, call_next: ToolExecution, event: ToolCallEvent, context: Context
+        ) -> ToolResultEvent:
+            seen.append(event.name)
+            return ToolResultEvent.from_call(event, result="denied by policy")
+
+    stream = MemoryStream()
+    context = Context(stream=stream)
+    tool = AnthropicBashTool(LocalEnvironment(str(tmp_path)))
+    call = ToolCallEvent(id="tc_1", name="bash", arguments='{"command": "echo hi"}')
+
+    with ExitStack() as stack:
+        tool.register(stack, context, middleware=[Deny(call, context)])
+        async with context.stream.get(ToolResultEvent.parent_id == "tc_1") as pending:
+            await context.send(call)
+            result = await pending
+
+    assert seen == ["bash"]
+    assert result.result == ToolResult("denied by policy")

--- a/test/config/bedrock/tools/test_unsupported.py
+++ b/test/config/bedrock/tools/test_unsupported.py
@@ -7,6 +7,7 @@ import pytest
 from ag2 import Context
 from ag2.config.bedrock.mappers import tool_to_api
 from ag2.exceptions import UnsupportedToolError
+from ag2.tools.builtin.anthropic_bash import AnthropicBashTool
 from ag2.tools.builtin.code_execution import CodeExecutionTool
 from ag2.tools.builtin.file_search import FileSearchTool
 from ag2.tools.builtin.google_maps import GoogleMapsTool
@@ -134,6 +135,16 @@ async def test_file_search(context: Context) -> None:
 @pytest.mark.asyncio
 async def test_google_maps(context: Context) -> None:
     tool = GoogleMapsTool()
+
+    [schema] = await tool.schemas(context)
+
+    with pytest.raises(UnsupportedToolError):
+        tool_to_api(schema)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_bash(context: Context) -> None:
+    tool = AnthropicBashTool()
 
     [schema] = await tool.schemas(context)
 

--- a/test/config/dashscope/tools/test_unsupported.py
+++ b/test/config/dashscope/tools/test_unsupported.py
@@ -7,6 +7,7 @@ import pytest
 from ag2 import Context
 from ag2.config.dashscope.mappers import tool_to_api
 from ag2.exceptions import UnsupportedToolError
+from ag2.tools.builtin.anthropic_bash import AnthropicBashTool
 from ag2.tools.builtin.code_execution import CodeExecutionTool
 from ag2.tools.builtin.file_search import FileSearchTool
 from ag2.tools.builtin.google_maps import GoogleMapsTool
@@ -134,6 +135,16 @@ async def test_file_search(context: Context) -> None:
 @pytest.mark.asyncio
 async def test_google_maps(context: Context) -> None:
     tool = GoogleMapsTool()
+
+    [schema] = await tool.schemas(context)
+
+    with pytest.raises(UnsupportedToolError):
+        tool_to_api(schema)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_bash(context: Context) -> None:
+    tool = AnthropicBashTool()
 
     [schema] = await tool.schemas(context)
 

--- a/test/config/gemini/tools/test_unsupported.py
+++ b/test/config/gemini/tools/test_unsupported.py
@@ -7,6 +7,7 @@ import pytest
 from ag2 import Context
 from ag2.config.gemini.mappers import build_tools
 from ag2.exceptions import UnsupportedToolError
+from ag2.tools.builtin.anthropic_bash import AnthropicBashTool
 from ag2.tools.builtin.file_search import FileSearchTool
 from ag2.tools.builtin.image_generation import ImageGenerationTool
 from ag2.tools.builtin.mcp_server import MCPServerTool
@@ -90,6 +91,16 @@ async def test_retrieval(context: Context) -> None:
 @pytest.mark.asyncio
 async def test_file_search(context: Context) -> None:
     tool = FileSearchTool(vector_store_ids=["vs_1"])
+
+    [schema] = await tool.schemas(context)
+
+    with pytest.raises(UnsupportedToolError):
+        build_tools([schema])
+
+
+@pytest.mark.asyncio
+async def test_anthropic_bash(context: Context) -> None:
+    tool = AnthropicBashTool()
 
     [schema] = await tool.schemas(context)
 

--- a/test/config/mistral/tools/test_unsupported.py
+++ b/test/config/mistral/tools/test_unsupported.py
@@ -12,6 +12,7 @@ import pytest
 from ag2 import Context
 from ag2.config.mistral.mappers import tool_to_api
 from ag2.exceptions import UnsupportedToolError
+from ag2.tools.builtin.anthropic_bash import AnthropicBashTool
 from ag2.tools.builtin.code_execution import CodeExecutionTool
 from ag2.tools.builtin.file_search import FileSearchTool
 from ag2.tools.builtin.google_maps import GoogleMapsTool
@@ -119,6 +120,15 @@ async def test_retrieval(context: Context) -> None:
 
 async def test_google_maps(context: Context) -> None:
     tool = GoogleMapsTool()
+
+    [schema] = await tool.schemas(context)
+
+    with pytest.raises(UnsupportedToolError, match="mistral"):
+        tool_to_api(schema)
+
+
+async def test_anthropic_bash(context: Context) -> None:
+    tool = AnthropicBashTool()
 
     [schema] = await tool.schemas(context)
 

--- a/test/config/ollama/tools/test_unsupported.py
+++ b/test/config/ollama/tools/test_unsupported.py
@@ -7,6 +7,7 @@ import pytest
 from ag2 import Context
 from ag2.config.ollama.mappers import tool_to_api
 from ag2.exceptions import UnsupportedToolError
+from ag2.tools.builtin.anthropic_bash import AnthropicBashTool
 from ag2.tools.builtin.code_execution import CodeExecutionTool
 from ag2.tools.builtin.file_search import FileSearchTool
 from ag2.tools.builtin.google_maps import GoogleMapsTool
@@ -134,6 +135,16 @@ async def test_file_search(context: Context) -> None:
 @pytest.mark.asyncio
 async def test_google_maps(context: Context) -> None:
     tool = GoogleMapsTool()
+
+    [schema] = await tool.schemas(context)
+
+    with pytest.raises(UnsupportedToolError):
+        tool_to_api(schema)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_bash(context: Context) -> None:
+    tool = AnthropicBashTool()
 
     [schema] = await tool.schemas(context)
 

--- a/test/config/openai/tools/test_unsupported.py
+++ b/test/config/openai/tools/test_unsupported.py
@@ -7,6 +7,7 @@ import pytest
 from ag2 import Context
 from ag2.config.openai.mappers import tool_to_api, tool_to_responses_api
 from ag2.exceptions import UnsupportedToolError
+from ag2.tools.builtin.anthropic_bash import AnthropicBashTool
 from ag2.tools.builtin.code_execution import CodeExecutionTool
 from ag2.tools.builtin.file_search import FileSearchTool
 from ag2.tools.builtin.google_maps import GoogleMapsTool
@@ -130,6 +131,15 @@ class TestCompletionsApi:
         with pytest.raises(UnsupportedToolError):
             tool_to_api(schema)
 
+    @pytest.mark.asyncio
+    async def test_anthropic_bash(self, context: Context) -> None:
+        tool = AnthropicBashTool()
+
+        [schema] = await tool.schemas(context)
+
+        with pytest.raises(UnsupportedToolError):
+            tool_to_api(schema)
+
 
 class TestResponsesApi:
     @pytest.mark.asyncio
@@ -171,6 +181,15 @@ class TestResponsesApi:
     @pytest.mark.asyncio
     async def test_google_maps(self, context: Context) -> None:
         tool = GoogleMapsTool()
+
+        [schema] = await tool.schemas(context)
+
+        with pytest.raises(UnsupportedToolError):
+            tool_to_responses_api(schema)
+
+    @pytest.mark.asyncio
+    async def test_anthropic_bash(self, context: Context) -> None:
+        tool = AnthropicBashTool()
 
         [schema] = await tool.schemas(context)
 

--- a/test/config/xai/tools/test_unsupported.py
+++ b/test/config/xai/tools/test_unsupported.py
@@ -7,6 +7,7 @@ import pytest
 from ag2 import Context
 from ag2.config.xai.mappers import tool_to_api
 from ag2.exceptions import UnsupportedToolError
+from ag2.tools.builtin.anthropic_bash import AnthropicBashTool
 from ag2.tools.builtin.file_search import FileSearchTool
 from ag2.tools.builtin.google_maps import GoogleMapsTool
 from ag2.tools.builtin.image_generation import ImageGenerationTool
@@ -90,6 +91,16 @@ async def test_file_search(context: Context) -> None:
 @pytest.mark.asyncio
 async def test_google_maps(context: Context) -> None:
     tool = GoogleMapsTool()
+
+    [schema] = await tool.schemas(context)
+
+    with pytest.raises(UnsupportedToolError, match="xai"):
+        tool_to_api(schema)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_bash(context: Context) -> None:
+    tool = AnthropicBashTool()
 
     [schema] = await tool.schemas(context)
 

--- a/test/config/zai/tools/test_unsupported.py
+++ b/test/config/zai/tools/test_unsupported.py
@@ -7,6 +7,7 @@ import pytest
 from ag2 import Context
 from ag2.config.zai.mappers import tool_to_api
 from ag2.exceptions import UnsupportedToolError
+from ag2.tools.builtin.anthropic_bash import AnthropicBashTool
 from ag2.tools.builtin.code_execution import CodeExecutionTool
 from ag2.tools.builtin.file_search import FileSearchTool
 from ag2.tools.builtin.google_maps import GoogleMapsTool
@@ -112,6 +113,16 @@ async def test_file_search(context: Context) -> None:
 @pytest.mark.asyncio
 async def test_google_maps(context: Context) -> None:
     tool = GoogleMapsTool()
+
+    [schema] = await tool.schemas(context)
+
+    with pytest.raises(UnsupportedToolError, match="zai"):
+        tool_to_api(schema)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_bash(context: Context) -> None:
+    tool = AnthropicBashTool()
 
     [schema] = await tool.schemas(context)
 

--- a/website/docs/user-guide/tools/builtin_tools.mdx
+++ b/website/docs/user-guide/tools/builtin_tools.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Built-in Tools
 
 # Built-in Provider Tools
 
-AG2 includes built-in tools that map to server-side capabilities offered by LLM providers. These tools are executed by the provider's API — not locally — and require no function implementation on your side.
+AG2 includes built-in tools that map to capabilities offered by LLM providers. Almost all of them are executed by the provider's API — not locally — and require no function implementation on your side. The one exception is marked in the table below.
 
 | Tool | Anthropic | OpenAI | Gemini | xAI | Z.AI |
 | :--- | :---: | :---: | :---: | :---: | :---: |
@@ -13,7 +13,8 @@ AG2 includes built-in tools that map to server-side capabilities offered by LLM 
 | `WebSearchTool` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `WebFetchTool` | ✓ | ✗ | ✓ | ✗ | ✗ |
 | `FileSearchTool` | ✗ | ✓ | ✓ | ✗ | ✗ |
-| `ShellTool` | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `ShellTool` | ✗ | ✓ | ✗ | ✗ | ✗ |
+| `AnthropicBashTool` | ✓ | ✗ | ✗ | ✗ | ✗ |
 | `SkillsTool` | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `MCPServerTool` | ✓ | ✓ | ✗ | ✓ | ✗ |
 | `ImageGenerationTool` | ✗ | ✓ | ✗ | ✗ | ✗ |
@@ -21,6 +22,11 @@ AG2 includes built-in tools that map to server-side capabilities offered by LLM 
 | `XSearchTool` | ✗ | ✗ | ✗ | ✓ | ✗ |
 | `RetrievalTool` | ✗ | ✗ | ✗ | ✗ | ✓ |
 | `GoogleMapsTool` | ✗ | ✗ | ✓ | ✗ | ✗ |
+
+!!! note
+    `AnthropicBashTool` is the exception: Anthropic ships the tool definition
+    but does not run it, so AG2 executes the command on your machine and sends
+    the output back. See [Anthropic Bash](#anthropic-bash).
 
 ## Web Search
 
@@ -206,21 +212,7 @@ agent = Agent(
 
 ## Shell
 
-Gives the model the ability to run shell commands. The execution environment depends on the provider.
-
-```python linenums="1"
-from ag2 import Agent
-from ag2.config import AnthropicConfig
-from ag2.tools import ShellTool
-
-agent = Agent(
-    "devops",
-    config=AnthropicConfig(model="claude-sonnet-5"),
-    tools=[ShellTool()],
-)
-```
-
-OpenAI supports configuring the execution environment:
+Gives the model the ability to run shell commands inside a provider-hosted environment. Only OpenAI offers one; the environment carries the backend configuration.
 
 ```python linenums="1"
 from ag2 import Agent
@@ -258,6 +250,88 @@ agent = Agent(
 
 !!! warning
     `ShellTool` gives the model direct shell access. Use it only with trusted prompts and consider restricting the environment.
+
+!!! note "Not available on Anthropic"
+
+    Anthropic's own shell tool is client-executed — it defines the tool but runs
+    nothing, so a provider-hosted shell has no meaning there and `ShellTool`
+    raises `UnsupportedToolError`. Use [`AnthropicBashTool`](#anthropic-bash) for
+    Anthropic's tool, or [`SandboxShellTool`](/docs/user-guide/tools/local_shell)
+    for a provider-neutral shell.
+
+## Anthropic Bash
+
+`AnthropicBashTool` declares Anthropic's `bash_20250124` tool. Anthropic does not
+execute it: the model returns an ordinary `tool_use` block and waits for a
+`tool_result`, so **AG2 runs the command for you** and sends the output back.
+
+```python linenums="1"
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.tools import AnthropicBashTool
+
+agent = Agent(
+    "devops",
+    config=AnthropicConfig(model="claude-sonnet-5"),
+    tools=[AnthropicBashTool()],
+)
+
+reply = await agent.ask("How many Python files are in this directory?")
+print(await reply.content())
+```
+
+With no arguments, commands run in a local subprocess. Execution is backed by the
+same machinery as [`SandboxShellTool`](/docs/user-guide/tools/local_shell), so the
+first argument picks the backend and the keyword arguments restrict what the model
+may run:
+
+```python linenums="1"
+from ag2.extensions.docker import DockerEnvironment
+from ag2.tools import AnthropicBashTool
+
+bash = AnthropicBashTool(
+    DockerEnvironment(image="python:3.12-slim", network_mode="none"),
+    allowed=["ls", "cat", "python"],
+    ignore=["**/.env", "*.key"],
+)
+```
+
+| Parameter | Description |
+| :--- | :--- |
+| `environment` | Execution backend (`LocalEnvironment`, `DockerEnvironment`, `DaytonaEnvironment`, `TenkiEnvironment`, or a custom one). `None` means a local subprocess. |
+| `allowed` | Whitelist of command prefixes. |
+| `blocked` | Blacklist of command prefixes. Best-effort: it matches the head command only, so chaining bypasses it. |
+| `ignore` | Gitignore-style path patterns. A command referencing a matching path is refused. |
+| `readonly` | When `True` and `allowed` is unset, restricts to a built-in read-only command set (`cat`, `ls`, `grep`, …). |
+
+The semantics are identical to `SandboxShellTool`'s — see [Command Filtering](/docs/user-guide/tools/local_shell#command-filtering) for the details.
+
+### Which Anthropic tool runs shell commands
+
+Anthropic exposes bash twice, and the two are not interchangeable:
+
+| | Runs where | AG2 tool |
+| :--- | :--- | :--- |
+| `bash_20250124` | On your machine, in the environment you pass | `AnthropicBashTool` |
+| bash inside `code_execution_*` | In Anthropic's container | [`CodeExecutionTool`](#code-execution) |
+
+Pick `CodeExecutionTool` when a throwaway sandbox on Anthropic's side is enough;
+pick `AnthropicBashTool` when the commands must act on your own files.
+
+!!! note
+    Each command runs in a fresh sandbox, so there is no session to carry over.
+    When the model asks for a `restart`, AG2 answers that there was nothing to
+    restart rather than report a restart that never happened.
+
+!!! note
+    `AnthropicBashTool` is Anthropic-only; other providers reject the schema with
+    `UnsupportedToolError`. For a client-executed shell that works everywhere, use
+    [`SandboxShellTool`](/docs/user-guide/tools/local_shell).
+
+!!! warning
+    `AnthropicBashTool` executes model-authored commands on your machine. Use it
+    only with trusted prompts, and prefer a container environment together with an
+    `allowed` list.
 
 ## Provider Skills
 

--- a/website/docs/user-guide/tools/local_shell.mdx
+++ b/website/docs/user-guide/tools/local_shell.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Sandbox Shell
 
 # Sandbox Shell Tool
 
-`SandboxShellTool` lets an agent run shell commands inside an **environment** you choose — a local subprocess, a Docker container, a Daytona or Tenki sandbox, or any custom backend. Unlike the provider-native [`ShellTool`](/docs/user-guide/tools/builtin_tools#shell) (which runs server-side and only on Anthropic/OpenAI), it executes client-side, so it works with **any model provider**.
+`SandboxShellTool` lets an agent run shell commands inside an **environment** you choose — a local subprocess, a Docker container, a Daytona or Tenki sandbox, or any custom backend. Unlike the provider-hosted [`ShellTool`](/docs/user-guide/tools/builtin_tools#shell) (which runs server-side, and only on OpenAI), it executes client-side, so it works with **any model provider**.
 
 The design has two orthogonal pieces:
 
@@ -147,11 +147,18 @@ reply3 = await reply2.ask("Read the counter and tell me the value")
 !!! warning
     A `LocalEnvironment` gives the agent direct access to your filesystem and the ability to run arbitrary commands. Always set `allowed`, `blocked`, or `readonly` when exposing it to untrusted prompts, or use a `DockerEnvironment`, `DaytonaEnvironment`, or `TenkiEnvironment` for real isolation.
 
-## SandboxShellTool vs ShellTool
+## SandboxShellTool vs ShellTool vs AnthropicBashTool
 
-| | `SandboxShellTool` | `ShellTool` |
-| :--- | :--- | :--- |
-| **Execution** | Client-side, in your environment | Provider-side (Anthropic / OpenAI) |
-| **Provider support** | Any provider | Anthropic, OpenAI only |
-| **Environment control** | Full (`allowed`, `blocked`, `ignore`, backend choice) | Limited (provider-dependent) |
-| **Import** | `ag2.tools.SandboxShellTool` | `ag2.tools.ShellTool` |
+| | `SandboxShellTool` | `ShellTool` | `AnthropicBashTool` |
+| :--- | :--- | :--- | :--- |
+| **Execution** | Client-side, in your environment | Provider-side, in OpenAI's container | Client-side, in your environment |
+| **Provider support** | Any provider | OpenAI only | Anthropic only |
+| **Tool definition** | AG2's `run_shell_command` function | OpenAI's hosted shell | Anthropic's `bash_20250124` |
+| **Environment control** | Full (`allowed`, `blocked`, `ignore`, backend choice) | Limited (provider-dependent) | Full — same options as `SandboxShellTool` |
+| **Import** | `ag2.tools.SandboxShellTool` | `ag2.tools.ShellTool` | `ag2.tools.AnthropicBashTool` |
+
+`AnthropicBashTool` exists because Anthropic ships its own bash tool definition
+but does not run it. It reuses everything on this page for execution, so reach for
+it when you want Claude to use the tool it was trained on; reach for
+`SandboxShellTool` when the same agent code has to run against several providers.
+See [Anthropic Bash](/docs/user-guide/tools/builtin_tools#anthropic-bash).


### PR DESCRIPTION
## Why are these changes needed?

### New: `AnthropicBashTool`

Anthropic ships a bash tool (`bash_20250124`) but doesn't run it — the model
returns a plain `tool_use` block and waits for a `tool_result`. AG2 had no way to
declare it, so there was no way to use Claude's own bash tool at all.

```python
from ag2 import Agent
from ag2.config import AnthropicConfig
from ag2.tools import AnthropicBashTool

agent = Agent(
    "devops",
    config=AnthropicConfig(model="claude-sonnet-5"),
    tools=[AnthropicBashTool()],
)

reply = await agent.ask("How many Python files are in this directory?")
print(await reply.content())
```

With no arguments the commands run in a local subprocess. Execution goes through
the same machinery as `SandboxShellTool`, so the first argument picks the backend
and the keyword arguments restrict what the model may run:

```python
from ag2.extensions.docker import DockerEnvironment

bash = AnthropicBashTool(
    DockerEnvironment(image="python:3.12-slim", network_mode="none"),
    allowed=["ls", "cat", "python"],
    ignore=["**/.env", "*.key"],
)
```

| | Runs where | Providers |
| :--- | :--- | :--- |
| `AnthropicBashTool` (new) | Client-side, in the environment you pass | Anthropic only |
| `ShellTool` | Provider-side, in OpenAI's container | OpenAI only |
| `SandboxShellTool` | Client-side, in the environment you pass | Any |

### Fixes found while wiring it up

Four things the Anthropic client silently lost. Each was measured against the live
API and is pinned by a test:

- **Dropped blocks** — the response loop had no `else`, so `redacted_thinking` and
  `container_upload` produced no event, no warning, no history entry. Both are
  recorded now (the first replays verbatim as Anthropic requires; the second never
  replays — the API 400s on it inside an assistant turn), and any future block type
  is logged instead of vanishing.
- **Streaming replayed an empty server-tool input** — `server_tool_use` input
  arrives as `input_json_delta` chunks, but the event was built at
  `content_block_start` with `input={}`. Same prompt: `streaming=True` replayed
  `{"input": {}, "name": "web_search"}`, `streaming=False` replayed
  `{"input": {"query": "capital of Iceland"}}`. Now built at `content_block_stop`
  from the accumulated JSON.
- **Failed tools looked successful** — `ToolErrorEvent` rendered as an ordinary
  `tool_result`, so the model read a traceback as a result. It now sets
  `is_error: true`.
- **`caller` / `toolset_name` were dropped** from `tool_use`. The API refuses a
  `tool_result` for a browser/computer member tool that doesn't repeat the paired
  `tool_use`'s `toolset_name`. Both now ride on `ToolCallEvent.vendor_metadata`.

One known defect is marked, not fixed: `test_text_blocks.py` has an
`xfail(strict=True)` for multi-block answers (with citations on, Anthropic splits
one answer across several `TextBlock`s and only the last survives, so `reply.body`
returns a trailing fragment). Fixing it needs a representation for a multi-block
answer that no model event has today.

### Docs

The compatibility matrix claimed Anthropic supports `ShellTool` (`✓`) while the
mapper has always raised — corrected, plus a section for `AnthropicBashTool` and a
three-way comparison on the Sandbox Shell page.

## Related issue number

<!-- Closes #____ -->

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
