### PR TITLE
feat(mcp): serve MCP Apps, with structured tool output and extensions

### DIFF
--- a/ag2/mcp/__init__.py
+++ b/ag2/mcp/__init__.py
@@ -5,7 +5,7 @@
 from ag2.exceptions import missing_optional_dependency
 
 try:
-    from .apps import AppResource, client_supports_apps
+    from .apps import AppSandbox, MCPApp, client_supports_apps
     from .executor import AskContext, ContextProvider
     from .extensions import ExtensionMap, client_extension
     from .info import build_ask_tool
@@ -29,14 +29,16 @@ except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp] is a
     mcp_tool = missing_optional_dependency("mcp_tool", "mcp", e)  # type: ignore[misc]
     client_extension = missing_optional_dependency("client_extension", "mcp", e)  # type: ignore[misc]
     ExtensionMap = missing_optional_dependency("ExtensionMap", "mcp", e)  # type: ignore[misc]
-    AppResource = missing_optional_dependency("AppResource", "mcp", e)  # type: ignore[misc]
+    AppSandbox = missing_optional_dependency("AppSandbox", "mcp", e)  # type: ignore[misc]
+    MCPApp = missing_optional_dependency("MCPApp", "mcp", e)  # type: ignore[misc]
     client_supports_apps = missing_optional_dependency("client_supports_apps", "mcp", e)  # type: ignore[misc]
 
 __all__ = (
-    "AppResource",
+    "AppSandbox",
     "AskContext",
     "ContextProvider",
     "ExtensionMap",
+    "MCPApp",
     "MCPFunctionTool",
     "MCPServer",
     "Prompt",

--- a/ag2/mcp/__init__.py
+++ b/ag2/mcp/__init__.py
@@ -5,7 +5,16 @@
 from ag2.exceptions import missing_optional_dependency
 
 try:
-    from .apps import AppSandbox, MCPApp, client_supports_apps
+    from .apps import (
+        AppContent,
+        AppSandbox,
+        AppText,
+        MCPApp,
+        ResourceCsp,
+        ResourcePermissions,
+        Visibility,
+        client_supports_apps,
+    )
     from .executor import AskContext, ContextProvider
     from .extensions import ExtensionMap, client_extension
     from .info import build_ask_tool
@@ -13,7 +22,7 @@ try:
     from .resources import Resource, ResourceTemplate
     from .server import MCPServer
     from .sessions import SessionConfig
-    from .tools import MCPFunctionTool, mcp_tool
+    from .tools import MCPFunctionTool, MCPRequestContext, mcp_tool
 except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp] is absent
     MCPServer = missing_optional_dependency("MCPServer", "mcp", e)  # type: ignore[misc]
     build_ask_tool = missing_optional_dependency("build_ask_tool", "mcp", e)  # type: ignore[misc]
@@ -32,21 +41,33 @@ except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp] is a
     AppSandbox = missing_optional_dependency("AppSandbox", "mcp", e)  # type: ignore[misc]
     MCPApp = missing_optional_dependency("MCPApp", "mcp", e)  # type: ignore[misc]
     client_supports_apps = missing_optional_dependency("client_supports_apps", "mcp", e)  # type: ignore[misc]
+    MCPRequestContext = missing_optional_dependency("MCPRequestContext", "mcp", e)  # type: ignore[misc]
+    ResourceCsp = missing_optional_dependency("ResourceCsp", "mcp", e)  # type: ignore[misc]
+    ResourcePermissions = missing_optional_dependency("ResourcePermissions", "mcp", e)  # type: ignore[misc]
+    Visibility = missing_optional_dependency("Visibility", "mcp", e)  # type: ignore[misc]
+    AppContent = missing_optional_dependency("AppContent", "mcp", e)  # type: ignore[misc]
+    AppText = missing_optional_dependency("AppText", "mcp", e)  # type: ignore[misc]
 
 __all__ = (
+    "AppContent",
     "AppSandbox",
+    "AppText",
     "AskContext",
     "ContextProvider",
     "ExtensionMap",
     "MCPApp",
     "MCPFunctionTool",
+    "MCPRequestContext",
     "MCPServer",
     "Prompt",
     "PromptArgument",
     "PromptMessage",
     "Resource",
+    "ResourceCsp",
+    "ResourcePermissions",
     "ResourceTemplate",
     "SessionConfig",
+    "Visibility",
     "build_ask_tool",
     "client_extension",
     "client_supports_apps",

--- a/ag2/mcp/__init__.py
+++ b/ag2/mcp/__init__.py
@@ -6,6 +6,7 @@ from ag2.exceptions import missing_optional_dependency
 
 try:
     from .executor import AskContext, ContextProvider
+    from .extensions import client_extension
     from .info import build_ask_tool
     from .prompts import Prompt, PromptArgument, PromptMessage
     from .resources import Resource, ResourceTemplate
@@ -25,6 +26,7 @@ except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp] is a
     PromptMessage = missing_optional_dependency("PromptMessage", "mcp", e)  # type: ignore[misc]
     MCPFunctionTool = missing_optional_dependency("MCPFunctionTool", "mcp", e)  # type: ignore[misc]
     mcp_tool = missing_optional_dependency("mcp_tool", "mcp", e)  # type: ignore[misc]
+    client_extension = missing_optional_dependency("client_extension", "mcp", e)  # type: ignore[misc]
 
 __all__ = (
     "AskContext",
@@ -38,5 +40,6 @@ __all__ = (
     "ResourceTemplate",
     "SessionConfig",
     "build_ask_tool",
+    "client_extension",
     "mcp_tool",
 )

--- a/ag2/mcp/__init__.py
+++ b/ag2/mcp/__init__.py
@@ -5,8 +5,9 @@
 from ag2.exceptions import missing_optional_dependency
 
 try:
+    from .apps import AppResource, client_supports_apps
     from .executor import AskContext, ContextProvider
-    from .extensions import client_extension
+    from .extensions import ExtensionMap, client_extension
     from .info import build_ask_tool
     from .prompts import Prompt, PromptArgument, PromptMessage
     from .resources import Resource, ResourceTemplate
@@ -27,10 +28,15 @@ except ImportError as e:  # pragma: no cover - exercised only when ag2[mcp] is a
     MCPFunctionTool = missing_optional_dependency("MCPFunctionTool", "mcp", e)  # type: ignore[misc]
     mcp_tool = missing_optional_dependency("mcp_tool", "mcp", e)  # type: ignore[misc]
     client_extension = missing_optional_dependency("client_extension", "mcp", e)  # type: ignore[misc]
+    ExtensionMap = missing_optional_dependency("ExtensionMap", "mcp", e)  # type: ignore[misc]
+    AppResource = missing_optional_dependency("AppResource", "mcp", e)  # type: ignore[misc]
+    client_supports_apps = missing_optional_dependency("client_supports_apps", "mcp", e)  # type: ignore[misc]
 
 __all__ = (
+    "AppResource",
     "AskContext",
     "ContextProvider",
+    "ExtensionMap",
     "MCPFunctionTool",
     "MCPServer",
     "Prompt",
@@ -41,5 +47,6 @@ __all__ = (
     "SessionConfig",
     "build_ask_tool",
     "client_extension",
+    "client_supports_apps",
     "mcp_tool",
 )

--- a/ag2/mcp/apps.py
+++ b/ag2/mcp/apps.py
@@ -6,7 +6,7 @@
 
 An **app** is a document plus the tools that render it::
 
-    shop = AppResource("ui://shop/card", CARD_HTML)
+    shop = MCPApp("ui://shop/card", CARD_HTML)
 
     @shop.tool
     async def show_item(item_id: str) -> Item:
@@ -24,26 +24,33 @@ That is the opposite of :mod:`ag2.mcp_ui`, which builds HTML inside the handler
 from the arguments it was given. The two are alternatives; this module does not
 replace that one.
 
-Nothing here is a dead end. :attr:`AppResource.tools` are ordinary
-:class:`~ag2.mcp.MCPFunctionTool`\\ s, :attr:`AppResource.resource` is an ordinary
+Nothing here is a dead end. :attr:`MCPApp.tools` are ordinary
+:class:`~ag2.mcp.MCPFunctionTool`\\ s, :attr:`MCPApp.resource` is an ordinary
 :class:`~ag2.mcp.Resource`, and ``apps=[app]`` is defined as shorthand for
 passing those two to ``tools=`` and ``resources=`` by hand.
 """
 
 import json
+import os
 import re
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
-from dataclasses import replace
+from contextlib import AsyncExitStack
+from dataclasses import dataclass, replace
+from pathlib import Path
 from typing import Any, overload
 
 from mcp.server.apps import APP_MIME_TYPE, EXTENSION_ID, ResourceCsp, ResourcePermissions, Visibility
 from mcp.server.apps import client_supports_apps as client_supports_apps
 from mcp.types import CallToolResult, ToolAnnotations
 
+from ag2.annotations import Variable
+from ag2.tools.builtin._resolve import resolve_variable
+from ag2.utils import CONTEXT_OPTION_NAME, build_model
+
 from ._async import call_user_fn
 from .errors import MCPAppURIError, MCPDuplicateAppURIError
 from .resources import Resource as AG2Resource
-from .tools import MCPFunctionTool, ToolContext, mcp_tool, to_call_result
+from .tools import MCPExecutionContext, MCPFunctionTool, ToolContext, mcp_tool, resolve_context_value, to_call_result
 
 # The key ``_meta`` reserves for MCP Apps, on a tool and on a resource alike.
 UI_META_KEY = "ui"
@@ -62,13 +69,23 @@ TOOL_META_KEY = "ai.ag2/tool"
 # constant for the dialect spoken inside the frame.
 APP_PROTOCOL_VERSION = "2026-01-26"
 
-# The document body: a fixed string, or a sync/async callable producing one per
-# read, mirroring :class:`~ag2.mcp.Resource`'s reader contract. Text only — the
-# only MIME type a host will render a ``ui://`` resource under is HTML.
-AppBody = str | Callable[[], "Awaitable[str] | str"]
+# The document content: inline HTML, a path-like file read per request, a
+# request-time variable, or a sync/async callable producing HTML per read.
+AppContent = str | os.PathLike[str] | Variable | Callable[..., "Awaitable[str] | str"]
+AppBody = AppContent
+AppText = str | Variable
 
 
-class AppResource:
+@dataclass(frozen=True, slots=True)
+class AppSandbox:
+    """Sandbox policy for an MCP app document."""
+
+    csp: ResourceCsp | Variable | None = None
+    permissions: ResourcePermissions | Variable | None = None
+    domain: str | Variable | None = None
+
+
+class MCPApp:
     """A document and the tools that render it.
 
     ``uri`` must use the ``ui://`` scheme — a host discards anything else — and
@@ -96,52 +113,144 @@ class AppResource:
     ``@app.tool``'s ``meta`` rejects a ``ui`` key outright, since there the only
     thing in that slot is the binding the decorator itself writes.
 
-    ``bootstrap`` controls injection of the document runtime (see
+    ``inject_runtime`` controls injection of the document runtime (see
     :meth:`runtime_script`). Turn it off for a document that brings its own
     bundle: the body is then served byte-for-byte as given.
     """
 
     __slots__ = (
         "_uri",
-        "_html",
+        "_content",
         "_name",
         "_title",
         "_description",
         "_listed",
-        "_bootstrap",
+        "_inject_runtime",
+        "_sandbox",
         "_meta",
         "_tools",
+        "_frozen",
     )
+
+    @overload
+    def __init__(
+        self,
+        uri: str,
+        content: str,
+        *,
+        name: str | None = None,
+        title: AppText | None = None,
+        description: AppText | None = None,
+        listed: bool = False,
+        inject_runtime: bool | Variable = True,
+        sandbox: AppSandbox | None = None,
+        csp: ResourceCsp | Variable | None = None,
+        permissions: ResourcePermissions | Variable | None = None,
+        domain: str | Variable | None = None,
+        prefers_border: bool | Variable | None = None,
+        meta: Mapping[str, Any] | None = None,
+        tools: Sequence[Callable[..., Any] | MCPFunctionTool] = (),
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        uri: str,
+        content: os.PathLike[str],
+        *,
+        name: str | None = None,
+        title: AppText | None = None,
+        description: AppText | None = None,
+        listed: bool = False,
+        inject_runtime: bool | Variable = True,
+        sandbox: AppSandbox | None = None,
+        csp: ResourceCsp | Variable | None = None,
+        permissions: ResourcePermissions | Variable | None = None,
+        domain: str | Variable | None = None,
+        prefers_border: bool | Variable | None = None,
+        meta: Mapping[str, Any] | None = None,
+        tools: Sequence[Callable[..., Any] | MCPFunctionTool] = (),
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        uri: str,
+        content: Callable[..., Awaitable[str] | str],
+        *,
+        name: str | None = None,
+        title: AppText | None = None,
+        description: AppText | None = None,
+        listed: bool = False,
+        inject_runtime: bool | Variable = True,
+        sandbox: AppSandbox | None = None,
+        csp: ResourceCsp | Variable | None = None,
+        permissions: ResourcePermissions | Variable | None = None,
+        domain: str | Variable | None = None,
+        prefers_border: bool | Variable | None = None,
+        meta: Mapping[str, Any] | None = None,
+        tools: Sequence[Callable[..., Any] | MCPFunctionTool] = (),
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        uri: str,
+        content: Variable,
+        *,
+        name: str | None = None,
+        title: AppText | None = None,
+        description: AppText | None = None,
+        listed: bool = False,
+        inject_runtime: bool | Variable = True,
+        sandbox: AppSandbox | None = None,
+        csp: ResourceCsp | Variable | None = None,
+        permissions: ResourcePermissions | Variable | None = None,
+        domain: str | Variable | None = None,
+        prefers_border: bool | Variable | None = None,
+        meta: Mapping[str, Any] | None = None,
+        tools: Sequence[Callable[..., Any] | MCPFunctionTool] = (),
+    ) -> None: ...
 
     def __init__(
         self,
         uri: str,
-        html: AppBody,
+        content: AppContent,
         *,
         name: str | None = None,
-        title: str | None = None,
-        description: str | None = None,
+        title: AppText | None = None,
+        description: AppText | None = None,
         listed: bool = False,
-        bootstrap: bool = True,
-        csp: ResourceCsp | None = None,
-        permissions: ResourcePermissions | None = None,
-        domain: str | None = None,
-        prefers_border: bool | None = None,
+        inject_runtime: bool | Variable = True,
+        sandbox: AppSandbox | None = None,
+        csp: ResourceCsp | Variable | None = None,
+        permissions: ResourcePermissions | Variable | None = None,
+        domain: str | Variable | None = None,
+        prefers_border: bool | Variable | None = None,
         meta: Mapping[str, Any] | None = None,
+        tools: Sequence[Callable[..., Any] | MCPFunctionTool] = (),
     ) -> None:
         if not uri.startswith("ui://"):
             raise MCPAppURIError(uri)
         self._uri = uri
-        self._html = html
+        self._content = content
         self._name = name or uri
         self._title = title
         self._description = description
         self._listed = listed
-        self._bootstrap = bootstrap
+        self._inject_runtime = inject_runtime
+        self._sandbox = sandbox or AppSandbox(csp=csp, permissions=permissions, domain=domain)
         self._meta = _document_meta(
-            csp=csp, permissions=permissions, domain=domain, prefers_border=prefers_border, extra=meta
+            csp=self._sandbox.csp,
+            permissions=self._sandbox.permissions,
+            domain=self._sandbox.domain,
+            prefers_border=prefers_border,
+            extra=meta,
         )
         self._tools: list[MCPFunctionTool] = []
+        self._frozen = False
+        for tool in tools:
+            self.tool(tool)
 
     @property
     def uri(self) -> str:
@@ -167,7 +276,7 @@ class AppResource:
         return AG2Resource(
             uri=self._uri,
             name=self._name,
-            read=self._read,
+            read=_AppResourceReader(self),
             title=self._title,
             description=self._description,
             mime_type=APP_MIME_TYPE,
@@ -175,9 +284,10 @@ class AppResource:
             listed=self._listed,
         )
 
-    async def _read(self) -> str:
-        body = self._html if isinstance(self._html, str) else await call_user_fn(self._html)
-        return _inject(body, self.runtime_script()) if self._bootstrap else body
+    async def _read(self, context: MCPExecutionContext) -> str:
+        body = await _resolve_content(self._content, context)
+        inject_runtime = resolve_context_value(self._inject_runtime, context)
+        return _inject(body, self.runtime_script()) if inject_runtime else body
 
     def runtime_script(self) -> str:
         """The ``<script>`` element performing the MCP Apps handshake, as text.
@@ -195,12 +305,15 @@ class AppResource:
         promise; and automatic size reporting.
 
         This is the same text injection uses, exposed for a document that would
-        rather place it itself (with ``bootstrap=False``).
+        rather place it itself (with ``inject_runtime=False``).
         """
         return _runtime_script(self._name)
 
     @overload
     def tool(self, function: Callable[..., Any]) -> MCPFunctionTool: ...
+
+    @overload
+    def tool(self, function: MCPFunctionTool) -> MCPFunctionTool: ...
 
     @overload
     def tool(
@@ -219,7 +332,7 @@ class AppResource:
 
     def tool(
         self,
-        function: Callable[..., Any] | None = None,
+        function: Callable[..., Any] | MCPFunctionTool | None = None,
         *,
         name: str | None = None,
         description: str | None = None,
@@ -262,30 +375,65 @@ class AppResource:
         """
         if meta and UI_META_KEY in meta:
             raise ValueError(
-                f"@AppResource.tool owns _meta[{UI_META_KEY!r}]; pass visibility= rather than a 'ui' meta key, "
+                f"@MCPApp.tool owns _meta[{UI_META_KEY!r}]; pass visibility= rather than a 'ui' meta key, "
                 "or declare the tool with mcp_tool() if it should not be bound to this document."
             )
+        if self._frozen:
+            raise ValueError(f"MCPApp {self._uri!r} is frozen because it has already been registered with a server.")
         ui: dict[str, Any] = {"resourceUri": self._uri}
         if visibility is not None:
             ui["visibility"] = list(visibility)
         merged = {**(meta or {}), UI_META_KEY: ui}
 
-        def make(f: Callable[..., Any]) -> MCPFunctionTool:
-            built = mcp_tool(
-                f,
-                name=name,
-                description=description,
-                title=title,
-                annotations=annotations,
-                output_schema=output_schema,
-                meta=merged,
-                sync_to_thread=sync_to_thread,
-            )
+        def make(f: Callable[..., Any] | MCPFunctionTool) -> MCPFunctionTool:
+            if isinstance(f, MCPFunctionTool):
+                if (
+                    name is not None
+                    or description is not None
+                    or output_schema is not None
+                    or sync_to_thread is not True
+                ):
+                    raise ValueError(
+                        "Existing MCPFunctionTool objects already define name, description, schema, and execution."
+                    )
+                if f.meta and UI_META_KEY in f.meta and f.meta[UI_META_KEY].get("resourceUri") != self._uri:
+                    raise ValueError("Existing MCPFunctionTool is already bound to a different MCP app document.")
+                built = replace(
+                    f,
+                    title=title if title is not None else f.title,
+                    annotations=annotations if annotations is not None else f.annotations,
+                    meta={**dict(f.meta or {}), **merged},
+                )
+            else:
+                built = mcp_tool(
+                    f,
+                    name=name,
+                    description=description,
+                    title=title,
+                    annotations=annotations,
+                    output_schema=output_schema,
+                    meta=merged,
+                    sync_to_thread=sync_to_thread,
+                )
             stamped = replace(built, handler=_stamping(built.handler, built.name))
             self._tools.append(stamped)
             return stamped
 
         return make(function) if function is not None else make
+
+    def freeze(self) -> None:
+        """Freeze the app's routing identity and tool composition."""
+        self._frozen = True
+
+
+class _AppResourceReader:
+    __slots__ = ("_app",)
+
+    def __init__(self, app: MCPApp) -> None:
+        self._app = app
+
+    async def __call__(self, context: MCPExecutionContext) -> str:
+        return await self._app._read(context)
 
 
 def _stamping(handler: Callable[..., Any], tool_name: str) -> Callable[[dict[str, Any], ToolContext], Any]:
@@ -339,7 +487,7 @@ def binds_ui(tools: "Iterable[MCPFunctionTool]") -> bool:
     return any(tool.meta and UI_META_KEY in tool.meta for tool in tools)
 
 
-def collect_apps(apps: "Iterable[AppResource]") -> "tuple[tuple[MCPFunctionTool, ...], tuple[AG2Resource, ...]]":
+def collect_apps(apps: "Iterable[MCPApp]") -> "tuple[tuple[MCPFunctionTool, ...], tuple[AG2Resource, ...]]":
     """The tools and resources ``apps`` contributes, refusing a shared document URI.
 
     Two apps claiming one URI would silently shadow each other — one document
@@ -354,25 +502,50 @@ def collect_apps(apps: "Iterable[AppResource]") -> "tuple[tuple[MCPFunctionTool,
         if app.uri in seen:
             raise MCPDuplicateAppURIError(app.uri)
         seen.add(app.uri)
+        app.freeze()
         tools.extend(app.tools)
         resources.append(app.resource)
     return tuple(tools), tuple(resources)
 
 
+async def _resolve_content(content: AppContent, context: MCPExecutionContext) -> str:
+    resolved = resolve_variable(content, context, param_name="content")
+    if isinstance(resolved, str):
+        return resolved
+    if isinstance(resolved, os.PathLike):
+        try:
+            return Path(resolved).read_text()
+        except OSError as e:
+            raise ValueError(f"Could not read MCP app document from {resolved!s}: {e.strerror or e}") from e
+    if callable(resolved):
+        call_model = build_model(resolved, serialize_result=False)
+        async with AsyncExitStack() as stack:
+            value = await call_model.asolve(
+                **{CONTEXT_OPTION_NAME: context},
+                stack=stack,
+                cache_dependencies={},
+                dependency_provider=context.dependency_provider,
+            )
+        if isinstance(value, str):
+            return value
+        raise TypeError(f"MCP app content provider returned {type(value).__name__}; expected str.")
+    raise TypeError(f"MCP app content resolved to {type(resolved).__name__}; expected str, path-like, or callable.")
+
+
 def _document_meta(
     *,
-    csp: "ResourceCsp | None",
-    permissions: "ResourcePermissions | None",
-    domain: str | None,
-    prefers_border: bool | None,
+    csp: "ResourceCsp | Variable | None",
+    permissions: "ResourcePermissions | Variable | None",
+    domain: str | Variable | None,
+    prefers_border: bool | Variable | None,
     extra: "Mapping[str, Any] | None",
 ) -> dict[str, Any]:
     """The document's ``_meta``: its sandbox policy under ``ui``, plus a passthrough."""
     ui: dict[str, Any] = {}
     if csp is not None:
-        ui["csp"] = csp.model_dump(by_alias=True, exclude_none=True)
+        ui["csp"] = csp
     if permissions is not None:
-        ui["permissions"] = permissions.model_dump(by_alias=True, exclude_none=True)
+        ui["permissions"] = permissions
     if domain is not None:
         ui["domain"] = domain
     if prefers_border is not None:
@@ -661,7 +834,9 @@ __all__ = (
     "TOOL_META_KEY",
     "UI_META_KEY",
     "AppBody",
-    "AppResource",
+    "AppContent",
+    "AppSandbox",
+    "MCPApp",
     "ResourceCsp",
     "ResourcePermissions",
     "Visibility",

--- a/ag2/mcp/apps.py
+++ b/ag2/mcp/apps.py
@@ -34,7 +34,6 @@ import json
 import os
 import re
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
-from contextlib import AsyncExitStack
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, overload
@@ -45,12 +44,19 @@ from mcp.types import CallToolResult, ToolAnnotations
 
 from ag2.annotations import Variable
 from ag2.tools.builtin._resolve import resolve_variable
-from ag2.utils import CONTEXT_OPTION_NAME, build_model
 
 from ._async import call_user_fn
-from .errors import MCPAppURIError, MCPDuplicateAppURIError
+from .errors import MCPAppFrozenError, MCPAppURIError, MCPDuplicateAppURIError
 from .resources import Resource as AG2Resource
-from .tools import MCPExecutionContext, MCPFunctionTool, ToolContext, mcp_tool, resolve_context_value, to_call_result
+from .tools import (
+    MCPExecutionContext,
+    MCPFunctionTool,
+    ToolContext,
+    call_with_context,
+    mcp_tool,
+    resolve_context_value,
+    to_call_result,
+)
 
 # The key ``_meta`` reserves for MCP Apps, on a tool and on a resource alike.
 UI_META_KEY = "ui"
@@ -72,7 +78,8 @@ APP_PROTOCOL_VERSION = "2026-01-26"
 # The document content: inline HTML, a path-like file read per request, a
 # request-time variable, or a sync/async callable producing HTML per read.
 AppContent = str | os.PathLike[str] | Variable | Callable[..., "Awaitable[str] | str"]
-AppBody = AppContent
+
+# A document field a host displays, which may be resolved per request.
 AppText = str | Variable
 
 
@@ -89,11 +96,22 @@ class MCPApp:
     """A document and the tools that render it.
 
     ``uri`` must use the ``ui://`` scheme — a host discards anything else — and
-    is validated here rather than on the wire. ``html`` is the document body: a
-    string, or a sync/async callable invoked per read, matching
-    :class:`~ag2.mcp.Resource`'s reader contract. A file path is deliberately not
-    accepted: taking one would force ag2 to decide whether it is re-read per
-    request, which is the caller's decision to make inside a callable.
+    is validated here rather than on the wire.
+
+    ``content`` is the document body, in one of four forms, told apart by type
+    alone rather than by inspecting the filesystem:
+
+    * a ``str`` — always literal HTML, never a filename;
+    * an ``os.PathLike[str]`` — always a file, read on **every** resource read,
+      so a rebuilt bundle is picked up without restarting the server;
+    * a ``Variable`` — resolved per request from the ``AskContext`` the server's
+      ``context_provider`` returned;
+    * a sync or async callable invoked per read, matching
+      :class:`~ag2.mcp.Resource`'s reader contract. It may declare ``Variable``,
+      ``Depends``/``Inject`` and :data:`~ag2.mcp.MCPRequestContext` parameters,
+      which resolve like a tool's.
+
+    An overload per form makes each one visible in an IDE.
 
     ``name`` identifies the resource and defaults to the URI; ``title`` and
     ``description`` are what a client shows for it in ``resources/list``, so they
@@ -310,10 +328,19 @@ class MCPApp:
         return _runtime_script(self._name)
 
     @overload
-    def tool(self, function: Callable[..., Any]) -> MCPFunctionTool: ...
-
-    @overload
-    def tool(self, function: MCPFunctionTool) -> MCPFunctionTool: ...
+    def tool(
+        self,
+        function: Callable[..., Any] | MCPFunctionTool,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        title: str | None = None,
+        annotations: ToolAnnotations | None = None,
+        visibility: Sequence[Visibility] | None = None,
+        output_schema: dict[str, Any] | None = None,
+        meta: Mapping[str, Any] | None = None,
+        sync_to_thread: bool = True,
+    ) -> MCPFunctionTool: ...
 
     @overload
     def tool(
@@ -372,6 +399,8 @@ class MCPApp:
             ValueError: If ``meta`` carries a ``ui`` key. The binding between a
                 tool and its document is this decorator's to write; a caller
                 setting it by hand would be overwriting the app's own URI.
+            MCPAppFrozenError: If the app is already registered with a server,
+                which has read its tools; the tool would never be served.
         """
         if meta and UI_META_KEY in meta:
             raise ValueError(
@@ -379,7 +408,7 @@ class MCPApp:
                 "or declare the tool with mcp_tool() if it should not be bound to this document."
             )
         if self._frozen:
-            raise ValueError(f"MCPApp {self._uri!r} is frozen because it has already been registered with a server.")
+            raise MCPAppFrozenError(self._uri, name or getattr(function, "__name__", None))
         ui: dict[str, Any] = {"resourceUri": self._uri}
         if visibility is not None:
             ui["visibility"] = list(visibility)
@@ -421,8 +450,8 @@ class MCPApp:
 
         return make(function) if function is not None else make
 
-    def freeze(self) -> None:
-        """Freeze the app's routing identity and tool composition."""
+    def _freeze(self) -> None:
+        """Close the app's tool composition, once a server has read it."""
         self._frozen = True
 
 
@@ -502,7 +531,7 @@ def collect_apps(apps: "Iterable[MCPApp]") -> "tuple[tuple[MCPFunctionTool, ...]
         if app.uri in seen:
             raise MCPDuplicateAppURIError(app.uri)
         seen.add(app.uri)
-        app.freeze()
+        app._freeze()
         tools.extend(app.tools)
         resources.append(app.resource)
     return tuple(tools), tuple(resources)
@@ -518,14 +547,7 @@ async def _resolve_content(content: AppContent, context: MCPExecutionContext) ->
         except OSError as e:
             raise ValueError(f"Could not read MCP app document from {resolved!s}: {e.strerror or e}") from e
     if callable(resolved):
-        call_model = build_model(resolved, serialize_result=False)
-        async with AsyncExitStack() as stack:
-            value = await call_model.asolve(
-                **{CONTEXT_OPTION_NAME: context},
-                stack=stack,
-                cache_dependencies={},
-                dependency_provider=context.dependency_provider,
-            )
+        value = await call_with_context(resolved, context)
         if isinstance(value, str):
             return value
         raise TypeError(f"MCP app content provider returned {type(value).__name__}; expected str.")
@@ -833,7 +855,6 @@ __all__ = (
     "EXTENSION_ID",
     "TOOL_META_KEY",
     "UI_META_KEY",
-    "AppBody",
     "AppContent",
     "AppSandbox",
     "MCPApp",

--- a/ag2/mcp/apps.py
+++ b/ag2/mcp/apps.py
@@ -1,0 +1,672 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serve an interactive document — an MCP App — alongside an AG2 agent.
+
+An **app** is a document plus the tools that render it::
+
+    shop = AppResource("ui://shop/card", CARD_HTML)
+
+    @shop.tool
+    async def show_item(item_id: str) -> Item:
+        \"\"\"Show a product card.\"\"\"
+        return await catalog.get(item_id)
+
+    server = MCPServer(agent, apps=[shop])
+
+The constraint that shapes this whole API: a host reads the document **in
+parallel with** the call that references it, so the document cannot be built
+from the call's arguments. It is a static body registered as a resource; the
+per-call data reaches it as ``structuredContent`` on the result, which the host
+redelivers into the frame as a ``ui/notifications/tool-result`` notification.
+That is the opposite of :mod:`ag2.mcp_ui`, which builds HTML inside the handler
+from the arguments it was given. The two are alternatives; this module does not
+replace that one.
+
+Nothing here is a dead end. :attr:`AppResource.tools` are ordinary
+:class:`~ag2.mcp.MCPFunctionTool`\\ s, :attr:`AppResource.resource` is an ordinary
+:class:`~ag2.mcp.Resource`, and ``apps=[app]`` is defined as shorthand for
+passing those two to ``tools=`` and ``resources=`` by hand.
+"""
+
+import json
+import re
+from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
+from dataclasses import replace
+from typing import Any, overload
+
+from mcp.server.apps import APP_MIME_TYPE, EXTENSION_ID, ResourceCsp, ResourcePermissions, Visibility
+from mcp.server.apps import client_supports_apps as client_supports_apps
+from mcp.types import CallToolResult, ToolAnnotations
+
+from ._async import call_user_fn
+from .errors import MCPAppURIError, MCPDuplicateAppURIError
+from .resources import Resource as AG2Resource
+from .tools import MCPFunctionTool, ToolContext, mcp_tool, to_call_result
+
+# The key ``_meta`` reserves for MCP Apps, on a tool and on a resource alike.
+UI_META_KEY = "ui"
+
+# Where the answering tool's name is stamped on a call result, following the
+# existing ``ai.ag2/conversation`` handle key. MCP Apps gives the document no
+# correlation identifier of its own — the notification carrying a result names
+# neither the call nor the tool — so a document serving two tools would not
+# otherwise know which result arrived.
+TOOL_META_KEY = "ai.ag2/tool"
+
+# The revision of the View-to-Host dialect the runtime announces in
+# ``ui/initialize``, which the specification requires it to state. Restated here
+# rather than imported: the Python SDK ships only the server side of MCP Apps
+# (``mcp.server.apps`` is tools, resources and the client check), and has no
+# constant for the dialect spoken inside the frame.
+APP_PROTOCOL_VERSION = "2026-01-26"
+
+# The document body: a fixed string, or a sync/async callable producing one per
+# read, mirroring :class:`~ag2.mcp.Resource`'s reader contract. Text only — the
+# only MIME type a host will render a ``ui://`` resource under is HTML.
+AppBody = str | Callable[[], "Awaitable[str] | str"]
+
+
+class AppResource:
+    """A document and the tools that render it.
+
+    ``uri`` must use the ``ui://`` scheme — a host discards anything else — and
+    is validated here rather than on the wire. ``html`` is the document body: a
+    string, or a sync/async callable invoked per read, matching
+    :class:`~ag2.mcp.Resource`'s reader contract. A file path is deliberately not
+    accepted: taking one would force ag2 to decide whether it is re-read per
+    request, which is the caller's decision to make inside a callable.
+
+    ``name`` identifies the resource and defaults to the URI; ``title`` and
+    ``description`` are what a client shows for it in ``resources/list``, so they
+    are worth setting only alongside ``listed=True``.
+
+    ``listed`` defaults to false, keeping the document out of ``resources/list``
+    — the specification permits omitting UI-only resources, and a person browsing
+    a server's resources should not meet a file that is not one. Set it true for
+    a document meant to be discoverable.
+
+    ``csp``, ``permissions``, ``domain`` and ``prefers_border`` are the document's
+    sandbox policy, written into the resource's ``_meta.ui``; they are the SDK's
+    own models, so the wire spelling is never guessed at. ``meta`` is a raw
+    passthrough merged alongside, for whatever the specification adds next — and
+    here a ``ui`` key in it *merges over* the typed parameters rather than being
+    refused, because on a document that slot is shared. On a tool it is not:
+    ``@app.tool``'s ``meta`` rejects a ``ui`` key outright, since there the only
+    thing in that slot is the binding the decorator itself writes.
+
+    ``bootstrap`` controls injection of the document runtime (see
+    :meth:`runtime_script`). Turn it off for a document that brings its own
+    bundle: the body is then served byte-for-byte as given.
+    """
+
+    __slots__ = (
+        "_uri",
+        "_html",
+        "_name",
+        "_title",
+        "_description",
+        "_listed",
+        "_bootstrap",
+        "_meta",
+        "_tools",
+    )
+
+    def __init__(
+        self,
+        uri: str,
+        html: AppBody,
+        *,
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        listed: bool = False,
+        bootstrap: bool = True,
+        csp: ResourceCsp | None = None,
+        permissions: ResourcePermissions | None = None,
+        domain: str | None = None,
+        prefers_border: bool | None = None,
+        meta: Mapping[str, Any] | None = None,
+    ) -> None:
+        if not uri.startswith("ui://"):
+            raise MCPAppURIError(uri)
+        self._uri = uri
+        self._html = html
+        self._name = name or uri
+        self._title = title
+        self._description = description
+        self._listed = listed
+        self._bootstrap = bootstrap
+        self._meta = _document_meta(
+            csp=csp, permissions=permissions, domain=domain, prefers_border=prefers_border, extra=meta
+        )
+        self._tools: list[MCPFunctionTool] = []
+
+    @property
+    def uri(self) -> str:
+        """The ``ui://`` URI the document is served at and the tools point to."""
+        return self._uri
+
+    @property
+    def tools(self) -> tuple[MCPFunctionTool, ...]:
+        """The tools declared on this app, as ordinary tools.
+
+        Passing these to ``MCPServer(tools=...)`` is exactly what ``apps=``
+        does with them.
+        """
+        return tuple(self._tools)
+
+    @property
+    def resource(self) -> AG2Resource:
+        """The document, as an ordinary resource.
+
+        Passing this to ``MCPServer(resources=...)`` is exactly what ``apps=``
+        does with it.
+        """
+        return AG2Resource(
+            uri=self._uri,
+            name=self._name,
+            read=self._read,
+            title=self._title,
+            description=self._description,
+            mime_type=APP_MIME_TYPE,
+            meta=self._meta or None,
+            listed=self._listed,
+        )
+
+    async def _read(self) -> str:
+        body = self._html if isinstance(self._html, str) else await call_user_fn(self._html)
+        return _inject(body, self.runtime_script()) if self._bootstrap else body
+
+    def runtime_script(self) -> str:
+        """The ``<script>`` element performing the MCP Apps handshake, as text.
+
+        A host discards every message from a view that has not completed the
+        ``ui/initialize`` exchange, and says nothing about it — so a hand-written
+        button on a document without this is silently dead. The script performs
+        that exchange and defines a global ``ag2ui`` exposing the View-side
+        surface: ``callTool``, ``sendMessage``, ``openLink``, ``readResource``,
+        ``updateContext``, ``log``, ``requestDisplayMode``, ``downloadFile`` and
+        ``sampling``; the ``onToolInput`` / ``onToolInputPartial`` /
+        ``onToolResult`` / ``onHostContextChanged`` / ``onCancelled``
+        subscriptions; the negotiated
+        ``ag2ui.host.capabilities`` and ``ag2ui.host.context``; an ``ag2ui.ready``
+        promise; and automatic size reporting.
+
+        This is the same text injection uses, exposed for a document that would
+        rather place it itself (with ``bootstrap=False``).
+        """
+        return _runtime_script(self._name)
+
+    @overload
+    def tool(self, function: Callable[..., Any]) -> MCPFunctionTool: ...
+
+    @overload
+    def tool(
+        self,
+        function: None = None,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        title: str | None = None,
+        annotations: ToolAnnotations | None = None,
+        visibility: Sequence[Visibility] | None = None,
+        output_schema: dict[str, Any] | None = None,
+        meta: Mapping[str, Any] | None = None,
+        sync_to_thread: bool = True,
+    ) -> Callable[[Callable[..., Any]], MCPFunctionTool]: ...
+
+    def tool(
+        self,
+        function: Callable[..., Any] | None = None,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        title: str | None = None,
+        annotations: ToolAnnotations | None = None,
+        visibility: Sequence[Visibility] | None = None,
+        output_schema: dict[str, Any] | None = None,
+        meta: Mapping[str, Any] | None = None,
+        sync_to_thread: bool = True,
+    ) -> "MCPFunctionTool | Callable[[Callable[..., Any]], MCPFunctionTool]":
+        """Declare a tool that renders this app's document.
+
+        Takes everything :func:`~ag2.mcp.mcp_tool` takes, plus ``visibility``
+        (where the host surfaces the tool: ``["model", "app"]``). The tool is an
+        ordinary :class:`~ag2.mcp.MCPFunctionTool` carrying the document's URI in
+        ``_meta.ui.resourceUri``, and is collected into :attr:`tools`.
+
+        Several tools may be declared on one app — a card that both renders and
+        updates itself is one app, not two — and each result is stamped with the
+        answering tool's name under :data:`TOOL_META_KEY` so the document can
+        route it. The stamp reaches a ``CallToolResult`` the handler assembled
+        itself, which is the one respect in which such a result is modified; a
+        handler that sets that key keeps its own value.
+
+        Args:
+            function: The function (when used as a bare ``@app.tool``).
+            name: Tool name. Defaults to the function name.
+            description: Tool description. Defaults to the function docstring.
+            title: Human-readable display name for ``tools/list``.
+            annotations: ``mcp.types.ToolAnnotations`` behavior hints.
+            visibility: Where the host surfaces the tool (``_meta.ui.visibility``).
+            output_schema: Overrides the schema derived from the return annotation.
+            meta: Additional ``_meta`` keys, merged alongside the ``ui`` entry.
+            sync_to_thread: Run a sync function in a worker thread.
+
+        Raises:
+            ValueError: If ``meta`` carries a ``ui`` key. The binding between a
+                tool and its document is this decorator's to write; a caller
+                setting it by hand would be overwriting the app's own URI.
+        """
+        if meta and UI_META_KEY in meta:
+            raise ValueError(
+                f"@AppResource.tool owns _meta[{UI_META_KEY!r}]; pass visibility= rather than a 'ui' meta key, "
+                "or declare the tool with mcp_tool() if it should not be bound to this document."
+            )
+        ui: dict[str, Any] = {"resourceUri": self._uri}
+        if visibility is not None:
+            ui["visibility"] = list(visibility)
+        merged = {**(meta or {}), UI_META_KEY: ui}
+
+        def make(f: Callable[..., Any]) -> MCPFunctionTool:
+            built = mcp_tool(
+                f,
+                name=name,
+                description=description,
+                title=title,
+                annotations=annotations,
+                output_schema=output_schema,
+                meta=merged,
+                sync_to_thread=sync_to_thread,
+            )
+            stamped = replace(built, handler=_stamping(built.handler, built.name))
+            self._tools.append(stamped)
+            return stamped
+
+        return make(function) if function is not None else make
+
+
+def _stamping(handler: Callable[..., Any], tool_name: str) -> Callable[[dict[str, Any], ToolContext], Any]:
+    """Wrap ``handler`` so every result names the tool that produced it.
+
+    The stamp is applied at every rung of the result ladder, including a
+    ``CallToolResult`` the author assembled themselves — **the one respect in
+    which such a result is modified**. It is skipped when the author's own
+    ``_meta`` already occupies :data:`TOOL_META_KEY`, so the escape hatch stays
+    open, and every other key they set travels alongside it untouched.
+
+    Mapping the ladder here rather than leaving it to
+    :meth:`~ag2.mcp.MCPFunctionTool.call` is what makes one wrapper enough: the
+    result this returns is already a ``CallToolResult``, which that method
+    passes through untouched.
+    """
+
+    async def stamp(arguments: dict[str, Any], request_context: ToolContext) -> CallToolResult:
+        result = to_call_result(await call_user_fn(handler, arguments, request_context))
+        meta = dict(result.meta or {})
+        if TOOL_META_KEY in meta:
+            return result
+        meta[TOOL_META_KEY] = tool_name
+        return result.model_copy(update={"meta": meta})
+
+    return stamp
+
+
+def visible_meta(meta: "Mapping[str, Any] | None", *, supports_apps: bool) -> "Mapping[str, Any] | None":
+    """``meta`` as a client that may or may not render apps should see it.
+
+    The UI binding is a promise that the client can read the document and render
+    it. To a client that did not advertise the extension it is a promise about a
+    document it will never fetch, so it is withheld — correctness rather than
+    policy, and hence not switchable. Everything else the author put in ``_meta``
+    is unaffected, and the tool still lists and still calls: a UI-bound tool
+    returns text alongside its data either way.
+    """
+    if supports_apps or not meta or UI_META_KEY not in meta:
+        return meta
+    return {key: value for key, value in meta.items() if key != UI_META_KEY}
+
+
+def binds_ui(tools: "Iterable[MCPFunctionTool]") -> bool:
+    """Whether any of ``tools`` advertises a UI binding.
+
+    Read off the tools themselves rather than off the apps they came from, so a
+    server given ``app.tools`` by hand advertises the extension exactly as one
+    given ``apps=[app]`` does.
+    """
+    return any(tool.meta and UI_META_KEY in tool.meta for tool in tools)
+
+
+def collect_apps(apps: "Iterable[AppResource]") -> "tuple[tuple[MCPFunctionTool, ...], tuple[AG2Resource, ...]]":
+    """The tools and resources ``apps`` contributes, refusing a shared document URI.
+
+    Two apps claiming one URI would silently shadow each other — one document
+    would win the registration and the other app's tools would point at a body
+    nobody wrote — so it raises where the server is built, as a duplicate tool
+    name already does.
+    """
+    tools: list[MCPFunctionTool] = []
+    resources: list[AG2Resource] = []
+    seen: set[str] = set()
+    for app in apps:
+        if app.uri in seen:
+            raise MCPDuplicateAppURIError(app.uri)
+        seen.add(app.uri)
+        tools.extend(app.tools)
+        resources.append(app.resource)
+    return tuple(tools), tuple(resources)
+
+
+def _document_meta(
+    *,
+    csp: "ResourceCsp | None",
+    permissions: "ResourcePermissions | None",
+    domain: str | None,
+    prefers_border: bool | None,
+    extra: "Mapping[str, Any] | None",
+) -> dict[str, Any]:
+    """The document's ``_meta``: its sandbox policy under ``ui``, plus a passthrough."""
+    ui: dict[str, Any] = {}
+    if csp is not None:
+        ui["csp"] = csp.model_dump(by_alias=True, exclude_none=True)
+    if permissions is not None:
+        ui["permissions"] = permissions.model_dump(by_alias=True, exclude_none=True)
+    if domain is not None:
+        ui["domain"] = domain
+    if prefers_border is not None:
+        ui["prefersBorder"] = prefers_border
+    meta: dict[str, Any] = dict(extra or {})
+    if ui:
+        # The caller's own ``ui`` keys win: the typed parameters are the spelling
+        # aid, not the authority on a slot the passthrough exists to reach.
+        meta[UI_META_KEY] = {**ui, **meta.get(UI_META_KEY, {})}
+    return meta
+
+
+# An opening tag is its name followed by whitespace or ``>`` — matching on
+# ``"<head "`` alone would miss a tag whose attributes start on the next line.
+_HEAD_TAG = re.compile(r"<head(?=[\s>])", re.IGNORECASE)
+_HTML_TAG = re.compile(r"<html(?=[\s>])", re.IGNORECASE)
+
+
+def _inject(html: str, script: str) -> str:
+    """Place ``script`` at the head of ``html``.
+
+    After ``<head>`` when there is one, after ``<html …>`` when there is not, and
+    at the very front for a fragment — which is what a small document usually is.
+    The runtime must run before the author's own script, which may call it.
+    """
+    for pattern in (_HEAD_TAG, _HTML_TAG):
+        match = pattern.search(html)
+        if match:
+            end = html.find(">", match.start()) + 1
+            return html[:end] + script + html[end:]
+    return script + html
+
+
+def _js(value: object) -> str:
+    """``value`` as a JavaScript literal that cannot close the surrounding script."""
+    return json.dumps(value).replace("</", "<\\/")
+
+
+def _runtime_script(app_name: str) -> str:
+    """The document runtime, specialised with the app's name for the handshake.
+
+    Written to the constraints the specification's own CSP imposes: inline
+    script is permitted and is how the ecosystem ships, but ``eval`` and dynamic
+    function construction are not available, and no network call may be made
+    unless the app declared ``connect`` domains — so this makes none. Messages go
+    to ``window.parent`` with a ``"*"`` target origin, because a sandboxed view
+    has an opaque origin and pinning is not workable; inbound messages are
+    filtered on ``event.source`` instead, and anything that is not JSON-RPC is
+    ignored.
+    """
+    return (
+        _RUNTIME_TEMPLATE
+        .replace("__AG2_APP_NAME__", _js(app_name))
+        .replace("__AG2_TOOL_KEY__", _js(TOOL_META_KEY))
+        .replace("__AG2_PROTOCOL_VERSION__", _js(APP_PROTOCOL_VERSION))
+    )
+
+
+# ``ui/message`` sends its content as an array. The specification's prose says a
+# single object, but its shipped types, its generated schema and the reference
+# host's validator all require the array, and the wire is what a host validates.
+_RUNTIME_TEMPLATE = """<script>
+(function () {
+  "use strict";
+  if (window.ag2ui) { return; }
+
+  var TOOL_KEY = __AG2_TOOL_KEY__;
+  var nextId = 1;
+  var pending = {};
+  var subscribers = {
+    toolInput: [], toolInputPartial: [], toolResult: [], hostContextChanged: [], cancelled: []
+  };
+  var byTool = {};
+  var settle = {};
+  var ready = new Promise(function (resolve, reject) { settle.resolve = resolve; settle.reject = reject; });
+  // A host that refuses the handshake rejects this promise whether or not the
+  // document awaited it; without a handler here that becomes an unhandled
+  // rejection. Awaiting ag2ui.ready still throws — this only marks it handled.
+  ready.catch(function () {});
+  var host = { protocolVersion: null, info: null, capabilities: {}, context: {} };
+  var negotiated = false;
+
+  function post(message) { window.parent.postMessage(message, "*"); }
+
+  function request(method, params) {
+    var id = nextId++;
+    return new Promise(function (resolve, reject) {
+      pending[id] = { resolve: resolve, reject: reject };
+      post({ jsonrpc: "2.0", id: id, method: method, params: params || {} });
+    });
+  }
+
+  function notify(method, params) { post({ jsonrpc: "2.0", method: method, params: params || {} }); }
+
+  function needs(capability, method) {
+    if (!negotiated) {
+      throw new Error("ag2ui." + method + ": await ag2ui.ready before calling the host.");
+    }
+    if (!host.capabilities || !host.capabilities[capability]) {
+      throw new Error(
+        "ag2ui." + method + ": the host did not advertise '" + capability + "'. " +
+        "A host discards a call it did not advertise without answering, so this is refused here instead."
+      );
+    }
+  }
+
+  function reportError(e) {
+    if (window.console && window.console.error) { window.console.error("ag2ui subscriber failed", e); }
+  }
+
+  function emit(list, payload) {
+    for (var i = 0; i < list.length; i++) {
+      try { list[i](payload); } catch (e) { reportError(e); }
+    }
+  }
+
+  function subscribe(list, fn) {
+    list.push(fn);
+    return function () {
+      var at = list.indexOf(fn);
+      if (at !== -1) { list.splice(at, 1); }
+    };
+  }
+
+  function onNotification(method, params) {
+    if (method === "ui/notifications/tool-input") { emit(subscribers.toolInput, params); return; }
+    if (method === "ui/notifications/tool-input-partial") {
+      emit(subscribers.toolInputPartial, params);
+      return;
+    }
+    if (method === "ui/notifications/tool-result") {
+      emit(subscribers.toolResult, params);
+      var meta = params ? params._meta : null;
+      var name = meta ? meta[TOOL_KEY] : null;
+      if (name && byTool[name]) { emit(byTool[name], params); }
+      return;
+    }
+    if (method === "ui/notifications/host-context-changed") {
+      var merged = {};
+      var key;
+      for (key in host.context) { merged[key] = host.context[key]; }
+      for (key in (params || {})) { merged[key] = params[key]; }
+      host.context = merged;
+      emit(subscribers.hostContextChanged, host.context);
+      return;
+    }
+    if (method === "ui/notifications/tool-cancelled") { emit(subscribers.cancelled, params); return; }
+  }
+
+  function onRequest(message) {
+    // Teardown is answered so the host may proceed; ping because a health check
+    // this view refused would read as a view that had stopped responding.
+    if (message.method === "ui/resource-teardown" || message.method === "ping") {
+      post({ jsonrpc: "2.0", id: message.id, result: {} });
+      return;
+    }
+    post({
+      jsonrpc: "2.0",
+      id: message.id,
+      error: { code: -32601, message: "This view does not serve " + message.method + "." }
+    });
+  }
+
+  window.addEventListener("message", function (event) {
+    if (event.source !== window.parent) { return; }
+    var message = event.data;
+    if (!message || message.jsonrpc !== "2.0") { return; }
+    if (typeof message.method === "string") {
+      if (message.id === undefined || message.id === null) { onNotification(message.method, message.params); }
+      else { onRequest(message); }
+      return;
+    }
+    var entry = pending[message.id];
+    if (!entry) { return; }
+    delete pending[message.id];
+    if (message.error) { entry.reject(new Error(message.error.message || "The host refused the call.")); }
+    else { entry.resolve(message.result); }
+  });
+
+  var lastWidth = -1;
+  var lastHeight = -1;
+
+  function reportSize() {
+    var root = document.documentElement;
+    if (!root) { return; }
+    var width = Math.ceil(root.scrollWidth);
+    var height = Math.ceil(root.scrollHeight);
+    if (width === lastWidth && height === lastHeight) { return; }
+    lastWidth = width;
+    lastHeight = height;
+    notify("ui/notifications/size-changed", { width: width, height: height });
+  }
+
+  function watchSize() {
+    reportSize();
+    if (typeof ResizeObserver === "function" && document.documentElement) {
+      new ResizeObserver(reportSize).observe(document.documentElement);
+    }
+  }
+
+  window.ag2ui = {
+    ready: ready,
+    host: host,
+    callTool: function (name, args) {
+      needs("serverTools", "callTool");
+      return request("tools/call", { name: name, arguments: args || {} });
+    },
+    sendMessage: function (text) {
+      needs("message", "sendMessage");
+      return request("ui/message", { role: "user", content: [{ type: "text", text: text }] });
+    },
+    openLink: function (url) {
+      needs("openLinks", "openLink");
+      return request("ui/open-link", { url: url });
+    },
+    readResource: function (uri) {
+      needs("serverResources", "readResource");
+      return request("resources/read", { uri: uri });
+    },
+    updateContext: function (payload) {
+      needs("updateModelContext", "updateContext");
+      return request("ui/update-model-context", payload || {});
+    },
+    log: function (level, data) {
+      needs("logging", "log");
+      notify("notifications/message", { level: level, data: data });
+    },
+    requestDisplayMode: function (mode) {
+      var available = host.context ? host.context.availableDisplayModes : null;
+      if (!available || available.indexOf(mode) === -1) {
+        throw new Error("ag2ui.requestDisplayMode: the host did not offer the '" + mode + "' display mode.");
+      }
+      return request("ui/request-display-mode", { mode: mode }).then(function (result) {
+        // The host answers with the mode it actually applied, which may not be
+        // the one asked for. Recording it keeps ag2ui.host.context from reading
+        // stale until the host happens to send host-context-changed.
+        if (result && result.displayMode) { host.context.displayMode = result.displayMode; }
+        return result;
+      });
+    },
+    downloadFile: function (contents) {
+      needs("downloadFile", "downloadFile");
+      return request("ui/download-file", { contents: contents });
+    },
+    sampling: function (params) {
+      needs("sampling", "sampling");
+      return request("sampling/createMessage", params || {});
+    },
+    onToolInput: function (fn) { return subscribe(subscribers.toolInput, fn); },
+    onToolInputPartial: function (fn) { return subscribe(subscribers.toolInputPartial, fn); },
+    onToolResult: function (nameOrFn, maybeFn) {
+      if (typeof nameOrFn === "function") { return subscribe(subscribers.toolResult, nameOrFn); }
+      if (!byTool[nameOrFn]) { byTool[nameOrFn] = []; }
+      return subscribe(byTool[nameOrFn], maybeFn);
+    },
+    onHostContextChanged: function (fn) { return subscribe(subscribers.hostContextChanged, fn); },
+    onCancelled: function (fn) { return subscribe(subscribers.cancelled, fn); },
+    reportSize: reportSize
+  };
+
+  request("ui/initialize", {
+    appInfo: { name: __AG2_APP_NAME__, version: "1" },
+    // Every display mode, because a document that reports its own size lays
+    // out in any of them. Declaring none is not the safe default it looks
+    // like: a host may decline a mode the view never claimed.
+    appCapabilities: { availableDisplayModes: ["inline", "fullscreen", "pip"] },
+    protocolVersion: __AG2_PROTOCOL_VERSION__
+  }).then(function (result) {
+    host.protocolVersion = result.protocolVersion || null;
+    host.info = result.hostInfo || null;
+    host.capabilities = result.hostCapabilities || {};
+    host.context = result.hostContext || {};
+    negotiated = true;
+    notify("ui/notifications/initialized", {});
+    watchSize();
+    settle.resolve(host);
+  }, settle.reject);
+})();
+</script>"""
+
+
+__all__ = (
+    "APP_MIME_TYPE",
+    "APP_PROTOCOL_VERSION",
+    "EXTENSION_ID",
+    "TOOL_META_KEY",
+    "UI_META_KEY",
+    "AppBody",
+    "AppResource",
+    "ResourceCsp",
+    "ResourcePermissions",
+    "Visibility",
+    "binds_ui",
+    "client_supports_apps",
+    "collect_apps",
+    "visible_meta",
+)

--- a/ag2/mcp/errors.py
+++ b/ag2/mcp/errors.py
@@ -76,3 +76,19 @@ class MCPDuplicateAppURIError(MCPServerError):
             f"Duplicate app document URI {uri!r}; one document would shadow the other and the losing "
             "app's tools would point at a body nobody wrote."
         )
+
+
+class MCPAppFrozenError(MCPServerError):
+    """Raised when a tool is declared on an app already registered with a server.
+
+    Registration is what reads an app's tool composition, so a tool added after
+    it would exist and never be served. Failing here names the tool rather than
+    leaving a silently absent one to be found on the wire.
+    """
+
+    def __init__(self, uri: str, name: str | None = None) -> None:
+        tool = f"Tool {name!r} cannot" if name else "A tool cannot"
+        super().__init__(
+            f"{tool} be declared on app {uri!r}: it is already registered with an MCPServer, which has "
+            "read its tools. Declare every tool before constructing the server."
+        )

--- a/ag2/mcp/errors.py
+++ b/ag2/mcp/errors.py
@@ -59,3 +59,20 @@ class UnknownConversationError(MCPServerError):
         super().__init__(
             "Unknown or expired conversation handle. Omit the 'conversation' argument to start a new conversation."
         )
+
+
+class MCPAppURIError(MCPServerError):
+    """Raised when an app's document URI does not use the ``ui://`` scheme."""
+
+    def __init__(self, uri: str) -> None:
+        super().__init__(f"An app document URI must use the ui:// scheme, got {uri!r}; a host discards anything else.")
+
+
+class MCPDuplicateAppURIError(MCPServerError):
+    """Raised when two apps registered on one server claim the same document URI."""
+
+    def __init__(self, uri: str) -> None:
+        super().__init__(
+            f"Duplicate app document URI {uri!r}; one document would shadow the other and the losing "
+            "app's tools would point at a body nobody wrote."
+        )

--- a/ag2/mcp/executor.py
+++ b/ag2/mcp/executor.py
@@ -45,6 +45,7 @@ class AskContext:
     left ``None`` is omitted, so the default is the stateless behavior."""
 
     variables: dict[str, Any] | None = None
+    dependencies: dict[Any, Any] | None = None
     tools: list[Any] | None = None
     prompt: list[str] | str | None = None
 
@@ -91,6 +92,11 @@ class AgentExecutor:
         self._stream_progress = stream_progress
         self._context_provider = context_provider
         self._session_store = session_store
+
+    @property
+    def context_provider(self) -> "ContextProvider | None":
+        """The optional per-request context provider shared by MCP handlers."""
+        return self._context_provider
 
     def list_tools(self) -> list[MCPTool]:
         return [
@@ -172,6 +178,8 @@ class AgentExecutor:
             ctx = await self._context_provider(get_access_token())
             if ctx.variables is not None:
                 ask_kwargs["variables"] = ctx.variables
+            if ctx.dependencies is not None:
+                ask_kwargs["dependencies"] = ctx.dependencies
             if ctx.tools is not None:
                 ask_kwargs["tools"] = ctx.tools
             if ctx.prompt is not None:

--- a/ag2/mcp/extensions.py
+++ b/ag2/mcp/extensions.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from mcp.server.extension import validate_extension_identifier
+
+if TYPE_CHECKING:
+    from mcp.server.context import ServerRequestContext
+
+# An SEP-2133 extension map: reverse-DNS identifier -> that extension's settings.
+# The settings object is opaque to ag2 — each extension defines its own keys.
+ExtensionMap = Mapping[str, Mapping[str, Any]]
+
+
+def validated_extensions(extensions: ExtensionMap) -> dict[str, dict[str, Any]]:
+    """Copy ``extensions`` into the shape the low-level server advertises, validating keys.
+
+    Every identifier is checked against the SEP-2133 grammar (a reverse-DNS
+    prefix, a ``/``, then a name) using the SDK's own validator, so a typo fails
+    where the server is built rather than on the wire. Values are copied so a
+    caller's mapping cannot mutate what is advertised afterwards.
+    """
+    validated: dict[str, dict[str, Any]] = {}
+    for identifier, settings in extensions.items():
+        validate_extension_identifier(identifier, owner="MCPServer(extensions=...)")
+        validated[identifier] = dict(settings)
+    return validated
+
+
+def client_extension(ctx: "ServerRequestContext[Any, Any] | None", identifier: str) -> dict[str, Any] | None:
+    """The settings the connected client advertised for ``identifier``, or ``None``.
+
+    ``None`` means the client said nothing about this extension; ``{}`` means it
+    advertised support with no settings. The wire distinguishes the two and so
+    does this, because "supported, nothing to configure" is a different answer
+    from "not supported". ``None`` also covers the case of no live request at
+    all, so a handler calling this outside one gets an answer rather than an
+    exception.
+
+    **Reading works in both eras.** A handshake-era client's
+    ``capabilities.extensions`` arrives intact and a modern-era request carries
+    its own capabilities envelope, so branching on what a client advertised is
+    useful today. Advertising in the other direction is not symmetric — see
+    :class:`~ag2.mcp.MCPServer`'s ``extensions`` parameter.
+    """
+    if ctx is None:
+        return None
+    capabilities = ctx.session.client_capabilities
+    extensions = capabilities.extensions if capabilities is not None else None
+    if not extensions:
+        return None
+    settings = extensions.get(identifier)
+    return None if settings is None else dict(settings)
+
+
+__all__ = (
+    "ExtensionMap",
+    "client_extension",
+    "validated_extensions",
+)

--- a/ag2/mcp/resources.py
+++ b/ag2/mcp/resources.py
@@ -48,6 +48,10 @@ class Resource:
     nothing of its own there — so an extension's keys (``ui`` for MCP Apps, say)
     go in verbatim. An empty mapping puts no ``_meta`` on the wire at all.
 
+    ``title`` is the display name a client shows in ``resources/list``; ``name``
+    stays the identifier. It reaches the listing entry only — the wire's read
+    result has no such field — so it is visible only on a listed resource.
+
     ``listed`` keeps the resource out of ``resources/list`` when false. It stays
     readable by URI: the listing is a browsing surface, and a body that only
     makes sense to a machine that was told its URI does not belong there.
@@ -56,6 +60,7 @@ class Resource:
     uri: str
     name: str
     read: ReadFn
+    title: str | None = None
     description: str | None = None
     mime_type: str | None = None
     meta: Mapping[str, Any] | None = None
@@ -184,6 +189,7 @@ def _to_mcp_resource(resource: Resource) -> MCPResource:
     return MCPResource(
         uri=resource.uri,
         name=resource.name,
+        title=resource.title,
         description=resource.description,
         mimeType=resource.mime_type,
         _meta=_meta(resource.meta),

--- a/ag2/mcp/resources.py
+++ b/ag2/mcp/resources.py
@@ -5,7 +5,6 @@
 import base64
 import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from typing import Any
 
@@ -22,11 +21,11 @@ from mcp.types import (
 from mcp.types import Resource as MCPResource
 from mcp.types import ResourceTemplate as MCPResourceTemplate
 
-from ag2.utils import CONTEXT_OPTION_NAME, build_model
+from ag2.annotations import Variable
 
 from ._async import call_user_fn
 from .errors import MCPResourceNotFoundError
-from .tools import MCPExecutionContext, resolve_context_value
+from .tools import MCPExecutionContext, call_with_context, resolve_context_value
 
 # Resource bodies are either text (``str``) or binary (``bytes``); the reader may
 # be sync or async. A template reader additionally receives the variables matched
@@ -56,14 +55,18 @@ class Resource:
     ``listed`` keeps the resource out of ``resources/list`` when false. It stays
     readable by URI: the listing is a browsing surface, and a body that only
     makes sense to a machine that was told its URI does not belong there.
+
+    ``title``, ``description``, ``mime_type`` and the values inside ``meta`` may
+    each be a ``Variable``, resolved per request against the ``AskContext`` the
+    server's ``context_provider`` returned.
     """
 
     uri: str
     name: str
     read: ReadFn
-    title: str | None = None
-    description: str | None = None
-    mime_type: str | None = None
+    title: str | Variable | None = None
+    description: str | Variable | None = None
+    mime_type: str | Variable | None = None
     meta: Mapping[str, Any] | None = None
     listed: bool = True
 
@@ -149,7 +152,11 @@ class ResourceProvider:
         if resource is not None:
             data = await _call_resource_read(resource.read, context)
             return [
-                ReadResourceContents(content=data, mime_type=resource.mime_type, meta=_meta(resource.meta, context))
+                ReadResourceContents(
+                    content=data,
+                    mime_type=resolve_context_value(resource.mime_type, context),
+                    meta=_meta(resource.meta, context),
+                )
             ]
         for pattern, template in self._compiled:
             match = pattern.match(uri)
@@ -162,14 +169,7 @@ class ResourceProvider:
 async def _call_resource_read(read: ReadFn, context: MCPExecutionContext | None) -> ResourceContent:
     if context is None:
         return await call_user_fn(read)
-    call_model = build_model(read, serialize_result=False)
-    async with AsyncExitStack() as stack:
-        return await call_model.asolve(
-            **{CONTEXT_OPTION_NAME: context},
-            stack=stack,
-            cache_dependencies={},
-            dependency_provider=context.dependency_provider,
-        )
+    return await call_with_context(read, context)
 
 
 def _to_wire_contents(uri: str, contents: ReadResourceContents) -> TextResourceContents | BlobResourceContents:
@@ -179,31 +179,27 @@ def _to_wire_contents(uri: str, contents: ReadResourceContents) -> TextResourceC
     returns a complete result, so the mapping — and its MIME-type defaults, which
     :class:`Resource` documents — moves here.
     """
+    meta = _meta(contents.meta)
     if isinstance(contents.content, bytes):
-        meta = contents.meta if isinstance(contents.meta, dict) else dict(contents.meta) if contents.meta else None
         return BlobResourceContents(
             uri=uri,
             mimeType=contents.mime_type or "application/octet-stream",
             blob=base64.b64encode(contents.content).decode("ascii"),
             _meta=meta,
         )
-    meta = contents.meta if isinstance(contents.meta, dict) else dict(contents.meta) if contents.meta else None
-    kwargs: dict[str, Any] = {
-        "uri": uri,
-        "mimeType": contents.mime_type or "text/plain",
-        "text": contents.content,
-        "_meta": meta,
-    }
-    if "annotations" in TextResourceContents.model_fields:
-        kwargs["annotations"] = None
-    return TextResourceContents(**kwargs)
+    return TextResourceContents(
+        uri=uri,
+        mimeType=contents.mime_type or "text/plain",
+        text=contents.content,
+        _meta=meta,
+    )
 
 
 def _meta(meta: Mapping[str, Any] | None, context: MCPExecutionContext | None = None) -> dict[str, Any] | None:
     """``meta`` as a wire ``_meta``, or ``None`` so an empty one is never sent."""
     if not meta:
         return None
-    resolved = resolve_context_value(meta, context) if context is not None else meta
+    resolved = resolve_context_value(meta, context)
     return dict(resolved) if resolved else None
 
 
@@ -211,11 +207,9 @@ def _to_mcp_resource(resource: Resource, context: MCPExecutionContext | None = N
     return MCPResource(
         uri=resource.uri,
         name=resource.name,
-        title=resolve_context_value(resource.title, context) if context is not None else resource.title,
-        description=resolve_context_value(resource.description, context)
-        if context is not None
-        else resource.description,
-        mimeType=resolve_context_value(resource.mime_type, context) if context is not None else resource.mime_type,
+        title=resolve_context_value(resource.title, context),
+        description=resolve_context_value(resource.description, context),
+        mimeType=resolve_context_value(resource.mime_type, context),
         _meta=_meta(resource.meta, context),
     )
 

--- a/ag2/mcp/resources.py
+++ b/ag2/mcp/resources.py
@@ -4,7 +4,7 @@
 
 import base64
 import re
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -42,6 +42,15 @@ class Resource:
     ``read`` returns the body (``str`` → text, ``bytes`` → binary) and may be sync
     or async. ``mime_type`` defaults to ``text/plain`` for text and
     ``application/octet-stream`` for bytes when left ``None``.
+
+    ``meta`` reaches ``_meta`` on both the listing entry and the read result. It
+    is a generic passthrough into the protocol's extension slot — ag2 puts
+    nothing of its own there — so an extension's keys (``ui`` for MCP Apps, say)
+    go in verbatim. An empty mapping puts no ``_meta`` on the wire at all.
+
+    ``listed`` keeps the resource out of ``resources/list`` when false. It stays
+    readable by URI: the listing is a browsing surface, and a body that only
+    makes sense to a machine that was told its URI does not belong there.
     """
 
     uri: str
@@ -49,6 +58,8 @@ class Resource:
     read: ReadFn
     description: str | None = None
     mime_type: str | None = None
+    meta: Mapping[str, Any] | None = None
+    listed: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,7 +127,7 @@ class ResourceProvider:
     async def on_list_resources(
         self, ctx: "ServerRequestContext[Any, Any]", params: PaginatedRequestParams | None
     ) -> ListResourcesResult:
-        return ListResourcesResult(resources=[_to_mcp_resource(r) for r in self._resources])
+        return ListResourcesResult(resources=[_to_mcp_resource(r) for r in self._resources if r.listed])
 
     async def on_list_resource_templates(
         self, ctx: "ServerRequestContext[Any, Any]", params: PaginatedRequestParams | None
@@ -133,7 +144,7 @@ class ResourceProvider:
         resource = self._by_uri.get(uri)
         if resource is not None:
             data = await call_user_fn(resource.read)
-            return [ReadResourceContents(content=data, mime_type=resource.mime_type)]
+            return [ReadResourceContents(content=data, mime_type=resource.mime_type, meta=_meta(resource.meta))]
         for pattern, template in self._compiled:
             match = pattern.match(uri)
             if match is not None:
@@ -164,12 +175,18 @@ def _to_wire_contents(uri: str, contents: ReadResourceContents) -> TextResourceC
     )
 
 
+def _meta(meta: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """``meta`` as a wire ``_meta``, or ``None`` so an empty one is never sent."""
+    return dict(meta) if meta else None
+
+
 def _to_mcp_resource(resource: Resource) -> MCPResource:
     return MCPResource(
         uri=resource.uri,
         name=resource.name,
         description=resource.description,
         mimeType=resource.mime_type,
+        _meta=_meta(resource.meta),
     )
 
 

--- a/ag2/mcp/resources.py
+++ b/ag2/mcp/resources.py
@@ -5,8 +5,9 @@
 import base64
 import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextlib import AsyncExitStack
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.types import (
@@ -21,17 +22,17 @@ from mcp.types import (
 from mcp.types import Resource as MCPResource
 from mcp.types import ResourceTemplate as MCPResourceTemplate
 
+from ag2.utils import CONTEXT_OPTION_NAME, build_model
+
 from ._async import call_user_fn
 from .errors import MCPResourceNotFoundError
-
-if TYPE_CHECKING:
-    from mcp.server.context import ServerRequestContext
+from .tools import MCPExecutionContext, resolve_context_value
 
 # Resource bodies are either text (``str``) or binary (``bytes``); the reader may
 # be sync or async. A template reader additionally receives the variables matched
 # out of the request URI.
 ResourceContent = str | bytes
-ReadFn = Callable[[], Awaitable[ResourceContent] | ResourceContent]
+ReadFn = Callable[..., Awaitable[ResourceContent] | ResourceContent]
 TemplateReadFn = Callable[[dict[str, str]], Awaitable[ResourceContent] | ResourceContent]
 
 
@@ -130,32 +131,45 @@ class ResourceProvider:
         return bool(self._templates)
 
     async def on_list_resources(
-        self, ctx: "ServerRequestContext[Any, Any]", params: PaginatedRequestParams | None
+        self, ctx: MCPExecutionContext, params: PaginatedRequestParams | None
     ) -> ListResourcesResult:
-        return ListResourcesResult(resources=[_to_mcp_resource(r) for r in self._resources if r.listed])
+        return ListResourcesResult(resources=[_to_mcp_resource(r, ctx) for r in self._resources if r.listed])
 
     async def on_list_resource_templates(
-        self, ctx: "ServerRequestContext[Any, Any]", params: PaginatedRequestParams | None
+        self, ctx: MCPExecutionContext, params: PaginatedRequestParams | None
     ) -> ListResourceTemplatesResult:
         return ListResourceTemplatesResult(resourceTemplates=[_to_mcp_template(t) for t in self._templates])
 
-    async def on_read_resource(
-        self, ctx: "ServerRequestContext[Any, Any]", params: ReadResourceRequestParams
-    ) -> ReadResourceResult:
-        contents = await self.read(params.uri)
+    async def on_read_resource(self, ctx: MCPExecutionContext, params: ReadResourceRequestParams) -> ReadResourceResult:
+        contents = await self.read(params.uri, ctx)
         return ReadResourceResult(contents=[_to_wire_contents(params.uri, c) for c in contents])
 
-    async def read(self, uri: str) -> list[ReadResourceContents]:
+    async def read(self, uri: str, context: MCPExecutionContext | None = None) -> list[ReadResourceContents]:
         resource = self._by_uri.get(uri)
         if resource is not None:
-            data = await call_user_fn(resource.read)
-            return [ReadResourceContents(content=data, mime_type=resource.mime_type, meta=_meta(resource.meta))]
+            data = await _call_resource_read(resource.read, context)
+            return [
+                ReadResourceContents(content=data, mime_type=resource.mime_type, meta=_meta(resource.meta, context))
+            ]
         for pattern, template in self._compiled:
             match = pattern.match(uri)
             if match is not None:
                 data = await call_user_fn(template.read, match.groupdict())
                 return [ReadResourceContents(content=data, mime_type=template.mime_type)]
         raise MCPResourceNotFoundError(uri)
+
+
+async def _call_resource_read(read: ReadFn, context: MCPExecutionContext | None) -> ResourceContent:
+    if context is None:
+        return await call_user_fn(read)
+    call_model = build_model(read, serialize_result=False)
+    async with AsyncExitStack() as stack:
+        return await call_model.asolve(
+            **{CONTEXT_OPTION_NAME: context},
+            stack=stack,
+            cache_dependencies={},
+            dependency_provider=context.dependency_provider,
+        )
 
 
 def _to_wire_contents(uri: str, contents: ReadResourceContents) -> TextResourceContents | BlobResourceContents:
@@ -166,33 +180,43 @@ def _to_wire_contents(uri: str, contents: ReadResourceContents) -> TextResourceC
     :class:`Resource` documents — moves here.
     """
     if isinstance(contents.content, bytes):
+        meta = contents.meta if isinstance(contents.meta, dict) else dict(contents.meta) if contents.meta else None
         return BlobResourceContents(
             uri=uri,
             mimeType=contents.mime_type or "application/octet-stream",
             blob=base64.b64encode(contents.content).decode("ascii"),
-            _meta=contents.meta,
+            _meta=meta,
         )
-    return TextResourceContents(
-        uri=uri,
-        mimeType=contents.mime_type or "text/plain",
-        text=contents.content,
-        _meta=contents.meta,
-    )
+    meta = contents.meta if isinstance(contents.meta, dict) else dict(contents.meta) if contents.meta else None
+    kwargs: dict[str, Any] = {
+        "uri": uri,
+        "mimeType": contents.mime_type or "text/plain",
+        "text": contents.content,
+        "_meta": meta,
+    }
+    if "annotations" in TextResourceContents.model_fields:
+        kwargs["annotations"] = None
+    return TextResourceContents(**kwargs)
 
 
-def _meta(meta: Mapping[str, Any] | None) -> dict[str, Any] | None:
+def _meta(meta: Mapping[str, Any] | None, context: MCPExecutionContext | None = None) -> dict[str, Any] | None:
     """``meta`` as a wire ``_meta``, or ``None`` so an empty one is never sent."""
-    return dict(meta) if meta else None
+    if not meta:
+        return None
+    resolved = resolve_context_value(meta, context) if context is not None else meta
+    return dict(resolved) if resolved else None
 
 
-def _to_mcp_resource(resource: Resource) -> MCPResource:
+def _to_mcp_resource(resource: Resource, context: MCPExecutionContext | None = None) -> MCPResource:
     return MCPResource(
         uri=resource.uri,
         name=resource.name,
-        title=resource.title,
-        description=resource.description,
-        mimeType=resource.mime_type,
-        _meta=_meta(resource.meta),
+        title=resolve_context_value(resource.title, context) if context is not None else resource.title,
+        description=resolve_context_value(resource.description, context)
+        if context is not None
+        else resource.description,
+        mimeType=resolve_context_value(resource.mime_type, context) if context is not None else resource.mime_type,
+        _meta=_meta(resource.meta, context),
     )
 
 

--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -388,6 +388,13 @@ class MCPServer:
             return tool_error(str(e) or type(e).__name__)
 
     async def _request_context(self, ctx: "ServerRequestContext[Any, Any]") -> MCPExecutionContext:
+        """The request-scoped context a resource read, tool listing or call resolves against.
+
+        Only the two fields of :class:`AskContext` that a non-conversational
+        request can use are carried over: ``prompt`` and ``tools`` shape an agent
+        turn, and this request is not one. The provider is called per request, so
+        the parallel document read and tool call stay independent.
+        """
         context = MCPExecutionContext(dependencies={MCP_REQUEST_CONTEXT_DEP: ctx})
         if self._executor.context_provider is None:
             return context
@@ -397,11 +404,6 @@ class MCPServer:
         if provided.dependencies is not None:
             context.dependencies.update(provided.dependencies)
             context.dependencies[MCP_REQUEST_CONTEXT_DEP] = ctx
-        if provided.prompt is not None:
-            if isinstance(provided.prompt, str):
-                context.prompt.append(provided.prompt)
-            else:
-                context.prompt.extend(provided.prompt)
         return context
 
     def _advertised_input_schema(self, name: str) -> dict[str, Any] | None:

--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -26,6 +26,7 @@ from ag2.history import MemoryStorage
 
 from .errors import MCPToolNameConflictError
 from .executor import AgentExecutor, ContextProvider
+from .extensions import ExtensionMap, validated_extensions
 from .mappers import input_validation_error, tool_error
 from .prompts import Prompt, PromptProvider
 from .resources import Resource, ResourceProvider, ResourceTemplate
@@ -151,6 +152,16 @@ class MCPServer:
     ``resources`` / ``resource_templates`` / ``prompts`` expose MCP resources and
     prompts alongside the conversational tool; the corresponding capability is
     advertised only when a non-empty collection is supplied.
+
+    ``extensions`` advertises SEP-2133 extension support: a mapping of
+    reverse-DNS identifier to that extension's settings, written to
+    ``ServerCapabilities.extensions``. Identifiers are validated here, so a
+    malformed one fails at construction the way a tool-name conflict does. The
+    two directions of SEP-2133 are **not** symmetric, and this one is the weaker:
+    the field does not exist in the 2025-11-25 wire schema, so a handshake-era
+    client never receives what is advertised here — only a 2026-07-28 client
+    does. Reading what a *client* advertised works in both eras; see
+    :func:`~ag2.mcp.extensions.client_extension`.
     """
 
     __slots__ = (
@@ -170,6 +181,7 @@ class MCPServer:
         "_resource_provider",
         "_prompt_provider",
         "_tool_provider",
+        "_extensions",
         "_http",
     )
 
@@ -195,6 +207,7 @@ class MCPServer:
         resource_templates: "Sequence[ResourceTemplate]" = (),
         prompts: "Sequence[Prompt]" = (),
         tools: "Sequence[MCPFunctionTool]" = (),
+        extensions: "ExtensionMap | None" = None,
         path: str = "/mcp",
         stateless: bool = False,
         json_response: bool = False,
@@ -224,6 +237,7 @@ class MCPServer:
                     raise MCPToolNameConflictError(tool.name, reserved=False)
                 seen.add(tool.name)
         self._tool_provider = ToolProvider(tools) if tools else None
+        self._extensions = validated_extensions(extensions) if extensions else {}
         self._executor = AgentExecutor(
             agent,
             tool_name=tool_name,
@@ -233,6 +247,7 @@ class MCPServer:
             session_store=self._session_store,
         )
         self._server = self._build_server()
+        self._server.extensions.update(self._extensions)
         routes, manager = self._streamable_routes(
             path=path, stateless=stateless, json_response=json_response, security=security
         )

--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -10,7 +10,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
+from mcp.server.auth.middleware.auth_context import AuthContextMiddleware, get_access_token
 from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend, RequireAuthMiddleware
 from mcp.server.auth.routes import build_resource_metadata_url, create_protected_resource_routes
 from mcp.server.caching import CacheHint, CacheableMethod
@@ -25,7 +25,7 @@ from starlette.routing import BaseRoute, Mount, Route
 from ag2.agent import Agent
 from ag2.history import MemoryStorage
 
-from .apps import EXTENSION_ID, AppResource, binds_ui, client_supports_apps, collect_apps, visible_meta
+from .apps import EXTENSION_ID, MCPApp, binds_ui, client_supports_apps, collect_apps, visible_meta
 from .errors import MCPToolNameConflictError
 from .executor import AgentExecutor, ContextProvider
 from .extensions import ExtensionMap, validated_extensions
@@ -34,7 +34,7 @@ from .prompts import Prompt, PromptProvider
 from .resources import Resource, ResourceProvider, ResourceTemplate
 from .security import Requirement
 from .sessions import SessionConfig, SessionStore
-from .tools import MCPFunctionTool, MetaFilter, ToolProvider
+from .tools import MCP_REQUEST_CONTEXT_DEP, MCPExecutionContext, MCPFunctionTool, MetaFilter, ToolProvider
 
 if TYPE_CHECKING:
     from mcp.server.context import ServerRequestContext
@@ -166,7 +166,7 @@ class MCPServer:
     advertised only when a non-empty collection is supplied.
 
     ``apps`` serves interactive documents — MCP Apps — alongside the agent: each
-    :class:`~ag2.mcp.apps.AppResource` contributes its tools to ``tools`` and its document
+    :class:`~ag2.mcp.apps.MCPApp` contributes its tools to ``tools`` and its document
     to ``resources``, so ``apps=[app]`` is exactly shorthand for passing
     ``app.tools`` and ``app.resource`` by hand. Two apps claiming one document URI
     raise here, as a duplicate tool name does. A server holding at least one app
@@ -228,7 +228,7 @@ class MCPServer:
         resource_templates: "Sequence[ResourceTemplate]" = (),
         prompts: "Sequence[Prompt]" = (),
         tools: "Sequence[MCPFunctionTool]" = (),
-        apps: "Sequence[AppResource]" = (),
+        apps: "Sequence[MCPApp]" = (),
         extensions: "ExtensionMap | None" = None,
         path: str = "/mcp",
         stateless: bool = False,
@@ -308,10 +308,10 @@ class MCPServer:
         if self._lifespan is not None:
             kwargs["lifespan"] = self._lifespan
         if self._resource_provider is not None:
-            kwargs["on_list_resources"] = self._resource_provider.on_list_resources
-            kwargs["on_read_resource"] = self._resource_provider.on_read_resource
+            kwargs["on_list_resources"] = self._on_list_resources
+            kwargs["on_read_resource"] = self._on_read_resource
             if self._resource_provider.has_templates:
-                kwargs["on_list_resource_templates"] = self._resource_provider.on_list_resource_templates
+                kwargs["on_list_resource_templates"] = self._on_list_resource_templates
         if self._prompt_provider is not None:
             kwargs["on_list_prompts"] = self._prompt_provider.on_list_prompts
             kwargs["on_get_prompt"] = self._prompt_provider.on_get_prompt
@@ -329,12 +329,29 @@ class MCPServer:
             **kwargs,
         )
 
+    async def _on_list_resources(
+        self, ctx: "ServerRequestContext[Any, Any]", params: PaginatedRequestParams | None
+    ) -> Any:
+        assert self._resource_provider is not None
+        return await self._resource_provider.on_list_resources(await self._request_context(ctx), params)
+
+    async def _on_list_resource_templates(
+        self, ctx: "ServerRequestContext[Any, Any]", params: PaginatedRequestParams | None
+    ) -> Any:
+        assert self._resource_provider is not None
+        return await self._resource_provider.on_list_resource_templates(await self._request_context(ctx), params)
+
+    async def _on_read_resource(self, ctx: "ServerRequestContext[Any, Any]", params: Any) -> Any:
+        assert self._resource_provider is not None
+        return await self._resource_provider.on_read_resource(await self._request_context(ctx), params)
+
     async def _on_list_tools(
         self, ctx: "ServerRequestContext[Any, Any]", params: PaginatedRequestParams | None
     ) -> ListToolsResult:
         tools = self._executor.list_tools()
         if self._tool_provider is not None:
-            tools += self._tool_provider.list_mcp_tools(_ui_binding_filter(ctx))
+            context = await self._request_context(ctx)
+            tools += self._tool_provider.list_mcp_tools(context, _ui_binding_filter(ctx))
         return ListToolsResult(tools=tools)
 
     async def _on_call_tool(
@@ -355,7 +372,7 @@ class MCPServer:
             # Custom tools run their handler directly; everything else is the
             # agent's conversational tool (name collisions are rejected at init).
             if self._tool_provider is not None and self._tool_provider.has(params.name):
-                return await self._tool_provider.call(params.name, arguments, ctx)
+                return await self._tool_provider.call(params.name, arguments, await self._request_context(ctx))
             return await self._executor.call(
                 params.name,
                 message=arguments.get("message", ""),
@@ -369,6 +386,23 @@ class MCPServer:
             # ``str`` is empty for a bare ``raise SomeError``; the class name is the
             # least a client can act on.
             return tool_error(str(e) or type(e).__name__)
+
+    async def _request_context(self, ctx: "ServerRequestContext[Any, Any]") -> MCPExecutionContext:
+        context = MCPExecutionContext(dependencies={MCP_REQUEST_CONTEXT_DEP: ctx})
+        if self._executor.context_provider is None:
+            return context
+        provided = await self._executor.context_provider(get_access_token())
+        if provided.variables is not None:
+            context.variables.update(provided.variables)
+        if provided.dependencies is not None:
+            context.dependencies.update(provided.dependencies)
+            context.dependencies[MCP_REQUEST_CONTEXT_DEP] = ctx
+        if provided.prompt is not None:
+            if isinstance(provided.prompt, str):
+                context.prompt.append(provided.prompt)
+            else:
+                context.prompt.extend(provided.prompt)
+        return context
 
     def _advertised_input_schema(self, name: str) -> dict[str, Any] | None:
         """The ``inputSchema`` ``tools/list`` advertises for ``name``, if any.

--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -6,6 +6,7 @@ import importlib.metadata
 import logging
 from collections.abc import AsyncGenerator, Callable, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from functools import partial
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -24,6 +25,7 @@ from starlette.routing import BaseRoute, Mount, Route
 from ag2.agent import Agent
 from ag2.history import MemoryStorage
 
+from .apps import EXTENSION_ID, AppResource, binds_ui, client_supports_apps, collect_apps, visible_meta
 from .errors import MCPToolNameConflictError
 from .executor import AgentExecutor, ContextProvider
 from .extensions import ExtensionMap, validated_extensions
@@ -32,7 +34,7 @@ from .prompts import Prompt, PromptProvider
 from .resources import Resource, ResourceProvider, ResourceTemplate
 from .security import Requirement
 from .sessions import SessionConfig, SessionStore
-from .tools import MCPFunctionTool, ToolProvider
+from .tools import MCPFunctionTool, MetaFilter, ToolProvider
 
 if TYPE_CHECKING:
     from mcp.server.context import ServerRequestContext
@@ -63,6 +65,16 @@ def _build_session_store(sessions: "bool | SessionConfig") -> SessionStore | Non
         ttl=cfg.ttl,
         storage=cfg.storage or MemoryStorage(),
     )
+
+
+def _ui_binding_filter(ctx: "ServerRequestContext[Any, Any]") -> MetaFilter:
+    """A ``_meta`` filter withholding the MCP Apps binding from a client that cannot render it.
+
+    Applied to every custom tool, whether it came from ``apps=`` or was
+    registered by hand, so the two routes describe the same server. It is a
+    no-op on a tool whose ``_meta`` has no ``ui`` key, which is most of them.
+    """
+    return partial(visible_meta, supports_apps=client_supports_apps(ctx))
 
 
 def _session_manager_lifespan(manager: StreamableHTTPSessionManager) -> "Lifespan[Any]":
@@ -153,6 +165,15 @@ class MCPServer:
     prompts alongside the conversational tool; the corresponding capability is
     advertised only when a non-empty collection is supplied.
 
+    ``apps`` serves interactive documents — MCP Apps — alongside the agent: each
+    :class:`~ag2.mcp.apps.AppResource` contributes its tools to ``tools`` and its document
+    to ``resources``, so ``apps=[app]`` is exactly shorthand for passing
+    ``app.tools`` and ``app.resource`` by hand. Two apps claiming one document URI
+    raise here, as a duplicate tool name does. A server holding at least one app
+    also advertises ``io.modelcontextprotocol/ui`` in ``extensions``, and withholds
+    each UI binding from a client that did not advertise it — see
+    :mod:`ag2.mcp.apps`.
+
     ``extensions`` advertises SEP-2133 extension support: a mapping of
     reverse-DNS identifier to that extension's settings, written to
     ``ServerCapabilities.extensions``. Identifiers are validated here, so a
@@ -207,6 +228,7 @@ class MCPServer:
         resource_templates: "Sequence[ResourceTemplate]" = (),
         prompts: "Sequence[Prompt]" = (),
         tools: "Sequence[MCPFunctionTool]" = (),
+        apps: "Sequence[AppResource]" = (),
         extensions: "ExtensionMap | None" = None,
         path: str = "/mcp",
         stateless: bool = False,
@@ -224,6 +246,10 @@ class MCPServer:
         self._cache_hints = cache_hints
         self._lifespan = lifespan
         self._session_store = _build_session_store(sessions)
+        if apps:
+            app_tools, app_resources = collect_apps(apps)
+            tools = (*tools, *app_tools)
+            resources = (*resources, *app_resources)
         self._resource_provider = (
             ResourceProvider(resources, resource_templates) if (resources or resource_templates) else None
         )
@@ -238,6 +264,14 @@ class MCPServer:
                 seen.add(tool.name)
         self._tool_provider = ToolProvider(tools) if tools else None
         self._extensions = validated_extensions(extensions) if extensions else {}
+        if binds_ui(tools):
+            # Read off the tools rather than off ``apps=``, so registering an app's
+            # pieces by hand yields the same server. Deliberate decoration: the
+            # specification defines only the client direction of SEP-2133 and says
+            # nothing about servers advertising at all, and a handshake-era client
+            # never receives it. Visible in discovery, inert otherwise. An explicit
+            # setting wins.
+            self._extensions.setdefault(EXTENSION_ID, {})
         self._executor = AgentExecutor(
             agent,
             tool_name=tool_name,
@@ -300,7 +334,7 @@ class MCPServer:
     ) -> ListToolsResult:
         tools = self._executor.list_tools()
         if self._tool_provider is not None:
-            tools += self._tool_provider.list_mcp_tools()
+            tools += self._tool_provider.list_mcp_tools(_ui_binding_filter(ctx))
         return ListToolsResult(tools=tools)
 
     async def _on_call_tool(

--- a/ag2/mcp/server.py
+++ b/ag2/mcp/server.py
@@ -321,7 +321,7 @@ class MCPServer:
             # Custom tools run their handler directly; everything else is the
             # agent's conversational tool (name collisions are rejected at init).
             if self._tool_provider is not None and self._tool_provider.has(params.name):
-                return CallToolResult(content=await self._tool_provider.call(params.name, arguments, ctx))
+                return await self._tool_provider.call(params.name, arguments, ctx)
             return await self._executor.call(
                 params.name,
                 message=arguments.get("message", ""),

--- a/ag2/mcp/tools.py
+++ b/ag2/mcp/tools.py
@@ -2,25 +2,34 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Awaitable, Callable, Sequence
+import json
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import AsyncExitStack
-from dataclasses import dataclass, field
-from typing import Annotated, Any, TypeAlias, overload
+from dataclasses import dataclass, field, is_dataclass
+from types import GenericAlias
+from typing import Annotated, Any, TypeAlias, get_type_hints, overload
 
 from fast_depends import dependency_provider
 from fast_depends.pydantic.schema import get_schema
 from mcp.server.context import ServerRequestContext
-from mcp.types import ContentBlock, TextContent, ToolAnnotations
+from mcp.types import CallToolResult, ContentBlock, TextContent, ToolAnnotations
 from mcp.types import Tool as MCPTool
+from pydantic import BaseModel, JsonValue
 
 from ag2.annotations import ContextField
+from ag2.response import ResponseSchema
 from ag2.utils import CONTEXT_OPTION_NAME, build_model
 
 from ._async import call_user_fn
+from .info import object_output_schema
+from .mappers import to_structured_dict
 
-# The result a handler may produce: the content block(s) to send back, or a
-# plain string (wrapped in a text block for convenience).
-ToolResult: TypeAlias = "ContentBlock | Sequence[ContentBlock] | str"
+# What a handler may return; :func:`_to_call_result` maps each arm onto the wire.
+# Any dataclass is accepted too, alongside ``BaseModel``: it has no runtime type
+# to name here, and naming it would cost this alias its resolvability.
+ToolResult: TypeAlias = (
+    "CallToolResult | str | ContentBlock | Sequence[ContentBlock] | Mapping[str, JsonValue] | BaseModel"
+)
 
 # The MCP request context handed to a handler (``None`` outside a live request).
 ToolContext: TypeAlias = "ServerRequestContext[Any, Any] | None"
@@ -44,13 +53,12 @@ class MCPFunctionTool:
 
     Usually produced by :func:`mcp_tool`. Constructed directly, ``handler`` takes
     the raw ``tools/call`` ``arguments`` dict and the MCP request context, and
-    returns the content block(s) — typically an :mod:`ag2.mcp_ui` resource, but
-    any content block (or plain string) works. ``input_schema`` is the JSON
-    Schema advertised in ``tools/list`` (defaults to an open object).
+    returns any :data:`ToolResult`.
 
+    ``input_schema`` / ``output_schema`` are advertised in ``tools/list``, as are
     ``title`` and ``annotations`` (``mcp.types.ToolAnnotations`` behavior hints
-    such as ``readOnlyHint`` / ``destructiveHint``) are passed through to
-    ``tools/list`` so hosts can decide e.g. whether to ask the user first.
+    such as ``readOnlyHint``). ``meta`` reaches ``_meta``, the protocol's
+    extension slot; an empty one is not sent at all.
     """
 
     name: str
@@ -59,23 +67,73 @@ class MCPFunctionTool:
     input_schema: dict[str, Any] = field(default_factory=lambda: {"type": "object"})
     title: str | None = None
     annotations: ToolAnnotations | None = None
+    output_schema: dict[str, Any] | None = None
+    meta: Mapping[str, Any] | None = None
 
     def _mcp_tool(self) -> MCPTool:
         return MCPTool(
             name=self.name,
             description=self.description,
             inputSchema=self.input_schema,
+            outputSchema=self.output_schema,
             title=self.title,
             annotations=self.annotations,
+            _meta=dict(self.meta) if self.meta else None,
         )
 
-    async def call(self, arguments: dict[str, Any], request_context: ToolContext = None) -> list[ContentBlock]:
-        result = await call_user_fn(self.handler, arguments, request_context)
-        if isinstance(result, str):
-            return [TextContent(type="text", text=result)]
-        if isinstance(result, ContentBlock):
-            return [result]
-        return list(result)
+    async def call(self, arguments: dict[str, Any], request_context: ToolContext = None) -> CallToolResult:
+        return _to_call_result(await call_user_fn(self.handler, arguments, request_context))
+
+
+def _to_call_result(result: "ToolResult") -> CallToolResult:
+    """Map a handler's return onto a ``tools/call`` result.
+
+    Ordered by how much is derived: a ``CallToolResult`` is already the answer,
+    and is also how a handler states its text and its data separately.
+    """
+    if isinstance(result, CallToolResult):
+        return result
+    if isinstance(result, str):
+        return CallToolResult(content=[TextContent(type="text", text=result)])
+    if isinstance(result, ContentBlock):
+        return CallToolResult(content=[result])
+    if isinstance(result, Mapping):
+        data = dict(result)
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps(data, default=str))],
+            structuredContent=data,
+        )
+    if isinstance(result, Sequence):
+        return CallToolResult(content=list(result))
+    # A dataclass lands here, which is why this arm is wider than the alias.
+    structured = to_structured_dict(result)
+    if structured is None:
+        raise TypeError(f"A tool handler cannot return {type(result).__name__}; see ag2.mcp.tools.ToolResult.")
+    # ``str()`` and not the JSON dump: a type defining ``__str__`` is saying what
+    # a reader should see, and a model is the reader here.
+    return CallToolResult(content=[TextContent(type="text", text=str(result))], structuredContent=structured)
+
+
+def derive_output_schema(f: Callable[..., Any]) -> dict[str, Any] | None:
+    """The ``outputSchema`` implied by ``f``'s return annotation, or ``None``.
+
+    Only a model or dataclass describes an object, which is what MCP requires
+    ``structuredContent`` to be; every other annotation — ``CallToolResult``
+    included — advertises none rather than failing.
+    """
+    try:
+        annotation = get_type_hints(f).get("return")
+    except Exception:  # pragma: no cover - a forward reference to a name that never resolves
+        return None
+    # Excluded before ``issubclass`` sees it: until 3.11 ``isinstance(list[int], type)``
+    # was ``True`` while ``issubclass(list[int], X)`` raised.
+    if not isinstance(annotation, type) or isinstance(annotation, GenericAlias):
+        return None
+    if issubclass(annotation, CallToolResult) or issubclass(annotation, ContentBlock):
+        return None
+    if not (issubclass(annotation, BaseModel) or is_dataclass(annotation)):
+        return None
+    return object_output_schema(ResponseSchema(annotation, embed=False))
 
 
 def _bind(call_model: Any) -> ToolHandler:
@@ -107,6 +165,8 @@ def mcp_tool(
     description: str | None = None,
     title: str | None = None,
     annotations: ToolAnnotations | None = None,
+    output_schema: dict[str, Any] | None = None,
+    meta: Mapping[str, Any] | None = None,
     sync_to_thread: bool = True,
 ) -> MCPFunctionTool: ...
 
@@ -119,6 +179,8 @@ def mcp_tool(
     description: str | None = None,
     title: str | None = None,
     annotations: ToolAnnotations | None = None,
+    output_schema: dict[str, Any] | None = None,
+    meta: Mapping[str, Any] | None = None,
     sync_to_thread: bool = True,
 ) -> Callable[[Callable[..., Any]], MCPFunctionTool]: ...
 
@@ -130,16 +192,18 @@ def mcp_tool(
     description: str | None = None,
     title: str | None = None,
     annotations: ToolAnnotations | None = None,
+    output_schema: dict[str, Any] | None = None,
+    meta: Mapping[str, Any] | None = None,
     sync_to_thread: bool = True,
 ) -> MCPFunctionTool | Callable[[Callable[..., Any]], MCPFunctionTool]:
     """Turn a function into a :class:`MCPFunctionTool` served alongside the agent's ``ask``.
 
     The tool ``name`` defaults to the function name, ``description`` to its
-    docstring, and ``input_schema`` is derived from the typed signature. The
-    function returns the MCP content block(s) for the result (e.g. an
-    :mod:`ag2.mcp_ui` resource) or a plain string. A parameter annotated with
-    :data:`MCPRequestContext` receives the live request context and is excluded
-    from the advertised schema. Pass the result in ``MCPServer(tools=[...])``.
+    docstring, ``input_schema`` is derived from the typed signature and
+    ``output_schema`` from the return annotation. The function returns any
+    :data:`ToolResult`. A parameter annotated with :data:`MCPRequestContext`
+    receives the live request context and is excluded from the advertised
+    schema. Pass the result in ``MCPServer(tools=[...])``.
 
     Args:
         function: The function (when used as a bare ``@mcp_tool``).
@@ -148,6 +212,8 @@ def mcp_tool(
         title: Human-readable display name for ``tools/list``.
         annotations: ``mcp.types.ToolAnnotations`` behavior hints
             (``readOnlyHint``, ``destructiveHint``, …) for the host.
+        output_schema: Overrides the schema derived from the return annotation.
+        meta: ``_meta`` to advertise on the tool.
         sync_to_thread: Run a sync function in a worker thread.
     """
 
@@ -163,6 +229,8 @@ def mcp_tool(
             input_schema=schema,
             title=title,
             annotations=annotations,
+            output_schema=output_schema if output_schema is not None else derive_output_schema(f),
+            meta=meta,
         )
 
     if function is not None:
@@ -198,7 +266,5 @@ class ToolProvider:
         """The JSON Schema advertised for ``name``."""
         return self._by_name[name].input_schema
 
-    async def call(
-        self, name: str, arguments: dict[str, Any], request_context: ToolContext = None
-    ) -> list[ContentBlock]:
+    async def call(self, name: str, arguments: dict[str, Any], request_context: ToolContext = None) -> CallToolResult:
         return await self._by_name[name].call(arguments, request_context)

--- a/ag2/mcp/tools.py
+++ b/ag2/mcp/tools.py
@@ -16,8 +16,10 @@ from mcp.types import CallToolResult, ContentBlock, TextContent, ToolAnnotations
 from mcp.types import Tool as MCPTool
 from pydantic import BaseModel, JsonValue
 
-from ag2.annotations import ContextField
+from ag2.annotations import ContextField, Variable
+from ag2.context import ConversationContext
 from ag2.response import ResponseSchema
+from ag2.tools.builtin._resolve import resolve_variable
 from ag2.utils import CONTEXT_OPTION_NAME, build_model
 
 from ._async import call_user_fn
@@ -40,6 +42,45 @@ ToolContext: TypeAlias = "ServerRequestContext[Any, Any] | None"
 # to whoever owns the key, so this module only takes the callable.
 MetaFilter: TypeAlias = Callable[["Mapping[str, Any] | None"], "Mapping[str, Any] | None"]
 
+# The live MCP request context is stored in the request-scoped dependency map
+# under this private key. The key is intentionally not a string: applications may
+# use string dependency names, while this is internal protocol plumbing.
+MCP_REQUEST_CONTEXT_DEP = object()
+
+
+@dataclass(slots=True)
+class MCPExecutionContext:
+    dependency_provider: Any = None
+    variables: dict[str, Any] = field(default_factory=dict)
+    dependencies: dict[Any, Any] = field(default_factory=dict)
+    prompt: list[str] = field(default_factory=list)
+
+
+class MCPRequestContextField(ContextField):
+    def use(self, /, **kwargs: Any) -> dict[str, Any]:
+        if ctx := kwargs.get(CONTEXT_OPTION_NAME):
+            assert self.param_name
+            if isinstance(ctx, ConversationContext | MCPExecutionContext):
+                kwargs[self.param_name] = ctx.dependencies.get(MCP_REQUEST_CONTEXT_DEP)
+            else:
+                kwargs[self.param_name] = ctx
+        return kwargs
+
+
+def resolve_context_value(value: Any, context: MCPExecutionContext | ConversationContext) -> Any:
+    if isinstance(value, Variable):
+        return resolve_variable(value, context)
+    if isinstance(value, BaseModel):
+        return value.model_dump(by_alias=True, exclude_none=True)
+    if isinstance(value, Mapping):
+        return {key: resolve_context_value(item, context) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return tuple(resolve_context_value(item, context) for item in value)
+    if isinstance(value, list):
+        return [resolve_context_value(item, context) for item in value]
+    return value
+
+
 # A tool handler receives the call's ``arguments`` and the live MCP request
 # context. Sync or async.
 ToolHandler: TypeAlias = Callable[[dict[str, Any], ToolContext], "Awaitable[ToolResult] | ToolResult"]
@@ -50,7 +91,7 @@ ToolHandler: TypeAlias = Callable[[dict[str, Any], ToolContext], "Awaitable[Tool
 #   async def my_tool(x: str, ctx: MCPRequestContext) -> ...
 # Mirrors ``ag2.annotations.Context``; the parameter is excluded from the
 # advertised ``inputSchema``.
-MCPRequestContext = Annotated[ServerRequestContext[Any, Any], ContextField(cast=False)]
+MCPRequestContext = Annotated[ServerRequestContext[Any, Any], MCPRequestContextField(cast=False)]
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,20 +112,24 @@ class MCPFunctionTool:
     description: str
     handler: ToolHandler
     input_schema: dict[str, Any] = field(default_factory=lambda: {"type": "object"})
-    title: str | None = None
-    annotations: ToolAnnotations | None = None
+    title: str | Variable | None = None
+    annotations: ToolAnnotations | Variable | None = None
     output_schema: dict[str, Any] | None = None
     meta: Mapping[str, Any] | None = None
 
-    def _mcp_tool(self, meta_filter: "MetaFilter | None" = None) -> MCPTool:
+    def _mcp_tool(
+        self, context: MCPExecutionContext | ConversationContext | None = None, meta_filter: "MetaFilter | None" = None
+    ) -> MCPTool:
         meta = self.meta if meta_filter is None else meta_filter(self.meta)
+        if context is not None:
+            meta = resolve_context_value(meta, context)
         return MCPTool(
             name=self.name,
             description=self.description,
             inputSchema=self.input_schema,
             outputSchema=self.output_schema,
-            title=self.title,
-            annotations=self.annotations,
+            title=resolve_context_value(self.title, context) if context is not None else self.title,
+            annotations=resolve_context_value(self.annotations, context) if context is not None else self.annotations,
             _meta=dict(meta) if meta else None,
         )
 
@@ -153,12 +198,15 @@ def _bind(call_model: Any) -> ToolHandler:
     """
 
     async def handler(arguments: dict[str, Any], request_context: ToolContext) -> Any:
+        context = request_context
+        if not isinstance(context, ConversationContext | MCPExecutionContext):
+            context = MCPExecutionContext(dependencies={MCP_REQUEST_CONTEXT_DEP: request_context})
         async with AsyncExitStack() as stack:
             return await call_model.asolve(
-                **(arguments | {CONTEXT_OPTION_NAME: request_context}),
+                **(arguments | {CONTEXT_OPTION_NAME: context}),
                 stack=stack,
                 cache_dependencies={},
-                dependency_provider=dependency_provider,
+                dependency_provider=context.dependency_provider or dependency_provider,
             )
 
     return handler
@@ -263,13 +311,15 @@ class ToolProvider:
     def names(self) -> frozenset[str]:
         return frozenset(self._by_name)
 
-    def list_mcp_tools(self, meta_filter: "MetaFilter | None" = None) -> list[MCPTool]:
+    def list_mcp_tools(
+        self, context: MCPExecutionContext | ConversationContext | None = None, meta_filter: "MetaFilter | None" = None
+    ) -> list[MCPTool]:
         """The advertised tools, with ``meta_filter`` applied to each one's ``_meta``.
 
         The filter is per request, because whether a key is worth sending can
         depend on what the requesting client advertised.
         """
-        return [t._mcp_tool(meta_filter) for t in self._tools]
+        return [t._mcp_tool(context, meta_filter) for t in self._tools]
 
     def has(self, name: str) -> bool:
         return name in self._by_name

--- a/ag2/mcp/tools.py
+++ b/ag2/mcp/tools.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field, is_dataclass
 from types import GenericAlias
 from typing import Annotated, Any, TypeAlias, get_type_hints, overload
 
-from fast_depends import dependency_provider
 from fast_depends.pydantic.schema import get_schema
 from mcp.server.context import ServerRequestContext
 from mcp.types import CallToolResult, ContentBlock, TextContent, ToolAnnotations
@@ -50,10 +49,16 @@ MCP_REQUEST_CONTEXT_DEP = object()
 
 @dataclass(slots=True)
 class MCPExecutionContext:
-    dependency_provider: Any = None
+    """The request-scoped values one MCP request resolves against.
+
+    Built per request from :class:`~ag2.mcp.AskContext`, so a ``Variable``, an
+    injected dependency or a :data:`MCPRequestContext` parameter resolves the
+    same way on a tool call and on the parallel resource read — while staying
+    two distinct requests that share no mutable turn state.
+    """
+
     variables: dict[str, Any] = field(default_factory=dict)
     dependencies: dict[Any, Any] = field(default_factory=dict)
-    prompt: list[str] = field(default_factory=list)
 
 
 class MCPRequestContextField(ContextField):
@@ -67,7 +72,14 @@ class MCPRequestContextField(ContextField):
         return kwargs
 
 
-def resolve_context_value(value: Any, context: MCPExecutionContext | ConversationContext) -> Any:
+def resolve_context_value(value: Any, context: "MCPExecutionContext | ConversationContext | None") -> Any:
+    """``value`` with any ``Variable`` inside it resolved against ``context``.
+
+    Returns ``value`` untouched when there is no context — every listing and read
+    path has one only inside a live request.
+    """
+    if context is None:
+        return value
     if isinstance(value, Variable):
         return resolve_variable(value, context)
     if isinstance(value, BaseModel):
@@ -79,6 +91,24 @@ def resolve_context_value(value: Any, context: MCPExecutionContext | Conversatio
     if isinstance(value, list):
         return [resolve_context_value(item, context) for item in value]
     return value
+
+
+async def call_with_context(fn: Callable[..., Any], context: "MCPExecutionContext | ConversationContext") -> Any:
+    """Invoke ``fn`` through ``fast_depends`` so its annotations resolve.
+
+    For a callable the protocol calls with no arguments of its own — a resource
+    reader, an app content provider — where the only inputs are what the
+    ``Variable``, ``Depends``/``Inject`` and :data:`MCPRequestContext`
+    annotations ask for.
+    """
+    call_model = build_model(fn, serialize_result=False)
+    async with AsyncExitStack() as stack:
+        return await call_model.asolve(
+            context,
+            **{CONTEXT_OPTION_NAME: context},
+            stack=stack,
+            cache_dependencies={},
+        )
 
 
 # A tool handler receives the call's ``arguments`` and the live MCP request
@@ -120,16 +150,14 @@ class MCPFunctionTool:
     def _mcp_tool(
         self, context: MCPExecutionContext | ConversationContext | None = None, meta_filter: "MetaFilter | None" = None
     ) -> MCPTool:
-        meta = self.meta if meta_filter is None else meta_filter(self.meta)
-        if context is not None:
-            meta = resolve_context_value(meta, context)
+        meta = resolve_context_value(self.meta if meta_filter is None else meta_filter(self.meta), context)
         return MCPTool(
             name=self.name,
             description=self.description,
             inputSchema=self.input_schema,
             outputSchema=self.output_schema,
-            title=resolve_context_value(self.title, context) if context is not None else self.title,
-            annotations=resolve_context_value(self.annotations, context) if context is not None else self.annotations,
+            title=resolve_context_value(self.title, context),
+            annotations=resolve_context_value(self.annotations, context),
             _meta=dict(meta) if meta else None,
         )
 
@@ -206,7 +234,6 @@ def _bind(call_model: Any) -> ToolHandler:
                 **(arguments | {CONTEXT_OPTION_NAME: context}),
                 stack=stack,
                 cache_dependencies={},
-                dependency_provider=context.dependency_provider or dependency_provider,
             )
 
     return handler

--- a/ag2/mcp/tools.py
+++ b/ag2/mcp/tools.py
@@ -24,7 +24,7 @@ from ._async import call_user_fn
 from .info import object_output_schema
 from .mappers import to_structured_dict
 
-# What a handler may return; :func:`_to_call_result` maps each arm onto the wire.
+# What a handler may return; :func:`to_call_result` maps each arm onto the wire.
 # Any dataclass is accepted too, alongside ``BaseModel``: it has no runtime type
 # to name here, and naming it would cost this alias its resolvability.
 ToolResult: TypeAlias = (
@@ -33,6 +33,12 @@ ToolResult: TypeAlias = (
 
 # The MCP request context handed to a handler (``None`` outside a live request).
 ToolContext: TypeAlias = "ServerRequestContext[Any, Any] | None"
+
+# A per-request view of a tool's ``_meta``, applied when the tool list is built.
+# Some metadata is addressed to a capability the requesting client may not have,
+# and is worth withholding from one that has not got it; what that means belongs
+# to whoever owns the key, so this module only takes the callable.
+MetaFilter: TypeAlias = Callable[["Mapping[str, Any] | None"], "Mapping[str, Any] | None"]
 
 # A tool handler receives the call's ``arguments`` and the live MCP request
 # context. Sync or async.
@@ -70,7 +76,8 @@ class MCPFunctionTool:
     output_schema: dict[str, Any] | None = None
     meta: Mapping[str, Any] | None = None
 
-    def _mcp_tool(self) -> MCPTool:
+    def _mcp_tool(self, meta_filter: "MetaFilter | None" = None) -> MCPTool:
+        meta = self.meta if meta_filter is None else meta_filter(self.meta)
         return MCPTool(
             name=self.name,
             description=self.description,
@@ -78,14 +85,14 @@ class MCPFunctionTool:
             outputSchema=self.output_schema,
             title=self.title,
             annotations=self.annotations,
-            _meta=dict(self.meta) if self.meta else None,
+            _meta=dict(meta) if meta else None,
         )
 
     async def call(self, arguments: dict[str, Any], request_context: ToolContext = None) -> CallToolResult:
-        return _to_call_result(await call_user_fn(self.handler, arguments, request_context))
+        return to_call_result(await call_user_fn(self.handler, arguments, request_context))
 
 
-def _to_call_result(result: "ToolResult") -> CallToolResult:
+def to_call_result(result: "ToolResult") -> CallToolResult:
     """Map a handler's return onto a ``tools/call`` result.
 
     Ordered by how much is derived: a ``CallToolResult`` is already the answer,
@@ -256,8 +263,13 @@ class ToolProvider:
     def names(self) -> frozenset[str]:
         return frozenset(self._by_name)
 
-    def list_mcp_tools(self) -> list[MCPTool]:
-        return [t._mcp_tool() for t in self._tools]
+    def list_mcp_tools(self, meta_filter: "MetaFilter | None" = None) -> list[MCPTool]:
+        """The advertised tools, with ``meta_filter`` applied to each one's ``_meta``.
+
+        The filter is per request, because whether a key is worth sending can
+        depend on what the requesting client advertised.
+        """
+        return [t._mcp_tool(meta_filter) for t in self._tools]
 
     def has(self, name: str) -> bool:
         return name in self._by_name

--- a/examples/mcp/server_apps.py
+++ b/examples/mcp/server_apps.py
@@ -1,0 +1,115 @@
+"""Serve an MCP App: an agent plus an interactive document a host renders.
+
+Run it over stdio and point an MCP Apps host (or the MCP Inspector) at it::
+
+    python examples/mcp/server_apps.py
+
+The document is static and registered as a resource — the host reads it *in
+parallel with* the call, so it cannot be built from the call's arguments. Each
+call's data arrives inside the frame as the result's ``structuredContent``.
+Contrast ``server_ui.py``, which builds HTML from arguments inside the handler;
+the two mechanisms are alternatives.
+"""
+
+import asyncio
+from dataclasses import dataclass
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import AppResource, MCPServer
+
+CATALOG = {"42": ("Espresso cup", 12), "43": ("Pour-over kettle", 48)}
+
+# One document, two tools. `ag2ui` is the injected runtime: it performs the
+# handshake a host requires before it will accept any message from the frame.
+CARD = """<!doctype html>
+<html>
+  <head>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 0; padding: 20px; }
+      #name { font-size: 20px; font-weight: 600; }
+      button { margin-top: 12px; padding: 8px 14px; }
+    </style>
+  </head>
+  <body>
+    <div id="name">Loading…</div>
+    <div id="price"></div>
+    <button id="buy" disabled>Add to cart</button>
+    <div id="status"></div>
+    <script>
+      var current = null;
+
+      ag2ui.onToolResult("show_item", function (result) {
+        current = result.structuredContent;
+        document.getElementById("name").textContent = current.name;
+        document.getElementById("price").textContent = "$" + current.price;
+        document.getElementById("buy").disabled = false;
+      });
+
+      ag2ui.onToolResult("add_to_cart", function (result) {
+        document.getElementById("status").textContent = result.structuredContent.status;
+      });
+
+      document.getElementById("buy").addEventListener("click", function () {
+        ag2ui.callTool("add_to_cart", { item_id: current.item_id });
+      });
+    </script>
+  </body>
+</html>
+"""
+
+shop = AppResource(
+    "ui://shop/card",
+    CARD,
+    title="Product card",
+    description="A product card that can add its item to the cart.",
+    prefers_border=True,
+)
+
+
+@dataclass
+class Item:
+    """The card's payload — and, via its schema, the tool's ``outputSchema``."""
+
+    item_id: str
+    name: str
+    price: int
+
+    def __str__(self) -> str:
+        # What a text-only client and the model see; the card reads the dump.
+        return f"{self.name} — ${self.price}"
+
+
+@dataclass
+class CartLine:
+    status: str
+
+    def __str__(self) -> str:
+        return self.status
+
+
+@shop.tool
+async def show_item(item_id: str) -> Item:
+    """Show the product card for an item."""
+    name, price = CATALOG.get(item_id, ("Unknown item", 0))
+    return Item(item_id=item_id, name=name, price=price)
+
+
+@shop.tool(visibility=["app"])
+async def add_to_cart(item_id: str) -> CartLine:
+    """Add an item to the cart. Called by the card's button, not by the model."""
+    name, _ = CATALOG.get(item_id, ("Unknown item", 0))
+    return CartLine(status=f"Added {name} to your cart ✓")
+
+
+agent = Agent(
+    name="shopkeeper",
+    prompt="You are a concise shop assistant.",
+    config=AnthropicConfig(model="claude-sonnet-5"),
+)
+
+server = MCPServer(agent, apps=[shop])
+
+
+if __name__ == "__main__":
+    asyncio.run(server.run_stdio())

--- a/examples/mcp/server_apps.py
+++ b/examples/mcp/server_apps.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 
 from ag2 import Agent
 from ag2.config import AnthropicConfig
-from ag2.mcp import AppResource, MCPServer
+from ag2.mcp import MCPApp, MCPServer
 
 CATALOG = {"42": ("Espresso cup", 12), "43": ("Pour-over kettle", 48)}
 
@@ -58,7 +58,7 @@ CARD = """<!doctype html>
 </html>
 """
 
-shop = AppResource(
+shop = MCPApp(
     "ui://shop/card",
     CARD,
     title="Product card",

--- a/test/mcp/_helpers.py
+++ b/test/mcp/_helpers.py
@@ -5,12 +5,39 @@
 from collections.abc import Sequence
 from typing import Any
 
+from mcp.types import CallToolResult, ListToolsResult, TextContent
+from mcp.types import Tool as MCPTool
+from pydantic import BaseModel
 from typing_extensions import Self
 
 from ag2 import Agent, Context
 from ag2.config.client import LLMClient
 from ag2.config.config import ModelConfig
 from ag2.events import BaseEvent, ModelMessage, ModelMessageChunk, ModelRequest, ModelResponse, TextInput
+from ag2.testing import TestConfig
+
+
+class Weather(BaseModel):
+    """The stock structured reply these tests hand an agent as its response schema."""
+
+    city: str
+    temp_c: float
+
+
+def text_of(result: CallToolResult) -> str:
+    """The text carried by a result's first content block."""
+    block = result.content[0]
+    assert isinstance(block, TextContent)
+    return block.text
+
+
+def tool_named(result: ListToolsResult, name: str) -> MCPTool:
+    """The advertised tool called ``name``.
+
+    By name and not by index: the conversational tool shares the listing, so a
+    positional read passes just as happily against the wrong tool.
+    """
+    return next(t for t in result.tools if t.name == name)
 
 
 class ChunkConfig(ModelConfig):
@@ -47,8 +74,15 @@ class ChunkClient(LLMClient):
         return ModelResponse(message=message)
 
 
-def make_agent(*, name: str = "test-agent", prompt: str = "", config: ModelConfig, **kwargs: Any) -> Agent:
-    return Agent(name, prompt, config=config, **kwargs)
+def make_agent(
+    *, name: str = "test-agent", prompt: str = "", config: ModelConfig | None = None, **kwargs: Any
+) -> Agent:
+    """An agent for server-side tests.
+
+    ``config`` defaults to a scripted one-line reply, for the many tests where
+    what the model says never enters the assertion.
+    """
+    return Agent(name, prompt, config=config if config is not None else TestConfig("hi"), **kwargs)
 
 
 class RecordingConfig(ModelConfig):

--- a/test/mcp/test_apps.py
+++ b/test/mcp/test_apps.py
@@ -1,0 +1,560 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""MCP Apps: an agent serving an interactive document.
+
+Everything here drives a real :class:`~ag2.mcp.MCPServer` through the real
+protocol and asserts on what crosses the wire — the tool list a client receives,
+the document it reads, the result it gets back. The one unavoidable exception is
+:meth:`~ag2.mcp.apps.AppResource.runtime_script`, which is a string as far as Python is
+concerned; what it does in a browser is not reachable from this suite and no
+attempt is made to fake it.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from mcp.client.extension import advertise
+from mcp.server.apps import APP_MIME_TYPE, EXTENSION_ID, ResourceCsp, ResourcePermissions
+from mcp.types import CallToolResult, DiscoverResult, TextContent, TextResourceContents
+from mcp_types.version import LATEST_MODERN_VERSION
+
+from ag2 import Agent
+from ag2.mcp import AppResource, MCPServer, mcp_tool
+from ag2.mcp.apps import TOOL_META_KEY
+from ag2.mcp.errors import MCPAppURIError, MCPDuplicateAppURIError, MCPToolNameConflictError
+from ag2.mcp.testing import connect, connect_modern
+from ag2.testing import TestConfig
+
+CARD = "<html><head><title>Card</title></head><body><div id='card'></div></body></html>"
+
+# What an MCP Apps client advertises: the extension, listing the one MIME type a
+# ``ui://`` document is ever served under.
+_UI_AD = {EXTENSION_ID: {"mimeTypes": [APP_MIME_TYPE]}}
+
+
+def _agent() -> Agent:
+    return Agent("shopkeeper", config=TestConfig("hi"))
+
+
+@dataclass
+class Item:
+    name: str
+    price: int
+
+    def __str__(self) -> str:
+        return f"{self.name} costs {self.price}."
+
+
+def _card_app(html: Any = CARD, **kwargs: Any) -> AppResource:
+    """An app with one tool, built fresh so each test owns its own tool list."""
+    app = AppResource("ui://shop/card", html, **kwargs)
+
+    @app.tool
+    async def show_item(item_id: str) -> Item:
+        """Show a product card."""
+        return Item(name=item_id, price=10)
+
+    return app
+
+
+def _tool(result: Any, name: str) -> Any:
+    """The advertised tool named ``name`` in a ``tools/list`` result."""
+    return next(t for t in result.tools if t.name == name)
+
+
+def _text(result: CallToolResult) -> str:
+    block = result.content[0]
+    assert isinstance(block, TextContent)
+    return block.text
+
+
+def _body(contents: Any) -> str:
+    assert isinstance(contents, TextResourceContents)
+    return contents.text
+
+
+@pytest.mark.asyncio
+class TestTheBinding:
+    async def test_a_tool_advertises_the_documents_uri(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app()])
+
+        async with connect(server, extensions=_UI_AD) as session:
+            listed = await session.list_tools()
+
+        assert _tool(listed, "show_item").meta == {"ui": {"resourceUri": "ui://shop/card"}}
+
+    async def test_several_tools_on_one_app_all_carry_it(self) -> None:
+        app = AppResource("ui://shop/card", CARD)
+
+        @app.tool
+        async def render() -> Item:
+            """Render the card."""
+            return Item("a", 1)
+
+        @app.tool(visibility=["app"])
+        async def refresh() -> Item:
+            """Refresh the card in place."""
+            return Item("b", 2)
+
+        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+            listed = await session.list_tools()
+
+        assert _tool(listed, "render").meta == {"ui": {"resourceUri": "ui://shop/card"}}
+        assert _tool(listed, "refresh").meta == {"ui": {"resourceUri": "ui://shop/card", "visibility": ["app"]}}
+
+    async def test_authors_own_meta_travels_alongside_the_binding(self) -> None:
+        app = AppResource("ui://shop/card", CARD)
+
+        @app.tool(meta={"com.example/hint": "left"})
+        async def render() -> Item:
+            """Render the card."""
+            return Item("a", 1)
+
+        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+            listed = await session.list_tools()
+
+        assert _tool(listed, "render").meta == {
+            "com.example/hint": "left",
+            "ui": {"resourceUri": "ui://shop/card"},
+        }
+
+    async def test_a_ui_meta_key_is_refused(self) -> None:
+        app = AppResource("ui://shop/card", CARD)
+
+        with pytest.raises(ValueError, match="owns _meta"):
+
+            @app.tool(meta={"ui": {"resourceUri": "ui://somewhere/else"}})
+            async def render() -> Item:
+                """Render the card."""
+                return Item("a", 1)
+
+
+@pytest.mark.asyncio
+class TestTheDocument:
+    async def test_it_is_read_with_the_required_mime_type(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app(bootstrap=False)])
+
+        async with connect(server) as session:
+            read = await session.read_resource("ui://shop/card")
+
+        assert read.contents[0].mime_type == APP_MIME_TYPE
+        assert _body(read.contents[0]) == CARD
+
+    async def test_it_is_hidden_from_the_listing_by_default(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app()])
+
+        async with connect(server) as session:
+            listed = await session.list_resources()
+            read = await session.read_resource("ui://shop/card")
+
+        assert [str(r.uri) for r in listed.resources] == []
+        # Hidden from browsing, still readable by URI — which is how a host gets it.
+        assert _body(read.contents[0])
+
+    async def test_it_is_listed_when_the_app_asks(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app(listed=True)])
+
+        async with connect(server) as session:
+            listed = await session.list_resources()
+
+        assert [str(r.uri) for r in listed.resources] == ["ui://shop/card"]
+
+    async def test_a_callable_body_is_invoked_per_read(self) -> None:
+        reads = []
+
+        def body() -> str:
+            reads.append(1)
+            return f"<p>read {len(reads)}</p>"
+
+        server = MCPServer(_agent(), apps=[_card_app(body)])
+
+        async with connect(server) as session:
+            first = await session.read_resource("ui://shop/card")
+            second = await session.read_resource("ui://shop/card")
+
+        assert "read 1" in _body(first.contents[0])
+        assert "read 2" in _body(second.contents[0])
+
+    async def test_an_async_callable_body_is_awaited(self) -> None:
+        async def body() -> str:
+            return "<p>async</p>"
+
+        server = MCPServer(_agent(), apps=[_card_app(body)])
+
+        async with connect(server) as session:
+            read = await session.read_resource("ui://shop/card")
+
+        assert "async" in _body(read.contents[0])
+
+    async def test_sandbox_policy_reaches_the_documents_meta(self) -> None:
+        app = _card_app(
+            csp=ResourceCsp(connect_domains=["https://api.example.com"]),
+            permissions=ResourcePermissions(camera={}),
+            domain="https://shop.example.com",
+            prefers_border=True,
+        )
+
+        async with connect(MCPServer(_agent(), apps=[app])) as session:
+            read = await session.read_resource("ui://shop/card")
+
+        assert read.contents[0].meta == {
+            "ui": {
+                "csp": {"connectDomains": ["https://api.example.com"]},
+                "permissions": {"camera": {}},
+                "domain": "https://shop.example.com",
+                "prefersBorder": True,
+            }
+        }
+
+    async def test_raw_meta_passes_through_alongside_the_policy(self) -> None:
+        app = _card_app(prefers_border=False, meta={"com.example/rev": 3})
+
+        async with connect(MCPServer(_agent(), apps=[app])) as session:
+            read = await session.read_resource("ui://shop/card")
+
+        assert read.contents[0].meta == {"com.example/rev": 3, "ui": {"prefersBorder": False}}
+
+    async def test_title_and_description_reach_the_listing(self) -> None:
+        app = _card_app(listed=True, title="Product card", description="A product card.")
+
+        async with connect(MCPServer(_agent(), apps=[app])) as session:
+            listed = await session.list_resources()
+
+        assert (listed.resources[0].title, listed.resources[0].description) == (
+            "Product card",
+            "A product card.",
+        )
+
+    async def test_a_non_ui_uri_raises_at_construction(self) -> None:
+        with pytest.raises(MCPAppURIError, match="ui://"):
+            AppResource("https://shop/card", CARD)
+
+    async def test_two_apps_sharing_a_uri_raise_at_construction(self) -> None:
+        with pytest.raises(MCPDuplicateAppURIError, match="ui://shop/card"):
+            MCPServer(_agent(), apps=[_card_app(), _card_app()])
+
+
+@pytest.mark.asyncio
+class TestTheRuntime:
+    async def test_a_served_document_carries_it_by_default(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app()])
+
+        async with connect(server) as session:
+            read = await session.read_resource("ui://shop/card")
+
+        assert "window.ag2ui" in _body(read.contents[0])
+
+    async def test_the_text_exposed_is_the_text_injected(self) -> None:
+        app = _card_app()
+        server = MCPServer(_agent(), apps=[app])
+
+        async with connect(server) as session:
+            read = await session.read_resource("ui://shop/card")
+
+        assert app.runtime_script() in _body(read.contents[0])
+
+    async def test_it_runs_before_the_authors_own_script(self) -> None:
+        app = _card_app()
+        server = MCPServer(_agent(), apps=[app])
+
+        async with connect(server) as session:
+            served = _body((await session.read_resource("ui://shop/card")).contents[0])
+
+        # Injected inside <head>, so a script later in the document may call it.
+        assert served.index("window.ag2ui") < served.index("<body>")
+
+    async def test_it_lands_inside_a_head_tag_carrying_attributes(self) -> None:
+        app = AppResource(
+            "ui://shop/card",
+            '<html><head\n  lang="en"><title>Card</title></head><body></body></html>',
+        )
+        server = MCPServer(_agent(), apps=[app])
+
+        async with connect(server) as session:
+            served = _body((await session.read_resource("ui://shop/card")).contents[0])
+
+        # Inside <head>, not wedged between <html> and it.
+        assert served.index("window.ag2ui") > served.index('lang="en"')
+        assert served.index("window.ag2ui") < served.index("<title>")
+
+    async def test_a_fragment_gets_it_at_the_front(self) -> None:
+        app = AppResource("ui://shop/card", "<div id='card'></div>")
+        server = MCPServer(_agent(), apps=[app])
+
+        async with connect(server) as session:
+            served = _body((await session.read_resource("ui://shop/card")).contents[0])
+
+        assert served == app.runtime_script() + "<div id='card'></div>"
+
+    async def test_turning_injection_off_leaves_the_document_byte_for_byte(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app(bootstrap=False)])
+
+        async with connect(server) as session:
+            read = await session.read_resource("ui://shop/card")
+
+        assert _body(read.contents[0]) == CARD
+
+    async def test_it_makes_no_network_call_and_constructs_no_function(self) -> None:
+        # The specification's CSP gives a document no network access unless the app
+        # declared connect domains, and forbids eval / dynamic function construction.
+        script = _card_app().runtime_script()
+
+        for forbidden in ("eval(", "new Function", "fetch(", "XMLHttpRequest", "WebSocket", "import("):
+            assert forbidden not in script
+
+    async def test_it_announces_the_dialect_revision(self) -> None:
+        # ``ui/initialize`` params require protocolVersion; without it the handshake
+        # fails validation at the host and every later message is discarded.
+        script = _card_app().runtime_script()
+
+        assert '"ui/initialize"' in script
+        assert 'protocolVersion: "2026-01-26"' in script
+
+    async def test_it_cannot_be_closed_by_the_apps_own_name(self) -> None:
+        app = AppResource("ui://x/y", "<p>hi</p>", name="</script><script>alert(1)</script>")
+
+        assert "</script><script>" not in app.runtime_script()
+
+
+@pytest.mark.asyncio
+class TestDegradation:
+    async def test_a_client_without_the_extension_does_not_see_the_binding(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app()])
+
+        async with connect(server) as session:
+            listed = await session.list_tools()
+            called = await session.call_tool("show_item", {"item_id": "mug"})
+
+        assert _tool(listed, "show_item").meta is None
+        # Still listed, still callable, and the text is the whole answer for it.
+        assert _text(called) == "mug costs 10."
+
+    async def test_the_extension_without_the_mime_type_is_not_support(self) -> None:
+        # Advertising the identifier alone says nothing about being able to render
+        # ``text/html;profile=mcp-app``, which is the only thing the binding promises.
+        server = MCPServer(_agent(), apps=[_card_app()])
+
+        async with connect(server, extensions={EXTENSION_ID: {}}) as session:
+            listed = await session.list_tools()
+
+        assert _tool(listed, "show_item").meta is None
+
+    async def test_other_meta_survives_the_withholding(self) -> None:
+        app = AppResource("ui://shop/card", CARD)
+
+        @app.tool(meta={"com.example/hint": "left"})
+        async def render() -> Item:
+            """Render the card."""
+            return Item("a", 1)
+
+        async with connect(MCPServer(_agent(), apps=[app])) as session:
+            listed = await session.list_tools()
+
+        assert _tool(listed, "render").meta == {"com.example/hint": "left"}
+
+    async def test_a_modern_client_that_advertised_sees_the_binding(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app()])
+
+        async with connect_modern(server, extensions=[advertise(EXTENSION_ID, {"mimeTypes": [APP_MIME_TYPE]})]) as s:
+            listed = await s.list_tools()
+
+        assert _tool(listed, "show_item").meta == {"ui": {"resourceUri": "ui://shop/card"}}
+
+    async def test_a_modern_client_that_advertised_nothing_does_not_see_it(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app()])
+
+        async with connect_modern(server) as session:
+            listed = await session.list_tools()
+            called = await session.call_tool("show_item", {"item_id": "mug"})
+
+        assert _tool(listed, "show_item").meta is None
+        assert _text(called) == "mug costs 10."
+
+    async def test_a_server_holding_an_app_advertises_the_extension(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app()])
+
+        async with connect_modern(server) as session:
+            discovered = DiscoverResult.model_validate(await session.send_discover(LATEST_MODERN_VERSION))
+
+        assert discovered.capabilities.extensions == {EXTENSION_ID: {}}
+
+    async def test_an_explicit_setting_wins_over_the_automatic_one(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app()], extensions={EXTENSION_ID: {"mimeTypes": ["x"]}})
+
+        async with connect_modern(server) as session:
+            discovered = DiscoverResult.model_validate(await session.send_discover(LATEST_MODERN_VERSION))
+
+        assert discovered.capabilities.extensions == {EXTENSION_ID: {"mimeTypes": ["x"]}}
+
+    async def test_a_server_without_apps_advertises_nothing(self) -> None:
+        @mcp_tool
+        async def plain() -> str:
+            """A tool with no document."""
+            return "ok"
+
+        async with connect_modern(MCPServer(_agent(), tools=[plain])) as session:
+            discovered = DiscoverResult.model_validate(await session.send_discover(LATEST_MODERN_VERSION))
+
+        assert discovered.capabilities.extensions is None
+
+
+@pytest.mark.asyncio
+class TestWhichToolAnswered:
+    async def test_a_result_names_the_tool_that_produced_it(self) -> None:
+        server = MCPServer(_agent(), apps=[_card_app()])
+
+        async with connect(server, extensions=_UI_AD) as session:
+            result = await session.call_tool("show_item", {"item_id": "mug"})
+
+        assert result.meta == {TOOL_META_KEY: "show_item"}
+        assert result.structured_content == {"name": "mug", "price": 10}
+
+    async def test_a_renamed_tool_is_stamped_with_its_advertised_name(self) -> None:
+        app = AppResource("ui://shop/card", CARD)
+
+        @app.tool(name="show")
+        async def show_item() -> Item:
+            """Show a product card."""
+            return Item("mug", 10)
+
+        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+            result = await session.call_tool("show", {})
+
+        assert result.meta == {TOOL_META_KEY: "show"}
+
+    async def test_a_fully_formed_result_is_stamped_too(self) -> None:
+        app = AppResource("ui://shop/card", CARD)
+
+        @app.tool
+        async def render() -> CallToolResult:
+            """Render, stating text and data separately."""
+            return CallToolResult(
+                content=[TextContent(type="text", text="a mug")],
+                structuredContent={"name": "mug"},
+            )
+
+        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+            result = await session.call_tool("render", {})
+
+        assert result.meta == {TOOL_META_KEY: "render"}
+        assert _text(result) == "a mug"
+        assert result.structured_content == {"name": "mug"}
+
+    async def test_an_author_who_sets_the_key_keeps_their_value(self) -> None:
+        app = AppResource("ui://shop/card", CARD)
+
+        @app.tool
+        async def render() -> CallToolResult:
+            """Route by my own scheme rather than by tool name."""
+            return CallToolResult(content=[], _meta={TOOL_META_KEY: "card:refresh"})
+
+        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+            result = await session.call_tool("render", {})
+
+        assert result.meta == {TOOL_META_KEY: "card:refresh"}
+
+    async def test_other_meta_the_author_set_is_preserved_alongside_the_stamp(self) -> None:
+        app = AppResource("ui://shop/card", CARD)
+
+        @app.tool
+        async def render() -> CallToolResult:
+            """Render with metadata of my own."""
+            return CallToolResult(content=[], _meta={"com.example/rev": 3})
+
+        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+            result = await session.call_tool("render", {})
+
+        assert result.meta == {"com.example/rev": 3, TOOL_META_KEY: "render"}
+
+    async def test_a_tool_outside_an_app_carries_no_stamp(self) -> None:
+        @mcp_tool
+        async def plain() -> Item:
+            """A tool with no document."""
+            return Item("mug", 10)
+
+        async with connect(MCPServer(_agent(), tools=[plain])) as session:
+            result = await session.call_tool("plain", {})
+
+        assert result.meta is None
+
+    async def test_the_stamp_survives_the_binding_being_withheld(self) -> None:
+        # The stamp is on the *result* and the binding is on the *tool*; a client
+        # without UI support loses one and not the other.
+        server = MCPServer(_agent(), apps=[_card_app()])
+
+        async with connect(server) as session:
+            result = await session.call_tool("show_item", {"item_id": "mug"})
+
+        assert result.meta == {TOOL_META_KEY: "show_item"}
+
+
+@pytest.mark.asyncio
+class TestDecomposition:
+    async def test_registering_the_pieces_by_hand_is_the_same_server(self) -> None:
+        """``apps=[app]`` is shorthand, and this holds it to that.
+
+        Compares what a client actually receives — the advertised tool, the
+        resource listing, the document read — between the two registrations.
+        """
+        shorthand = MCPServer(_agent(), apps=[_card_app(listed=True)])
+        by_hand_app = _card_app(listed=True)
+        by_hand = MCPServer(_agent(), tools=by_hand_app.tools, resources=[by_hand_app.resource])
+
+        async with connect(shorthand, extensions=_UI_AD) as session:
+            a_tools = await session.list_tools()
+            a_resources = await session.list_resources()
+            a_read = await session.read_resource("ui://shop/card")
+            a_call = await session.call_tool("show_item", {"item_id": "mug"})
+        async with connect(by_hand, extensions=_UI_AD) as session:
+            b_tools = await session.list_tools()
+            b_resources = await session.list_resources()
+            b_read = await session.read_resource("ui://shop/card")
+            b_call = await session.call_tool("show_item", {"item_id": "mug"})
+
+        assert a_tools.model_dump() == b_tools.model_dump()
+        assert a_resources.model_dump() == b_resources.model_dump()
+        assert a_read.model_dump() == b_read.model_dump()
+        assert a_call.model_dump() == b_call.model_dump()
+
+    async def test_the_extension_advertisement_follows_the_tools_too(self) -> None:
+        app = _card_app()
+        by_hand = MCPServer(_agent(), tools=app.tools, resources=[app.resource])
+
+        async with connect_modern(by_hand) as session:
+            discovered = DiscoverResult.model_validate(await session.send_discover(LATEST_MODERN_VERSION))
+
+        assert discovered.capabilities.extensions == {EXTENSION_ID: {}}
+
+    async def test_an_apps_tool_names_still_conflict_with_the_agents(self) -> None:
+        app = AppResource("ui://shop/card", CARD)
+
+        @app.tool(name="ask")
+        async def render() -> Item:
+            """Collide with the conversational tool."""
+            return Item("a", 1)
+
+        with pytest.raises(MCPToolNameConflictError, match="conversational tool"):
+            MCPServer(_agent(), apps=[app])
+
+
+@pytest.mark.asyncio
+class TestOrdinaryToolsAreUnaffected:
+    async def test_a_plain_tool_alongside_an_app_keeps_its_shape(self) -> None:
+        @mcp_tool
+        async def plain(word: str) -> str:
+            """Echo a word."""
+            return word
+
+        server = MCPServer(_agent(), tools=[plain], apps=[_card_app()])
+
+        async with connect(server, extensions=_UI_AD) as session:
+            listed = await session.list_tools()
+            result = await session.call_tool("plain", {"word": "hi"})
+
+        assert _tool(listed, "plain").meta is None
+        assert _tool(listed, "plain").output_schema is None
+        assert _text(result) == "hi"
+        assert result.meta is None

--- a/test/mcp/test_apps.py
+++ b/test/mcp/test_apps.py
@@ -16,27 +16,25 @@ from dataclasses import dataclass
 from typing import Any
 
 import pytest
+from dirty_equals import IsPartialDict
 from mcp.client.extension import advertise
 from mcp.server.apps import APP_MIME_TYPE, EXTENSION_ID, ResourceCsp, ResourcePermissions
 from mcp.types import CallToolResult, DiscoverResult, TextContent, TextResourceContents
 from mcp_types.version import LATEST_MODERN_VERSION
 
-from ag2 import Agent
-from ag2.mcp import AppResource, MCPServer, mcp_tool
+from ag2.mcp import AppResource, MCPServer, client_supports_apps, mcp_tool
 from ag2.mcp.apps import TOOL_META_KEY
 from ag2.mcp.errors import MCPAppURIError, MCPDuplicateAppURIError, MCPToolNameConflictError
 from ag2.mcp.testing import connect, connect_modern
-from ag2.testing import TestConfig
+from ag2.mcp.tools import MCPRequestContext
+
+from ._helpers import make_agent, text_of, tool_named
 
 CARD = "<html><head><title>Card</title></head><body><div id='card'></div></body></html>"
 
 # What an MCP Apps client advertises: the extension, listing the one MIME type a
 # ``ui://`` document is ever served under.
 _UI_AD = {EXTENSION_ID: {"mimeTypes": [APP_MIME_TYPE]}}
-
-
-def _agent() -> Agent:
-    return Agent("shopkeeper", config=TestConfig("hi"))
 
 
 @dataclass
@@ -60,17 +58,6 @@ def _card_app(html: Any = CARD, **kwargs: Any) -> AppResource:
     return app
 
 
-def _tool(result: Any, name: str) -> Any:
-    """The advertised tool named ``name`` in a ``tools/list`` result."""
-    return next(t for t in result.tools if t.name == name)
-
-
-def _text(result: CallToolResult) -> str:
-    block = result.content[0]
-    assert isinstance(block, TextContent)
-    return block.text
-
-
 def _body(contents: Any) -> str:
     assert isinstance(contents, TextResourceContents)
     return contents.text
@@ -79,12 +66,12 @@ def _body(contents: Any) -> str:
 @pytest.mark.asyncio
 class TestTheBinding:
     async def test_a_tool_advertises_the_documents_uri(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app()])
+        server = MCPServer(make_agent(), apps=[_card_app()])
 
         async with connect(server, extensions=_UI_AD) as session:
             listed = await session.list_tools()
 
-        assert _tool(listed, "show_item").meta == {"ui": {"resourceUri": "ui://shop/card"}}
+        assert tool_named(listed, "show_item").meta == {"ui": {"resourceUri": "ui://shop/card"}}
 
     async def test_several_tools_on_one_app_all_carry_it(self) -> None:
         app = AppResource("ui://shop/card", CARD)
@@ -99,11 +86,11 @@ class TestTheBinding:
             """Refresh the card in place."""
             return Item("b", 2)
 
-        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+        async with connect(MCPServer(make_agent(), apps=[app]), extensions=_UI_AD) as session:
             listed = await session.list_tools()
 
-        assert _tool(listed, "render").meta == {"ui": {"resourceUri": "ui://shop/card"}}
-        assert _tool(listed, "refresh").meta == {"ui": {"resourceUri": "ui://shop/card", "visibility": ["app"]}}
+        assert tool_named(listed, "render").meta == {"ui": {"resourceUri": "ui://shop/card"}}
+        assert tool_named(listed, "refresh").meta == {"ui": {"resourceUri": "ui://shop/card", "visibility": ["app"]}}
 
     async def test_authors_own_meta_travels_alongside_the_binding(self) -> None:
         app = AppResource("ui://shop/card", CARD)
@@ -113,10 +100,10 @@ class TestTheBinding:
             """Render the card."""
             return Item("a", 1)
 
-        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+        async with connect(MCPServer(make_agent(), apps=[app]), extensions=_UI_AD) as session:
             listed = await session.list_tools()
 
-        assert _tool(listed, "render").meta == {
+        assert tool_named(listed, "render").meta == {
             "com.example/hint": "left",
             "ui": {"resourceUri": "ui://shop/card"},
         }
@@ -135,7 +122,7 @@ class TestTheBinding:
 @pytest.mark.asyncio
 class TestTheDocument:
     async def test_it_is_read_with_the_required_mime_type(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app(bootstrap=False)])
+        server = MCPServer(make_agent(), apps=[_card_app(bootstrap=False)])
 
         async with connect(server) as session:
             read = await session.read_resource("ui://shop/card")
@@ -144,7 +131,7 @@ class TestTheDocument:
         assert _body(read.contents[0]) == CARD
 
     async def test_it_is_hidden_from_the_listing_by_default(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app()])
+        server = MCPServer(make_agent(), apps=[_card_app()])
 
         async with connect(server) as session:
             listed = await session.list_resources()
@@ -155,7 +142,7 @@ class TestTheDocument:
         assert _body(read.contents[0])
 
     async def test_it_is_listed_when_the_app_asks(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app(listed=True)])
+        server = MCPServer(make_agent(), apps=[_card_app(listed=True)])
 
         async with connect(server) as session:
             listed = await session.list_resources()
@@ -169,7 +156,7 @@ class TestTheDocument:
             reads.append(1)
             return f"<p>read {len(reads)}</p>"
 
-        server = MCPServer(_agent(), apps=[_card_app(body)])
+        server = MCPServer(make_agent(), apps=[_card_app(body)])
 
         async with connect(server) as session:
             first = await session.read_resource("ui://shop/card")
@@ -182,7 +169,7 @@ class TestTheDocument:
         async def body() -> str:
             return "<p>async</p>"
 
-        server = MCPServer(_agent(), apps=[_card_app(body)])
+        server = MCPServer(make_agent(), apps=[_card_app(body)])
 
         async with connect(server) as session:
             read = await session.read_resource("ui://shop/card")
@@ -197,7 +184,7 @@ class TestTheDocument:
             prefers_border=True,
         )
 
-        async with connect(MCPServer(_agent(), apps=[app])) as session:
+        async with connect(MCPServer(make_agent(), apps=[app])) as session:
             read = await session.read_resource("ui://shop/card")
 
         assert read.contents[0].meta == {
@@ -212,7 +199,7 @@ class TestTheDocument:
     async def test_raw_meta_passes_through_alongside_the_policy(self) -> None:
         app = _card_app(prefers_border=False, meta={"com.example/rev": 3})
 
-        async with connect(MCPServer(_agent(), apps=[app])) as session:
+        async with connect(MCPServer(make_agent(), apps=[app])) as session:
             read = await session.read_resource("ui://shop/card")
 
         assert read.contents[0].meta == {"com.example/rev": 3, "ui": {"prefersBorder": False}}
@@ -220,13 +207,12 @@ class TestTheDocument:
     async def test_title_and_description_reach_the_listing(self) -> None:
         app = _card_app(listed=True, title="Product card", description="A product card.")
 
-        async with connect(MCPServer(_agent(), apps=[app])) as session:
+        async with connect(MCPServer(make_agent(), apps=[app])) as session:
             listed = await session.list_resources()
 
-        assert (listed.resources[0].title, listed.resources[0].description) == (
-            "Product card",
-            "A product card.",
-        )
+        assert [r.model_dump() for r in listed.resources] == [
+            IsPartialDict({"title": "Product card", "description": "A product card."})
+        ]
 
     async def test_a_non_ui_uri_raises_at_construction(self) -> None:
         with pytest.raises(MCPAppURIError, match="ui://"):
@@ -234,13 +220,13 @@ class TestTheDocument:
 
     async def test_two_apps_sharing_a_uri_raise_at_construction(self) -> None:
         with pytest.raises(MCPDuplicateAppURIError, match="ui://shop/card"):
-            MCPServer(_agent(), apps=[_card_app(), _card_app()])
+            MCPServer(make_agent(), apps=[_card_app(), _card_app()])
 
 
 @pytest.mark.asyncio
 class TestTheRuntime:
     async def test_a_served_document_carries_it_by_default(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app()])
+        server = MCPServer(make_agent(), apps=[_card_app()])
 
         async with connect(server) as session:
             read = await session.read_resource("ui://shop/card")
@@ -249,7 +235,7 @@ class TestTheRuntime:
 
     async def test_the_text_exposed_is_the_text_injected(self) -> None:
         app = _card_app()
-        server = MCPServer(_agent(), apps=[app])
+        server = MCPServer(make_agent(), apps=[app])
 
         async with connect(server) as session:
             read = await session.read_resource("ui://shop/card")
@@ -258,7 +244,7 @@ class TestTheRuntime:
 
     async def test_it_runs_before_the_authors_own_script(self) -> None:
         app = _card_app()
-        server = MCPServer(_agent(), apps=[app])
+        server = MCPServer(make_agent(), apps=[app])
 
         async with connect(server) as session:
             served = _body((await session.read_resource("ui://shop/card")).contents[0])
@@ -271,7 +257,7 @@ class TestTheRuntime:
             "ui://shop/card",
             '<html><head\n  lang="en"><title>Card</title></head><body></body></html>',
         )
-        server = MCPServer(_agent(), apps=[app])
+        server = MCPServer(make_agent(), apps=[app])
 
         async with connect(server) as session:
             served = _body((await session.read_resource("ui://shop/card")).contents[0])
@@ -280,9 +266,18 @@ class TestTheRuntime:
         assert served.index("window.ag2ui") > served.index('lang="en"')
         assert served.index("window.ag2ui") < served.index("<title>")
 
+    async def test_it_lands_after_the_html_tag_when_there_is_no_head(self) -> None:
+        app = AppResource("ui://shop/card", "<html><body><div id='card'></div></body></html>")
+        server = MCPServer(make_agent(), apps=[app])
+
+        async with connect(server) as session:
+            served = _body((await session.read_resource("ui://shop/card")).contents[0])
+
+        assert served == "<html>" + app.runtime_script() + "<body><div id='card'></div></body></html>"
+
     async def test_a_fragment_gets_it_at_the_front(self) -> None:
         app = AppResource("ui://shop/card", "<div id='card'></div>")
-        server = MCPServer(_agent(), apps=[app])
+        server = MCPServer(make_agent(), apps=[app])
 
         async with connect(server) as session:
             served = _body((await session.read_resource("ui://shop/card")).contents[0])
@@ -290,7 +285,7 @@ class TestTheRuntime:
         assert served == app.runtime_script() + "<div id='card'></div>"
 
     async def test_turning_injection_off_leaves_the_document_byte_for_byte(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app(bootstrap=False)])
+        server = MCPServer(make_agent(), apps=[_card_app(bootstrap=False)])
 
         async with connect(server) as session:
             read = await session.read_resource("ui://shop/card")
@@ -322,25 +317,25 @@ class TestTheRuntime:
 @pytest.mark.asyncio
 class TestDegradation:
     async def test_a_client_without_the_extension_does_not_see_the_binding(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app()])
+        server = MCPServer(make_agent(), apps=[_card_app()])
 
         async with connect(server) as session:
             listed = await session.list_tools()
             called = await session.call_tool("show_item", {"item_id": "mug"})
 
-        assert _tool(listed, "show_item").meta is None
+        assert tool_named(listed, "show_item").meta is None
         # Still listed, still callable, and the text is the whole answer for it.
-        assert _text(called) == "mug costs 10."
+        assert text_of(called) == "mug costs 10."
 
     async def test_the_extension_without_the_mime_type_is_not_support(self) -> None:
         # Advertising the identifier alone says nothing about being able to render
         # ``text/html;profile=mcp-app``, which is the only thing the binding promises.
-        server = MCPServer(_agent(), apps=[_card_app()])
+        server = MCPServer(make_agent(), apps=[_card_app()])
 
         async with connect(server, extensions={EXTENSION_ID: {}}) as session:
             listed = await session.list_tools()
 
-        assert _tool(listed, "show_item").meta is None
+        assert tool_named(listed, "show_item").meta is None
 
     async def test_other_meta_survives_the_withholding(self) -> None:
         app = AppResource("ui://shop/card", CARD)
@@ -350,31 +345,47 @@ class TestDegradation:
             """Render the card."""
             return Item("a", 1)
 
-        async with connect(MCPServer(_agent(), apps=[app])) as session:
+        async with connect(MCPServer(make_agent(), apps=[app])) as session:
             listed = await session.list_tools()
 
-        assert _tool(listed, "render").meta == {"com.example/hint": "left"}
+        assert tool_named(listed, "render").meta == {"com.example/hint": "left"}
+
+    async def test_a_handler_can_ask_whether_the_client_will_render(self) -> None:
+        app = AppResource("ui://shop/card", CARD)
+
+        @app.tool
+        async def render(ctx: MCPRequestContext) -> str:
+            """Word the answer differently when there will be no card."""
+            return "a card is coming" if client_supports_apps(ctx) else "Espresso cup, $12, in stock."
+
+        async with connect(MCPServer(make_agent(), apps=[app]), extensions=_UI_AD) as session:
+            with_ui = await session.call_tool("render", {})
+        async with connect(MCPServer(make_agent(), apps=[app])) as session:
+            without_ui = await session.call_tool("render", {})
+
+        assert text_of(with_ui) == "a card is coming"
+        assert text_of(without_ui) == "Espresso cup, $12, in stock."
 
     async def test_a_modern_client_that_advertised_sees_the_binding(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app()])
+        server = MCPServer(make_agent(), apps=[_card_app()])
 
         async with connect_modern(server, extensions=[advertise(EXTENSION_ID, {"mimeTypes": [APP_MIME_TYPE]})]) as s:
             listed = await s.list_tools()
 
-        assert _tool(listed, "show_item").meta == {"ui": {"resourceUri": "ui://shop/card"}}
+        assert tool_named(listed, "show_item").meta == {"ui": {"resourceUri": "ui://shop/card"}}
 
     async def test_a_modern_client_that_advertised_nothing_does_not_see_it(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app()])
+        server = MCPServer(make_agent(), apps=[_card_app()])
 
         async with connect_modern(server) as session:
             listed = await session.list_tools()
             called = await session.call_tool("show_item", {"item_id": "mug"})
 
-        assert _tool(listed, "show_item").meta is None
-        assert _text(called) == "mug costs 10."
+        assert tool_named(listed, "show_item").meta is None
+        assert text_of(called) == "mug costs 10."
 
     async def test_a_server_holding_an_app_advertises_the_extension(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app()])
+        server = MCPServer(make_agent(), apps=[_card_app()])
 
         async with connect_modern(server) as session:
             discovered = DiscoverResult.model_validate(await session.send_discover(LATEST_MODERN_VERSION))
@@ -382,7 +393,7 @@ class TestDegradation:
         assert discovered.capabilities.extensions == {EXTENSION_ID: {}}
 
     async def test_an_explicit_setting_wins_over_the_automatic_one(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app()], extensions={EXTENSION_ID: {"mimeTypes": ["x"]}})
+        server = MCPServer(make_agent(), apps=[_card_app()], extensions={EXTENSION_ID: {"mimeTypes": ["x"]}})
 
         async with connect_modern(server) as session:
             discovered = DiscoverResult.model_validate(await session.send_discover(LATEST_MODERN_VERSION))
@@ -395,7 +406,7 @@ class TestDegradation:
             """A tool with no document."""
             return "ok"
 
-        async with connect_modern(MCPServer(_agent(), tools=[plain])) as session:
+        async with connect_modern(MCPServer(make_agent(), tools=[plain])) as session:
             discovered = DiscoverResult.model_validate(await session.send_discover(LATEST_MODERN_VERSION))
 
         assert discovered.capabilities.extensions is None
@@ -404,7 +415,7 @@ class TestDegradation:
 @pytest.mark.asyncio
 class TestWhichToolAnswered:
     async def test_a_result_names_the_tool_that_produced_it(self) -> None:
-        server = MCPServer(_agent(), apps=[_card_app()])
+        server = MCPServer(make_agent(), apps=[_card_app()])
 
         async with connect(server, extensions=_UI_AD) as session:
             result = await session.call_tool("show_item", {"item_id": "mug"})
@@ -420,7 +431,7 @@ class TestWhichToolAnswered:
             """Show a product card."""
             return Item("mug", 10)
 
-        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+        async with connect(MCPServer(make_agent(), apps=[app]), extensions=_UI_AD) as session:
             result = await session.call_tool("show", {})
 
         assert result.meta == {TOOL_META_KEY: "show"}
@@ -436,11 +447,11 @@ class TestWhichToolAnswered:
                 structuredContent={"name": "mug"},
             )
 
-        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+        async with connect(MCPServer(make_agent(), apps=[app]), extensions=_UI_AD) as session:
             result = await session.call_tool("render", {})
 
         assert result.meta == {TOOL_META_KEY: "render"}
-        assert _text(result) == "a mug"
+        assert text_of(result) == "a mug"
         assert result.structured_content == {"name": "mug"}
 
     async def test_an_author_who_sets_the_key_keeps_their_value(self) -> None:
@@ -451,7 +462,7 @@ class TestWhichToolAnswered:
             """Route by my own scheme rather than by tool name."""
             return CallToolResult(content=[], _meta={TOOL_META_KEY: "card:refresh"})
 
-        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+        async with connect(MCPServer(make_agent(), apps=[app]), extensions=_UI_AD) as session:
             result = await session.call_tool("render", {})
 
         assert result.meta == {TOOL_META_KEY: "card:refresh"}
@@ -464,7 +475,7 @@ class TestWhichToolAnswered:
             """Render with metadata of my own."""
             return CallToolResult(content=[], _meta={"com.example/rev": 3})
 
-        async with connect(MCPServer(_agent(), apps=[app]), extensions=_UI_AD) as session:
+        async with connect(MCPServer(make_agent(), apps=[app]), extensions=_UI_AD) as session:
             result = await session.call_tool("render", {})
 
         assert result.meta == {"com.example/rev": 3, TOOL_META_KEY: "render"}
@@ -475,7 +486,7 @@ class TestWhichToolAnswered:
             """A tool with no document."""
             return Item("mug", 10)
 
-        async with connect(MCPServer(_agent(), tools=[plain])) as session:
+        async with connect(MCPServer(make_agent(), tools=[plain])) as session:
             result = await session.call_tool("plain", {})
 
         assert result.meta is None
@@ -483,7 +494,7 @@ class TestWhichToolAnswered:
     async def test_the_stamp_survives_the_binding_being_withheld(self) -> None:
         # The stamp is on the *result* and the binding is on the *tool*; a client
         # without UI support loses one and not the other.
-        server = MCPServer(_agent(), apps=[_card_app()])
+        server = MCPServer(make_agent(), apps=[_card_app()])
 
         async with connect(server) as session:
             result = await session.call_tool("show_item", {"item_id": "mug"})
@@ -499,9 +510,9 @@ class TestDecomposition:
         Compares what a client actually receives — the advertised tool, the
         resource listing, the document read — between the two registrations.
         """
-        shorthand = MCPServer(_agent(), apps=[_card_app(listed=True)])
+        shorthand = MCPServer(make_agent(), apps=[_card_app(listed=True)])
         by_hand_app = _card_app(listed=True)
-        by_hand = MCPServer(_agent(), tools=by_hand_app.tools, resources=[by_hand_app.resource])
+        by_hand = MCPServer(make_agent(), tools=by_hand_app.tools, resources=[by_hand_app.resource])
 
         async with connect(shorthand, extensions=_UI_AD) as session:
             a_tools = await session.list_tools()
@@ -521,7 +532,7 @@ class TestDecomposition:
 
     async def test_the_extension_advertisement_follows_the_tools_too(self) -> None:
         app = _card_app()
-        by_hand = MCPServer(_agent(), tools=app.tools, resources=[app.resource])
+        by_hand = MCPServer(make_agent(), tools=app.tools, resources=[app.resource])
 
         async with connect_modern(by_hand) as session:
             discovered = DiscoverResult.model_validate(await session.send_discover(LATEST_MODERN_VERSION))
@@ -537,24 +548,25 @@ class TestDecomposition:
             return Item("a", 1)
 
         with pytest.raises(MCPToolNameConflictError, match="conversational tool"):
-            MCPServer(_agent(), apps=[app])
+            MCPServer(make_agent(), apps=[app])
 
 
 @pytest.mark.asyncio
-class TestOrdinaryToolsAreUnaffected:
-    async def test_a_plain_tool_alongside_an_app_keeps_its_shape(self) -> None:
-        @mcp_tool
-        async def plain(word: str) -> str:
-            """Echo a word."""
-            return word
+async def test_an_ordinary_tool_alongside_an_app_keeps_its_shape() -> None:
+    @mcp_tool
+    async def plain(word: str) -> str:
+        """Echo a word."""
+        return word
 
-        server = MCPServer(_agent(), tools=[plain], apps=[_card_app()])
+    server = MCPServer(make_agent(), tools=[plain], apps=[_card_app()])
 
-        async with connect(server, extensions=_UI_AD) as session:
-            listed = await session.list_tools()
-            result = await session.call_tool("plain", {"word": "hi"})
+    async with connect(server, extensions=_UI_AD) as session:
+        listed = await session.list_tools()
+        result = await session.call_tool("plain", {"word": "hi"})
 
-        assert _tool(listed, "plain").meta is None
-        assert _tool(listed, "plain").output_schema is None
-        assert _text(result) == "hi"
-        assert result.meta is None
+    advertised = tool_named(listed, "plain")
+
+    assert advertised.meta is None
+    assert advertised.output_schema is None
+    assert text_of(result) == "hi"
+    assert result.meta is None

--- a/test/mcp/test_apps.py
+++ b/test/mcp/test_apps.py
@@ -7,24 +7,28 @@
 Everything here drives a real :class:`~ag2.mcp.MCPServer` through the real
 protocol and asserts on what crosses the wire — the tool list a client receives,
 the document it reads, the result it gets back. The one unavoidable exception is
-:meth:`~ag2.mcp.apps.AppResource.runtime_script`, which is a string as far as Python is
+:meth:`~ag2.mcp.apps.MCPApp.runtime_script`, which is a string as far as Python is
 concerned; what it does in a browser is not reachable from this suite and no
 attempt is made to fake it.
 """
 
 from dataclasses import dataclass
-from typing import Any
+from pathlib import Path
+from typing import Annotated, Any
 
 import pytest
 from dirty_equals import IsPartialDict
 from mcp.client.extension import advertise
 from mcp.server.apps import APP_MIME_TYPE, EXTENSION_ID, ResourceCsp, ResourcePermissions
+from mcp.shared.exceptions import MCPError
 from mcp.types import CallToolResult, DiscoverResult, TextContent, TextResourceContents
 from mcp_types.version import LATEST_MODERN_VERSION
 
-from ag2.mcp import AppResource, MCPServer, client_supports_apps, mcp_tool
+from ag2 import Inject, Variable
+from ag2.mcp import AppSandbox, MCPApp, MCPServer, client_supports_apps, mcp_tool
 from ag2.mcp.apps import TOOL_META_KEY
 from ag2.mcp.errors import MCPAppURIError, MCPDuplicateAppURIError, MCPToolNameConflictError
+from ag2.mcp.executor import AskContext
 from ag2.mcp.testing import connect, connect_modern
 from ag2.mcp.tools import MCPRequestContext
 
@@ -46,9 +50,9 @@ class Item:
         return f"{self.name} costs {self.price}."
 
 
-def _card_app(html: Any = CARD, **kwargs: Any) -> AppResource:
+def _card_app(html: Any = CARD, **kwargs: Any) -> MCPApp:
     """An app with one tool, built fresh so each test owns its own tool list."""
-    app = AppResource("ui://shop/card", html, **kwargs)
+    app = MCPApp("ui://shop/card", html, **kwargs)
 
     @app.tool
     async def show_item(item_id: str) -> Item:
@@ -74,7 +78,7 @@ class TestTheBinding:
         assert tool_named(listed, "show_item").meta == {"ui": {"resourceUri": "ui://shop/card"}}
 
     async def test_several_tools_on_one_app_all_carry_it(self) -> None:
-        app = AppResource("ui://shop/card", CARD)
+        app = MCPApp("ui://shop/card", CARD)
 
         @app.tool
         async def render() -> Item:
@@ -93,7 +97,7 @@ class TestTheBinding:
         assert tool_named(listed, "refresh").meta == {"ui": {"resourceUri": "ui://shop/card", "visibility": ["app"]}}
 
     async def test_authors_own_meta_travels_alongside_the_binding(self) -> None:
-        app = AppResource("ui://shop/card", CARD)
+        app = MCPApp("ui://shop/card", CARD)
 
         @app.tool(meta={"com.example/hint": "left"})
         async def render() -> Item:
@@ -109,7 +113,7 @@ class TestTheBinding:
         }
 
     async def test_a_ui_meta_key_is_refused(self) -> None:
-        app = AppResource("ui://shop/card", CARD)
+        app = MCPApp("ui://shop/card", CARD)
 
         with pytest.raises(ValueError, match="owns _meta"):
 
@@ -122,7 +126,7 @@ class TestTheBinding:
 @pytest.mark.asyncio
 class TestTheDocument:
     async def test_it_is_read_with_the_required_mime_type(self) -> None:
-        server = MCPServer(make_agent(), apps=[_card_app(bootstrap=False)])
+        server = MCPServer(make_agent(), apps=[_card_app(inject_runtime=False)])
 
         async with connect(server) as session:
             read = await session.read_resource("ui://shop/card")
@@ -176,6 +180,34 @@ class TestTheDocument:
 
         assert "async" in _body(read.contents[0])
 
+    async def test_a_string_body_is_never_treated_as_a_path(self) -> None:
+        server = MCPServer(make_agent(), apps=[_card_app("missing.html", inject_runtime=False)])
+
+        async with connect(server) as session:
+            read = await session.read_resource("ui://shop/card")
+
+        assert _body(read.contents[0]) == "missing.html"
+
+    async def test_a_pathlike_body_is_reread_per_request(self, tmp_path: Path) -> None:
+        document = tmp_path / "card.html"
+        document.write_text("<p>first</p>")
+        server = MCPServer(make_agent(), apps=[_card_app(document, inject_runtime=False)])
+
+        async with connect(server) as session:
+            first = await session.read_resource("ui://shop/card")
+            document.write_text("<p>second</p>")
+            second = await session.read_resource("ui://shop/card")
+
+        assert _body(first.contents[0]) == "<p>first</p>"
+        assert _body(second.contents[0]) == "<p>second</p>"
+
+    async def test_a_missing_pathlike_body_fails_on_read(self, tmp_path: Path) -> None:
+        server = MCPServer(make_agent(), apps=[_card_app(tmp_path / "missing.html")])
+
+        async with connect(server, raise_exceptions=False) as session:
+            with pytest.raises(MCPError, match="Could not read MCP app document"):
+                await session.read_resource("ui://shop/card")
+
     async def test_sandbox_policy_reaches_the_documents_meta(self) -> None:
         app = _card_app(
             csp=ResourceCsp(connect_domains=["https://api.example.com"]),
@@ -194,6 +226,38 @@ class TestTheDocument:
                 "domain": "https://shop.example.com",
                 "prefersBorder": True,
             }
+        }
+
+    async def test_document_options_resolve_request_scoped_variables(self) -> None:
+        async def provider(access: object) -> AskContext:
+            return AskContext(
+                variables={
+                    "domain": "https://tenant.example.com",
+                    "border": True,
+                    "inject": False,
+                    "title": "Tenant card",
+                    "rev": 7,
+                }
+            )
+
+        app = _card_app(
+            inject_runtime=Variable("inject"),
+            title=Variable("title"),
+            sandbox=AppSandbox(domain=Variable("domain")),
+            prefers_border=Variable("border"),
+            meta={"com.example/rev": Variable("rev")},
+            listed=True,
+        )
+
+        async with connect(MCPServer(make_agent(), apps=[app], context_provider=provider)) as session:
+            listed = await session.list_resources()
+            read = await session.read_resource("ui://shop/card")
+
+        assert [r.model_dump() for r in listed.resources] == [IsPartialDict({"title": "Tenant card"})]
+        assert _body(read.contents[0]) == CARD
+        assert read.contents[0].meta == {
+            "com.example/rev": 7,
+            "ui": {"domain": "https://tenant.example.com", "prefersBorder": True},
         }
 
     async def test_raw_meta_passes_through_alongside_the_policy(self) -> None:
@@ -216,7 +280,7 @@ class TestTheDocument:
 
     async def test_a_non_ui_uri_raises_at_construction(self) -> None:
         with pytest.raises(MCPAppURIError, match="ui://"):
-            AppResource("https://shop/card", CARD)
+            MCPApp("https://shop/card", CARD)
 
     async def test_two_apps_sharing_a_uri_raise_at_construction(self) -> None:
         with pytest.raises(MCPDuplicateAppURIError, match="ui://shop/card"):
@@ -253,7 +317,7 @@ class TestTheRuntime:
         assert served.index("window.ag2ui") < served.index("<body>")
 
     async def test_it_lands_inside_a_head_tag_carrying_attributes(self) -> None:
-        app = AppResource(
+        app = MCPApp(
             "ui://shop/card",
             '<html><head\n  lang="en"><title>Card</title></head><body></body></html>',
         )
@@ -267,7 +331,7 @@ class TestTheRuntime:
         assert served.index("window.ag2ui") < served.index("<title>")
 
     async def test_it_lands_after_the_html_tag_when_there_is_no_head(self) -> None:
-        app = AppResource("ui://shop/card", "<html><body><div id='card'></div></body></html>")
+        app = MCPApp("ui://shop/card", "<html><body><div id='card'></div></body></html>")
         server = MCPServer(make_agent(), apps=[app])
 
         async with connect(server) as session:
@@ -276,7 +340,7 @@ class TestTheRuntime:
         assert served == "<html>" + app.runtime_script() + "<body><div id='card'></div></body></html>"
 
     async def test_a_fragment_gets_it_at_the_front(self) -> None:
-        app = AppResource("ui://shop/card", "<div id='card'></div>")
+        app = MCPApp("ui://shop/card", "<div id='card'></div>")
         server = MCPServer(make_agent(), apps=[app])
 
         async with connect(server) as session:
@@ -284,8 +348,8 @@ class TestTheRuntime:
 
         assert served == app.runtime_script() + "<div id='card'></div>"
 
-    async def test_turning_injection_off_leaves_the_document_byte_for_byte(self) -> None:
-        server = MCPServer(make_agent(), apps=[_card_app(bootstrap=False)])
+    async def test_inject_runtime_off_leaves_the_document_byte_for_byte(self) -> None:
+        server = MCPServer(make_agent(), apps=[_card_app(inject_runtime=False)])
 
         async with connect(server) as session:
             read = await session.read_resource("ui://shop/card")
@@ -309,7 +373,7 @@ class TestTheRuntime:
         assert 'protocolVersion: "2026-01-26"' in script
 
     async def test_it_cannot_be_closed_by_the_apps_own_name(self) -> None:
-        app = AppResource("ui://x/y", "<p>hi</p>", name="</script><script>alert(1)</script>")
+        app = MCPApp("ui://x/y", "<p>hi</p>", name="</script><script>alert(1)</script>")
 
         assert "</script><script>" not in app.runtime_script()
 
@@ -338,7 +402,7 @@ class TestDegradation:
         assert tool_named(listed, "show_item").meta is None
 
     async def test_other_meta_survives_the_withholding(self) -> None:
-        app = AppResource("ui://shop/card", CARD)
+        app = MCPApp("ui://shop/card", CARD)
 
         @app.tool(meta={"com.example/hint": "left"})
         async def render() -> Item:
@@ -351,7 +415,7 @@ class TestDegradation:
         assert tool_named(listed, "render").meta == {"com.example/hint": "left"}
 
     async def test_a_handler_can_ask_whether_the_client_will_render(self) -> None:
-        app = AppResource("ui://shop/card", CARD)
+        app = MCPApp("ui://shop/card", CARD)
 
         @app.tool
         async def render(ctx: MCPRequestContext) -> str:
@@ -365,6 +429,24 @@ class TestDegradation:
 
         assert text_of(with_ui) == "a card is coming"
         assert text_of(without_ui) == "Espresso cup, $12, in stock."
+
+    async def test_document_provider_receives_request_scoped_dependencies(self) -> None:
+        async def provider(access: object) -> AskContext:
+            return AskContext(variables={"tenant": "north"}, dependencies={"catalog": {"sku": "mug"}})
+
+        async def body(
+            tenant: Annotated[str, Variable("tenant")],
+            catalog: Annotated[dict[str, str], Inject("catalog")],
+            ctx: MCPRequestContext,
+        ) -> str:
+            return f"<p>{tenant}:{catalog['sku']}:{ctx.session is not None}</p>"
+
+        app = MCPApp("ui://shop/card", body, inject_runtime=False)
+
+        async with connect(MCPServer(make_agent(), apps=[app], context_provider=provider)) as session:
+            read = await session.read_resource("ui://shop/card")
+
+        assert _body(read.contents[0]) == "<p>north:mug:True</p>"
 
     async def test_a_modern_client_that_advertised_sees_the_binding(self) -> None:
         server = MCPServer(make_agent(), apps=[_card_app()])
@@ -424,7 +506,7 @@ class TestWhichToolAnswered:
         assert result.structured_content == {"name": "mug", "price": 10}
 
     async def test_a_renamed_tool_is_stamped_with_its_advertised_name(self) -> None:
-        app = AppResource("ui://shop/card", CARD)
+        app = MCPApp("ui://shop/card", CARD)
 
         @app.tool(name="show")
         async def show_item() -> Item:
@@ -437,7 +519,7 @@ class TestWhichToolAnswered:
         assert result.meta == {TOOL_META_KEY: "show"}
 
     async def test_a_fully_formed_result_is_stamped_too(self) -> None:
-        app = AppResource("ui://shop/card", CARD)
+        app = MCPApp("ui://shop/card", CARD)
 
         @app.tool
         async def render() -> CallToolResult:
@@ -455,7 +537,7 @@ class TestWhichToolAnswered:
         assert result.structured_content == {"name": "mug"}
 
     async def test_an_author_who_sets_the_key_keeps_their_value(self) -> None:
-        app = AppResource("ui://shop/card", CARD)
+        app = MCPApp("ui://shop/card", CARD)
 
         @app.tool
         async def render() -> CallToolResult:
@@ -468,7 +550,7 @@ class TestWhichToolAnswered:
         assert result.meta == {TOOL_META_KEY: "card:refresh"}
 
     async def test_other_meta_the_author_set_is_preserved_alongside_the_stamp(self) -> None:
-        app = AppResource("ui://shop/card", CARD)
+        app = MCPApp("ui://shop/card", CARD)
 
         @app.tool
         async def render() -> CallToolResult:
@@ -540,7 +622,7 @@ class TestDecomposition:
         assert discovered.capabilities.extensions == {EXTENSION_ID: {}}
 
     async def test_an_apps_tool_names_still_conflict_with_the_agents(self) -> None:
-        app = AppResource("ui://shop/card", CARD)
+        app = MCPApp("ui://shop/card", CARD)
 
         @app.tool(name="ask")
         async def render() -> Item:
@@ -549,6 +631,34 @@ class TestDecomposition:
 
         with pytest.raises(MCPToolNameConflictError, match="conversational tool"):
             MCPServer(make_agent(), apps=[app])
+
+    async def test_an_existing_tool_is_copied_when_bound_to_an_app(self) -> None:
+        @mcp_tool(meta={"com.example/hint": "left"})
+        async def render() -> str:
+            """Render."""
+            return "ok"
+
+        app = MCPApp("ui://shop/card", CARD, tools=[render])
+
+        assert render.meta == {"com.example/hint": "left"}
+        assert app.tools[0].meta == {"com.example/hint": "left", "ui": {"resourceUri": "ui://shop/card"}}
+
+    async def test_late_tool_registration_after_server_construction_is_rejected(self) -> None:
+        app = _card_app()
+        MCPServer(make_agent(), apps=[app])
+
+        with pytest.raises(ValueError, match="frozen"):
+
+            @app.tool
+            async def late() -> str:
+                """Too late."""
+                return "late"
+
+    async def test_a_frozen_app_can_be_registered_more_than_once(self) -> None:
+        app = _card_app()
+
+        MCPServer(make_agent(), apps=[app])
+        MCPServer(make_agent(), apps=[app])
 
 
 @pytest.mark.asyncio

--- a/test/mcp/test_apps.py
+++ b/test/mcp/test_apps.py
@@ -25,12 +25,17 @@ from mcp.types import CallToolResult, DiscoverResult, TextContent, TextResourceC
 from mcp_types.version import LATEST_MODERN_VERSION
 
 from ag2 import Inject, Variable
-from ag2.mcp import AppSandbox, MCPApp, MCPServer, client_supports_apps, mcp_tool
+from ag2.mcp import AppSandbox, MCPApp, MCPRequestContext, MCPServer, client_supports_apps, mcp_tool
 from ag2.mcp.apps import TOOL_META_KEY
-from ag2.mcp.errors import MCPAppURIError, MCPDuplicateAppURIError, MCPToolNameConflictError
+from ag2.mcp.errors import (
+    MCPAppFrozenError,
+    MCPAppURIError,
+    MCPDuplicateAppURIError,
+    MCPServerError,
+    MCPToolNameConflictError,
+)
 from ag2.mcp.executor import AskContext
 from ag2.mcp.testing import connect, connect_modern
-from ag2.mcp.tools import MCPRequestContext
 
 from ._helpers import make_agent, text_of, tool_named
 
@@ -50,9 +55,9 @@ class Item:
         return f"{self.name} costs {self.price}."
 
 
-def _card_app(html: Any = CARD, **kwargs: Any) -> MCPApp:
+def _card_app(content: Any = CARD, **kwargs: Any) -> MCPApp:
     """An app with one tool, built fresh so each test owns its own tool list."""
-    app = MCPApp("ui://shop/card", html, **kwargs)
+    app = MCPApp("ui://shop/card", content, **kwargs)
 
     @app.tool
     async def show_item(item_id: str) -> Item:
@@ -206,6 +211,60 @@ class TestTheDocument:
 
         async with connect(server, raise_exceptions=False) as session:
             with pytest.raises(MCPError, match="Could not read MCP app document"):
+                await session.read_resource("ui://shop/card")
+
+    async def test_a_variable_body_is_resolved_per_request(self) -> None:
+        bodies = iter(["<p>north</p>", "<p>south</p>"])
+
+        async def provider(access: object) -> AskContext:
+            return AskContext(variables={"card": next(bodies)})
+
+        app = _card_app(Variable("card"), inject_runtime=False)
+        server = MCPServer(make_agent(), apps=[app], context_provider=provider)
+
+        async with connect(server) as session:
+            first = await session.read_resource("ui://shop/card")
+            second = await session.read_resource("ui://shop/card")
+
+        # Each read is its own request, so each one calls the provider again.
+        assert _body(first.contents[0]) == "<p>north</p>"
+        assert _body(second.contents[0]) == "<p>south</p>"
+
+    async def test_a_content_provider_returning_a_non_string_fails_on_read(self) -> None:
+        server = MCPServer(make_agent(), apps=[_card_app(lambda: 42)])
+
+        async with connect(server, raise_exceptions=False) as session:
+            with pytest.raises(MCPError, match="content provider returned int"):
+                await session.read_resource("ui://shop/card")
+
+    async def test_a_variable_body_resolving_to_an_unsupported_type_fails_on_read(self) -> None:
+        async def provider(access: object) -> AskContext:
+            return AskContext(variables={"card": 42})
+
+        server = MCPServer(make_agent(), apps=[_card_app(Variable("card"))], context_provider=provider)
+
+        async with connect(server, raise_exceptions=False) as session:
+            with pytest.raises(MCPError, match="resolved to int"):
+                await session.read_resource("ui://shop/card")
+
+    async def test_a_content_provider_that_raises_surfaces_its_message(self) -> None:
+        def unavailable() -> str:
+            raise RuntimeError("bundle store offline")
+
+        server = MCPServer(make_agent(), apps=[_card_app(unavailable)])
+
+        async with connect(server, raise_exceptions=False) as session:
+            with pytest.raises(MCPError, match="bundle store offline"):
+                await session.read_resource("ui://shop/card")
+
+    async def test_a_missing_body_variable_fails_on_read(self) -> None:
+        async def provider(access: object) -> AskContext:
+            return AskContext(variables={"other": "x"})
+
+        server = MCPServer(make_agent(), apps=[_card_app(Variable("card"))], context_provider=provider)
+
+        async with connect(server, raise_exceptions=False) as session:
+            with pytest.raises(MCPError):
                 await session.read_resource("ui://shop/card")
 
     async def test_sandbox_policy_reaches_the_documents_meta(self) -> None:
@@ -612,6 +671,59 @@ class TestDecomposition:
         assert a_read.model_dump() == b_read.model_dump()
         assert a_call.model_dump() == b_call.model_dump()
 
+    async def test_registering_the_pieces_by_hand_resolves_context_the_same_way(self) -> None:
+        """The decomposition holds for request-scoped values, not just static ones.
+
+        Registration must not be what decides whether a ``Variable``, an
+        injected dependency or the live request context reaches a document and
+        its tools.
+        """
+
+        async def provider(access: object) -> AskContext:
+            return AskContext(variables={"tenant": "north"}, dependencies={"catalog": {"sku": "mug"}})
+
+        def build(app: MCPApp) -> MCPApp:
+            @app.tool
+            async def whoami(
+                tenant: Annotated[str, Variable("tenant")],
+                catalog: Annotated[dict[str, str], Inject("catalog")],
+                ctx: MCPRequestContext,
+            ) -> str:
+                """Report the request-scoped values."""
+                return f"{tenant}:{catalog['sku']}:{ctx.session is not None}"
+
+            return app
+
+        def app_for() -> MCPApp:
+            async def body(tenant: Annotated[str, Variable("tenant")]) -> str:
+                return f"<p>{tenant}</p>"
+
+            return build(MCPApp("ui://shop/card", body, inject_runtime=False, title=Variable("tenant"), listed=True))
+
+        shorthand = MCPServer(make_agent(), apps=[app_for()], context_provider=provider)
+        by_hand_app = app_for()
+        by_hand = MCPServer(
+            make_agent(),
+            tools=by_hand_app.tools,
+            resources=[by_hand_app.resource],
+            context_provider=provider,
+        )
+
+        async with connect(shorthand, extensions=_UI_AD) as session:
+            a_resources = await session.list_resources()
+            a_read = await session.read_resource("ui://shop/card")
+            a_call = await session.call_tool("whoami", {})
+        async with connect(by_hand, extensions=_UI_AD) as session:
+            b_resources = await session.list_resources()
+            b_read = await session.read_resource("ui://shop/card")
+            b_call = await session.call_tool("whoami", {})
+
+        assert _body(a_read.contents[0]) == "<p>north</p>"
+        assert text_of(a_call) == "north:mug:True"
+        assert a_resources.model_dump() == b_resources.model_dump()
+        assert a_read.model_dump() == b_read.model_dump()
+        assert a_call.model_dump() == b_call.model_dump()
+
     async def test_the_extension_advertisement_follows_the_tools_too(self) -> None:
         app = _card_app()
         by_hand = MCPServer(make_agent(), tools=app.tools, resources=[app.resource])
@@ -647,12 +759,18 @@ class TestDecomposition:
         app = _card_app()
         MCPServer(make_agent(), apps=[app])
 
-        with pytest.raises(ValueError, match="frozen"):
+        with pytest.raises(MCPAppFrozenError) as caught:
 
             @app.tool
             async def late() -> str:
                 """Too late."""
                 return "late"
+
+        # A dedicated error, not a bare ValueError, and it names the tool that
+        # would have gone missing rather than only the app.
+        assert isinstance(caught.value, MCPServerError)
+        assert "late" in str(caught.value)
+        assert "ui://shop/card" in str(caught.value)
 
     async def test_a_frozen_app_can_be_registered_more_than_once(self) -> None:
         app = _card_app()

--- a/test/mcp/test_context_provider.py
+++ b/test/mcp/test_context_provider.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from mcp.types import CallToolResult
 from pydantic import BaseModel
 
 from ag2 import Agent
@@ -11,14 +10,11 @@ from ag2.events import ModelResponse
 from ag2.mcp.executor import AgentExecutor, AskContext
 from ag2.testing import TestConfig
 
+from ._helpers import text_of
+
 
 class _Weather(BaseModel):
     city: str
-
-
-def _text(result: CallToolResult) -> str:
-    block = result.content[0]
-    return getattr(block, "text", "")
 
 
 @pytest.mark.asyncio
@@ -40,7 +36,7 @@ class TestContextProvider:
         # No auth context bound in this unit test, so the provider gets None.
         assert seen["access"] is None
         # The reply came back (the injected variables/prompt were accepted by ask()).
-        assert _text(result) == "hi"
+        assert text_of(result) == "hi"
 
     async def test_no_provider_is_stateless(self) -> None:
         agent = Agent("greeter", config=TestConfig("hi"))
@@ -48,7 +44,7 @@ class TestContextProvider:
 
         result = await executor.call("ask", message="hello", context=None, request_context=None)
 
-        assert _text(result) == "hi"
+        assert text_of(result) == "hi"
 
     async def test_empty_message_is_error(self) -> None:
         executor = AgentExecutor(Agent("greeter", config=TestConfig("hi")), stream_progress=False)
@@ -69,7 +65,7 @@ class TestContextProvider:
 
         result = await executor.call("ask", message="hello", context=None, request_context=None)
 
-        assert _text(result) == "hi"
+        assert text_of(result) == "hi"
 
     async def test_structured_output_none_is_error(self) -> None:
         # Object response_schema + an empty model reply -> content() is None ->

--- a/test/mcp/test_context_provider.py
+++ b/test/mcp/test_context_provider.py
@@ -2,12 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Annotated
+
 import pytest
+from dirty_equals import IsPartialDict
 from pydantic import BaseModel
 
-from ag2 import Agent
+from ag2 import Agent, Inject, Variable
 from ag2.events import ModelResponse
+from ag2.mcp import MCPServer, Resource, mcp_tool
 from ag2.mcp.executor import AgentExecutor, AskContext
+from ag2.mcp.testing import connect
+from ag2.mcp.tools import MCPRequestContext
 from ag2.testing import TestConfig
 
 from ._helpers import text_of
@@ -76,3 +82,79 @@ class TestContextProvider:
         result = await executor.call("ask", message="weather?", context=None, request_context=None)
 
         assert result.is_error is True  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+class TestRequestScopedContext:
+    async def test_resource_reads_resolve_variables_dependencies_and_mcp_context(self) -> None:
+        async def provider(access: object) -> AskContext:
+            return AskContext(variables={"tenant": "north"}, dependencies={"catalog": {"sku": "mug"}})
+
+        async def read(
+            tenant: Annotated[str, Variable("tenant")],
+            catalog: Annotated[dict[str, str], Inject("catalog")],
+            ctx: MCPRequestContext,
+        ) -> str:
+            return f"{tenant}:{catalog['sku']}:{ctx.session is not None}"
+
+        server = MCPServer(
+            Agent("g", config=TestConfig("hi")),
+            resources=[Resource("catalog://card", "card", read)],
+            context_provider=provider,
+        )
+
+        async with connect(server) as session:
+            result = await session.read_resource("catalog://card")
+
+        assert [c.model_dump() for c in result.contents] == [IsPartialDict({"text": "north:mug:True"})]
+
+    async def test_resource_reads_do_not_receive_an_ag2_context(self) -> None:
+        async def read(ctx: MCPRequestContext) -> str:
+            return f"mcp={ctx.session is not None}"
+
+        server = MCPServer(
+            Agent("g", config=TestConfig("hi")),
+            resources=[Resource("catalog://card", "card", read)],
+        )
+
+        async with connect(server) as session:
+            result = await session.read_resource("catalog://card")
+
+        assert [c.model_dump() for c in result.contents] == [IsPartialDict({"text": "mcp=True"})]
+
+    async def test_tool_listing_resolves_request_scoped_metadata(self) -> None:
+        @mcp_tool(title=Variable("tool_title"), meta={"tenant": Variable("tenant")})
+        async def read_scope() -> str:
+            """Read request-scoped data."""
+            return "ok"
+
+        async def provider(access: object) -> AskContext:
+            return AskContext(variables={"tenant": "north", "tool_title": "North catalog"})
+
+        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[read_scope], context_provider=provider)
+
+        async with connect(server) as session:
+            result = await session.list_tools()
+
+        listed = next(t for t in result.tools if t.name == "read_scope")
+        assert listed.model_dump() == IsPartialDict({"title": "North catalog", "meta": {"tenant": "north"}})
+
+    async def test_custom_tools_resolve_request_scoped_values(self) -> None:
+        @mcp_tool
+        async def read_scope(
+            tenant: Annotated[str, Variable("tenant")],
+            catalog: Annotated[dict[str, str], Inject("catalog")],
+            ctx: MCPRequestContext,
+        ) -> str:
+            """Read request-scoped data."""
+            return f"{tenant}:{catalog['sku']}:{ctx.session is not None}"
+
+        async def provider(access: object) -> AskContext:
+            return AskContext(variables={"tenant": "north"}, dependencies={"catalog": {"sku": "mug"}})
+
+        server = MCPServer(Agent("g", config=TestConfig("hi")), tools=[read_scope], context_provider=provider)
+
+        async with connect(server) as session:
+            result = await session.call_tool("read_scope", {})
+
+        assert text_of(result) == "north:mug:True"

--- a/test/mcp/test_context_provider.py
+++ b/test/mcp/test_context_provider.py
@@ -122,6 +122,34 @@ class TestRequestScopedContext:
 
         assert [c.model_dump() for c in result.contents] == [IsPartialDict({"text": "mcp=True"})]
 
+    async def test_resource_listing_resolves_request_scoped_metadata(self) -> None:
+        async def provider(access: object) -> AskContext:
+            return AskContext(variables={"tenant": "North catalog", "kind": "text/markdown"})
+
+        server = MCPServer(
+            Agent("g", config=TestConfig("hi")),
+            resources=[
+                Resource(
+                    "catalog://card",
+                    "card",
+                    lambda: "body",
+                    title=Variable("tenant"),
+                    mime_type=Variable("kind"),
+                )
+            ],
+            context_provider=provider,
+        )
+
+        async with connect(server) as session:
+            listed = await session.list_resources()
+            read = await session.read_resource("catalog://card")
+
+        assert [r.model_dump() for r in listed.resources] == [
+            IsPartialDict({"title": "North catalog", "mime_type": "text/markdown"})
+        ]
+        # The read result carries the resolved value too, not the Variable.
+        assert [c.model_dump() for c in read.contents] == [IsPartialDict({"mime_type": "text/markdown"})]
+
     async def test_tool_listing_resolves_request_scoped_metadata(self) -> None:
         @mcp_tool(title=Variable("tool_title"), meta={"tenant": Variable("tenant")})
         async def read_scope() -> str:

--- a/test/mcp/test_conversations.py
+++ b/test/mcp/test_conversations.py
@@ -20,7 +20,6 @@ from mcp.types import CallToolResult, TextContent
 from mcp.types import Tool as MCPTool
 from mcp_types import CLIENT_CAPABILITIES_META_KEY, PROTOCOL_VERSION_META_KEY
 from mcp_types.version import LATEST_HANDSHAKE_VERSION, LATEST_MODERN_VERSION
-from pydantic import BaseModel
 
 from ag2 import Agent, Context
 from ag2.context import StreamId
@@ -33,14 +32,9 @@ from ag2.mcp.testing import connect, connect_modern, serve
 from ag2.mcp.tools import ToolContext
 from ag2.testing import TestConfig
 
-from ._helpers import RecordingConfig
+from ._helpers import RecordingConfig, Weather
 
 _JSON = {"Accept": f"{CONTENT_TYPE_JSON}, {CONTENT_TYPE_SSE}", "Content-Type": CONTENT_TYPE_JSON}
-
-
-class Weather(BaseModel):
-    city: str
-    temp_c: float
 
 
 def _agent(config: RecordingConfig) -> Agent:

--- a/test/mcp/test_e2e_structured.py
+++ b/test/mcp/test_e2e_structured.py
@@ -3,17 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from pydantic import BaseModel
 
 from ag2 import Agent
 from ag2.mcp import MCPServer
 from ag2.mcp.testing import connect
 from ag2.testing import TestConfig
 
-
-class Weather(BaseModel):
-    city: str
-    temp_c: float
+from ._helpers import Weather, tool_named
 
 
 @pytest.mark.asyncio
@@ -27,7 +23,7 @@ class TestE2EStructured:
         server = MCPServer(agent)
 
         async with connect(server) as session:
-            tool = next(t for t in (await session.list_tools()).tools if t.name == "ask")
+            tool = tool_named(await session.list_tools(), "ask")
             result = await session.call_tool("ask", {"message": "weather in SF?"})
 
         assert tool.output_schema is not None

--- a/test/mcp/test_extensions.py
+++ b/test/mcp/test_extensions.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 from mcp.client.extension import advertise
-from mcp.types import DiscoverResult
+from mcp.types import CallToolResult, DiscoverResult, TextContent
 from mcp_types.version import LATEST_MODERN_VERSION
 
 from ag2 import Agent
@@ -33,6 +33,13 @@ async def read_thing(ctx: MCPRequestContext) -> str:
 def _handshake_ad(settings: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """What ``connect`` forwards to ``ClientSession(extensions=...)``."""
     return {_ID: settings}
+
+
+def _reported(result: CallToolResult) -> Any:
+    """What ``read_thing`` saw, decoded from its one text block."""
+    block = result.content[0]
+    assert isinstance(block, TextContent)
+    return json.loads(block.text)
 
 
 async def _discovered(session: Any) -> DiscoverResult:
@@ -87,7 +94,7 @@ class TestServerReadsClientExtensions:
         async with connect(server, extensions=_handshake_ad({"level": 1})) as session:
             result = await session.call_tool("read_thing", {})
 
-        assert json.loads(result.content[0].text) == {"level": 1}  # type: ignore[union-attr]
+        assert _reported(result) == {"level": 1}
 
     async def test_modern_client_advertisement_is_readable(self) -> None:
         server = MCPServer(_agent(), tools=[read_thing])
@@ -95,7 +102,7 @@ class TestServerReadsClientExtensions:
         async with connect_modern(server, extensions=[advertise(_ID, {"level": 1})]) as session:
             result = await session.call_tool("read_thing", {})
 
-        assert json.loads(result.content[0].text) == {"level": 1}  # type: ignore[union-attr]
+        assert _reported(result) == {"level": 1}
 
     async def test_empty_settings_are_distinguishable_from_no_advertisement(self) -> None:
         server = MCPServer(_agent(), tools=[read_thing])
@@ -105,8 +112,8 @@ class TestServerReadsClientExtensions:
         async with connect(server) as session:
             silent = await session.call_tool("read_thing", {})
 
-        assert json.loads(supported.content[0].text) == {}  # type: ignore[union-attr]
-        assert json.loads(silent.content[0].text) is None  # type: ignore[union-attr]
+        assert _reported(supported) == {}
+        assert _reported(silent) is None
 
     async def test_reading_outside_a_request_yields_none(self) -> None:
         assert client_extension(None, _ID) is None

--- a/test/mcp/test_extensions.py
+++ b/test/mcp/test_extensions.py
@@ -7,21 +7,17 @@ from typing import Any
 
 import pytest
 from mcp.client.extension import advertise
-from mcp.types import CallToolResult, DiscoverResult, TextContent
+from mcp.types import CallToolResult, DiscoverResult
 from mcp_types.version import LATEST_MODERN_VERSION
 
-from ag2 import Agent
 from ag2.mcp import MCPServer, mcp_tool
 from ag2.mcp.extensions import client_extension
 from ag2.mcp.testing import connect, connect_modern
 from ag2.mcp.tools import MCPRequestContext
-from ag2.testing import TestConfig
+
+from ._helpers import make_agent, text_of
 
 _ID = "com.example/thing"
-
-
-def _agent() -> Agent:
-    return Agent("g", config=TestConfig("hi"))
 
 
 @mcp_tool
@@ -37,9 +33,7 @@ def _handshake_ad(settings: dict[str, Any]) -> dict[str, dict[str, Any]]:
 
 def _reported(result: CallToolResult) -> Any:
     """What ``read_thing`` saw, decoded from its one text block."""
-    block = result.content[0]
-    assert isinstance(block, TextContent)
-    return json.loads(block.text)
+    return json.loads(text_of(result))
 
 
 async def _discovered(session: Any) -> DiscoverResult:
@@ -55,7 +49,7 @@ async def _discovered(session: Any) -> DiscoverResult:
 @pytest.mark.asyncio
 class TestServerAdvertisesExtensions:
     async def test_modern_client_receives_the_extension_map(self) -> None:
-        server = MCPServer(_agent(), extensions={_ID: {"level": 2}})
+        server = MCPServer(make_agent(), extensions={_ID: {"level": 2}})
 
         async with connect_modern(server) as session:
             discovered = await _discovered(session)
@@ -66,7 +60,7 @@ class TestServerAdvertisesExtensions:
         # Not a bug to fix: ``ServerCapabilities.extensions`` does not exist in the
         # 2025-11-25 wire schema, so handshake-era serialization drops the field.
         # Advertising is modern-era only; reading a client's advertisement is not.
-        server = MCPServer(_agent(), extensions={_ID: {"level": 2}})
+        server = MCPServer(make_agent(), extensions={_ID: {"level": 2}})
 
         async with connect(server) as session:
             capabilities = session.server_capabilities
@@ -77,10 +71,10 @@ class TestServerAdvertisesExtensions:
     async def test_invalid_identifier_raises_at_construction(self) -> None:
         # A reverse-DNS prefix is mandatory; "thing" has none.
         with pytest.raises(TypeError, match="vendor-prefix/name"):
-            MCPServer(_agent(), extensions={"thing": {}})
+            MCPServer(make_agent(), extensions={"thing": {}})
 
     async def test_no_extensions_advertises_nothing(self) -> None:
-        async with connect_modern(MCPServer(_agent())) as session:
+        async with connect_modern(MCPServer(make_agent())) as session:
             discovered = await _discovered(session)
 
         assert discovered.capabilities.extensions is None
@@ -89,7 +83,7 @@ class TestServerAdvertisesExtensions:
 @pytest.mark.asyncio
 class TestServerReadsClientExtensions:
     async def test_handshake_client_advertisement_is_readable(self) -> None:
-        server = MCPServer(_agent(), tools=[read_thing])
+        server = MCPServer(make_agent(), tools=[read_thing])
 
         async with connect(server, extensions=_handshake_ad({"level": 1})) as session:
             result = await session.call_tool("read_thing", {})
@@ -97,7 +91,7 @@ class TestServerReadsClientExtensions:
         assert _reported(result) == {"level": 1}
 
     async def test_modern_client_advertisement_is_readable(self) -> None:
-        server = MCPServer(_agent(), tools=[read_thing])
+        server = MCPServer(make_agent(), tools=[read_thing])
 
         async with connect_modern(server, extensions=[advertise(_ID, {"level": 1})]) as session:
             result = await session.call_tool("read_thing", {})
@@ -105,7 +99,7 @@ class TestServerReadsClientExtensions:
         assert _reported(result) == {"level": 1}
 
     async def test_empty_settings_are_distinguishable_from_no_advertisement(self) -> None:
-        server = MCPServer(_agent(), tools=[read_thing])
+        server = MCPServer(make_agent(), tools=[read_thing])
 
         async with connect(server, extensions=_handshake_ad({})) as session:
             supported = await session.call_tool("read_thing", {})

--- a/test/mcp/test_extensions.py
+++ b/test/mcp/test_extensions.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from typing import Any
+
+import pytest
+from mcp.client.extension import advertise
+from mcp.types import DiscoverResult
+from mcp_types.version import LATEST_MODERN_VERSION
+
+from ag2 import Agent
+from ag2.mcp import MCPServer, mcp_tool
+from ag2.mcp.extensions import client_extension
+from ag2.mcp.testing import connect, connect_modern
+from ag2.mcp.tools import MCPRequestContext
+from ag2.testing import TestConfig
+
+_ID = "com.example/thing"
+
+
+def _agent() -> Agent:
+    return Agent("g", config=TestConfig("hi"))
+
+
+@mcp_tool
+async def read_thing(ctx: MCPRequestContext) -> str:
+    """Report what the client advertised for the example extension."""
+    return json.dumps(client_extension(ctx, _ID))
+
+
+def _handshake_ad(settings: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """What ``connect`` forwards to ``ClientSession(extensions=...)``."""
+    return {_ID: settings}
+
+
+async def _discovered(session: Any) -> DiscoverResult:
+    """The server's own modern-era capability announcement.
+
+    ``connect_modern`` adopts a synthesized handshake (the modern era has none),
+    so the session's cached capabilities are the client's assumption rather than
+    the server's statement. ``server/discover`` is what actually asks.
+    """
+    return DiscoverResult.model_validate(await session.send_discover(LATEST_MODERN_VERSION))
+
+
+@pytest.mark.asyncio
+class TestServerAdvertisesExtensions:
+    async def test_modern_client_receives_the_extension_map(self) -> None:
+        server = MCPServer(_agent(), extensions={_ID: {"level": 2}})
+
+        async with connect_modern(server) as session:
+            discovered = await _discovered(session)
+
+        assert discovered.capabilities.extensions == {_ID: {"level": 2}}
+
+    async def test_handshake_client_does_not_receive_it_and_that_is_expected(self) -> None:
+        # Not a bug to fix: ``ServerCapabilities.extensions`` does not exist in the
+        # 2025-11-25 wire schema, so handshake-era serialization drops the field.
+        # Advertising is modern-era only; reading a client's advertisement is not.
+        server = MCPServer(_agent(), extensions={_ID: {"level": 2}})
+
+        async with connect(server) as session:
+            capabilities = session.server_capabilities
+
+        assert capabilities is not None
+        assert capabilities.extensions is None
+
+    async def test_invalid_identifier_raises_at_construction(self) -> None:
+        # A reverse-DNS prefix is mandatory; "thing" has none.
+        with pytest.raises(TypeError, match="vendor-prefix/name"):
+            MCPServer(_agent(), extensions={"thing": {}})
+
+    async def test_no_extensions_advertises_nothing(self) -> None:
+        async with connect_modern(MCPServer(_agent())) as session:
+            discovered = await _discovered(session)
+
+        assert discovered.capabilities.extensions is None
+
+
+@pytest.mark.asyncio
+class TestServerReadsClientExtensions:
+    async def test_handshake_client_advertisement_is_readable(self) -> None:
+        server = MCPServer(_agent(), tools=[read_thing])
+
+        async with connect(server, extensions=_handshake_ad({"level": 1})) as session:
+            result = await session.call_tool("read_thing", {})
+
+        assert json.loads(result.content[0].text) == {"level": 1}  # type: ignore[union-attr]
+
+    async def test_modern_client_advertisement_is_readable(self) -> None:
+        server = MCPServer(_agent(), tools=[read_thing])
+
+        async with connect_modern(server, extensions=[advertise(_ID, {"level": 1})]) as session:
+            result = await session.call_tool("read_thing", {})
+
+        assert json.loads(result.content[0].text) == {"level": 1}  # type: ignore[union-attr]
+
+    async def test_empty_settings_are_distinguishable_from_no_advertisement(self) -> None:
+        server = MCPServer(_agent(), tools=[read_thing])
+
+        async with connect(server, extensions=_handshake_ad({})) as session:
+            supported = await session.call_tool("read_thing", {})
+        async with connect(server) as session:
+            silent = await session.call_tool("read_thing", {})
+
+        assert json.loads(supported.content[0].text) == {}  # type: ignore[union-attr]
+        assert json.loads(silent.content[0].text) is None  # type: ignore[union-attr]
+
+    async def test_reading_outside_a_request_yields_none(self) -> None:
+        assert client_extension(None, _ID) is None

--- a/test/mcp/test_input_validation.py
+++ b/test/mcp/test_input_validation.py
@@ -7,11 +7,11 @@ from typing import Any
 import pytest
 from mcp.types import TextContent
 
-from ag2 import Agent
 from ag2.mcp import MCPFunctionTool, MCPServer, mcp_tool
 from ag2.mcp.testing import connect
 from ag2.mcp.tools import ToolContext
-from ag2.testing import TestConfig
+
+from ._helpers import make_agent, text_of
 
 _SCHEMA = {
     "type": "object",
@@ -26,11 +26,7 @@ async def _echo_n(args: dict[str, Any], _ctx: ToolContext) -> TextContent:
 
 
 def _server(*tools: MCPFunctionTool) -> MCPServer:
-    return MCPServer(Agent("g", config=TestConfig("hi")), tools=list(tools))
-
-
-def _text(result: Any) -> str:
-    return result.content[0].text
+    return MCPServer(make_agent(), tools=list(tools))
 
 
 @pytest.mark.asyncio
@@ -46,8 +42,8 @@ class TestDeclaredSchemaIsEnforced:
             result = await session.call_tool("echo", {"n": "5"})
 
         assert result.is_error is True
-        assert _text(result).startswith("Input validation error:")
-        assert "'5' is not of type 'integer'" in _text(result)
+        assert text_of(result).startswith("Input validation error:")
+        assert "'5' is not of type 'integer'" in text_of(result)
 
     async def test_missing_required_argument_is_a_tool_error(self) -> None:
         server = _server(MCPFunctionTool("echo", "Echo n", _echo_n, _SCHEMA))
@@ -56,7 +52,7 @@ class TestDeclaredSchemaIsEnforced:
             result = await session.call_tool("echo", {})
 
         assert result.is_error is True
-        assert _text(result) == "Input validation error: 'n' is a required property"
+        assert text_of(result) == "Input validation error: 'n' is a required property"
 
     async def test_valid_arguments_still_reach_the_handler(self) -> None:
         server = _server(MCPFunctionTool("echo", "Echo n", _echo_n, _SCHEMA))
@@ -65,7 +61,7 @@ class TestDeclaredSchemaIsEnforced:
             result = await session.call_tool("echo", {"n": 5})
 
         assert result.is_error is False
-        assert _text(result) == "5 int"
+        assert text_of(result) == "5 int"
 
     async def test_schemaless_tool_accepts_anything(self) -> None:
         """The default schema is a bare object, so it constrains nothing."""
@@ -79,7 +75,7 @@ class TestDeclaredSchemaIsEnforced:
             result = await session.call_tool("any", {"whatever": 1})
 
         assert result.is_error is False
-        assert _text(result) == "got ['whatever']"
+        assert text_of(result) == "got ['whatever']"
 
     async def test_a_malformed_schema_stays_a_tool_error(self) -> None:
         """Validating against an invalid schema raises ``SchemaError``, which must
@@ -113,9 +109,9 @@ class TestTypedToolErrorsStayClean:
             result = await session.call_tool("add", {})
 
         assert result.is_error is True
-        assert _text(result) == "Input validation error: 'n' is a required property"
-        assert "__ctx__" not in _text(result)
-        assert "ServerRequest" not in _text(result)
+        assert text_of(result) == "Input validation error: 'n' is a required property"
+        assert "__ctx__" not in text_of(result)
+        assert "ServerRequest" not in text_of(result)
 
 
 @pytest.mark.asyncio
@@ -127,4 +123,4 @@ class TestAgentToolIsValidatedToo:
             result = await session.call_tool("ask", {"message": 7})
 
         assert result.is_error is True
-        assert _text(result).startswith("Input validation error:")
+        assert text_of(result).startswith("Input validation error:")

--- a/test/mcp/test_server_info.py
+++ b/test/mcp/test_server_info.py
@@ -6,17 +6,13 @@ import importlib.metadata
 
 import pytest
 from mcp.server import CacheHint
-from pydantic import BaseModel
 
 from ag2 import Agent
 from ag2.mcp import MCPServer, build_ask_tool
 from ag2.mcp.testing import serve
 from ag2.testing import TestConfig
 
-
-class Weather(BaseModel):
-    city: str
-    temp_c: float
+from ._helpers import Weather
 
 
 def test_server_exposes_agent() -> None:

--- a/test/mcp/test_structured_tools.py
+++ b/test/mcp/test_structured_tools.py
@@ -10,10 +10,10 @@ from dirty_equals import IsPartialDict
 from mcp.types import CallToolResult, TextContent
 from pydantic import BaseModel
 
-from ag2 import Agent
 from ag2.mcp import MCPFunctionTool, MCPServer, Resource, mcp_tool
 from ag2.mcp.testing import connect
-from ag2.testing import TestConfig
+
+from ._helpers import make_agent, tool_named
 
 
 class Item(BaseModel):
@@ -27,10 +27,6 @@ class Item(BaseModel):
 @dataclass
 class Crate:
     label: str
-
-
-def _agent() -> Agent:
-    return Agent("g", config=TestConfig("hi"))
 
 
 @mcp_tool
@@ -67,6 +63,12 @@ async def get_blocks() -> list[TextContent]:
 
 
 @mcp_tool
+async def get_count() -> int:
+    """Return a bare int, which the ladder cannot map onto a result."""
+    return 7
+
+
+@mcp_tool
 async def get_raw() -> CallToolResult:
     """Return a fully-formed result."""
     return CallToolResult(
@@ -79,46 +81,45 @@ async def get_raw() -> CallToolResult:
 @pytest.mark.asyncio
 class TestTypedReturn:
     async def test_model_annotation_is_advertised_as_output_schema(self) -> None:
-        async with connect(MCPServer(_agent(), tools=[get_item])) as session:
+        async with connect(MCPServer(make_agent(), tools=[get_item])) as session:
             tools = await session.list_tools()
 
-        assert tools.tools[1].output_schema == IsPartialDict({
+        assert tool_named(tools, "get_item").output_schema == IsPartialDict({
             "type": "object",
             "required": ["id", "price"],
         })
 
     async def test_model_return_produces_structured_content_and_its_string_form(self) -> None:
-        async with connect(MCPServer(_agent(), tools=[get_item])) as session:
+        async with connect(MCPServer(make_agent(), tools=[get_item])) as session:
             result = await session.call_tool("get_item", {"item_id": "a"})
 
         assert result.structured_content == {"id": "a", "price": 9.5}
         assert result.content == [TextContent(type="text", text="Item a costs 9.5")]
 
     async def test_dataclass_return_is_structured_too(self) -> None:
-        async with connect(MCPServer(_agent(), tools=[get_crate])) as session:
+        async with connect(MCPServer(make_agent(), tools=[get_crate])) as session:
             tools = await session.list_tools()
             result = await session.call_tool("get_crate", {})
 
-        assert tools.tools[1].output_schema == IsPartialDict({"type": "object", "required": ["label"]})
+        assert tool_named(tools, "get_crate").output_schema == IsPartialDict({"type": "object", "required": ["label"]})
         assert result.structured_content == {"label": "wood"}
 
 
 @pytest.mark.asyncio
-class TestMappingReturn:
-    async def test_mapping_is_structured_content_with_no_schema(self) -> None:
-        async with connect(MCPServer(_agent(), tools=[get_mapping])) as session:
-            tools = await session.list_tools()
-            result = await session.call_tool("get_mapping", {})
+async def test_a_mapping_is_structured_content_with_no_schema() -> None:
+    async with connect(MCPServer(make_agent(), tools=[get_mapping])) as session:
+        tools = await session.list_tools()
+        result = await session.call_tool("get_mapping", {})
 
-        assert tools.tools[1].output_schema is None
-        assert result.structured_content == {"total": 3}
-        assert result.content == [TextContent(type="text", text='{"total": 3}')]
+    assert tool_named(tools, "get_mapping").output_schema is None
+    assert result.structured_content == {"total": 3}
+    assert result.content == [TextContent(type="text", text='{"total": 3}')]
 
 
 @pytest.mark.asyncio
 class TestTextAndDataStatedSeparately:
     async def test_text_and_data_are_taken_verbatim(self) -> None:
-        async with connect(MCPServer(_agent(), tools=[get_both])) as session:
+        async with connect(MCPServer(make_agent(), tools=[get_both])) as session:
             result = await session.call_tool("get_both", {})
 
         assert result.content == [TextContent(type="text", text="one item, cheap")]
@@ -128,16 +129,16 @@ class TestTextAndDataStatedSeparately:
         # The schema follows the *annotation*, decided once at decoration time —
         # so assembling the result by hand does not withdraw the promise the
         # listing already made. Annotating ``-> CallToolResult`` is what opts out.
-        async with connect(MCPServer(_agent(), tools=[get_both])) as session:
+        async with connect(MCPServer(make_agent(), tools=[get_both])) as session:
             tools = await session.list_tools()
 
-        assert tools.tools[1].output_schema == IsPartialDict({"type": "object"})
+        assert tool_named(tools, "get_both").output_schema == IsPartialDict({"type": "object"})
 
 
 @pytest.mark.asyncio
 class TestCallToolResultReturn:
     async def test_it_reaches_the_wire_unchanged(self) -> None:
-        async with connect(MCPServer(_agent(), tools=[get_raw])) as session:
+        async with connect(MCPServer(make_agent(), tools=[get_raw])) as session:
             result = await session.call_tool("get_raw", {})
 
         assert result.content == [TextContent(type="text", text="verbatim")]
@@ -145,25 +146,38 @@ class TestCallToolResultReturn:
         assert result.is_error is True
 
     async def test_nothing_is_derived_from_the_annotation(self) -> None:
-        async with connect(MCPServer(_agent(), tools=[get_raw])) as session:
+        async with connect(MCPServer(make_agent(), tools=[get_raw])) as session:
             tools = await session.list_tools()
 
-        assert tools.tools[1].output_schema is None
+        assert tool_named(tools, "get_raw").output_schema is None
 
 
 @pytest.mark.asyncio
-class TestContentBlockReturn:
-    async def test_a_parameterised_annotation_advertises_no_schema(self) -> None:
-        # ``list[TextContent]`` is not a class the schema can be read off. Until
-        # 3.11 it nonetheless answered ``isinstance(x, type)`` with ``True``,
-        # so classifying it must not reach ``issubclass``.
-        async with connect(MCPServer(_agent(), tools=[get_blocks])) as session:
-            tools = await session.list_tools()
-            result = await session.call_tool("get_blocks", {})
+async def test_a_parameterised_annotation_advertises_no_schema() -> None:
+    # ``list[TextContent]`` is not a class the schema can be read off. Until
+    # 3.11 it nonetheless answered ``isinstance(x, type)`` with ``True``,
+    # so classifying it must not reach ``issubclass``.
+    async with connect(MCPServer(make_agent(), tools=[get_blocks])) as session:
+        tools = await session.list_tools()
+        result = await session.call_tool("get_blocks", {})
 
-        assert tools.tools[1].output_schema is None
-        assert result.content == [TextContent(type="text", text="block")]
-        assert result.structured_content is None
+    assert tool_named(tools, "get_blocks").output_schema is None
+    assert result.content == [TextContent(type="text", text="block")]
+    assert result.structured_content is None
+
+
+@pytest.mark.asyncio
+async def test_a_return_the_ladder_cannot_map_reaches_the_caller_as_an_error() -> None:
+    # The one arm of the ladder that refuses: an author who returns something
+    # that is not a ToolResult should be told which type, not handed a silent
+    # empty result.
+    async with connect(MCPServer(make_agent(), tools=[get_count])) as session:
+        result = await session.call_tool("get_count", {})
+
+    assert result.is_error is True
+    assert result.content == [
+        TextContent(type="text", text="A tool handler cannot return int; see ag2.mcp.tools.ToolResult.")
+    ]
 
 
 @pytest.mark.asyncio
@@ -171,18 +185,18 @@ class TestToolMetadata:
     async def test_metadata_is_advertised(self) -> None:
         tool = MCPFunctionTool("m", "with meta", lambda a, c: "ok", meta={"vendor/key": {"n": 1}})
 
-        async with connect(MCPServer(_agent(), tools=[tool])) as session:
+        async with connect(MCPServer(make_agent(), tools=[tool])) as session:
             tools = await session.list_tools()
 
-        assert tools.tools[1].meta == {"vendor/key": {"n": 1}}
+        assert tool_named(tools, "m").meta == {"vendor/key": {"n": 1}}
 
     async def test_no_metadata_puts_no_meta_on_the_wire(self) -> None:
         tool = MCPFunctionTool("m", "no meta", lambda a, c: "ok")
 
-        async with connect(MCPServer(_agent(), tools=[tool])) as session:
+        async with connect(MCPServer(make_agent(), tools=[tool])) as session:
             tools = await session.list_tools()
 
-        assert tools.tools[1].meta is None
+        assert tool_named(tools, "m").meta is None
 
     async def test_decorator_passes_metadata_through(self) -> None:
         @mcp_tool(meta={"vendor/key": "v"})
@@ -190,10 +204,10 @@ class TestToolMetadata:
             """Tagged."""
             return "ok"
 
-        async with connect(MCPServer(_agent(), tools=[tagged])) as session:
+        async with connect(MCPServer(make_agent(), tools=[tagged])) as session:
             tools = await session.list_tools()
 
-        assert tools.tools[1].meta == {"vendor/key": "v"}
+        assert tool_named(tools, "tagged").meta == {"vendor/key": "v"}
 
 
 @pytest.mark.asyncio
@@ -201,7 +215,7 @@ class TestResourceMetadata:
     async def test_metadata_is_carried_in_a_read_result(self) -> None:
         resource = Resource("res://a", "a", lambda: "body", meta={"vendor/key": {"n": 1}})
 
-        async with connect(MCPServer(_agent(), resources=[resource])) as session:
+        async with connect(MCPServer(make_agent(), resources=[resource])) as session:
             read = await session.read_resource("res://a")
 
         assert read.contents[0].meta == {"vendor/key": {"n": 1}}
@@ -209,7 +223,7 @@ class TestResourceMetadata:
     async def test_no_metadata_puts_no_meta_on_the_wire(self) -> None:
         resource = Resource("res://a", "a", lambda: "body")
 
-        async with connect(MCPServer(_agent(), resources=[resource])) as session:
+        async with connect(MCPServer(make_agent(), resources=[resource])) as session:
             read = await session.read_resource("res://a")
             listed = await session.list_resources()
 

--- a/test/mcp/test_structured_tools.py
+++ b/test/mcp/test_structured_tools.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from dirty_equals import IsPartialDict
+from mcp.types import CallToolResult, TextContent
+from pydantic import BaseModel
+
+from ag2 import Agent
+from ag2.mcp import MCPFunctionTool, MCPServer, Resource, mcp_tool
+from ag2.mcp.testing import connect
+from ag2.testing import TestConfig
+
+
+class Item(BaseModel):
+    id: str
+    price: float
+
+    def __str__(self) -> str:
+        return f"Item {self.id} costs {self.price}"
+
+
+@dataclass
+class Crate:
+    label: str
+
+
+def _agent() -> Agent:
+    return Agent("g", config=TestConfig("hi"))
+
+
+@mcp_tool
+async def get_item(item_id: str) -> Item:
+    """Return an item."""
+    return Item(id=item_id, price=9.5)
+
+
+@mcp_tool
+async def get_crate() -> Crate:
+    """Return a crate."""
+    return Crate(label="wood")
+
+
+@mcp_tool
+async def get_mapping() -> dict[str, Any]:
+    """Return a bare mapping."""
+    return {"total": 3}
+
+
+@mcp_tool
+async def get_both() -> Item:
+    """State the text and the data separately."""
+    return CallToolResult(
+        content=[TextContent(type="text", text="one item, cheap")],
+        structuredContent={"id": "a", "price": 1.0},
+    )
+
+
+@mcp_tool
+async def get_blocks() -> list[TextContent]:
+    """Return content blocks under a parameterised annotation."""
+    return [TextContent(type="text", text="block")]
+
+
+@mcp_tool
+async def get_raw() -> CallToolResult:
+    """Return a fully-formed result."""
+    return CallToolResult(
+        content=[TextContent(type="text", text="verbatim")],
+        structuredContent={"untouched": True},
+        isError=True,
+    )
+
+
+@pytest.mark.asyncio
+class TestTypedReturn:
+    async def test_model_annotation_is_advertised_as_output_schema(self) -> None:
+        async with connect(MCPServer(_agent(), tools=[get_item])) as session:
+            tools = await session.list_tools()
+
+        assert tools.tools[1].output_schema == IsPartialDict({
+            "type": "object",
+            "required": ["id", "price"],
+        })
+
+    async def test_model_return_produces_structured_content_and_its_string_form(self) -> None:
+        async with connect(MCPServer(_agent(), tools=[get_item])) as session:
+            result = await session.call_tool("get_item", {"item_id": "a"})
+
+        assert result.structured_content == {"id": "a", "price": 9.5}
+        assert result.content == [TextContent(type="text", text="Item a costs 9.5")]
+
+    async def test_dataclass_return_is_structured_too(self) -> None:
+        async with connect(MCPServer(_agent(), tools=[get_crate])) as session:
+            tools = await session.list_tools()
+            result = await session.call_tool("get_crate", {})
+
+        assert tools.tools[1].output_schema == IsPartialDict({"type": "object", "required": ["label"]})
+        assert result.structured_content == {"label": "wood"}
+
+
+@pytest.mark.asyncio
+class TestMappingReturn:
+    async def test_mapping_is_structured_content_with_no_schema(self) -> None:
+        async with connect(MCPServer(_agent(), tools=[get_mapping])) as session:
+            tools = await session.list_tools()
+            result = await session.call_tool("get_mapping", {})
+
+        assert tools.tools[1].output_schema is None
+        assert result.structured_content == {"total": 3}
+        assert result.content == [TextContent(type="text", text='{"total": 3}')]
+
+
+@pytest.mark.asyncio
+class TestTextAndDataStatedSeparately:
+    async def test_text_and_data_are_taken_verbatim(self) -> None:
+        async with connect(MCPServer(_agent(), tools=[get_both])) as session:
+            result = await session.call_tool("get_both", {})
+
+        assert result.content == [TextContent(type="text", text="one item, cheap")]
+        assert result.structured_content == {"id": "a", "price": 1.0}
+
+    async def test_schema_still_comes_from_the_annotation(self) -> None:
+        # The schema follows the *annotation*, decided once at decoration time —
+        # so assembling the result by hand does not withdraw the promise the
+        # listing already made. Annotating ``-> CallToolResult`` is what opts out.
+        async with connect(MCPServer(_agent(), tools=[get_both])) as session:
+            tools = await session.list_tools()
+
+        assert tools.tools[1].output_schema == IsPartialDict({"type": "object"})
+
+
+@pytest.mark.asyncio
+class TestCallToolResultReturn:
+    async def test_it_reaches_the_wire_unchanged(self) -> None:
+        async with connect(MCPServer(_agent(), tools=[get_raw])) as session:
+            result = await session.call_tool("get_raw", {})
+
+        assert result.content == [TextContent(type="text", text="verbatim")]
+        assert result.structured_content == {"untouched": True}
+        assert result.is_error is True
+
+    async def test_nothing_is_derived_from_the_annotation(self) -> None:
+        async with connect(MCPServer(_agent(), tools=[get_raw])) as session:
+            tools = await session.list_tools()
+
+        assert tools.tools[1].output_schema is None
+
+
+@pytest.mark.asyncio
+class TestContentBlockReturn:
+    async def test_a_parameterised_annotation_advertises_no_schema(self) -> None:
+        # ``list[TextContent]`` is not a class the schema can be read off. Until
+        # 3.11 it nonetheless answered ``isinstance(x, type)`` with ``True``,
+        # so classifying it must not reach ``issubclass``.
+        async with connect(MCPServer(_agent(), tools=[get_blocks])) as session:
+            tools = await session.list_tools()
+            result = await session.call_tool("get_blocks", {})
+
+        assert tools.tools[1].output_schema is None
+        assert result.content == [TextContent(type="text", text="block")]
+        assert result.structured_content is None
+
+
+@pytest.mark.asyncio
+class TestToolMetadata:
+    async def test_metadata_is_advertised(self) -> None:
+        tool = MCPFunctionTool("m", "with meta", lambda a, c: "ok", meta={"vendor/key": {"n": 1}})
+
+        async with connect(MCPServer(_agent(), tools=[tool])) as session:
+            tools = await session.list_tools()
+
+        assert tools.tools[1].meta == {"vendor/key": {"n": 1}}
+
+    async def test_no_metadata_puts_no_meta_on_the_wire(self) -> None:
+        tool = MCPFunctionTool("m", "no meta", lambda a, c: "ok")
+
+        async with connect(MCPServer(_agent(), tools=[tool])) as session:
+            tools = await session.list_tools()
+
+        assert tools.tools[1].meta is None
+
+    async def test_decorator_passes_metadata_through(self) -> None:
+        @mcp_tool(meta={"vendor/key": "v"})
+        async def tagged() -> str:
+            """Tagged."""
+            return "ok"
+
+        async with connect(MCPServer(_agent(), tools=[tagged])) as session:
+            tools = await session.list_tools()
+
+        assert tools.tools[1].meta == {"vendor/key": "v"}
+
+
+@pytest.mark.asyncio
+class TestResourceMetadata:
+    async def test_metadata_is_carried_in_a_read_result(self) -> None:
+        resource = Resource("res://a", "a", lambda: "body", meta={"vendor/key": {"n": 1}})
+
+        async with connect(MCPServer(_agent(), resources=[resource])) as session:
+            read = await session.read_resource("res://a")
+
+        assert read.contents[0].meta == {"vendor/key": {"n": 1}}
+
+    async def test_no_metadata_puts_no_meta_on_the_wire(self) -> None:
+        resource = Resource("res://a", "a", lambda: "body")
+
+        async with connect(MCPServer(_agent(), resources=[resource])) as session:
+            read = await session.read_resource("res://a")
+            listed = await session.list_resources()
+
+        assert read.contents[0].meta is None
+        assert listed.resources[0].meta is None

--- a/website/docs/user-guide/tools/mcp_apps.mdx
+++ b/website/docs/user-guide/tools/mcp_apps.mdx
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 
 from ag2 import Agent
 from ag2.config import AnthropicConfig
-from ag2.mcp import AppResource, MCPServer
+from ag2.mcp import MCPApp, MCPServer
 
 CARD = """<div id="name">Loading…</div>
 <script>
@@ -39,7 +39,7 @@ CARD = """<div id="name">Loading…</div>
   });
 </script>"""
 
-shop = AppResource("ui://shop/card", CARD)
+shop = MCPApp("ui://shop/card", CARD)
 
 @dataclass
 class Item:
@@ -199,11 +199,65 @@ Omit it and no `visibility` is advertised at all, leaving the host to its own de
 
 ### Bringing your own bundle
 
-`bootstrap=False` turns injection off and the body is served byte-for-byte as you wrote it. `app.runtime_script()` returns the same `<script>` element as text if you would rather place it yourself.
+`inject_runtime=False` turns injection off and the body is served byte-for-byte as you wrote it. `app.runtime_script()` returns the same `<script>` element as text if you would rather place it yourself.
 
 ```python linenums="1"
-shop = AppResource("ui://shop/card", BUNDLED_HTML, bootstrap=False)
+shop = MCPApp("ui://shop/card", BUNDLED_HTML, inject_runtime=False)
 ```
+
+## Where the body comes from
+
+`content` takes four forms, told apart **by type alone** — never by looking at the filesystem, so a string is always literal HTML and never a filename:
+
+```python linenums="1"
+from pathlib import Path
+
+from ag2 import Variable
+
+MCPApp("ui://shop/card", CARD)                          # inline HTML
+MCPApp("ui://shop/card", Path("dist/card.html"))        # a built bundle, reread per read
+MCPApp("ui://shop/card", Variable("card"))              # a request-scoped variable
+MCPApp("ui://shop/card", render_card)                   # a sync or async callable
+```
+
+There is an overload per form, so an IDE shows you which one you are using.
+
+**A path-like value is reread on every resource read.** Rebuild the bundle and the next read serves it; there is no cache to invalidate and no server to restart. A file that has gone missing fails that read with a message naming the path, rather than at construction — the document is only promised at read time.
+
+```python linenums="1"
+shop = MCPApp("ui://shop/card", Path(__file__).parent / "dist" / "card.html", inject_runtime=False)
+```
+
+### Request-scoped bodies and metadata
+
+An app resolves runtime values from the same `context_provider` the conversational path uses, so a document is not a second dependency system. `content` may be a `Variable`, and a callable body may declare `Variable`, `Depends`/`Inject` and `MCPRequestContext` parameters exactly as a tool does:
+
+```python linenums="1"
+from typing import Annotated
+
+from ag2 import Inject, Variable
+from ag2.mcp import AskContext, MCPApp, MCPRequestContext, MCPServer
+
+async def provider(access) -> AskContext:
+    return AskContext(variables={"tenant": "north"}, dependencies={"branding": BRANDING})
+
+async def card(
+    tenant: Annotated[str, Variable("tenant")],
+    branding: Annotated[Branding, Inject("branding")],
+    ctx: MCPRequestContext,
+) -> str:
+    return render(tenant, branding)
+
+shop = MCPApp("ui://shop/card", card, title=Variable("tenant"), listed=True)
+server = MCPServer(agent, apps=[shop], context_provider=provider)
+```
+
+`title`, `description`, `inject_runtime`, the sandbox fields and the values inside `meta=` may each be a `Variable` too, resolved per request for the listing and the read.
+
+!!! warning "The context is request-scoped, not turn-scoped"
+    The host's document read and its tool call are **two separate MCP requests**, made in parallel. Each one calls your provider again and gets its own context; they share no mutable state. Do not use a variable to pass something from the call to the document — that is what `structuredContent` is for.
+
+An ordinary `Resource` and an `@mcp_tool` resolve the same way, which is what keeps [taking an app apart](#taking-an-app-apart) honest.
 
 ## Degradation
 
@@ -212,8 +266,7 @@ shop = AppResource("ui://shop/card", BUNDLED_HTML, bootstrap=False)
 That client sees the same tool without `_meta.ui`, calls it successfully, and gets the text your `__str__` produced. Because a UI-bound tool always returns text alongside its data, you usually need no branch at all. When you want to word an answer differently:
 
 ```python linenums="1"
-from ag2.mcp import client_supports_apps
-from ag2.mcp.tools import MCPRequestContext
+from ag2.mcp import MCPRequestContext, client_supports_apps
 
 @shop.tool
 async def show_item(item_id: str, ctx: MCPRequestContext) -> Item:
@@ -231,25 +284,27 @@ A server holding at least one app also advertises the extension itself, with emp
 ## The document
 
 ```python linenums="1"
-from ag2.mcp.apps import ResourceCsp, ResourcePermissions
+from ag2.mcp import AppSandbox, MCPApp, ResourceCsp, ResourcePermissions
 
-shop = AppResource(
+shop = MCPApp(
     "ui://shop/card",
     CARD,
     title="Product card",
     description="A product card that can add its item to the cart.",
     listed=False,
-    csp=ResourceCsp(connect_domains=["https://api.example.com"]),
-    permissions=ResourcePermissions(camera={}),
-    domain="https://shop.example.com",
+    sandbox=AppSandbox(
+        csp=ResourceCsp(connect_domains=["https://api.example.com"]),
+        permissions=ResourcePermissions(camera={}),
+        domain="https://shop.example.com",
+    ),
     prefers_border=True,
 )
 ```
 
-- **`ui://` is required.** A host discards any other scheme, so a URI that is not `ui://` raises when the `AppResource` is constructed, and two apps claiming one URI raise when the server is.
+- **`ui://` is required.** A host discards any other scheme, so a URI that is not `ui://` raises when the `MCPApp` is constructed, and two apps claiming one URI raise when the server is.
 - **`listed` defaults to `False`.** The document stays out of `resources/list` — a person browsing a server's resources should not meet a file that is not one — while remaining readable by URI, which is how the host gets it. Set `listed=True` for a document meant to be discoverable.
-- **The body may be a callable**, sync or async, invoked per read — for a document built per locale, per deployment, or per feature flag. A file path is deliberately not accepted: taking one would force ag2 to decide whether it is re-read per request, which is your decision to make inside the callable.
-- **Sandbox policy is typed.** `csp`, `permissions`, `domain` and `prefers_border` use the SDK's own models, so the wire spelling is never guessed at. `meta=` is a raw passthrough merged alongside, for whatever the specification adds next.
+- **The body has four forms** — inline HTML, a path-like bundle, a `Variable`, or a sync/async callable invoked per read. See [where the body comes from](#where-the-body-comes-from).
+- **Sandbox policy is typed and grouped.** `csp`, `permissions` and `domain` travel together in `sandbox=AppSandbox(...)` and use the SDK's own models, so the wire spelling is never guessed at. They are also accepted as bare keywords for a one-field policy. `prefers_border` stays separate — it is a presentation hint, not a sandbox rule. `meta=` is a raw passthrough merged alongside, for whatever the specification adds next.
 - **The `ui` slot behaves differently on a document and on a tool.** On the document it is shared, so a `ui` key inside `meta=` *merges over* the typed parameters above rather than being refused — the typed parameters are the spelling aid, not the authority. On a tool it is not shared: `@app.tool`'s `meta=` **rejects** a `ui` key outright, because the only thing in that slot is the binding the decorator itself writes. Pass `visibility=` instead, or declare the tool with `@mcp_tool` if it should not be bound to this document at all.
 
 ## Taking an app apart
@@ -269,6 +324,17 @@ server = MCPServer(agent, tools=shop.tools, resources=[shop.resource])
 Both produce the same tool list, the same resource listing, the same document and the same results — a test in the suite holds that equivalence so it cannot rot into a lie. Reach for the long form when you need an unusual arrangement; it is a rearrangement, not a rewrite.
 
 Ordinary tools are unaffected throughout. A tool declared with `@mcp_tool` and passed in `tools=` behaves exactly as it did before apps existed, alongside any number of them.
+
+**Registration closes the app's tool list.** Constructing the server is what reads `app.tools`, so a tool declared after that would exist and never be served. Declaring one raises `MCPAppFrozenError` naming the tool, instead of leaving you to find it missing on the wire:
+
+```python linenums="1"
+server = MCPServer(agent, apps=[shop])
+
+@shop.tool                      # MCPAppFrozenError: 'restock' cannot be declared on 'ui://shop/card'
+async def restock() -> str: ...
+```
+
+The app itself stays reusable — registering the same one with a second server is fine; it is the composition that is closed, not the object.
 
 ## See also
 

--- a/website/docs/user-guide/tools/mcp_apps.mdx
+++ b/website/docs/user-guide/tools/mcp_apps.mdx
@@ -22,7 +22,7 @@ Everything below follows from that one fact: why the HTML is declared next to th
 
 ## A first app
 
-`ag2ui` in the HTML below is not imported and not a package you install. It is a global that `ag2.mcp` itself injects: the server prepends a `<script>` to the document body before serving it, so by the time your own script runs the global exists. What it is and what it exposes is [below](#inside-the-document-ag2ui).
+`ag2ui` in the HTML below is not imported and not a package you install. It is a global that `ag2.mcp` itself injects: the server places a `<script>` at the head of the document before serving it — inside `<head>` when there is one, after `<html>` when there is not, at the very front of a fragment like the one below — so by the time your own script runs the global exists. What it is and what it exposes is [below](#inside-the-document-ag2ui).
 
 ```python linenums="1"
 import asyncio
@@ -77,7 +77,7 @@ That is the whole thing. `MCPServer(agent, apps=[shop])` registers the document 
 
 Which is why `__str__` is worth writing: a text-only client gets *"Espresso cup costs $12."* rather than a JSON dump.
 
-Both pydantic models and dataclasses work. This applies to any custom tool, not only a UI-bound one — see [Structured output](/docs/user-guide/tools/serving_mcp).
+Both pydantic models and dataclasses work. This applies to any custom tool, not only a UI-bound one — see [Structured output](/docs/user-guide/tools/serving_mcp#structured-output).
 
 ### Three levels of control
 
@@ -133,12 +133,17 @@ await ag2ui.requestDisplayMode("fullscreen");
 await ag2ui.downloadFile(contents);
 await ag2ui.sampling({ messages: [...] });
 ag2ui.log("info", "rendered");
+ag2ui.reportSize();                      // force a size report; it is automatic otherwise
 
-ag2ui.host.capabilities;   // what the host advertised
-ag2ui.host.context;        // theme, styles, display mode, container size
+ag2ui.host.capabilities;     // what the host advertised
+ag2ui.host.context;          // theme, styles, display mode, container size
+ag2ui.host.protocolVersion;  // the dialect revision the host answered with
+ag2ui.host.info;             // the host's name and version
 ```
 
 Each subscription returns an unsubscribe function. The document's size is reported automatically via a `ResizeObserver`, so the host can size the frame without your writing one.
+
+**Subscribe whenever you like; call only after `ag2ui.ready`.** Registering a handler is local and is safe the moment the document parses — which is why the card above awaits nothing. Everything that *talks* to the host is refused until the handshake completes, so `await ag2ui.ready` before the first `callTool`, `sendMessage` or `readResource`; calling earlier throws rather than posting into a channel the host is still discarding.
 
 Errors arrive on the **same** channel as results — a failed call is a result carrying `isError`, matching how `ag2.mcp` already treats a tool error as a result rather than an exception.
 
@@ -152,6 +157,8 @@ try {
 }
 ```
 
+`requestDisplayMode` refuses locally in the same way, against `ag2ui.host.context.availableDisplayModes` rather than against a capability: asking for a mode the host never offered throws instead of hanging on an answer that will not come.
+
 ### Which tool answered
 
 MCP Apps gives the document nothing to correlate with: the notification carrying a result names neither the call nor the tool. With one tool per document that does not matter. With two — a card that renders itself *and* updates after an action — it does.
@@ -164,6 +171,31 @@ ag2ui.onToolResult("add_to_cart", showConfirmation);
 ```
 
 Set that key yourself and your value travels instead, so you can route by your own scheme. This is the one respect in which a `CallToolResult` you assembled yourself is modified; every other key you set travels untouched alongside the stamp.
+
+### Who may call a tool
+
+A tool the document calls through `ag2ui.callTool` need not be one the model can call. `visibility=` says where the host surfaces it — `"model"` in the model's tool list, `"app"` to the document:
+
+```python linenums="1" hl_lines="8 13"
+@dataclass
+class CartLine:
+    status: str
+
+    def __str__(self) -> str:
+        return self.status
+
+@shop.tool
+async def show_item(item_id: str) -> Item:
+    """Show a product card."""
+    return Item(name="Espresso cup", price=12)
+
+@shop.tool(visibility=["app"])
+async def add_to_cart(item_id: str) -> CartLine:
+    """Add an item to the cart. Called by the card's button, not by the model."""
+    return CartLine(status="Added to your cart")
+```
+
+Omit it and no `visibility` is advertised at all, leaving the host to its own default. It is a hint about where to *surface* a tool, not an authorization boundary: the tool is served and dispatched exactly like any other, so anything that must not be called by the model has to refuse in the handler.
 
 ### Bringing your own bundle
 
@@ -217,7 +249,8 @@ shop = AppResource(
 - **`ui://` is required.** A host discards any other scheme, so a URI that is not `ui://` raises when the `AppResource` is constructed, and two apps claiming one URI raise when the server is.
 - **`listed` defaults to `False`.** The document stays out of `resources/list` — a person browsing a server's resources should not meet a file that is not one — while remaining readable by URI, which is how the host gets it. Set `listed=True` for a document meant to be discoverable.
 - **The body may be a callable**, sync or async, invoked per read — for a document built per locale, per deployment, or per feature flag. A file path is deliberately not accepted: taking one would force ag2 to decide whether it is re-read per request, which is your decision to make inside the callable.
-- **Sandbox policy is typed.** `csp`, `permissions`, `domain` and `prefers_border` use the SDK's own models, so the wire spelling is never guessed at. `meta=` is a raw passthrough merged alongside, for whatever the specification adds next — as is `meta=` on `@app.tool`.
+- **Sandbox policy is typed.** `csp`, `permissions`, `domain` and `prefers_border` use the SDK's own models, so the wire spelling is never guessed at. `meta=` is a raw passthrough merged alongside, for whatever the specification adds next.
+- **The `ui` slot behaves differently on a document and on a tool.** On the document it is shared, so a `ui` key inside `meta=` *merges over* the typed parameters above rather than being refused — the typed parameters are the spelling aid, not the authority. On a tool it is not shared: `@app.tool`'s `meta=` **rejects** a `ui` key outright, because the only thing in that slot is the binding the decorator itself writes. Pass `visibility=` instead, or declare the tool with `@mcp_tool` if it should not be bound to this document at all.
 
 ## Taking an app apart
 

--- a/website/docs/user-guide/tools/mcp_apps.mdx
+++ b/website/docs/user-guide/tools/mcp_apps.mdx
@@ -1,0 +1,244 @@
+---
+title: MCP Apps
+sidebarTitle: MCP Apps
+---
+
+# MCP Apps
+
+[MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview){.external-link target="_blank"} — the `io.modelcontextprotocol/ui` extension — lets a served agent hand a host a **real interface** instead of a wall of text. `ag2.mcp.apps` serves one as an **app**: a document plus the tools that render it.
+
+## The constraint that shapes everything
+
+**The host reads the document in parallel with the call that references it.** It does not wait for your handler; it fetches the `ui://` resource as soon as it sees the tool being called, often before.
+
+So the document **cannot be built from the call's arguments**. It is a static body, registered as a resource and read by URI. The per-call data reaches it afterwards, as the result's `structuredContent`, which the host redelivers into the frame as a `ui/notifications/tool-result` notification.
+
+Everything below follows from that one fact: why the HTML is declared next to the tool rather than returned by it, why your return type matters so much, and why a document that serves two tools needs to be told which result just arrived.
+
+!!! warning "MCP Apps and MCP-UI are alternatives — pick one"
+    [`ag2.mcp_ui`](/docs/user-guide/tools/mcp_ui) teaches the **opposite** pattern: its handler builds HTML from the arguments it was given and returns it inside the call result. That is exactly what a host implementing MCP Apps will not render, and the parallel read is why.
+
+    The two modules coexist and neither replaces the other. `ag2.mcp_ui` targets [MCP-UI](https://mcpui.dev/){.external-link target="_blank"} clients and ships as the `ag2[mcp-ui]` extra; `ag2.mcp.apps` targets MCP Apps hosts and needs nothing beyond `ag2[mcp]`. Choose by the host you are serving.
+
+## A first app
+
+`ag2ui` in the HTML below is not imported and not a package you install. It is a global that `ag2.mcp` itself injects: the server prepends a `<script>` to the document body before serving it, so by the time your own script runs the global exists. What it is and what it exposes is [below](#inside-the-document-ag2ui).
+
+```python linenums="1"
+import asyncio
+from dataclasses import dataclass
+
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import AppResource, MCPServer
+
+CARD = """<div id="name">Loading…</div>
+<script>
+  ag2ui.onToolResult(function (result) {
+    document.getElementById("name").textContent = result.structuredContent.name;
+  });
+</script>"""
+
+shop = AppResource("ui://shop/card", CARD)
+
+@dataclass
+class Item:
+    name: str
+    price: int
+
+    def __str__(self) -> str:
+        return f"{self.name} costs ${self.price}."
+
+@shop.tool
+async def show_item(item_id: str) -> Item:
+    """Show a product card."""
+    return Item(name="Espresso cup", price=12)
+
+agent = Agent(name="shopkeeper", config=AnthropicConfig(model="claude-sonnet-5"))
+server = MCPServer(agent, apps=[shop])
+
+if __name__ == "__main__":
+    asyncio.run(server.run_stdio())
+```
+
+That is the whole thing. `MCPServer(agent, apps=[shop])` registers the document as a resource served with `text/html;profile=mcp-app` (the only MIME type a host will render a `ui://` resource under), advertises `_meta.ui.resourceUri` on `show_item`, and injects the document runtime that makes `ag2ui` exist.
+
+`examples/mcp/server_apps.py` is the runnable version, with a button that calls a second tool.
+
+## The return type does three jobs
+
+`Item` above is doing more work than it looks. From one annotation the framework derives all three of the things MCP wants:
+
+| From `-> Item` | Becomes | Read by |
+|---|---|---|
+| its JSON schema | the tool's `outputSchema` | the client, to validate |
+| its dump | the result's `structuredContent` | your document |
+| its `__str__` | the result's text content | the model, and a text-only client |
+
+Which is why `__str__` is worth writing: a text-only client gets *"Espresso cup costs $12."* rather than a JSON dump.
+
+Both pydantic models and dataclasses work. This applies to any custom tool, not only a UI-bound one — see [Structured output](/docs/user-guide/tools/serving_mcp).
+
+### Three levels of control
+
+A handler returns whichever of these fits, in increasing order of control:
+
+```python linenums="1"
+from mcp.types import CallToolResult, TextContent
+
+@shop.tool
+async def typed() -> Item:
+    """A typed value: schema, structured content and text all derived."""
+    return Item(name="Espresso cup", price=12)
+
+@shop.tool
+async def mapping() -> dict:
+    """A mapping: structured content verbatim, text a JSON rendering, no schema."""
+    return {"name": "Espresso cup", "price": 12}
+
+@shop.tool
+async def explicit() -> CallToolResult:
+    """A full result: nothing derived. Also how you state text and data separately."""
+    return CallToolResult(
+        content=[TextContent(type="text", text="One espresso cup, $12.")],
+        structuredContent={"name": "Espresso cup", "price": 12},
+    )
+```
+
+!!! note "The schema follows the annotation, not the value"
+    `outputSchema` is decided once, when the tool is declared. Annotating `-> CallToolResult` is what opts a tool out of an advertised schema; returning one from a handler annotated `-> Item` still advertises `Item`'s schema, and MCP requires your `structuredContent` to conform to it.
+
+## Inside the document: `ag2ui`
+
+A host **discards every message from a view that has not completed the `ui/initialize` handshake**, and tells it nothing. A hand-written button on a document without that handshake is silently dead — which is why the runtime is injected by default.
+
+It defines one global, `ag2ui`:
+
+```javascript
+await ag2ui.ready;                       // the handshake completed
+
+ag2ui.onToolResult(fn);                  // every result for this document
+ag2ui.onToolResult("show_item", fn);     // only that tool's results
+ag2ui.onToolInput(fn);                   // the call's arguments
+ag2ui.onToolInputPartial(fn);            // arguments while the model is still writing them
+ag2ui.onHostContextChanged(fn);          // theme, display mode, styles, locale…
+ag2ui.onCancelled(fn);
+
+await ag2ui.callTool("add_to_cart", { item_id: "42" });
+await ag2ui.sendMessage("Show me the kettle");   // into the conversation
+await ag2ui.openLink("https://example.com");
+await ag2ui.readResource("ui://shop/card");
+await ag2ui.updateContext({ content: [{ type: "text", text: "Viewing item 42" }] });
+await ag2ui.requestDisplayMode("fullscreen");
+await ag2ui.downloadFile(contents);
+await ag2ui.sampling({ messages: [...] });
+ag2ui.log("info", "rendered");
+
+ag2ui.host.capabilities;   // what the host advertised
+ag2ui.host.context;        // theme, styles, display mode, container size
+```
+
+Each subscription returns an unsubscribe function. The document's size is reported automatically via a `ResizeObserver`, so the host can size the frame without your writing one.
+
+Errors arrive on the **same** channel as results — a failed call is a result carrying `isError`, matching how `ag2.mcp` already treats a tool error as a result rather than an exception.
+
+Calling something the host did not advertise **throws in JavaScript before anything is sent**, because a host's own answer to an unadvertised method is silence:
+
+```javascript
+try {
+  await ag2ui.downloadFile(contents);
+} catch (e) {
+  // "the host did not advertise 'downloadFile'" — rather than a button that does nothing.
+}
+```
+
+### Which tool answered
+
+MCP Apps gives the document nothing to correlate with: the notification carrying a result names neither the call nor the tool. With one tool per document that does not matter. With two — a card that renders itself *and* updates after an action — it does.
+
+The server therefore stamps the answering tool's name into the result's `_meta` under `ai.ag2/tool`, and `ag2ui.onToolResult(name, fn)` routes on it:
+
+```javascript
+ag2ui.onToolResult("show_item", renderCard);
+ag2ui.onToolResult("add_to_cart", showConfirmation);
+```
+
+Set that key yourself and your value travels instead, so you can route by your own scheme. This is the one respect in which a `CallToolResult` you assembled yourself is modified; every other key you set travels untouched alongside the stamp.
+
+### Bringing your own bundle
+
+`bootstrap=False` turns injection off and the body is served byte-for-byte as you wrote it. `app.runtime_script()` returns the same `<script>` element as text if you would rather place it yourself.
+
+```python linenums="1"
+shop = AppResource("ui://shop/card", BUNDLED_HTML, bootstrap=False)
+```
+
+## Degradation
+
+**The UI binding is withheld from a client that did not advertise the extension.** It is a promise that the client can read the document and render it; to a client that cannot, it is a promise about a document it will never fetch. There is no switch — this is correctness, not policy.
+
+That client sees the same tool without `_meta.ui`, calls it successfully, and gets the text your `__str__` produced. Because a UI-bound tool always returns text alongside its data, you usually need no branch at all. When you want to word an answer differently:
+
+```python linenums="1"
+from ag2.mcp import client_supports_apps
+from ag2.mcp.tools import MCPRequestContext
+
+@shop.tool
+async def show_item(item_id: str, ctx: MCPRequestContext) -> Item:
+    """Show a product card."""
+    item = Item(name="Espresso cup", price=12)
+    if not client_supports_apps(ctx):
+        ...  # a fuller sentence, since there will be no card
+    return item
+```
+
+A client that advertised the identifier but not the `text/html;profile=mcp-app` MIME type counts as unable to render — advertising the extension alone says nothing about being able to display the one format a document arrives in.
+
+A server holding at least one app also advertises the extension itself, with empty settings. Be clear-eyed about what that is worth: the specification defines only the client direction and says nothing about servers advertising at all, and a handshake-era client never receives it — see [the two directions are not symmetric](/docs/user-guide/tools/serving_mcp#the-two-directions-are-not-symmetric). It is visible in discovery and inert otherwise.
+
+## The document
+
+```python linenums="1"
+from ag2.mcp.apps import ResourceCsp, ResourcePermissions
+
+shop = AppResource(
+    "ui://shop/card",
+    CARD,
+    title="Product card",
+    description="A product card that can add its item to the cart.",
+    listed=False,
+    csp=ResourceCsp(connect_domains=["https://api.example.com"]),
+    permissions=ResourcePermissions(camera={}),
+    domain="https://shop.example.com",
+    prefers_border=True,
+)
+```
+
+- **`ui://` is required.** A host discards any other scheme, so a URI that is not `ui://` raises when the `AppResource` is constructed, and two apps claiming one URI raise when the server is.
+- **`listed` defaults to `False`.** The document stays out of `resources/list` — a person browsing a server's resources should not meet a file that is not one — while remaining readable by URI, which is how the host gets it. Set `listed=True` for a document meant to be discoverable.
+- **The body may be a callable**, sync or async, invoked per read — for a document built per locale, per deployment, or per feature flag. A file path is deliberately not accepted: taking one would force ag2 to decide whether it is re-read per request, which is your decision to make inside the callable.
+- **Sandbox policy is typed.** `csp`, `permissions`, `domain` and `prefers_border` use the SDK's own models, so the wire spelling is never guessed at. `meta=` is a raw passthrough merged alongside, for whatever the specification adds next — as is `meta=` on `@app.tool`.
+
+## Taking an app apart
+
+An app is not a special kind of registration. `app.tools` are ordinary `MCPFunctionTool`s and `app.resource` is an ordinary `Resource`, so this:
+
+```python linenums="1"
+server = MCPServer(agent, apps=[shop])
+```
+
+is defined as shorthand for this:
+
+```python linenums="1"
+server = MCPServer(agent, tools=shop.tools, resources=[shop.resource])
+```
+
+Both produce the same tool list, the same resource listing, the same document and the same results — a test in the suite holds that equivalence so it cannot rot into a lie. Reach for the long form when you need an unusual arrangement; it is a rearrangement, not a rewrite.
+
+Ordinary tools are unaffected throughout. A tool declared with `@mcp_tool` and passed in `tools=` behaves exactly as it did before apps existed, alongside any number of them.
+
+## See also
+
+- [Serving an Agent as an MCP Server](/docs/user-guide/tools/serving_mcp) — transports, conversations, security, and protocol extensions.
+- [MCP-UI Resources](/docs/user-guide/tools/mcp_ui) — the other mechanism, for MCP-UI clients.
+- [MCP Servers](/docs/user-guide/tools/mcp_servers) — the inverse direction, consuming an MCP server as tools.

--- a/website/docs/user-guide/tools/mcp_ui.mdx
+++ b/website/docs/user-guide/tools/mcp_ui.mdx
@@ -12,6 +12,9 @@ AG2 builds these resources and the interactive callbacks (**UI Actions**) in `ag
 !!! note "This is the serving side of MCP"
     `ag2.mcp.MCPServer` exposes an agent **as** an MCP server — see [Serving an Agent as an MCP Server](/docs/user-guide/tools/serving_mcp) for transports, conversations and security. This is the inverse of consuming an MCP server as tools with `MCPToolkit` / `MCPServerTool` — see [MCP Servers](/docs/user-guide/tools/mcp_servers) for that.
 
+!!! warning "MCP-UI and MCP Apps are alternatives — pick one"
+    [MCP Apps](/docs/user-guide/tools/mcp_apps) — `ag2.mcp.apps`, the `io.modelcontextprotocol/ui` extension — is the other mechanism, and it inverts this one. There the document is registered as a resource and read by URI **in parallel with** the call, so it cannot be built from the call's arguments; the per-call data reaches it as the result's `structuredContent` instead. A host implementing MCP Apps will not render UI a handler returned. Choose by the host you are serving.
+
 ## Installation
 
 `ag2.mcp_ui` ships as an optional extra (it is **not** pulled in by `ag2[mcp]`):

--- a/website/docs/user-guide/tools/serving_mcp.mdx
+++ b/website/docs/user-guide/tools/serving_mcp.mdx
@@ -301,6 +301,7 @@ Reading is useful today; advertising mostly is not. `ServerCapabilities.extensio
 ## Beyond the conversational tool
 
 - **Custom tools** run a handler of yours directly instead of invoking the agent — see [MCP-UI Resources](/docs/user-guide/tools/mcp_ui) for `@mcp_tool` and returning renderable UI. Their state is their own; conversation handles apply only to the conversational tool.
+- **Apps** serve an interactive document alongside the agent, with `apps=[App(...)]` — see [MCP Apps](/docs/user-guide/tools/mcp_apps). A host reads the document in parallel with the call, so it is a registered resource rather than something a handler returns; that is the difference from MCP-UI above.
 - **Resources and prompts** are exposed by passing `resources=[Resource(...)]`, `resource_templates=[ResourceTemplate(...)]` and `prompts=[Prompt(...)]` from `ag2.mcp`; the matching capability is advertised only when a non-empty collection is supplied.
 - **Progress and logs** — while the agent runs, its stream events are forwarded to the client as progress notifications and log messages. Turn this off with `stream_progress=False`.
 - **Protocol extensions** are declared with `extensions=` and read back with `client_extension()` — see [Protocol extensions](#protocol-extensions).

--- a/website/docs/user-guide/tools/serving_mcp.mdx
+++ b/website/docs/user-guide/tools/serving_mcp.mdx
@@ -298,10 +298,78 @@ Reading is useful today; advertising mostly is not. `ServerCapabilities.extensio
 !!! warning "Do not gate behaviour on a client having seen your advertisement"
     A handshake-era client cannot receive it, so it can never acknowledge it. Branch on what the *client* declared — that reaches you in both eras — and treat your own advertisement as discovery decoration for modern-era clients.
 
+## Structured output
+
+A **custom tool** runs a handler of yours instead of invoking the agent. Declare one with `@mcp_tool` — see [MCP-UI Resources](/docs/user-guide/tools/mcp_ui#serving-a-ui-resource) for the decorator itself — and pass it in `MCPServer(tools=[...])`.
+
+MCP wants three separate things back from such a tool: a schema advertised up front, machine-readable data, and text a model can read. All three are derived from what the handler returns, ordered here by how much is derived:
+
+| the handler returns | `outputSchema` | `structuredContent` | text content |
+|---|---|---|---|
+| a pydantic model or a dataclass | its JSON schema | its dump | its `__str__` |
+| a mapping | none | the mapping verbatim | a JSON rendering |
+| a `str` or a content block | none | none | the value |
+| a sequence of content blocks | none | none | the blocks |
+| a `CallToolResult` | none | whatever you set | whatever you set |
+
+A typed return gets you all three from one annotation:
+
+```python linenums="1" hl_lines="4 9 13"
+from dataclasses import dataclass
+from ag2.mcp import mcp_tool
+
+@dataclass
+class Reading:
+    station: str
+    celsius: float
+
+    def __str__(self) -> str:
+        return f"{self.station}: {self.celsius}°C"
+
+@mcp_tool
+async def temperature(station: str) -> Reading:
+    """The latest temperature at a weather station."""
+    return Reading(station=station, celsius=11.4)
+```
+
+Which is why `__str__` is worth writing: a client that only shows text gets *"Gullfoss: 11.4°C"* rather than a JSON dump, while a client that reads `structuredContent` gets the fields.
+
+At the other end, returning a `CallToolResult` derives nothing and is how you state the text and the data separately:
+
+```python linenums="1"
+from mcp.types import CallToolResult, TextContent
+
+@mcp_tool
+async def temperature(station: str) -> CallToolResult:
+    """The latest temperature at a weather station."""
+    return CallToolResult(
+        content=[TextContent(type="text", text="Mild, around 11 degrees.")],
+        structuredContent={"station": station, "celsius": 11.4},
+    )
+```
+
+!!! note "The schema follows the annotation, not the value"
+    `outputSchema` is decided once, when the tool is declared. Annotating `-> CallToolResult` is what opts a tool out of an advertised schema; returning one from a handler annotated `-> Reading` still advertises `Reading`'s schema, and MCP requires your `structuredContent` to conform to it. `output_schema=` overrides the derivation when you want to describe something the annotation cannot.
+
+### Metadata
+
+`meta=` advertises `_meta` on a tool. `ag2.mcp` puts nothing of its own there, so an extension's keys go in verbatim, and no `meta=` means no `_meta` on the wire at all:
+
+```python linenums="1"
+@mcp_tool(meta={"com.example/audit": {"level": "full"}})
+async def temperature(station: str) -> Reading:
+    """The latest temperature at a weather station."""
+    return Reading(station=station, celsius=11.4)
+```
+
+The one key that does not travel unconditionally is `ui`: a tool bound to an [MCP App](/docs/user-guide/tools/mcp_apps) has its binding withheld from a client that cannot render the document, since to that client it is a promise about a resource it will never fetch.
+
+`Resource` takes the same `meta=`, plus a `title` — the display name a client shows in `resources/list`, where `name` stays the identifier. `title` reaches the listing entry only, so it is visible only on a resource that is `listed`.
+
 ## Beyond the conversational tool
 
-- **Custom tools** run a handler of yours directly instead of invoking the agent — see [MCP-UI Resources](/docs/user-guide/tools/mcp_ui) for `@mcp_tool` and returning renderable UI. Their state is their own; conversation handles apply only to the conversational tool.
-- **Apps** serve an interactive document alongside the agent, with `apps=[App(...)]` — see [MCP Apps](/docs/user-guide/tools/mcp_apps). A host reads the document in parallel with the call, so it is a registered resource rather than something a handler returns; that is the difference from MCP-UI above.
+- **Custom tools** run a handler of yours directly instead of invoking the agent — see [Structured output](#structured-output) for what a handler may return, and [MCP-UI Resources](/docs/user-guide/tools/mcp_ui) for `@mcp_tool` and returning renderable UI. Their state is their own; conversation handles apply only to the conversational tool.
+- **Apps** serve an interactive document alongside the agent, with `apps=[AppResource(...)]` — see [MCP Apps](/docs/user-guide/tools/mcp_apps). A host reads the document in parallel with the call, so it is a registered resource rather than something a handler returns; that is the difference from MCP-UI above.
 - **Resources and prompts** are exposed by passing `resources=[Resource(...)]`, `resource_templates=[ResourceTemplate(...)]` and `prompts=[Prompt(...)]` from `ag2.mcp`; the matching capability is advertised only when a non-empty collection is supplied.
 - **Progress and logs** — while the agent runs, its stream events are forwarded to the client as progress notifications and log messages. Turn this off with `stream_progress=False`.
 - **Protocol extensions** are declared with `extensions=` and read back with `client_extension()` — see [Protocol extensions](#protocol-extensions).

--- a/website/docs/user-guide/tools/serving_mcp.mdx
+++ b/website/docs/user-guide/tools/serving_mcp.mdx
@@ -369,7 +369,7 @@ The one key that does not travel unconditionally is `ui`: a tool bound to an [MC
 ## Beyond the conversational tool
 
 - **Custom tools** run a handler of yours directly instead of invoking the agent — see [Structured output](#structured-output) for what a handler may return, and [MCP-UI Resources](/docs/user-guide/tools/mcp_ui) for `@mcp_tool` and returning renderable UI. Their state is their own; conversation handles apply only to the conversational tool.
-- **Apps** serve an interactive document alongside the agent, with `apps=[AppResource(...)]` — see [MCP Apps](/docs/user-guide/tools/mcp_apps). A host reads the document in parallel with the call, so it is a registered resource rather than something a handler returns; that is the difference from MCP-UI above.
+- **Apps** serve an interactive document alongside the agent, with `apps=[MCPApp(...)]` — see [MCP Apps](/docs/user-guide/tools/mcp_apps). A host reads the document in parallel with the call, so it is a registered resource rather than something a handler returns; that is the difference from MCP-UI above.
 - **Resources and prompts** are exposed by passing `resources=[Resource(...)]`, `resource_templates=[ResourceTemplate(...)]` and `prompts=[Prompt(...)]` from `ag2.mcp`; the matching capability is advertised only when a non-empty collection is supplied.
 - **Progress and logs** — while the agent runs, its stream events are forwarded to the client as progress notifications and log messages. Turn this off with `stream_progress=False`.
 - **Protocol extensions** are declared with `extensions=` and read back with `client_extension()` — see [Protocol extensions](#protocol-extensions).

--- a/website/docs/user-guide/tools/serving_mcp.mdx
+++ b/website/docs/user-guide/tools/serving_mcp.mdx
@@ -240,8 +240,67 @@ With authentication configured, a conversation records the principal that create
 !!! warning "Without `security`, the handle is the only credential"
     With no authentication there is no principal to bind to, so anyone holding a handle can continue the conversation it names. The handle travels through readable content — the model's context, client logs, tracing in between — so decide whether that is acceptable for your deployment before serving unauthenticated.
 
+## Protocol extensions
+
+MCP lets each side declare support for a named **extension** (SEP-2133): a reverse-DNS identifier such as `io.modelcontextprotocol/ui`, mapped to that extension's own settings, carried under `capabilities.extensions`. `ag2.mcp` gives you both directions and knows nothing about any particular extension — the settings object is opaque to it.
+
+### Reading what a client advertised
+
+`client_extension(ctx, identifier)` returns the settings the connected client declared, so a tool can answer differently depending on what the caller can actually do. Take the live request context with `MCPRequestContext`:
+
+```python linenums="1"
+from ag2.mcp import client_extension, mcp_tool
+from ag2.mcp.tools import MCPRequestContext
+
+UI = "io.modelcontextprotocol/ui"
+
+@mcp_tool
+async def sales_report(ctx: MCPRequestContext) -> str:
+    """Report sales, richer for a client that can render it."""
+    settings = client_extension(ctx, UI)
+    if settings is None:
+        return "Q3 revenue: 4.2M."
+    return f"Q3 revenue: 4.2M. (client renders {settings.get('mimeTypes', [])})"
+```
+
+Three answers are possible, and the middle one is easy to miss:
+
+| return value | the client said |
+|---|---|
+| `None` | nothing about this extension — or there is no live request |
+| `{}` | **supported, nothing to configure** |
+| a settings mapping | supported, with these settings |
+
+`{}` and `None` are different on the wire, so they are different here. Test for `is None` rather than for falsiness, or a client that supports an extension with no settings will be treated as one that does not.
+
+### Advertising your own
+
+`extensions=` declares what *this server* supports. Identifiers are validated when the server is constructed, so a malformed one fails at startup the way a tool-name conflict does — never on the wire:
+
+```python linenums="1"
+from ag2 import Agent
+from ag2.config import AnthropicConfig
+from ag2.mcp import MCPServer
+
+agent = Agent(name="assistant", config=AnthropicConfig(model="claude-haiku-4-5-20251001"))
+app = MCPServer(agent, extensions={"com.example/audit": {"level": "full"}})
+```
+
+### The two directions are not symmetric
+
+Reading is useful today; advertising mostly is not. `ServerCapabilities.extensions` does not exist in the 2025-11-25 wire schema, so what you declare is dropped at serialization for every handshake-era client:
+
+| direction | handshake era (up to 2025-11-25) | modern era (2026-07-28) |
+|---|---|---|
+| what a **client** advertised, via `client_extension()` | arrives intact | arrives intact |
+| what **this server** advertises, via `extensions=` | **dropped — never received** | received |
+
+!!! warning "Do not gate behaviour on a client having seen your advertisement"
+    A handshake-era client cannot receive it, so it can never acknowledge it. Branch on what the *client* declared — that reaches you in both eras — and treat your own advertisement as discovery decoration for modern-era clients.
+
 ## Beyond the conversational tool
 
 - **Custom tools** run a handler of yours directly instead of invoking the agent — see [MCP-UI Resources](/docs/user-guide/tools/mcp_ui) for `@mcp_tool` and returning renderable UI. Their state is their own; conversation handles apply only to the conversational tool.
 - **Resources and prompts** are exposed by passing `resources=[Resource(...)]`, `resource_templates=[ResourceTemplate(...)]` and `prompts=[Prompt(...)]` from `ag2.mcp`; the matching capability is advertised only when a non-empty collection is supplied.
 - **Progress and logs** — while the agent runs, its stream events are forwarded to the client as progress notifications and log messages. Turn this off with `stream_progress=False`.
+- **Protocol extensions** are declared with `extensions=` and read back with `client_extension()` — see [Protocol extensions](#protocol-extensions).

--- a/website/mint-json-template.json.jinja
+++ b/website/mint-json-template.json.jinja
@@ -82,6 +82,7 @@
             "docs/user-guide/tools/mcp_servers",
             "docs/user-guide/tools/serving_mcp",
             "docs/user-guide/tools/mcp_ui",
+            "docs/user-guide/tools/mcp_apps",
             "docs/user-guide/tools/builtin_tools",
             "docs/user-guide/tools/code_execution",
             "docs/user-guide/tools/local_shell",


### PR DESCRIPTION
## Why are these changes needed?

A served agent could hand a client renderable UI only through `ag2.mcp_ui` (the MCP-UI format), where the handler builds HTML from the call's arguments and returns it inside the result.

Hosts implementing **MCP Apps** (`io.modelcontextprotocol/ui`) will not render that. There the document is a *registered resource* read by URI, the tool only *references* it, and the host reads the document **in parallel with** the call — so it cannot be built from the arguments. Per-call data arrives afterwards as the result's `structuredContent`.

Three gaps in `ag2.mcp` made that inexpressible, each worth closing on its own:

1. a custom tool could not return structured output — only the agent's `ask` tool produced `structuredContent` / `outputSchema`;
2. neither a tool nor a resource could carry `_meta`, so the binding MCP Apps rests on could not reach the wire;
3. nothing read a client's SEP-2133 advertisement, so the server could not tell an app-capable client from one that would only see a broken promise.

### What it looks like

```python
from ag2.mcp import MCPApp, MCPServer

shop = MCPApp("ui://shop/card", CARD_HTML)

@shop.tool
async def show_item(item_id: str) -> Item:
    """Show a product card."""
    return await catalog.get(item_id)

@shop.tool(visibility=["app"])  # the card's button calls this; the model never sees it
async def add_to_cart(item_id: str) -> CartLine:
    """Add an item to the cart."""
    return await cart.add(item_id)

server = MCPServer(agent, apps=[shop])
```

`MCPApp` is the one high-level aggregate: a single UI document plus every tool bound to it. `-> Item` does three jobs at once — its JSON schema becomes the tool's `outputSchema`, its dump becomes the result's `structuredContent` (what the document renders), and its `__str__` becomes the text content (what the model and a text-only client read).

Inside the document, `ag2ui` is a global the server injects. It performs the `ui/initialize` handshake a host requires before it will accept any message from the frame — without it a hand-written button is silently dead — and exposes the View-side surface:

```javascript
ag2ui.onToolResult("show_item", renderCard);
buy.onclick = () => ag2ui.callTool("add_to_cart", { item_id: current.item_id });
```

### The document body has four forms

`content` is typed, and the forms are told apart **by type alone** — never by inspecting the filesystem, so a string is always literal HTML and never a filename. There is an overload per form, so an IDE shows which one is in use:

```python
MCPApp("ui://shop/card", CARD)                     # inline HTML
MCPApp("ui://shop/card", Path("dist/card.html"))   # a built bundle, reread on every read
MCPApp("ui://shop/card", Variable("card"))         # a request-scoped variable
MCPApp("ui://shop/card", render_card)              # a sync or async callable
```

A path-like value is read on **every** resource read, so rebuilding a bundle is picked up without restarting the server; a file that has gone missing fails that one read, naming the path, rather than failing at construction.

### Runtime configuration follows AG2's dependency model

An app document is read in a separate MCP request, in parallel with its tool call, so it previously could not use the rest of AG2's dependency model at all. `MCPServer.context_provider` now feeds one shared request pipeline, and `Resource`, `MCPFunctionTool` and `MCPApp` all resolve against it:

```python
async def provider(access) -> AskContext:
    return AskContext(variables={"tenant": "north"}, dependencies={"branding": BRANDING})

async def card(
    tenant: Annotated[str, Variable("tenant")],
    branding: Annotated[Branding, Inject("branding")],
    ctx: MCPRequestContext,
) -> str:
    return render(tenant, branding)

shop = MCPApp("ui://shop/card", card, title=Variable("tenant"), listed=True)
server = MCPServer(agent, apps=[shop], context_provider=provider)
```

`title`, `description`, `inject_runtime`, the sandbox fields and the values inside `meta=` may each be a `Variable` too, resolved per request for both the listing and the read. The same holds for a plain `Resource` and an `@mcp_tool`, which is what keeps the decomposition below honest.

**This context is request-scoped, not turn-scoped.** The document read and the tool call stay two distinct MCP requests that share no mutable turn state; each calls the provider again. `AskContext.prompt` and `AskContext.tools` are deliberately *not* carried into it — they shape an agent turn, and neither of these requests is one.

### What's added

- **`ag2.mcp.apps`** — `MCPApp` (a document plus the tools that render it), `MCPServer(apps=[...])`, the injected `ag2ui` runtime, per-tool `visibility=`, and sandbox policy grouped into `AppSandbox(csp=, permissions=, domain=)` with the presentation hint `prefers_border` kept separate. `MCPApp.tool` works both as a decorator and as a direct factory call, returns an ordinary `MCPFunctionTool`, and accepts prebuilt ones — no new app-tool class or standalone factory is introduced.
- **The request pipeline** — `MCPRequestContext`, `Variable` and `Depends`/`Inject` resolve identically on a tool call and on a resource read. `Resource.title` / `.description` / `.mime_type` accept a `Variable` and are resolved on both the listing and the read.
- **Structured output from custom tools** — a handler may return a pydantic model / dataclass → a mapping → a `CallToolResult`, in increasing order of control. Strings and content blocks behave exactly as before.
- **`_meta` passthrough** on `MCPFunctionTool` and `Resource`, plus `Resource(title=..., listed=...)`. Generic, not UI-specific.
- **SEP-2133 extensions** — `MCPServer(extensions=...)` and `client_extension()`. Identifiers are validated at construction, so a typo fails at startup rather than on the wire; `{}` and `None` stay distinct, as on the wire.
- **Public surface** — `MCPApp`, `AppSandbox`, `AppContent`, `AppText`, `MCPRequestContext` and the SDK's `ResourceCsp` / `ResourcePermissions` / `Visibility` are re-exported from `ag2.mcp` and listed in its `__all__`, so no example reaches into a private module.
- **Docs** — a new *MCP Apps* page, a *Structured output* section on *Serving an Agent as an MCP Server*, and a runnable `examples/mcp/server_apps.py`.
- **Test helpers** — `make_agent` / `text_of` / `tool_named` / `Weather` moved into `test/mcp/_helpers.py`, replacing copies spread across six files. This is why files unrelated to the feature appear in the diff.

### Worth a reviewer's eye

- **The UI binding is withheld, not configurable.** `_meta.ui` is dropped per `tools/list` request for a client that did not advertise the extension — to that client it is a promise about a document it will never fetch. The tool still lists, still calls, and still returns usable text, so there is no switch. A client advertising the identifier without the `text/html;profile=mcp-app` MIME type counts as unable to render.
- **`apps=[app]` is *defined* as shorthand** for `tools=app.tools, resources=[app.resource]`. Two tests compare the full wire output of both registrations — one on a static document, one on a document and tool that resolve `Variable`s, injected dependencies and the live request context — so the claim cannot rot into a lie for either the static or the dynamic path.
- **Registration closes an app's tool composition.** Constructing the server is what reads `app.tools`, so a tool declared afterwards would exist and never be served. It raises `MCPAppFrozenError` naming the tool, rather than leaving a silently absent tool to be found on the wire. The app object itself stays reusable across servers.
- **Which tool answered.** MCP Apps gives the document no correlation identifier, so the server stamps the answering tool's name into the result's `_meta` under `ai.ag2/tool`, following the existing `ai.ag2/conversation` key. It is skipped when the author's own result already occupies that key.
- **`ag2.mcp_ui` is untouched.** The two mechanisms are alternatives and coexist; both doc pages now open by stating the difference so an author picks one deliberately.
- The runtime's JavaScript follows the **shipped `ext-apps` types**, not the specification's prose, which disagrees with them in places (e.g. `ui/message` content being an array). Each disagreement is recorded in a code comment. What that JavaScript does in a browser is not reachable from the suite and nothing fakes it; the tests assert the string's contract instead — present by default, absent under `inject_runtime=False`, identical to `runtime_script()`, and free of `eval`, dynamic function construction and network calls (all forbidden by the specification's CSP).

## Related issue number

Closes #3187 — that issue's body asks for something unimplementable as worded (a handshake-era client cannot receive a server's extension advertisement), so it needs correcting to match what is deliverable.

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

Verification:

- `pytest test/mcp` — 230 passed. Full suite — 4799 passed, 360 skipped, 1 xfailed, no failures.
- `ruff check` / `ruff format` — clean.
- `just docs-build` — builds clean; no warnings on any changed page.
- Coverage over `ag2/mcp` — 98% branch. `apps.py` is at 98%: the two uncovered lines are the validation branches that reject a prebuilt `MCPFunctionTool` carrying a conflicting name/schema or a different document's `ui` binding.
- `mypy` as CI runs it (bare, scoped by `[tool.mypy].files`) — clean. Run explicitly and strictly over the whole package, `mypy ag2/mcp/` reports 11 errors: one pre-existing in `testing.py` (untouched here), the rest where `fast_depends`' `asolve` and `resolve_variable` signatures meet `MCPExecutionContext`. That is a typing gap at the dependency-injection boundary, not a behavioural one, and it is down from 15 before the last commit.
- Every constructor form, overload and error path shown in this description and on the new documentation page was executed against the shipped API, and `examples/mcp/server_apps.py` imports and builds its app.

## AI assistance

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.
