### PR TITLE
feat(tealtiger): add output_scan governance policy

### DIFF
--- a/ag2/extensions/tealtiger/__init__.py
+++ b/ag2/extensions/tealtiger/__init__.py
@@ -17,6 +17,7 @@ from ag2.extensions.tealtiger.types import (
     GovernancePolicy,
     InjectionFinding,
     InjectionPattern,
+    OutputAction,
     TEECReceipt,
 )
 
@@ -29,6 +30,7 @@ __all__ = [
     "GovernancePolicy",
     "InjectionFinding",
     "InjectionPattern",
+    "OutputAction",
     "TEECReceipt",
     "TealTigerMiddleware",
 ]

--- a/ag2/extensions/tealtiger/middleware.py
+++ b/ag2/extensions/tealtiger/middleware.py
@@ -12,9 +12,8 @@ No external dependencies beyond AG2 and the standard library.
 
 import fnmatch
 import hashlib
-import re
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -23,37 +22,25 @@ if TYPE_CHECKING:
     from ag2.middleware.base import ToolExecution
 
 from ag2.events import ToolErrorEvent, ToolResultEvent
-from ag2.events.input_events import TextInput
+from ag2.events.input_events import DataInput, TextInput
 from ag2.extensions.tealtiger.types import (
     ARG_TYPES_BY_NAME,
     DEFAULT_INJECTION_CONFIDENCE_THRESHOLD,
     INJECTION_PATTERNS,
     INJECTION_TECHNIQUES,
+    PII_PATTERNS,
+    SECRET_PATTERNS,
     GovernanceDecision,
     GovernanceMode,
     GovernancePolicy,
     InjectionFinding,
+    OutputAction,
     TEECReceipt,
+    most_restrictive,
 )
 from ag2.middleware import BaseMiddleware
 from ag2.middleware.base import ToolResultType
 from ag2.utils import AGENT_CONTEXT_DEPENDENCY_KEY
-
-_PII_PATTERNS: dict[str, re.Pattern[str]] = {
-    "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
-    "credit_card": re.compile(r"\b(?:\d{4}[-\s]?){3}\d{4}\b"),
-    "email": re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),
-    "phone": re.compile(r"\b(?:\+1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b"),
-}
-
-_SECRET_PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"\b(sk-[a-zA-Z0-9]{20,})\b"),
-    re.compile(r"\b(ghp_[a-zA-Z0-9]{36,})\b"),
-    re.compile(r"\b(AKIA[0-9A-Z]{16})\b"),
-    re.compile(r"\b(xox[bpors]-[a-zA-Z0-9-]+)\b"),
-    re.compile(r"(?i)(?:api[_-]?key|apikey)\s*[:=]\s*['\"]?[a-zA-Z0-9_\-]{20,}"),
-    re.compile(r"-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----"),
-]
 
 # Injection findings keep a snippet of the match as evidence, not the whole argument.
 _MAX_MATCHED_TEXT_CHARS = 100
@@ -61,6 +48,59 @@ _MAX_MATCHED_TEXT_CHARS = 100
 # Stands in for the argument name in an arg_validation reason code when the call's
 # arguments were not a mapping and the hit cannot be attributed to one argument.
 _UNNAMED_ARG = "*"
+
+
+def _string_leaves(value: Any) -> list[str]:
+    """Every string inside a structured tool result, in traversal order.
+
+    Non-string scalars are skipped: they cannot be rewritten in place, so matching one
+    would mean withholding results over numeric ids that merely look like a phone number.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Mapping):
+        return [leaf for item in value.values() for leaf in _string_leaves(item)]
+    if isinstance(value, (list, tuple, set)):
+        return [leaf for item in value for leaf in _string_leaves(item)]
+    return []
+
+
+def _rewrite_string_leaves(value: Any, rewrite: Callable[[str], str]) -> Any:
+    """`value` with `rewrite` applied to every string `_string_leaves` would collect."""
+    if isinstance(value, str):
+        return rewrite(value)
+    if isinstance(value, Mapping):
+        return {key: _rewrite_string_leaves(item, rewrite) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_rewrite_string_leaves(item, rewrite) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_rewrite_string_leaves(item, rewrite) for item in value)
+    if isinstance(value, set):
+        return {_rewrite_string_leaves(item, rewrite) for item in value}
+    return value
+
+
+def _scannable_text(part: Any) -> str | None:
+    """The text an output scan reads from one result part, or `None` if it has none.
+
+    A tool that returns a `dict` hands back a `DataInput`, not a `TextInput` — an
+    SSN in `{"ssn": "123-45-6789"}` leaks just as readily as one in a sentence, so
+    structured parts are scanned through their strings.
+    """
+    if isinstance(part, TextInput) and isinstance(part.content, str):
+        return part.content
+    if isinstance(part, DataInput):
+        leaves = _string_leaves(part.data)
+        return "\n".join(leaves) if leaves else None
+    return None
+
+
+def _rewrite_part(part: Any, rewrite: Callable[[str], str]) -> None:
+    """Apply `rewrite` in place to whatever `_scannable_text` reads from `part`."""
+    if isinstance(part, TextInput):
+        part.content = rewrite(part.content)
+    elif isinstance(part, DataInput):
+        part.data = _rewrite_string_leaves(part.data, rewrite)
 
 
 def _matches_blocked_terms(text: str, spec: dict[str, Any]) -> bool:
@@ -295,7 +335,11 @@ class _TealTigerPerTurn(BaseMiddleware):
         event: "ToolCallEvent",
         context: "Context",
     ) -> "ToolResultType":
-        """Evaluate governance policies before tool execution."""
+        """Govern a tool call on both sides of its execution.
+
+        Policies over the call's *arguments* are evaluated before it runs and can
+        deny it; `output_scan` policies then scan the *result* on the way back.
+        """
         start_time = time.perf_counter()
         tool_name = event.name
         tool_args = event.serialized_arguments
@@ -457,24 +501,11 @@ class _TealTigerPerTurn(BaseMiddleware):
             cumulative_cost=self._factory._cumulative_cost,
         )
 
-    def _scan_result(
-        self, event: "ToolCallEvent", tool_name: str, result: "ToolResultType"
-    ) -> "ToolResultType":
-        """Scan a tool result for PII/secrets (post-tool defense).
+    def _scan_result(self, event: "ToolCallEvent", tool_name: str, result: "ToolResultType") -> "ToolResultType":
+        """Scan a successful tool result for PII/secrets, and redact, withhold, or flag it.
 
-        Only successful ``ToolResultEvent`` results are scanned; errors and
-        other result types pass through untouched. For each configured
-        ``output_scan`` policy, the concatenated text of the result's parts is
-        scanned. The most restrictive action across findings wins
-        (BLOCK > REDACT > FLAG):
-
-        - BLOCK (ENFORCE only): the result is replaced with a governance error.
-          In MONITOR the block degrades to REDACT so the value still never
-          reaches the model.
-        - REDACT: matched values in each text part are replaced in place.
-        - FLAG: recorded only; the result is returned unchanged.
-
-        A GovernanceDecision (+ receipt) is recorded whenever findings occur.
+        Each detector resolves its own action across the configured ``output_scan``
+        policies, taking the most restrictive one asked for.
         """
         # Only successful results carry scannable content; skip errors/others.
         if not isinstance(result, ToolResultEvent) or isinstance(result, ToolErrorEvent):
@@ -484,21 +515,17 @@ class _TealTigerPerTurn(BaseMiddleware):
         if not policies:
             return result
 
-        # Gather the text parts of the result (TextInput.content) with indices.
-        text_parts = [
-            (idx, part)
-            for idx, part in enumerate(result.result.parts)
-            if isinstance(part, TextInput) and isinstance(part.content, str)
-        ]
-        if not text_parts:
+        scannable = [part for part in result.result.parts if _scannable_text(part) is not None]
+        if not scannable:
             return result
 
-        combined = "\n".join(part.content for _, part in text_parts)
+        combined = "\n".join(_scannable_text(part) or "" for part in scannable)
 
+        # Resolve each detector independently: which categories actually hit, and
+        # the most restrictive action any policy that scanned them asked for.
         pii_hits: list[str] = []
-        secret_hit = False
-        pii_action = "REDACT"
-        secret_action = "BLOCK"
+        pii_actions: list[OutputAction] = []
+        secret_actions: list[OutputAction] = []
 
         for policy in policies:
             cfg = policy.config
@@ -506,69 +533,109 @@ class _TealTigerPerTurn(BaseMiddleware):
                 found = self._detect_pii(combined, cfg.get("categories", []))
                 if found:
                     pii_hits.extend(found)
-                    pii_action = cfg.get("pii_action", "REDACT")
+                    pii_actions.append(OutputAction(cfg.get("pii_action", OutputAction.REDACT)))
             if cfg.get("scan_secrets", True) and self._detect_secrets(combined):
-                secret_hit = True
-                secret_action = cfg.get("secret_action", "BLOCK")
+                secret_actions.append(OutputAction(cfg.get("secret_action", OutputAction.BLOCK)))
 
-        if not pii_hits and not secret_hit:
+        pii_categories = list(dict.fromkeys(pii_hits))
+        secret_hit = bool(secret_actions)
+        if not pii_categories and not secret_hit:
             return result
 
-        reason_codes: list[str] = []
-        if pii_hits:
-            reason_codes.extend(f"OUTPUT_PII_DETECTED:{cat}" for cat in dict.fromkeys(pii_hits))
+        pii_action = most_restrictive(pii_actions, default=OutputAction.FLAG)
+        secret_action = most_restrictive(secret_actions, default=OutputAction.FLAG)
+
+        reason_codes = [f"OUTPUT_PII_DETECTED:{cat}" for cat in pii_categories]
         if secret_hit:
             reason_codes.append("OUTPUT_SECRET_DETECTED")
-
-        # Effective action: most restrictive across triggered detectors.
-        actions = set()
-        if pii_hits:
-            actions.add(pii_action)
-        if secret_hit:
-            actions.add(secret_action)
         risk_score = 90 if secret_hit else 60
         agent_name = self._agent_name or "unknown"
 
-        # BLOCK (ENFORCE only) — replace the result with a governance error.
-        if "BLOCK" in actions and self._factory.mode == GovernanceMode.ENFORCE:
-            reason_codes.append("OUTPUT_BLOCKED")
-            decision = GovernanceDecision(
-                action="DENY",
-                mode=self._factory.mode.value,
-                agent_name=agent_name,
-                tool_name=tool_name,
-                reason_codes=reason_codes,
-                risk_score=risk_score,
-                cumulative_cost=self._factory._cumulative_cost,
-            )
-            self._factory._decisions.append(decision)
-            if self._factory.on_decision:
-                self._factory.on_decision(decision)
-            self._emit_receipt(decision, execution_outcome="blocked")
-            reason = ", ".join(reason_codes)
-            return ToolErrorEvent.from_call(
-                event,
-                error=Exception(
-                    f"[GOVERNANCE DENIED] Result of tool '{tool_name}' withheld — "
-                    f"sensitive data detected. Reason: {reason}. Decision ID: {decision.decision_id}"
-                ),
-            )
+        enforcing = self._factory.mode == GovernanceMode.ENFORCE
+        triggered = [pii_action] if pii_categories else []
+        if secret_hit:
+            triggered.append(secret_action)
 
-        # REDACT — either an explicit REDACT action, or a BLOCK degraded because
-        # we are not in ENFORCE mode (the value must still not leak).
-        should_redact = "REDACT" in actions or ("BLOCK" in actions and self._factory.mode != GovernanceMode.ENFORCE)
-        if should_redact:
+        # BLOCK (ENFORCE only) — withhold the whole result.
+        if OutputAction.BLOCK in triggered and enforcing:
+            return self._withhold_result(event, tool_name, reason_codes, risk_score, agent_name)
+
+        # A BLOCK outside ENFORCE degrades to redaction so the value still never leaks.
+        redact_pii = bool(pii_categories) and pii_action in (OutputAction.REDACT, OutputAction.BLOCK)
+        redact_secrets = secret_hit and secret_action in (OutputAction.REDACT, OutputAction.BLOCK)
+
+        action_value = "ALLOW"
+        if redact_pii or redact_secrets:
             reason_codes.append("OUTPUT_REDACTED")
-            categories = sorted({p for policy in policies for p in policy.config.get("categories", [])})
-            for _, part in text_parts:
-                part.content = self._redact(part.content, categories, redact_secrets=secret_hit)
-            action_value = "MONITOR" if self._factory.mode == GovernanceMode.MONITOR else "ALLOW"
-        else:
-            # FLAG only — record but pass the result through unchanged.
-            action_value = "ALLOW"
+            categories = pii_categories if redact_pii else []
+            for part in scannable:
+                _rewrite_part(part, lambda text: self._redact(text, categories, redact_secrets))
 
-        decision = GovernanceDecision(
+            # Detection runs over the joined parts, redaction over each part alone, so a
+            # value straddling two parts can be found but not removed. Rather than let it
+            # through, withhold the result (or, outside ENFORCE, the offending parts).
+            residual = "\n".join(_scannable_text(part) or "" for part in scannable)
+            if self._detect_pii(residual, categories) or (redact_secrets and self._detect_secrets(residual)):
+                reason_codes.append("OUTPUT_REDACTION_INCOMPLETE")
+                if enforcing:
+                    return self._withhold_result(event, tool_name, reason_codes, risk_score, agent_name)
+                for part in scannable:
+                    _rewrite_part(part, lambda _text: "[REDACTED:unredactable]")
+
+            # `action` carries only ALLOW/DENY/MONITOR; a rewritten-but-delivered result
+            # is an ALLOW, and `OUTPUT_REDACTED` in the reason codes is what says it was
+            # rewritten. MONITOR keeps its own marker, as it does for a call it let past.
+            action_value = "MONITOR" if self._factory.mode == GovernanceMode.MONITOR else "ALLOW"
+
+        self._record_decision(
             action=action_value,
+            agent_name=agent_name,
+            tool_name=tool_name,
+            reason_codes=reason_codes,
+            risk_score=risk_score,
+            execution_outcome="executed",
+        )
+        return result
+
+    def _withhold_result(
+        self,
+        event: "ToolCallEvent",
+        tool_name: str,
+        reason_codes: list[str],
+        risk_score: int,
+        agent_name: str,
+    ) -> "ToolErrorEvent":
+        """Replace a result carrying sensitive data with a governance error."""
+        reason_codes = [*reason_codes, "OUTPUT_BLOCKED"]
+        decision = self._record_decision(
+            action="DENY",
+            agent_name=agent_name,
+            tool_name=tool_name,
+            reason_codes=reason_codes,
+            risk_score=risk_score,
+            execution_outcome="blocked",
+        )
+        reason = ", ".join(reason_codes)
+        return ToolErrorEvent.from_call(
+            event,
+            error=Exception(
+                f"[GOVERNANCE DENIED] Result of tool '{tool_name}' withheld — "
+                f"sensitive data detected. Reason: {reason}. Decision ID: {decision.decision_id}"
+            ),
+        )
+
+    def _record_decision(
+        self,
+        action: str,
+        agent_name: str,
+        tool_name: str,
+        reason_codes: list[str],
+        risk_score: int,
+        execution_outcome: str,
+    ) -> GovernanceDecision:
+        """Record a decision on the factory, notify `on_decision`, and emit its receipt."""
+        decision = GovernanceDecision(
+            action=action,
             mode=self._factory.mode.value,
             agent_name=agent_name,
             tool_name=tool_name,
@@ -579,20 +646,19 @@ class _TealTigerPerTurn(BaseMiddleware):
         self._factory._decisions.append(decision)
         if self._factory.on_decision:
             self._factory.on_decision(decision)
-        self._emit_receipt(decision, execution_outcome="executed")
-
-        return result
+        self._emit_receipt(decision, execution_outcome=execution_outcome)
+        return decision
 
     @staticmethod
     def _redact(text: str, categories: list[str], redact_secrets: bool) -> str:
         """Replace PII (in ``categories``) and, if requested, secrets with markers."""
         redacted = text
         for cat in categories:
-            pattern = _PII_PATTERNS.get(cat)
+            pattern = PII_PATTERNS.get(cat)
             if pattern is not None:
                 redacted = pattern.sub(f"[REDACTED:{cat}]", redacted)
         if redact_secrets:
-            for pattern in _SECRET_PATTERNS:
+            for pattern in SECRET_PATTERNS:
                 redacted = pattern.sub("[REDACTED:secret]", redacted)
         return redacted
 
@@ -617,7 +683,7 @@ class _TealTigerPerTurn(BaseMiddleware):
         """Detect PII patterns in text."""
         found = []
         for cat in categories:
-            pattern = _PII_PATTERNS.get(cat)
+            pattern = PII_PATTERNS.get(cat)
             if pattern and pattern.search(text):
                 found.append(cat)
         return found
@@ -625,7 +691,7 @@ class _TealTigerPerTurn(BaseMiddleware):
     @staticmethod
     def _detect_secrets(text: str) -> bool:
         """Detect secret patterns in text."""
-        return any(p.search(text) for p in _SECRET_PATTERNS)
+        return any(p.search(text) for p in SECRET_PATTERNS)
 
     @staticmethod
     def _validate_args(tool_args: Any, args_str: str, constraints: dict[str, dict[str, Any]]) -> str | None:

--- a/ag2/extensions/tealtiger/middleware.py
+++ b/ag2/extensions/tealtiger/middleware.py
@@ -103,6 +103,19 @@ def _rewrite_part(part: Any, rewrite: Callable[[str], str]) -> None:
         part.data = _rewrite_string_leaves(part.data, rewrite)
 
 
+def _reconstructable(exc: BaseException) -> bool:
+    """Whether `type(exc)(message)` is safe to construct.
+
+    Custom exceptions can take extra required constructor args; for those we fall
+    back to a plain `Exception` rather than risk a TypeError while sanitizing.
+    """
+    try:
+        type(exc)(str(exc))
+    except Exception:
+        return False
+    return True
+
+
 def _matches_blocked_terms(text: str, spec: dict[str, Any]) -> bool:
     """Whether `text` contains any of the spec's blocked terms, case-insensitively."""
     if "blocked_terms" not in spec:
@@ -398,7 +411,7 @@ class _TealTigerPerTurn(BaseMiddleware):
         self._emit_receipt(decision, execution_outcome=outcome)
 
         # Post-tool defense: scan the RESULT for PII/secrets before it flows back
-        # into agent context. Runs only on successful results (not errors) and
+        # into agent context. Applies to successful and error results alike, and
         # only if an output_scan policy is configured.
         return self._scan_result(event, tool_name, result)
 
@@ -502,13 +515,21 @@ class _TealTigerPerTurn(BaseMiddleware):
         )
 
     def _scan_result(self, event: "ToolCallEvent", tool_name: str, result: "ToolResultType") -> "ToolResultType":
-        """Scan a successful tool result for PII/secrets, and redact, withhold, or flag it.
+        """Scan a tool result for PII/secrets, and redact, withhold, or flag it.
 
-        Each detector resolves its own action across the configured ``output_scan``
-        policies, taking the most restrictive one asked for.
+        Applies to both successful results and error results (``ToolErrorEvent``),
+        whose exception message and traceback reach the model just like a returned
+        value. Each detector resolves its own action across the configured
+        ``output_scan`` policies, taking the most restrictive one asked for. An
+        error stays an error: a blocked error result is replaced with a sanitized
+        governance error, never turned into a success.
         """
-        # Only successful results carry scannable content; skip errors/others.
-        if not isinstance(result, ToolResultEvent) or isinstance(result, ToolErrorEvent):
+        is_error = isinstance(result, ToolErrorEvent)
+        # ToolResultEvent covers both successful results and ToolErrorEvent
+        # (a subclass): a tool that raises with an SSN or credential in its
+        # message leaks it into model context just as a returned value would,
+        # so error results are scanned too. Non-result types have nothing to scan.
+        if not isinstance(result, ToolResultEvent):
             return result
 
         policies = [p for p in self._factory.policies if p.type == "output_scan"]
@@ -570,6 +591,10 @@ class _TealTigerPerTurn(BaseMiddleware):
             categories = pii_categories if redact_pii else []
             for part in scannable:
                 _rewrite_part(part, lambda text: self._redact(text, categories, redact_secrets))
+            # An error result also carries the exception itself; `str(error)` reaches
+            # the model independently of the parts, so redact it in place too.
+            if is_error:
+                self._redact_error(result, categories, redact_secrets)
 
             # Detection runs over the joined parts, redaction over each part alone, so a
             # value straddling two parts can be found but not removed. Rather than let it
@@ -648,6 +673,19 @@ class _TealTigerPerTurn(BaseMiddleware):
             self._factory.on_decision(decision)
         self._emit_receipt(decision, execution_outcome=execution_outcome)
         return decision
+
+    def _redact_error(self, result: "ToolErrorEvent", categories: list[str], redact_secrets: bool) -> None:
+        """Sanitize the exception carried by an error result, in place.
+
+        `ToolErrorEvent.error` is a separate `Exception` whose rendered string
+        reaches the model alongside `result.parts`. Redacting the parts alone
+        would leave the credential/PII visible via `str(error)`, so the error is
+        replaced with one carrying the redacted message.
+        """
+        original = str(result.error)
+        redacted = self._redact(original, categories, redact_secrets)
+        if redacted != original:
+            result.error = type(result.error)(redacted) if _reconstructable(result.error) else Exception(redacted)
 
     @staticmethod
     def _redact(text: str, categories: list[str], redact_secrets: bool) -> str:

--- a/ag2/extensions/tealtiger/middleware.py
+++ b/ag2/extensions/tealtiger/middleware.py
@@ -22,7 +22,8 @@ if TYPE_CHECKING:
     from ag2.events import BaseEvent, ToolCallEvent
     from ag2.middleware.base import ToolExecution
 
-from ag2.events import ToolErrorEvent
+from ag2.events import ToolErrorEvent, ToolResultEvent
+from ag2.events.input_events import TextInput
 from ag2.extensions.tealtiger.types import (
     ARG_TYPES_BY_NAME,
     DEFAULT_INJECTION_CONFIDENCE_THRESHOLD,
@@ -352,7 +353,10 @@ class _TealTigerPerTurn(BaseMiddleware):
         outcome = "error" if isinstance(result, ToolErrorEvent) else "executed"
         self._emit_receipt(decision, execution_outcome=outcome)
 
-        return result
+        # Post-tool defense: scan the RESULT for PII/secrets before it flows back
+        # into agent context. Runs only on successful results (not errors) and
+        # only if an output_scan policy is configured.
+        return self._scan_result(event, tool_name, result)
 
     def _evaluate(self, tool_name: str, tool_args: Any) -> GovernanceDecision:
         """Evaluate governance policies deterministically."""
@@ -452,6 +456,145 @@ class _TealTigerPerTurn(BaseMiddleware):
             risk_score=risk_score,
             cumulative_cost=self._factory._cumulative_cost,
         )
+
+    def _scan_result(
+        self, event: "ToolCallEvent", tool_name: str, result: "ToolResultType"
+    ) -> "ToolResultType":
+        """Scan a tool result for PII/secrets (post-tool defense).
+
+        Only successful ``ToolResultEvent`` results are scanned; errors and
+        other result types pass through untouched. For each configured
+        ``output_scan`` policy, the concatenated text of the result's parts is
+        scanned. The most restrictive action across findings wins
+        (BLOCK > REDACT > FLAG):
+
+        - BLOCK (ENFORCE only): the result is replaced with a governance error.
+          In MONITOR the block degrades to REDACT so the value still never
+          reaches the model.
+        - REDACT: matched values in each text part are replaced in place.
+        - FLAG: recorded only; the result is returned unchanged.
+
+        A GovernanceDecision (+ receipt) is recorded whenever findings occur.
+        """
+        # Only successful results carry scannable content; skip errors/others.
+        if not isinstance(result, ToolResultEvent) or isinstance(result, ToolErrorEvent):
+            return result
+
+        policies = [p for p in self._factory.policies if p.type == "output_scan"]
+        if not policies:
+            return result
+
+        # Gather the text parts of the result (TextInput.content) with indices.
+        text_parts = [
+            (idx, part)
+            for idx, part in enumerate(result.result.parts)
+            if isinstance(part, TextInput) and isinstance(part.content, str)
+        ]
+        if not text_parts:
+            return result
+
+        combined = "\n".join(part.content for _, part in text_parts)
+
+        pii_hits: list[str] = []
+        secret_hit = False
+        pii_action = "REDACT"
+        secret_action = "BLOCK"
+
+        for policy in policies:
+            cfg = policy.config
+            if cfg.get("scan_pii", True):
+                found = self._detect_pii(combined, cfg.get("categories", []))
+                if found:
+                    pii_hits.extend(found)
+                    pii_action = cfg.get("pii_action", "REDACT")
+            if cfg.get("scan_secrets", True) and self._detect_secrets(combined):
+                secret_hit = True
+                secret_action = cfg.get("secret_action", "BLOCK")
+
+        if not pii_hits and not secret_hit:
+            return result
+
+        reason_codes: list[str] = []
+        if pii_hits:
+            reason_codes.extend(f"OUTPUT_PII_DETECTED:{cat}" for cat in dict.fromkeys(pii_hits))
+        if secret_hit:
+            reason_codes.append("OUTPUT_SECRET_DETECTED")
+
+        # Effective action: most restrictive across triggered detectors.
+        actions = set()
+        if pii_hits:
+            actions.add(pii_action)
+        if secret_hit:
+            actions.add(secret_action)
+        risk_score = 90 if secret_hit else 60
+        agent_name = self._agent_name or "unknown"
+
+        # BLOCK (ENFORCE only) — replace the result with a governance error.
+        if "BLOCK" in actions and self._factory.mode == GovernanceMode.ENFORCE:
+            reason_codes.append("OUTPUT_BLOCKED")
+            decision = GovernanceDecision(
+                action="DENY",
+                mode=self._factory.mode.value,
+                agent_name=agent_name,
+                tool_name=tool_name,
+                reason_codes=reason_codes,
+                risk_score=risk_score,
+                cumulative_cost=self._factory._cumulative_cost,
+            )
+            self._factory._decisions.append(decision)
+            if self._factory.on_decision:
+                self._factory.on_decision(decision)
+            self._emit_receipt(decision, execution_outcome="blocked")
+            reason = ", ".join(reason_codes)
+            return ToolErrorEvent.from_call(
+                event,
+                error=Exception(
+                    f"[GOVERNANCE DENIED] Result of tool '{tool_name}' withheld — "
+                    f"sensitive data detected. Reason: {reason}. Decision ID: {decision.decision_id}"
+                ),
+            )
+
+        # REDACT — either an explicit REDACT action, or a BLOCK degraded because
+        # we are not in ENFORCE mode (the value must still not leak).
+        should_redact = "REDACT" in actions or ("BLOCK" in actions and self._factory.mode != GovernanceMode.ENFORCE)
+        if should_redact:
+            reason_codes.append("OUTPUT_REDACTED")
+            categories = sorted({p for policy in policies for p in policy.config.get("categories", [])})
+            for _, part in text_parts:
+                part.content = self._redact(part.content, categories, redact_secrets=secret_hit)
+            action_value = "MONITOR" if self._factory.mode == GovernanceMode.MONITOR else "ALLOW"
+        else:
+            # FLAG only — record but pass the result through unchanged.
+            action_value = "ALLOW"
+
+        decision = GovernanceDecision(
+            action=action_value,
+            mode=self._factory.mode.value,
+            agent_name=agent_name,
+            tool_name=tool_name,
+            reason_codes=reason_codes,
+            risk_score=risk_score,
+            cumulative_cost=self._factory._cumulative_cost,
+        )
+        self._factory._decisions.append(decision)
+        if self._factory.on_decision:
+            self._factory.on_decision(decision)
+        self._emit_receipt(decision, execution_outcome="executed")
+
+        return result
+
+    @staticmethod
+    def _redact(text: str, categories: list[str], redact_secrets: bool) -> str:
+        """Replace PII (in ``categories``) and, if requested, secrets with markers."""
+        redacted = text
+        for cat in categories:
+            pattern = _PII_PATTERNS.get(cat)
+            if pattern is not None:
+                redacted = pattern.sub(f"[REDACTED:{cat}]", redacted)
+        if redact_secrets:
+            for pattern in _SECRET_PATTERNS:
+                redacted = pattern.sub("[REDACTED:secret]", redacted)
+        return redacted
 
     def _emit_receipt(self, decision: GovernanceDecision, execution_outcome: str) -> None:
         """Emit a TEEC receipt for the governance decision."""

--- a/ag2/extensions/tealtiger/types.py
+++ b/ag2/extensions/tealtiger/types.py
@@ -225,6 +225,88 @@ class GovernancePolicy:
         return cls(type="secret_detection", config={})
 
     @classmethod
+    def output_scan(
+        cls,
+        scan_pii: bool = True,
+        scan_secrets: bool = True,
+        pii_action: str = "REDACT",
+        secret_action: str = "BLOCK",
+        categories: list[str] | None = None,
+    ) -> "GovernancePolicy":
+        """Scan tool *results* for PII/secrets before they flow back into agent context.
+
+        Where `pii_block` / `secret_detection` inspect a tool's *arguments*
+        before it runs, this inspects what the tool *returns* — the data-leakage
+        direction. A tool that reads a database, file, or API can hand back an
+        SSN or a leaked credential that would otherwise land straight in the
+        model's context on the next turn. This policy scans that result and
+        redacts, blocks, or flags it first.
+
+        Each detector has an independent action:
+
+        | Action | Effect |
+        |--------|--------|
+        | `REDACT` | Replace matched values in the result with `[REDACTED:<type>]`; the sanitized result flows through. |
+        | `BLOCK` | Replace the whole result with a governance error (ENFORCE only). In MONITOR/OBSERVE it degrades to REDACT so the value still never leaks. |
+        | `FLAG` | Record the finding in the decision/receipt trail; pass the result through unchanged. |
+
+        Defaults mirror the sensible split: PII is redacted (the agent usually
+        still needs the surrounding result), secrets are blocked (a leaked
+        credential should not reach the model at all).
+
+        Example::
+
+            GovernancePolicy.output_scan()  # redact PII, block secrets
+            GovernancePolicy.output_scan(
+                pii_action="BLOCK", categories=["ssn", "credit_card"]
+            )
+
+        Args:
+            scan_pii: Scan results for PII. Default True.
+            scan_secrets: Scan results for leaked credentials. Default True.
+            pii_action: Action when PII is found — `REDACT`, `BLOCK`, or `FLAG`.
+            secret_action: Action when a secret is found — `REDACT`, `BLOCK`, or `FLAG`.
+            categories: PII categories to detect. Default:
+                `["ssn", "credit_card", "email", "phone"]`.
+
+        Raises:
+            ValueError: If both `scan_pii` and `scan_secrets` are False (the
+                policy would scan nothing), if an action is not one of
+                `REDACT`/`BLOCK`/`FLAG`, or if `categories` names an unknown
+                PII category — any of which would silently do nothing.
+        """
+        valid_actions = {"REDACT", "BLOCK", "FLAG"}
+        valid_categories = {"ssn", "credit_card", "email", "phone"}
+
+        if not scan_pii and not scan_secrets:
+            raise ValueError(
+                "output_scan must scan something: set scan_pii and/or scan_secrets to True."
+            )
+        for label, value in (("pii_action", pii_action), ("secret_action", secret_action)):
+            if value not in valid_actions:
+                raise ValueError(
+                    f"Invalid {label} '{value}'. Valid actions: {', '.join(sorted(valid_actions))}."
+                )
+        resolved_categories = categories if categories is not None else ["ssn", "credit_card", "email", "phone"]
+        unknown = set(resolved_categories) - valid_categories
+        if unknown:
+            raise ValueError(
+                f"Unknown PII category(ies): {', '.join(sorted(unknown))}. "
+                f"Valid categories: {', '.join(sorted(valid_categories))}."
+            )
+
+        return cls(
+            type="output_scan",
+            config={
+                "scan_pii": scan_pii,
+                "scan_secrets": scan_secrets,
+                "pii_action": pii_action,
+                "secret_action": secret_action,
+                "categories": resolved_categories,
+            },
+        )
+
+    @classmethod
     def cost_limit(cls, max_per_session: float) -> "GovernancePolicy":
         """Deny tool calls once cumulative session cost exceeds the limit.
 

--- a/ag2/extensions/tealtiger/types.py
+++ b/ag2/extensions/tealtiger/types.py
@@ -323,9 +323,11 @@ class GovernancePolicy:
 
         Raises:
             ValueError: If both `scan_pii` and `scan_secrets` are False (the
-                policy would scan nothing), if an action is not one of
-                `REDACT`/`BLOCK`/`FLAG`, or if `categories` names an unknown
-                PII category — any of which would silently do nothing.
+                policy would scan nothing), if `scan_pii` is True but
+                `categories` is an empty list (PII scanning that scans no
+                category), if an action is not one of `REDACT`/`BLOCK`/`FLAG`,
+                or if `categories` names an unknown PII category — any of which
+                would silently do nothing.
         """
         if not scan_pii and not scan_secrets:
             raise ValueError("output_scan must scan something: set scan_pii and/or scan_secrets to True.")
@@ -339,6 +341,12 @@ class GovernancePolicy:
                 raise ValueError(f"Invalid {label} '{value}'. Valid actions: {valid}.") from None
 
         resolved_categories = list(categories) if categories is not None else list(PII_CATEGORIES)
+        if scan_pii and not resolved_categories:
+            raise ValueError(
+                "output_scan(scan_pii=True) needs at least one PII category to scan; "
+                "pass a non-empty `categories` list or omit it to scan every category "
+                f"({', '.join(PII_CATEGORIES)})."
+            )
         unknown = set(resolved_categories) - set(PII_CATEGORIES)
         if unknown:
             raise ValueError(

--- a/ag2/extensions/tealtiger/types.py
+++ b/ag2/extensions/tealtiger/types.py
@@ -6,6 +6,7 @@
 import re
 import time
 import uuid
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -17,6 +18,51 @@ class GovernanceMode(str, Enum):
     OBSERVE = "OBSERVE"  # Log decisions, never block
     MONITOR = "MONITOR"  # Log decisions with warnings, never block
     ENFORCE = "ENFORCE"  # Log decisions AND block denied tool calls
+
+
+class OutputAction(str, Enum):
+    """What an ``output_scan`` detector does with a finding in a tool result."""
+
+    REDACT = "REDACT"  # Replace matched values in place; the sanitized result flows through
+    BLOCK = "BLOCK"  # Withhold the whole result (ENFORCE only; degrades to REDACT elsewhere)
+    FLAG = "FLAG"  # Record the finding only; the result passes through unchanged
+
+
+# Severity order for resolving one effective action out of several policies.
+# A more restrictive action always wins.
+_OUTPUT_ACTION_SEVERITY: dict[OutputAction, int] = {
+    OutputAction.FLAG: 0,
+    OutputAction.REDACT: 1,
+    OutputAction.BLOCK: 2,
+}
+
+
+def most_restrictive(actions: Iterable[OutputAction], default: OutputAction) -> OutputAction:
+    """The most restrictive of `actions` (BLOCK > REDACT > FLAG), or `default` if empty."""
+    return max(actions, key=lambda a: _OUTPUT_ACTION_SEVERITY[a], default=default)
+
+
+# PII detection patterns, keyed by the category name policies refer to. This dict is
+# the single source of truth for which categories exist: `PII_CATEGORIES` is derived
+# from it, and both the `pii_block` / `output_scan` validators and the middleware's
+# detection and redaction read it rather than restating the list.
+PII_PATTERNS: dict[str, re.Pattern[str]] = {
+    "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+    "credit_card": re.compile(r"\b(?:\d{4}[-\s]?){3}\d{4}\b"),
+    "email": re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),
+    "phone": re.compile(r"\b(?:\+1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b"),
+}
+
+PII_CATEGORIES: tuple[str, ...] = tuple(PII_PATTERNS)
+
+SECRET_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\b(sk-[a-zA-Z0-9]{20,})\b"),
+    re.compile(r"\b(ghp_[a-zA-Z0-9]{36,})\b"),
+    re.compile(r"\b(AKIA[0-9A-Z]{16})\b"),
+    re.compile(r"\b(xox[bpors]-[a-zA-Z0-9-]+)\b"),
+    re.compile(r"(?i)(?:api[_-]?key|apikey)\s*[:=]\s*['\"]?[a-zA-Z0-9_\-]{20,}"),
+    re.compile(r"-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----"),
+]
 
 
 # Minimum pattern confidence a prompt-injection finding needs to trigger a block.
@@ -212,11 +258,12 @@ class GovernancePolicy:
         """Block tool calls containing PII in arguments.
 
         Args:
-            categories: PII categories to detect. Default: ["ssn", "credit_card", "email", "phone"].
+            categories: PII categories to detect. Default: every category in
+                `PII_CATEGORIES`.
         """
         return cls(
             type="pii_block",
-            config={"categories": categories or ["ssn", "credit_card", "email", "phone"]},
+            config={"categories": categories or list(PII_CATEGORIES)},
         )
 
     @classmethod
@@ -229,8 +276,8 @@ class GovernancePolicy:
         cls,
         scan_pii: bool = True,
         scan_secrets: bool = True,
-        pii_action: str = "REDACT",
-        secret_action: str = "BLOCK",
+        pii_action: str | OutputAction = OutputAction.REDACT,
+        secret_action: str | OutputAction = OutputAction.BLOCK,
         categories: list[str] | None = None,
     ) -> "GovernancePolicy":
         """Scan tool *results* for PII/secrets before they flow back into agent context.
@@ -247,8 +294,14 @@ class GovernancePolicy:
         | Action | Effect |
         |--------|--------|
         | `REDACT` | Replace matched values in the result with `[REDACTED:<type>]`; the sanitized result flows through. |
-        | `BLOCK` | Replace the whole result with a governance error (ENFORCE only). In MONITOR/OBSERVE it degrades to REDACT so the value still never leaks. |
+        | `BLOCK` | Replace the whole result with a governance error (ENFORCE only). In MONITOR it degrades to REDACT so the value still never leaks. |
         | `FLAG` | Record the finding in the decision/receipt trail; pass the result through unchanged. |
+
+        The two actions are independent: flagging PII while redacting secrets records
+        the PII and rewrites only the credential. In OBSERVE mode results are not
+        scanned at all, consistent with OBSERVE never altering a call. When several
+        `output_scan` policies are configured, the most restrictive action any of
+        them asks for wins, per detector.
 
         Defaults mirror the sensible split: PII is redacted (the agent usually
         still needs the surrounding result), secrets are blocked (a leaked
@@ -257,17 +310,16 @@ class GovernancePolicy:
         Example::
 
             GovernancePolicy.output_scan()  # redact PII, block secrets
-            GovernancePolicy.output_scan(
-                pii_action="BLOCK", categories=["ssn", "credit_card"]
-            )
+            GovernancePolicy.output_scan(pii_action="BLOCK", categories=["ssn", "credit_card"])
 
         Args:
             scan_pii: Scan results for PII. Default True.
             scan_secrets: Scan results for leaked credentials. Default True.
-            pii_action: Action when PII is found — `REDACT`, `BLOCK`, or `FLAG`.
-            secret_action: Action when a secret is found — `REDACT`, `BLOCK`, or `FLAG`.
-            categories: PII categories to detect. Default:
-                `["ssn", "credit_card", "email", "phone"]`.
+            pii_action: Action when PII is found — an `OutputAction` member or its
+                string name (`REDACT`, `BLOCK`, `FLAG`).
+            secret_action: Action when a secret is found, same accepted values.
+            categories: PII categories to detect. Default: every category in
+                `PII_CATEGORIES`. Ignored when `scan_pii` is False.
 
         Raises:
             ValueError: If both `scan_pii` and `scan_secrets` are False (the
@@ -275,24 +327,23 @@ class GovernancePolicy:
                 `REDACT`/`BLOCK`/`FLAG`, or if `categories` names an unknown
                 PII category — any of which would silently do nothing.
         """
-        valid_actions = {"REDACT", "BLOCK", "FLAG"}
-        valid_categories = {"ssn", "credit_card", "email", "phone"}
-
         if not scan_pii and not scan_secrets:
-            raise ValueError(
-                "output_scan must scan something: set scan_pii and/or scan_secrets to True."
-            )
+            raise ValueError("output_scan must scan something: set scan_pii and/or scan_secrets to True.")
+
+        actions: dict[str, OutputAction] = {}
         for label, value in (("pii_action", pii_action), ("secret_action", secret_action)):
-            if value not in valid_actions:
-                raise ValueError(
-                    f"Invalid {label} '{value}'. Valid actions: {', '.join(sorted(valid_actions))}."
-                )
-        resolved_categories = categories if categories is not None else ["ssn", "credit_card", "email", "phone"]
-        unknown = set(resolved_categories) - valid_categories
+            try:
+                actions[label] = OutputAction(value)
+            except ValueError:
+                valid = ", ".join(a.value for a in OutputAction)
+                raise ValueError(f"Invalid {label} '{value}'. Valid actions: {valid}.") from None
+
+        resolved_categories = list(categories) if categories is not None else list(PII_CATEGORIES)
+        unknown = set(resolved_categories) - set(PII_CATEGORIES)
         if unknown:
             raise ValueError(
                 f"Unknown PII category(ies): {', '.join(sorted(unknown))}. "
-                f"Valid categories: {', '.join(sorted(valid_categories))}."
+                f"Valid categories: {', '.join(sorted(PII_CATEGORIES))}."
             )
 
         return cls(
@@ -300,8 +351,8 @@ class GovernancePolicy:
             config={
                 "scan_pii": scan_pii,
                 "scan_secrets": scan_secrets,
-                "pii_action": pii_action,
-                "secret_action": secret_action,
+                "pii_action": actions["pii_action"].value,
+                "secret_action": actions["secret_action"].value,
                 "categories": resolved_categories,
             },
         )

--- a/test/extensions/tealtiger/test_output_scan.py
+++ b/test/extensions/tealtiger/test_output_scan.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for TealTiger output scanning (post-tool defense).
+
+Where `pii_block` / `secret_detection` inspect a tool's *arguments* before it
+runs, `output_scan` inspects what the tool *returns* — the data-leakage
+direction. A tool that reads a database, file, or API can hand back an SSN or a
+leaked credential that would otherwise land in the model's context on the next
+turn.
+
+The end-to-end cases script a real agent turn with ``TestConfig`` so the policy
+runs where it does in production and the sensitive value comes back the way a
+tool would actually return it. Because scanning happens *after* the tool runs,
+"blocked" is observed as the turn failing with a GOVERNANCE DENIED error, and
+"redacted" is observed on the recorded ``GovernanceDecision`` plus a direct
+check that the result content was rewritten in place.
+"""
+
+import json
+from typing import Any
+
+import pytest
+
+from ag2 import Agent
+from ag2.events import ToolCallEvent, ToolResultEvent
+from ag2.events.input_events import TextInput
+from ag2.events.tool_events import ToolResult
+from ag2.extensions.tealtiger import GovernanceMode, GovernancePolicy, TealTigerMiddleware
+from ag2.extensions.tealtiger.middleware import _TealTigerPerTurn
+from ag2.testing import TestConfig
+
+SSN = "123-45-6789"
+AWS_KEY = "AKIA1234567890ABCDEF"
+
+
+def _call(tool_name: str, **arguments: Any) -> ToolCallEvent:
+    return ToolCallEvent(name=tool_name, arguments=json.dumps(arguments))
+
+
+# ── Policy validation ────────────────────────────────────────────────────────
+
+
+class TestOutputScanPolicyValidation:
+    def test_scanning_nothing_is_rejected(self):
+        with pytest.raises(ValueError, match="must scan something"):
+            GovernancePolicy.output_scan(scan_pii=False, scan_secrets=False)
+
+    def test_invalid_action_is_rejected(self):
+        with pytest.raises(ValueError, match="Invalid pii_action"):
+            GovernancePolicy.output_scan(pii_action="NUKE")
+
+    def test_unknown_category_is_rejected(self):
+        with pytest.raises(ValueError, match="Unknown PII category"):
+            GovernancePolicy.output_scan(categories=["ssn", "passport"])
+
+    def test_defaults(self):
+        policy = GovernancePolicy.output_scan()
+        assert policy.type == "output_scan"
+        assert policy.config["pii_action"] == "REDACT"
+        assert policy.config["secret_action"] == "BLOCK"
+        assert policy.config["scan_pii"] and policy.config["scan_secrets"]
+
+
+# ── End-to-end: block ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestSecretInResultIsBlocked:
+    async def test_secret_result_blocks_the_turn_in_enforce(self):
+        def read_config(key: str) -> str:
+            # The tool itself runs fine — the danger is in what it returns.
+            return f"aws_key={AWS_KEY}"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],  # secret_action defaults to BLOCK
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("read_config", key="aws"), "Done."),
+            tools=[read_config],
+            middleware=[governance],
+        )
+        with pytest.raises(Exception, match=r"\[GOVERNANCE DENIED\].*OUTPUT_SECRET_DETECTED"):
+            await agent.ask("what is the aws key")
+
+        decision = governance.decisions[-1]
+        assert decision.action == "DENY"
+        assert "OUTPUT_BLOCKED" in decision.reason_codes
+        assert governance.receipts[-1].execution_outcome == "blocked"
+
+
+# ── End-to-end: PII redaction (default) ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestPiiInResultIsRedacted:
+    async def test_pii_result_is_recorded_as_redacted(self):
+        def lookup_customer(name: str) -> str:
+            return f"{name} SSN {SSN}"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],  # pii_action defaults to REDACT
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("lookup_customer", name="Ada"), "Done."),
+            tools=[lookup_customer],
+            middleware=[governance],
+        )
+        reply = await agent.ask("look up Ada")
+        # Redaction does not fail the turn — the sanitized result flows through.
+        assert reply.body == "Done."
+        decision = governance.decisions[-1]
+        assert decision.action == "ALLOW"
+        assert any(rc.startswith("OUTPUT_PII_DETECTED") for rc in decision.reason_codes)
+        assert "OUTPUT_REDACTED" in decision.reason_codes
+
+    async def test_clean_result_passes_through_without_findings(self):
+        def get_weather(city: str) -> str:
+            return "Sunny, 22C"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],
+            mode=GovernanceMode.ENFORCE,
+        )
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("get_weather", city="Paris"), "Done."),
+            tools=[get_weather],
+            middleware=[governance],
+        )
+        reply = await agent.ask("weather in Paris")
+        assert reply.body == "Done."
+        # No output-scan decision recorded for a clean result (only the pre-exec ALLOW).
+        assert all("OUTPUT_" not in rc for d in governance.decisions for rc in d.reason_codes)
+
+
+# ── Direct: prove the result content is actually rewritten ─────────────────────
+
+
+class _StubContext:
+    """Minimal context: _get_agent_name reads context.dependencies.get(...)."""
+
+    def __init__(self) -> None:
+        self.dependencies: dict[Any, Any] = {}
+
+
+def _result_event(text: str) -> ToolResultEvent:
+    return ToolResultEvent(parent_id="call_1", name="tool_x", result=ToolResult(TextInput(text)))
+
+
+def _perturn(factory: TealTigerMiddleware) -> _TealTigerPerTurn:
+    # Build a per-turn instance without a real event; _scan_result only needs
+    # the factory state and the (event, tool_name, result) it is given.
+    inst = _TealTigerPerTurn.__new__(_TealTigerPerTurn)
+    inst._factory = factory
+    inst._agent_name = "assistant"
+    return inst
+
+
+class TestRedactionRewritesContent:
+    def test_pii_value_removed_from_result_content(self):
+        factory = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan(scan_secrets=False)],
+            mode=GovernanceMode.ENFORCE,
+        )
+        inst = _perturn(factory)
+        event = _call("lookup", name="x")
+        result = _result_event(f"the ssn is {SSN}")
+
+        scanned = inst._scan_result(event, "lookup", result)
+
+        # Same event type (redact, not block), but the SSN is gone.
+        assert isinstance(scanned, ToolResultEvent)
+        content = scanned.result.parts[0].content
+        assert SSN not in content
+        assert "[REDACTED:ssn]" in content
+
+    def test_secret_block_degrades_to_redaction_in_monitor(self):
+        factory = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],
+            mode=GovernanceMode.MONITOR,  # BLOCK cannot terminate here
+        )
+        inst = _perturn(factory)
+        event = _call("read_config", key="k")
+        result = _result_event(f"key={AWS_KEY}")
+
+        scanned = inst._scan_result(event, "read_config", result)
+
+        # Not terminated (still a ToolResultEvent), but the secret never leaks.
+        assert isinstance(scanned, ToolResultEvent)
+        assert AWS_KEY not in scanned.result.parts[0].content
+        assert "OUTPUT_REDACTED" in factory.decisions[-1].reason_codes
+
+    def test_flag_passes_result_through_unchanged(self):
+        factory = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan(pii_action="FLAG", scan_secrets=False)],
+            mode=GovernanceMode.ENFORCE,
+        )
+        inst = _perturn(factory)
+        event = _call("lookup", name="x")
+        result = _result_event(f"ssn {SSN}")
+
+        scanned = inst._scan_result(event, "lookup", result)
+
+        # FLAG records but does not modify.
+        assert scanned.result.parts[0].content == f"ssn {SSN}"
+        assert any(rc.startswith("OUTPUT_PII_DETECTED") for rc in factory.decisions[-1].reason_codes)
+        assert "OUTPUT_REDACTED" not in factory.decisions[-1].reason_codes
+
+    def test_no_output_scan_policy_leaves_result_untouched(self):
+        factory = TealTigerMiddleware(
+            policies=[GovernancePolicy.tool_allowlist(["*"])],
+            mode=GovernanceMode.ENFORCE,
+        )
+        inst = _perturn(factory)
+        event = _call("lookup", name="x")
+        result = _result_event(f"ssn {SSN}")
+
+        scanned = inst._scan_result(event, "lookup", result)
+        assert scanned is result  # untouched, same object

--- a/test/extensions/tealtiger/test_output_scan.py
+++ b/test/extensions/tealtiger/test_output_scan.py
@@ -349,9 +349,7 @@ class TestToolErrorsAreScannedToo:
             mode=GovernanceMode.ENFORCE,
         )
         # raise_tool_errors=False models a real provider, which is handed the failure.
-        tracking = TrackingConfig(
-            TestConfig(_call("lookup_customer", name="Ada"), "Done.", raise_tool_errors=False)
-        )
+        tracking = TrackingConfig(TestConfig(_call("lookup_customer", name="Ada"), "Done.", raise_tool_errors=False))
         agent = Agent("assistant", config=tracking, tools=[lookup_customer], middleware=[governance])
 
         await agent.ask("look up Ada")
@@ -370,9 +368,7 @@ class TestToolErrorsAreScannedToo:
             policies=[GovernancePolicy.output_scan()],  # secret_action BLOCK
             mode=GovernanceMode.ENFORCE,
         )
-        tracking = TrackingConfig(
-            TestConfig(_call("read_config", key="aws"), "Done.", raise_tool_errors=False)
-        )
+        tracking = TrackingConfig(TestConfig(_call("read_config", key="aws"), "Done.", raise_tool_errors=False))
         agent = Agent("assistant", config=tracking, tools=[read_config], middleware=[governance])
 
         await agent.ask("what is the aws key")
@@ -390,9 +386,7 @@ class TestToolErrorsAreScannedToo:
             policies=[GovernancePolicy.output_scan()],
             mode=GovernanceMode.ENFORCE,
         )
-        tracking = TrackingConfig(
-            TestConfig(_call("lookup_customer", name="Ada"), "Done.", raise_tool_errors=False)
-        )
+        tracking = TrackingConfig(TestConfig(_call("lookup_customer", name="Ada"), "Done.", raise_tool_errors=False))
         agent = Agent("assistant", config=tracking, tools=[lookup_customer], middleware=[governance])
 
         await agent.ask("look up Ada")

--- a/test/extensions/tealtiger/test_output_scan.py
+++ b/test/extensions/tealtiger/test_output_scan.py
@@ -1,20 +1,10 @@
 # Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for TealTiger output scanning (post-tool defense).
+"""Tests for TealTiger output scanning: PII/secrets in what a tool *returns*.
 
-Where `pii_block` / `secret_detection` inspect a tool's *arguments* before it
-runs, `output_scan` inspects what the tool *returns* — the data-leakage
-direction. A tool that reads a database, file, or API can hand back an SSN or a
-leaked credential that would otherwise land in the model's context on the next
-turn.
-
-The end-to-end cases script a real agent turn with ``TestConfig`` so the policy
-runs where it does in production and the sensitive value comes back the way a
-tool would actually return it. Because scanning happens *after* the tool runs,
-"blocked" is observed as the turn failing with a GOVERNANCE DENIED error, and
-"redacted" is observed on the recorded ``GovernanceDecision`` plus a direct
-check that the result content was rewritten in place.
+Each case scripts a real turn with ``TestConfig`` and reads what actually reached
+the model through ``TrackingConfig``, so "redacted" is observed rather than claimed.
 """
 
 import json
@@ -23,22 +13,36 @@ from typing import Any
 import pytest
 
 from ag2 import Agent
-from ag2.events import ToolCallEvent, ToolResultEvent
+from ag2.events import ToolCallEvent, ToolResultsEvent
 from ag2.events.input_events import TextInput
 from ag2.events.tool_events import ToolResult
-from ag2.extensions.tealtiger import GovernanceMode, GovernancePolicy, TealTigerMiddleware
-from ag2.extensions.tealtiger.middleware import _TealTigerPerTurn
-from ag2.testing import TestConfig
+from ag2.extensions.tealtiger import GovernanceMode, GovernancePolicy, OutputAction, TealTigerMiddleware
+from ag2.testing import TestConfig, TrackingConfig
 
 SSN = "123-45-6789"
 AWS_KEY = "AKIA1234567890ABCDEF"
+EMAIL = "ada@example.com"
 
 
 def _call(tool_name: str, **arguments: Any) -> ToolCallEvent:
+    """The tool call a model would emit for these arguments."""
     return ToolCallEvent(name=tool_name, arguments=json.dumps(arguments))
 
 
-# ── Policy validation ────────────────────────────────────────────────────────
+def _results_seen_by_model(tracking: TrackingConfig) -> list[Any]:
+    """The tool-result payloads the framework handed the model on its last call."""
+    message = tracking.mock.call_args.args[0]
+    assert isinstance(message, ToolResultsEvent)
+    return [
+        part.content if isinstance(part, TextInput) else part.data
+        for result in message.results
+        for part in result.result.parts
+    ]
+
+
+def _reason_codes(governance: TealTigerMiddleware) -> list[str]:
+    """Every reason code recorded across the session, in order."""
+    return [code for decision in governance.decisions for code in decision.reason_codes]
 
 
 class TestOutputScanPolicyValidation:
@@ -54,26 +58,231 @@ class TestOutputScanPolicyValidation:
         with pytest.raises(ValueError, match="Unknown PII category"):
             GovernancePolicy.output_scan(categories=["ssn", "passport"])
 
+    def test_an_action_is_accepted_as_an_enum_member_or_its_string_name(self):
+        from_enum = GovernancePolicy.output_scan(pii_action=OutputAction.BLOCK)
+        from_string = GovernancePolicy.output_scan(pii_action="BLOCK")
+
+        # Either way the policy stores the plain string, so receipts stay JSON-clean.
+        assert from_enum.config == from_string.config
+        assert from_enum.config["pii_action"] == "BLOCK"
+
     def test_defaults(self):
         policy = GovernancePolicy.output_scan()
-        assert policy.type == "output_scan"
-        assert policy.config["pii_action"] == "REDACT"
-        assert policy.config["secret_action"] == "BLOCK"
-        assert policy.config["scan_pii"] and policy.config["scan_secrets"]
 
-
-# ── End-to-end: block ─────────────────────────────────────────────────────────
+        assert policy.config == {
+            "scan_pii": True,
+            "scan_secrets": True,
+            "pii_action": "REDACT",
+            "secret_action": "BLOCK",
+            "categories": ["ssn", "credit_card", "email", "phone"],
+        }
 
 
 @pytest.mark.asyncio
-class TestSecretInResultIsBlocked:
-    async def test_secret_result_blocks_the_turn_in_enforce(self):
+async def test_a_secret_in_the_result_blocks_the_turn_in_enforce():
+    def read_config(key: str) -> str:
+        # The tool itself runs fine — the danger is in what it returns.
+        return f"aws_key={AWS_KEY}"
+
+    governance = TealTigerMiddleware(
+        policies=[GovernancePolicy.output_scan()],  # secret_action defaults to BLOCK
+        mode=GovernanceMode.ENFORCE,
+    )
+    agent = Agent(
+        "assistant",
+        config=TestConfig(_call("read_config", key="aws"), "Done."),
+        tools=[read_config],
+        middleware=[governance],
+    )
+
+    with pytest.raises(Exception, match=r"\[GOVERNANCE DENIED\].*OUTPUT_SECRET_DETECTED"):
+        await agent.ask("what is the aws key")
+
+    assert governance.deny_count == 1
+    assert "OUTPUT_BLOCKED" in _reason_codes(governance)
+    assert governance.receipts[-1].execution_outcome == "blocked"
+
+
+@pytest.mark.asyncio
+class TestPiiInTheResultIsRedacted:
+    async def test_the_pii_never_reaches_the_model(self):
+        def lookup_customer(name: str) -> str:
+            return f"{name} SSN {SSN}"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],  # pii_action defaults to REDACT
+            mode=GovernanceMode.ENFORCE,
+        )
+        tracking = TrackingConfig(TestConfig(_call("lookup_customer", name="Ada"), "Done."))
+        agent = Agent("assistant", config=tracking, tools=[lookup_customer], middleware=[governance])
+
+        reply = await agent.ask("look up Ada")
+
+        # Redaction does not fail the turn — the sanitized result flows through.
+        assert reply.body == "Done."
+        assert _results_seen_by_model(tracking) == ["Ada SSN [REDACTED:ssn]"]
+        assert "OUTPUT_PII_DETECTED:ssn" in _reason_codes(governance)
+        assert "OUTPUT_REDACTED" in _reason_codes(governance)
+
+    async def test_a_clean_result_passes_through_without_findings(self):
+        def get_weather(city: str) -> str:
+            return "Sunny, 22C"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],
+            mode=GovernanceMode.ENFORCE,
+        )
+        tracking = TrackingConfig(TestConfig(_call("get_weather", city="Paris"), "Done."))
+        agent = Agent("assistant", config=tracking, tools=[get_weather], middleware=[governance])
+
+        reply = await agent.ask("weather in Paris")
+
+        assert reply.body == "Done."
+        assert _results_seen_by_model(tracking) == ["Sunny, 22C"]
+        assert all(not code.startswith("OUTPUT_") for code in _reason_codes(governance))
+
+
+@pytest.mark.asyncio
+class TestOutputScanRespectsMode:
+    async def test_observe_passes_the_result_through_unmodified(self):
+        def lookup_customer(name: str) -> str:
+            return f"{name} SSN {SSN}"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],
+            mode=GovernanceMode.OBSERVE,
+        )
+        tracking = TrackingConfig(TestConfig(_call("lookup_customer", name="Ada"), "Done."))
+        agent = Agent("assistant", config=tracking, tools=[lookup_customer], middleware=[governance])
+
+        await agent.ask("look up Ada")
+
+        # OBSERVE never alters a call, so it never alters a result either.
+        assert _results_seen_by_model(tracking) == [f"Ada SSN {SSN}"]
+        assert _reason_codes(governance) == ["OBSERVE_PASSTHROUGH"]
+
+    async def test_monitor_degrades_a_block_to_redaction(self):
         def read_config(key: str) -> str:
-            # The tool itself runs fine — the danger is in what it returns.
             return f"aws_key={AWS_KEY}"
 
         governance = TealTigerMiddleware(
-            policies=[GovernancePolicy.output_scan()],  # secret_action defaults to BLOCK
+            policies=[GovernancePolicy.output_scan()],  # secret_action BLOCK...
+            mode=GovernanceMode.MONITOR,  # ...which cannot terminate the turn here
+        )
+        tracking = TrackingConfig(TestConfig(_call("read_config", key="aws"), "Done."))
+        agent = Agent("assistant", config=tracking, tools=[read_config], middleware=[governance])
+
+        reply = await agent.ask("what is the aws key")
+
+        # The turn survives, but the secret still never reaches the model.
+        assert reply.body == "Done."
+        assert _results_seen_by_model(tracking) == ["aws_key=[REDACTED:secret]"]
+        assert "OUTPUT_REDACTED" in _reason_codes(governance)
+        assert "OUTPUT_BLOCKED" not in _reason_codes(governance)
+
+
+@pytest.mark.asyncio
+class TestEachDetectorActsIndependently:
+    async def test_flag_records_the_finding_and_changes_nothing(self):
+        def lookup_customer(name: str) -> str:
+            return f"ssn {SSN}"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan(pii_action="FLAG", scan_secrets=False)],
+            mode=GovernanceMode.ENFORCE,
+        )
+        tracking = TrackingConfig(TestConfig(_call("lookup_customer", name="Ada"), "Done."))
+        agent = Agent("assistant", config=tracking, tools=[lookup_customer], middleware=[governance])
+
+        await agent.ask("look up Ada")
+
+        assert _results_seen_by_model(tracking) == [f"ssn {SSN}"]
+        assert "OUTPUT_PII_DETECTED:ssn" in _reason_codes(governance)
+        assert "OUTPUT_REDACTED" not in _reason_codes(governance)
+
+    async def test_scan_pii_false_leaves_pii_alone_while_redacting_a_secret(self):
+        def read_config(key: str) -> str:
+            return f"owner {EMAIL} key={AWS_KEY}"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan(scan_pii=False, secret_action="REDACT")],
+            mode=GovernanceMode.ENFORCE,
+        )
+        tracking = TrackingConfig(TestConfig(_call("read_config", key="aws"), "Done."))
+        agent = Agent("assistant", config=tracking, tools=[read_config], middleware=[governance])
+
+        await agent.ask("read the config")
+
+        # The email is PII the policy was told not to scan — it must survive untouched.
+        assert _results_seen_by_model(tracking) == [f"owner {EMAIL} key=[REDACTED:secret]"]
+        assert all(not code.startswith("OUTPUT_PII_DETECTED") for code in _reason_codes(governance))
+
+    async def test_a_flagged_detector_does_not_redact_alongside_a_redacting_one(self):
+        def read_record(key: str) -> str:
+            return f"ssn {SSN} key={AWS_KEY}"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan(pii_action="FLAG", secret_action="REDACT")],
+            mode=GovernanceMode.ENFORCE,
+        )
+        tracking = TrackingConfig(TestConfig(_call("read_record", key="ada"), "Done."))
+        agent = Agent("assistant", config=tracking, tools=[read_record], middleware=[governance])
+
+        await agent.ask("read the record")
+
+        assert _results_seen_by_model(tracking) == [f"ssn {SSN} key=[REDACTED:secret]"]
+        assert "OUTPUT_PII_DETECTED:ssn" in _reason_codes(governance)
+
+
+@pytest.mark.asyncio
+async def test_the_most_restrictive_action_across_policies_wins():
+    def lookup_customer(name: str) -> str:
+        return f"ssn {SSN}"
+
+    governance = TealTigerMiddleware(
+        policies=[
+            GovernancePolicy.output_scan(pii_action="BLOCK", scan_secrets=False),
+            GovernancePolicy.output_scan(pii_action="FLAG", scan_secrets=False),
+        ],
+        mode=GovernanceMode.ENFORCE,
+    )
+    agent = Agent(
+        "assistant",
+        config=TestConfig(_call("lookup_customer", name="Ada"), "Done."),
+        tools=[lookup_customer],
+        middleware=[governance],
+    )
+
+    # The later FLAG policy must not soften the earlier BLOCK.
+    with pytest.raises(Exception, match=r"\[GOVERNANCE DENIED\].*OUTPUT_PII_DETECTED:ssn"):
+        await agent.ask("look up Ada")
+
+
+@pytest.mark.asyncio
+class TestStructuredResultsAreScannedToo:
+    async def test_pii_in_a_dict_result_is_redacted(self):
+        def lookup_customer(name: str) -> dict[str, str]:
+            return {"name": name, "ssn": SSN}
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],
+            mode=GovernanceMode.ENFORCE,
+        )
+        tracking = TrackingConfig(TestConfig(_call("lookup_customer", name="Ada"), "Done."))
+        agent = Agent("assistant", config=tracking, tools=[lookup_customer], middleware=[governance])
+
+        await agent.ask("look up Ada")
+
+        # A dict result arrives as a DataInput, not a TextInput — it leaks just the same.
+        assert _results_seen_by_model(tracking) == [{"name": "Ada", "ssn": "[REDACTED:ssn]"}]
+        assert "OUTPUT_PII_DETECTED:ssn" in _reason_codes(governance)
+
+    async def test_a_secret_nested_in_a_dict_result_blocks_the_turn(self):
+        def read_config(key: str) -> dict[str, Any]:
+            return {"env": "prod", "credentials": [{"aws": AWS_KEY}]}
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],
             mode=GovernanceMode.ENFORCE,
         )
         agent = Agent(
@@ -82,143 +291,69 @@ class TestSecretInResultIsBlocked:
             tools=[read_config],
             middleware=[governance],
         )
+
         with pytest.raises(Exception, match=r"\[GOVERNANCE DENIED\].*OUTPUT_SECRET_DETECTED"):
-            await agent.ask("what is the aws key")
-
-        decision = governance.decisions[-1]
-        assert decision.action == "DENY"
-        assert "OUTPUT_BLOCKED" in decision.reason_codes
-        assert governance.receipts[-1].execution_outcome == "blocked"
-
-
-# ── End-to-end: PII redaction (default) ────────────────────────────────────────
+            await agent.ask("read the config")
 
 
 @pytest.mark.asyncio
-class TestPiiInResultIsRedacted:
-    async def test_pii_result_is_recorded_as_redacted(self):
-        def lookup_customer(name: str) -> str:
-            return f"{name} SSN {SSN}"
+async def test_a_value_split_across_parts_is_withheld_rather_than_half_redacted():
+    def read_card() -> ToolResult:
+        # Neither part matches on its own; together they spell a card number.
+        return ToolResult(TextInput("card 4111"), TextInput("1111 1111 1111 on file"))
 
-        governance = TealTigerMiddleware(
-            policies=[GovernancePolicy.output_scan()],  # pii_action defaults to REDACT
-            mode=GovernanceMode.ENFORCE,
-        )
-        agent = Agent(
-            "assistant",
-            config=TestConfig(_call("lookup_customer", name="Ada"), "Done."),
-            tools=[lookup_customer],
-            middleware=[governance],
-        )
-        reply = await agent.ask("look up Ada")
-        # Redaction does not fail the turn — the sanitized result flows through.
-        assert reply.body == "Done."
-        decision = governance.decisions[-1]
-        assert decision.action == "ALLOW"
-        assert any(rc.startswith("OUTPUT_PII_DETECTED") for rc in decision.reason_codes)
-        assert "OUTPUT_REDACTED" in decision.reason_codes
+    governance = TealTigerMiddleware(
+        policies=[GovernancePolicy.output_scan()],
+        mode=GovernanceMode.ENFORCE,
+    )
+    agent = Agent(
+        "assistant",
+        config=TestConfig(_call("read_card"), "Done."),
+        tools=[read_card],
+        middleware=[governance],
+    )
 
-    async def test_clean_result_passes_through_without_findings(self):
-        def get_weather(city: str) -> str:
-            return "Sunny, 22C"
+    # Redaction works part by part and cannot cut a value that spans two parts,
+    # so the result is withheld instead of passed on half-sanitized.
+    with pytest.raises(Exception, match=r"\[GOVERNANCE DENIED\].*OUTPUT_REDACTION_INCOMPLETE"):
+        await agent.ask("show the card on file")
 
-        governance = TealTigerMiddleware(
-            policies=[GovernancePolicy.output_scan()],
-            mode=GovernanceMode.ENFORCE,
-        )
-        agent = Agent(
-            "assistant",
-            config=TestConfig(_call("get_weather", city="Paris"), "Done."),
-            tools=[get_weather],
-            middleware=[governance],
-        )
-        reply = await agent.ask("weather in Paris")
-        assert reply.body == "Done."
-        # No output-scan decision recorded for a clean result (only the pre-exec ALLOW).
-        assert all("OUTPUT_" not in rc for d in governance.decisions for rc in d.reason_codes)
+    assert "OUTPUT_PII_DETECTED:credit_card" in _reason_codes(governance)
 
 
-# ── Direct: prove the result content is actually rewritten ─────────────────────
+@pytest.mark.asyncio
+async def test_a_tool_error_passes_through_untouched():
+    def lookup_customer(name: str) -> str:
+        raise RuntimeError(f"lookup failed for SSN {SSN}")
+
+    governance = TealTigerMiddleware(
+        policies=[GovernancePolicy.output_scan()],
+        mode=GovernanceMode.ENFORCE,
+    )
+    # raise_tool_errors=False models a real provider, which is handed the failure.
+    tracking = TrackingConfig(TestConfig(_call("lookup_customer", name="Ada"), "Done.", raise_tool_errors=False))
+    agent = Agent("assistant", config=tracking, tools=[lookup_customer], middleware=[governance])
+
+    await agent.ask("look up Ada")
+
+    [error_text] = _results_seen_by_model(tracking)
+    assert SSN in error_text
+    assert all(not code.startswith("OUTPUT_") for code in _reason_codes(governance))
 
 
-class _StubContext:
-    """Minimal context: _get_agent_name reads context.dependencies.get(...)."""
+@pytest.mark.asyncio
+async def test_the_result_is_untouched_without_an_output_scan_policy():
+    def lookup_customer(name: str) -> str:
+        return f"ssn {SSN}"
 
-    def __init__(self) -> None:
-        self.dependencies: dict[Any, Any] = {}
+    governance = TealTigerMiddleware(
+        policies=[GovernancePolicy.tool_allowlist(["*"])],
+        mode=GovernanceMode.ENFORCE,
+    )
+    tracking = TrackingConfig(TestConfig(_call("lookup_customer", name="Ada"), "Done."))
+    agent = Agent("assistant", config=tracking, tools=[lookup_customer], middleware=[governance])
 
+    await agent.ask("look up Ada")
 
-def _result_event(text: str) -> ToolResultEvent:
-    return ToolResultEvent(parent_id="call_1", name="tool_x", result=ToolResult(TextInput(text)))
-
-
-def _perturn(factory: TealTigerMiddleware) -> _TealTigerPerTurn:
-    # Build a per-turn instance without a real event; _scan_result only needs
-    # the factory state and the (event, tool_name, result) it is given.
-    inst = _TealTigerPerTurn.__new__(_TealTigerPerTurn)
-    inst._factory = factory
-    inst._agent_name = "assistant"
-    return inst
-
-
-class TestRedactionRewritesContent:
-    def test_pii_value_removed_from_result_content(self):
-        factory = TealTigerMiddleware(
-            policies=[GovernancePolicy.output_scan(scan_secrets=False)],
-            mode=GovernanceMode.ENFORCE,
-        )
-        inst = _perturn(factory)
-        event = _call("lookup", name="x")
-        result = _result_event(f"the ssn is {SSN}")
-
-        scanned = inst._scan_result(event, "lookup", result)
-
-        # Same event type (redact, not block), but the SSN is gone.
-        assert isinstance(scanned, ToolResultEvent)
-        content = scanned.result.parts[0].content
-        assert SSN not in content
-        assert "[REDACTED:ssn]" in content
-
-    def test_secret_block_degrades_to_redaction_in_monitor(self):
-        factory = TealTigerMiddleware(
-            policies=[GovernancePolicy.output_scan()],
-            mode=GovernanceMode.MONITOR,  # BLOCK cannot terminate here
-        )
-        inst = _perturn(factory)
-        event = _call("read_config", key="k")
-        result = _result_event(f"key={AWS_KEY}")
-
-        scanned = inst._scan_result(event, "read_config", result)
-
-        # Not terminated (still a ToolResultEvent), but the secret never leaks.
-        assert isinstance(scanned, ToolResultEvent)
-        assert AWS_KEY not in scanned.result.parts[0].content
-        assert "OUTPUT_REDACTED" in factory.decisions[-1].reason_codes
-
-    def test_flag_passes_result_through_unchanged(self):
-        factory = TealTigerMiddleware(
-            policies=[GovernancePolicy.output_scan(pii_action="FLAG", scan_secrets=False)],
-            mode=GovernanceMode.ENFORCE,
-        )
-        inst = _perturn(factory)
-        event = _call("lookup", name="x")
-        result = _result_event(f"ssn {SSN}")
-
-        scanned = inst._scan_result(event, "lookup", result)
-
-        # FLAG records but does not modify.
-        assert scanned.result.parts[0].content == f"ssn {SSN}"
-        assert any(rc.startswith("OUTPUT_PII_DETECTED") for rc in factory.decisions[-1].reason_codes)
-        assert "OUTPUT_REDACTED" not in factory.decisions[-1].reason_codes
-
-    def test_no_output_scan_policy_leaves_result_untouched(self):
-        factory = TealTigerMiddleware(
-            policies=[GovernancePolicy.tool_allowlist(["*"])],
-            mode=GovernanceMode.ENFORCE,
-        )
-        inst = _perturn(factory)
-        event = _call("lookup", name="x")
-        result = _result_event(f"ssn {SSN}")
-
-        scanned = inst._scan_result(event, "lookup", result)
-        assert scanned is result  # untouched, same object
+    assert _results_seen_by_model(tracking) == [f"ssn {SSN}"]
+    assert all(not code.startswith("OUTPUT_") for code in _reason_codes(governance))

--- a/test/extensions/tealtiger/test_output_scan.py
+++ b/test/extensions/tealtiger/test_output_scan.py
@@ -58,6 +58,16 @@ class TestOutputScanPolicyValidation:
         with pytest.raises(ValueError, match="Unknown PII category"):
             GovernancePolicy.output_scan(categories=["ssn", "passport"])
 
+    def test_scan_pii_with_empty_categories_is_rejected(self):
+        # scan_pii=True + [] would construct but scan no category — must fail loudly.
+        with pytest.raises(ValueError, match="at least one PII category"):
+            GovernancePolicy.output_scan(scan_pii=True, scan_secrets=False, categories=[])
+
+    def test_empty_categories_is_allowed_when_only_secrets_are_scanned(self):
+        # With scan_pii=False the empty PII category list is irrelevant, not an error.
+        policy = GovernancePolicy.output_scan(scan_pii=False, scan_secrets=True, categories=[])
+        assert policy.config["scan_pii"] is False
+
     def test_an_action_is_accepted_as_an_enum_member_or_its_string_name(self):
         from_enum = GovernancePolicy.output_scan(pii_action=OutputAction.BLOCK)
         from_string = GovernancePolicy.output_scan(pii_action="BLOCK")
@@ -322,23 +332,74 @@ async def test_a_value_split_across_parts_is_withheld_rather_than_half_redacted(
 
 
 @pytest.mark.asyncio
-async def test_a_tool_error_passes_through_untouched():
-    def lookup_customer(name: str) -> str:
-        raise RuntimeError(f"lookup failed for SSN {SSN}")
+class TestToolErrorsAreScannedToo:
+    """A tool that raises can leak PII/secrets through its exception message.
 
-    governance = TealTigerMiddleware(
-        policies=[GovernancePolicy.output_scan()],
-        mode=GovernanceMode.ENFORCE,
-    )
-    # raise_tool_errors=False models a real provider, which is handed the failure.
-    tracking = TrackingConfig(TestConfig(_call("lookup_customer", name="Ada"), "Done.", raise_tool_errors=False))
-    agent = Agent("assistant", config=tracking, tools=[lookup_customer], middleware=[governance])
+    ``ToolErrorEvent`` subclasses ``ToolResultEvent`` and carries the traceback in
+    its result parts plus the exception itself, both of which reach the model — so
+    output scanning covers error results, not only successful ones.
+    """
 
-    await agent.ask("look up Ada")
+    async def test_pii_in_an_exception_is_redacted_not_leaked(self):
+        def lookup_customer(name: str) -> str:
+            raise RuntimeError(f"lookup failed for SSN {SSN}")
 
-    [error_text] = _results_seen_by_model(tracking)
-    assert SSN in error_text
-    assert all(not code.startswith("OUTPUT_") for code in _reason_codes(governance))
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],  # pii_action REDACT
+            mode=GovernanceMode.ENFORCE,
+        )
+        # raise_tool_errors=False models a real provider, which is handed the failure.
+        tracking = TrackingConfig(
+            TestConfig(_call("lookup_customer", name="Ada"), "Done.", raise_tool_errors=False)
+        )
+        agent = Agent("assistant", config=tracking, tools=[lookup_customer], middleware=[governance])
+
+        await agent.ask("look up Ada")
+
+        [error_text] = _results_seen_by_model(tracking)
+        assert SSN not in error_text
+        assert "[REDACTED:ssn]" in error_text
+        assert "OUTPUT_PII_DETECTED:ssn" in _reason_codes(governance)
+        assert "OUTPUT_REDACTED" in _reason_codes(governance)
+
+    async def test_a_secret_in_an_exception_is_withheld_in_enforce(self):
+        def read_config(key: str) -> str:
+            raise RuntimeError(f"connection string aws_key={AWS_KEY}")
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],  # secret_action BLOCK
+            mode=GovernanceMode.ENFORCE,
+        )
+        tracking = TrackingConfig(
+            TestConfig(_call("read_config", key="aws"), "Done.", raise_tool_errors=False)
+        )
+        agent = Agent("assistant", config=tracking, tools=[read_config], middleware=[governance])
+
+        await agent.ask("what is the aws key")
+
+        # The credential must not reach the model on any error path.
+        [error_text] = _results_seen_by_model(tracking)
+        assert AWS_KEY not in error_text
+        assert "OUTPUT_SECRET_DETECTED" in _reason_codes(governance)
+
+    async def test_a_clean_exception_passes_through_untouched(self):
+        def lookup_customer(name: str) -> str:
+            raise RuntimeError("customer not found")
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.output_scan()],
+            mode=GovernanceMode.ENFORCE,
+        )
+        tracking = TrackingConfig(
+            TestConfig(_call("lookup_customer", name="Ada"), "Done.", raise_tool_errors=False)
+        )
+        agent = Agent("assistant", config=tracking, tools=[lookup_customer], middleware=[governance])
+
+        await agent.ask("look up Ada")
+
+        [error_text] = _results_seen_by_model(tracking)
+        assert "customer not found" in error_text
+        assert all(not code.startswith("OUTPUT_") for code in _reason_codes(governance))
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "ag2"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/website/docs/user-guide/extensions/tealtiger.mdx
+++ b/website/docs/user-guide/extensions/tealtiger.mdx
@@ -3,7 +3,7 @@ title: TealTiger Governance
 sidebarTitle: TealTiger
 ---
 
-The `ag2.extensions.tealtiger` module adds deterministic governance guardrails to AG2 agents. `TealTigerMiddleware` enforces tool allowlists and blocklists, validates tool arguments, detects PII and secrets in tool arguments, blocks prompt injection attempts, tracks per-session cost, provides per-agent kill switches, and produces structured TEEC audit receipts — with no LLM in the governance path.
+The `ag2.extensions.tealtiger` module adds deterministic governance guardrails to AG2 agents. `TealTigerMiddleware` enforces tool allowlists and blocklists, validates tool arguments, detects PII and secrets in tool arguments and in tool results, blocks prompt injection attempts, tracks per-session cost, provides per-agent kill switches, and produces structured TEEC audit receipts — with no LLM in the governance path.
 
 ## Installation
 
@@ -21,6 +21,7 @@ from ag2.extensions.tealtiger import (
     GovernanceDecision,
     GovernanceMode,
     GovernancePolicy,
+    OutputAction,
     TEECReceipt,
     TealTigerMiddleware,
 )
@@ -30,7 +31,7 @@ from ag2.extensions.tealtiger import (
 
 `TealTigerMiddleware` is a [middleware factory](/docs/user-guide/middleware) — pass the instance straight into an agent's `middleware` list.
 
-```python linenums="1" hl_lines="7-15 21"
+```python linenums="1" hl_lines="7-16 21"
 import asyncio
 
 from ag2 import Agent
@@ -67,21 +68,24 @@ Every tool call now flows through deterministic governance evaluation before exe
 
 ## Multi-Stage Defense
 
-TealTiger governs at two stages of the AG2 agent lifecycle:
+TealTiger governs at three stages of the AG2 agent lifecycle:
 
 ```mermaid
 flowchart LR
     A[👤 User Message] --> B{🛡️ Stage 1<br/>on_turn}
     B -->|Kill Switch<br/>Check| C[🤖 Agent<br/>Processing]
     C --> D[🔧 Tool Call]
-    D --> E{🛡️ Stage 2<br/>on_tool_execution}
+    D --> E{🛡️ Stage 2<br/>pre-tool}
     E -->|"✅ ALLOW"| F[⚡ Execute Tool]
     E -->|"❌ DENY"| G[🚫 ToolErrorEvent]
-    F --> H[📝 TEEC Receipt]
+    F --> I{🛡️ Stage 3<br/>output_scan}
+    I -->|"✅ clean or redacted"| H[📝 TEEC Receipt]
+    I -->|"❌ BLOCK"| G
     G --> H
 
     style B fill:#f0fdfa,stroke:#14b8a6,stroke-width:2px
     style E fill:#f0fdfa,stroke:#14b8a6,stroke-width:2px
+    style I fill:#f0fdfa,stroke:#14b8a6,stroke-width:2px
     style H fill:#f0fdfa,stroke:#14b8a6,stroke-width:2px
     style F fill:#f0fdf4,stroke:#16a34a
     style G fill:#fef2f2,stroke:#dc2626
@@ -91,8 +95,9 @@ flowchart LR
 |------|-------|-------------|
 | `on_turn` | Turn defense | Kill switch enforcement — frozen agents cannot take turns |
 | `on_tool_execution` | Pre-tool defense | Tool allowlist/blocklist, argument validation, PII scan, secret scan, cost limit check |
+| `on_tool_execution` | Post-tool defense | Output scan — PII and secrets in the tool's *result*, before it re-enters the model's context |
 
-Both stages activate from a single middleware instance. The **middleware factory** pattern keeps state (decisions, receipts, cost, frozen agents) alive across turns.
+All three stages activate from a single middleware instance. The **middleware factory** pattern keeps state (decisions, receipts, cost, frozen agents) alive across turns.
 
 !!! note "Receipts come from the tool stage"
 
@@ -271,8 +276,9 @@ Every policy above inspects a tool's *arguments* before it runs. `output_scan` i
 # Redact PII, block secrets (the defaults)
 GovernancePolicy.output_scan()
 
-# Block on any PII too, and only scan the categories you care about
-GovernancePolicy.output_scan(pii_action="BLOCK", categories=["ssn", "credit_card"])
+# Block on any PII too, and only scan the categories you care about.
+# Actions take an OutputAction member or its string name, as `mode` takes GovernanceMode.
+GovernancePolicy.output_scan(pii_action=OutputAction.BLOCK, categories=["ssn", "credit_card"])
 ```
 
 Each detector carries its own action:
@@ -283,11 +289,29 @@ Each detector carries its own action:
 | `BLOCK` | Withhold the whole result and fail the turn with a governance error (ENFORCE only). In MONITOR it degrades to `REDACT` so the value still never leaks. |
 | `FLAG` | Record the finding in the decision and receipt trail; pass the result through unchanged. |
 
-The defaults mirror the sensible split: PII is redacted (the agent usually still needs the surrounding result), secrets are blocked (a leaked credential should not reach the model at all). When both a PII and a secret finding occur, the more restrictive action wins.
+The defaults mirror the sensible split: PII is redacted (the agent usually still needs the surrounding result), secrets are blocked (a leaked credential should not reach the model at all).
 
-Findings are recorded with reason codes `OUTPUT_PII_DETECTED:{category}` and `OUTPUT_SECRET_DETECTED`, plus `OUTPUT_REDACTED` or `OUTPUT_BLOCKED` describing what was done. Risk score is 90 when a secret is present, 60 for PII only.
+The two detectors act independently: `output_scan(pii_action="FLAG", secret_action="REDACT")` records the PII it finds and rewrites only the credential. Where they overlap — a single result carrying both, or several `output_scan` policies disagreeing about the same detector — the more restrictive action wins.
+
+Results are scanned whatever shape they arrive in. A tool returning a `dict` or a list leaks just as readily as one returning a sentence, so structured results are scanned and redacted through their strings:
+
+```python linenums="1"
+# A tool whose result is a dict, not a sentence
+def lookup_customer(name: str) -> dict[str, str]:
+    return {"name": name, "ssn": "123-45-6789"}
+
+# With GovernancePolicy.output_scan() configured, the model receives:
+#   {"name": "Ada", "ssn": "[REDACTED:ssn]"}
+```
+
+Findings are recorded with reason codes `OUTPUT_PII_DETECTED:{category}` and `OUTPUT_SECRET_DETECTED`, plus `OUTPUT_REDACTED`, `OUTPUT_REDACTION_INCOMPLETE`, or `OUTPUT_BLOCKED` describing what was done. Risk score is 90 when a secret is present, 60 for PII only.
+
+!!! warning "A value spanning two result parts is withheld, not half-redacted"
+
+    Detection reads a result's parts together, while redaction rewrites each part on its own — so a value split across a part boundary can be found but not cut out. Rather than pass on a result it could not fully sanitize, TealTiger withholds it and adds the reason code `OUTPUT_REDACTION_INCOMPLETE`. Outside ENFORCE the affected parts are replaced with `[REDACTED:unredactable]`.
 
 !!! note "Runs after the tool, in MONITOR and ENFORCE"
+
     Output scanning evaluates the tool's result, so it necessarily runs *after* the tool executes — it governs what re-enters the model's context, not whether the tool runs. In OBSERVE mode results pass through unmodified, consistent with OBSERVE never altering a call.
 
 ### Cost Limit
@@ -422,7 +446,7 @@ for decision in governance.decisions:
 | `mode` | `str` | Mode the decision was made under: `OBSERVE`, `MONITOR`, or `ENFORCE` |
 | `agent_name` | `str` | Agent that made the call, or `unknown` |
 | `tool_name` | `str` | Tool that was evaluated (`*` for turn-level denials) |
-| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `TOOL_BLOCKED`, `ARG_VALIDATION:{argument}:{check}` (`{argument}` is `*` when the call's arguments were not a mapping), `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `OUTPUT_PII_DETECTED:{category}`, `OUTPUT_SECRET_DETECTED`, `OUTPUT_REDACTED`, `OUTPUT_BLOCKED`, `BUDGET_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
+| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `TOOL_BLOCKED`, `ARG_VALIDATION:{argument}:{check}` (`{argument}` is `*` when the call's arguments were not a mapping), `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `OUTPUT_PII_DETECTED:{category}`, `OUTPUT_SECRET_DETECTED`, `OUTPUT_REDACTED`, `OUTPUT_REDACTION_INCOMPLETE`, `OUTPUT_BLOCKED`, `BUDGET_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
 | `risk_score` | `int` | 0 (safe) to 100 (critical) |
 | `evaluation_time_ms` | `float` | Governance latency for this decision |
 | `cost_tracked` | `float` | Cost attributed to this call in USD |
@@ -599,7 +623,7 @@ if __name__ == "__main__":
 
 ## Evaluation Order
 
-Two checks always run first, in this order. Everything after them is your policy list, walked in the order you declared it — the first DENY wins and short-circuits the rest:
+Two checks always run first, in this order. Everything after them is your policy list, walked in the order you declared it — the first DENY wins and short-circuits the rest. Once the tool has run, `output_scan` gets the last word on its result:
 
 ```mermaid
 flowchart TD
@@ -609,14 +633,22 @@ flowchart TD
     S2{{"2️⃣ Factory Budget<br/>(risk: 70)"}} -->|exceeded| DENY
     S2 -->|within budget| S3
     S3{{"3️⃣ Your policies, in list order<br/>first DENY wins"}} -->|violation| DENY
-    S3 -->|all clean| ALLOW[✅ ALLOW]
+    S3 -->|all clean| RUN[/Tool executes/]
+    RUN --> S4
+    S4{{"4️⃣ Output scan, on the result<br/>(risk: 90 secret / 60 PII)"}} -->|BLOCK| DENY
+    S4 -->|REDACT| SANITIZED[✅ ALLOW<br/>sanitized result]
+    S4 -->|FLAG or clean| ALLOW[✅ ALLOW]
 
     style S1 fill:#fef2f2,stroke:#fca5a5
     style S2 fill:#fef9c3,stroke:#fde047
     style S3 fill:#eff6ff,stroke:#93c5fd
+    style S4 fill:#faf5ff,stroke:#c4b5fd
     style DENY fill:#fef2f2,stroke:#dc2626,stroke-width:2px
     style ALLOW fill:#f0fdf4,stroke:#16a34a,stroke-width:2px
+    style SANITIZED fill:#f0fdf4,stroke:#16a34a,stroke-width:2px
 ```
+
+Steps 1–3 govern whether the tool runs; step 4 governs what its result is allowed to carry back. Only step 4 runs after execution, and it is skipped entirely in OBSERVE mode.
 
 Each policy type carries its own risk score when it denies:
 
@@ -691,6 +723,5 @@ print(f"{slowest.tool_name}: {slowest.evaluation_time_ms:.3f}ms")
 - [TealTiger AG2 integration guide](https://docs.tealtiger.ai/integrations/ag2){.external-link target="_blank"} — advanced capabilities beyond the bundled extension
 - [TealTiger on GitHub](https://github.com/agentguard-ai/tealtiger){.external-link target="_blank"} (Apache 2.0)
 - [TealTiger governance platform on PyPI](https://pypi.org/project/tealtiger/){.external-link target="_blank"}
-- [Discord — AG2 × TealTiger discussion](https://discord.gg/P88xMbxbd){.external-link target="_blank"} — questions, issues, and feedback on the AG2 extension
 
 Maintainer: [@nagasatish007](https://github.com/nagasatish007){.external-link target="_blank"} / TealTiger.

--- a/website/docs/user-guide/extensions/tealtiger.mdx
+++ b/website/docs/user-guide/extensions/tealtiger.mdx
@@ -263,6 +263,33 @@ GovernancePolicy.secret_detection()
 
 Denied with reason code `SECRET_DETECTED` and risk score 95 — the highest of the policy checks.
 
+### Output Scanning
+
+Every policy above inspects a tool's *arguments* before it runs. `output_scan` inspects what a tool *returns* — the data-leakage direction. A tool that reads a database, a file, or an external API can hand back an SSN or a leaked credential that would otherwise land straight in the model's context on the next turn. This scans the result first and redacts, blocks, or flags it.
+
+```python linenums="1"
+# Redact PII, block secrets (the defaults)
+GovernancePolicy.output_scan()
+
+# Block on any PII too, and only scan the categories you care about
+GovernancePolicy.output_scan(pii_action="BLOCK", categories=["ssn", "credit_card"])
+```
+
+Each detector carries its own action:
+
+| Action | Effect |
+|--------|--------|
+| `REDACT` | Replace matched values in the result with `[REDACTED:{type}]`; the sanitized result flows through to the model. |
+| `BLOCK` | Withhold the whole result and fail the turn with a governance error (ENFORCE only). In MONITOR it degrades to `REDACT` so the value still never leaks. |
+| `FLAG` | Record the finding in the decision and receipt trail; pass the result through unchanged. |
+
+The defaults mirror the sensible split: PII is redacted (the agent usually still needs the surrounding result), secrets are blocked (a leaked credential should not reach the model at all). When both a PII and a secret finding occur, the more restrictive action wins.
+
+Findings are recorded with reason codes `OUTPUT_PII_DETECTED:{category}` and `OUTPUT_SECRET_DETECTED`, plus `OUTPUT_REDACTED` or `OUTPUT_BLOCKED` describing what was done. Risk score is 90 when a secret is present, 60 for PII only.
+
+!!! note "Runs after the tool, in MONITOR and ENFORCE"
+    Output scanning evaluates the tool's result, so it necessarily runs *after* the tool executes — it governs what re-enters the model's context, not whether the tool runs. In OBSERVE mode results pass through unmodified, consistent with OBSERVE never altering a call.
+
 ### Cost Limit
 
 Enforce per-session cost ceilings:
@@ -395,7 +422,7 @@ for decision in governance.decisions:
 | `mode` | `str` | Mode the decision was made under: `OBSERVE`, `MONITOR`, or `ENFORCE` |
 | `agent_name` | `str` | Agent that made the call, or `unknown` |
 | `tool_name` | `str` | Tool that was evaluated (`*` for turn-level denials) |
-| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `TOOL_BLOCKED`, `ARG_VALIDATION:{argument}:{check}` (`{argument}` is `*` when the call's arguments were not a mapping), `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `BUDGET_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
+| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `TOOL_BLOCKED`, `ARG_VALIDATION:{argument}:{check}` (`{argument}` is `*` when the call's arguments were not a mapping), `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `OUTPUT_PII_DETECTED:{category}`, `OUTPUT_SECRET_DETECTED`, `OUTPUT_REDACTED`, `OUTPUT_BLOCKED`, `BUDGET_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
 | `risk_score` | `int` | 0 (safe) to 100 (critical) |
 | `evaluation_time_ms` | `float` | Governance latency for this decision |
 | `cost_tracked` | `float` | Cost attributed to this call in USD |
@@ -603,6 +630,7 @@ Each policy type carries its own risk score when it denies:
 | Tool allowlist | `TOOL_NOT_ALLOWED` | 80 |
 | Tool blocklist | `TOOL_BLOCKED` | 80 |
 | Cost limit / factory budget | `BUDGET_EXCEEDED` | 70 |
+| Output scan (post-tool, on the result) | `OUTPUT_SECRET_DETECTED` / `OUTPUT_PII_DETECTED:{category}` | 90 / 60 |
 
 !!! warning "Policy order is yours to choose"
 
@@ -663,5 +691,6 @@ print(f"{slowest.tool_name}: {slowest.evaluation_time_ms:.3f}ms")
 - [TealTiger AG2 integration guide](https://docs.tealtiger.ai/integrations/ag2){.external-link target="_blank"} — advanced capabilities beyond the bundled extension
 - [TealTiger on GitHub](https://github.com/agentguard-ai/tealtiger){.external-link target="_blank"} (Apache 2.0)
 - [TealTiger governance platform on PyPI](https://pypi.org/project/tealtiger/){.external-link target="_blank"}
+- [Discord — AG2 × TealTiger discussion](https://discord.gg/P88xMbxbd){.external-link target="_blank"} — questions, issues, and feedback on the AG2 extension
 
 Maintainer: [@nagasatish007](https://github.com/nagasatish007){.external-link target="_blank"} / TealTiger.

--- a/website/docs/user-guide/extensions/tealtiger.mdx
+++ b/website/docs/user-guide/extensions/tealtiger.mdx
@@ -306,13 +306,17 @@ def lookup_customer(name: str) -> dict[str, str]:
 
 Findings are recorded with reason codes `OUTPUT_PII_DETECTED:{category}` and `OUTPUT_SECRET_DETECTED`, plus `OUTPUT_REDACTED`, `OUTPUT_REDACTION_INCOMPLETE`, or `OUTPUT_BLOCKED` describing what was done. Risk score is 90 when a secret is present, 60 for PII only.
 
+Error results are scanned too. A tool that *raises* with an SSN or credential in its exception message leaks it into the model's context just as a returned value would, so `output_scan` scans a `ToolErrorEvent`'s message and traceback on the same terms. An error stays an error: its content is redacted in place, and a `BLOCK` in ENFORCE replaces it with a sanitized governance error rather than turning the failure into a success.
+
 !!! warning "A value spanning two result parts is withheld, not half-redacted"
 
     Detection reads a result's parts together, while redaction rewrites each part on its own — so a value split across a part boundary can be found but not cut out. Rather than pass on a result it could not fully sanitize, TealTiger withholds it and adds the reason code `OUTPUT_REDACTION_INCOMPLETE`. Outside ENFORCE the affected parts are replaced with `[REDACTED:unredactable]`.
 
+`output_scan` validates its own configuration: scanning nothing (`scan_pii=False, scan_secrets=False`), an invalid action, an unknown PII category, or `scan_pii=True` with an empty `categories` list all raise `ValueError` at construction, so a policy that would silently scan nothing cannot be created by mistake.
+
 !!! note "Runs after the tool, in MONITOR and ENFORCE"
 
-    Output scanning evaluates the tool's result, so it necessarily runs *after* the tool executes — it governs what re-enters the model's context, not whether the tool runs. In OBSERVE mode results pass through unmodified, consistent with OBSERVE never altering a call.
+    Output scanning evaluates the tool's result — successful or error — so it necessarily runs *after* the tool executes; it governs what re-enters the model's context, not whether the tool runs. In OBSERVE mode results pass through unmodified, consistent with OBSERVE never altering a call.
 
 ### Cost Limit
 


### PR DESCRIPTION

## Why are these changes needed?

The built-in TealTiger extension can govern a tool's *inputs* — which tools run (`tool_allowlist` / `tool_blocklist`), what they're called with (`arg_validation`), and whether their arguments carry PII or secrets (`pii_block` / `secret_detection`). What it can't do yet is govern a tool's **output**.

That's the data-leakage direction, and it's a real gap: a tool that reads a database, a file, or an external API can hand back an SSN or a leaked credential that lands straight in the model's context on the next turn — even when every argument passed every pre-execution check. An allowlisted `lookup_customer` can still *return* `123-45-6789`; a permitted `read_config` can still *return* an AWS key.

This adds `GovernancePolicy.output_scan(...)`, which scans a tool's result before it flows back into agent context and redacts, blocks, or flags it.

```python
from ag2.extensions.tealtiger import GovernancePolicy, TealTigerMiddleware, GovernanceMode

governance = TealTigerMiddleware(
    policies=[GovernancePolicy.output_scan()],  # redact PII, block secrets (defaults)
    mode=GovernanceMode.ENFORCE,
)
```

Each detector carries its own action:

| Action | Effect |
|--------|--------|
| `REDACT` | Replace matched values in the result with `[REDACTED:{type}]`; the sanitized result flows through. |
| `BLOCK` | Withhold the whole result and fail the turn with a governance error (ENFORCE only). In MONITOR it degrades to `REDACT` so the value still never leaks. |
| `FLAG` | Record the finding in the decision/receipt trail; pass the result through unchanged. |

Defaults mirror the sensible split: **PII is redacted** (the agent usually still needs the surrounding result), **secrets are blocked** (a leaked credential should not reach the model at all). When both a PII and a secret finding occur, the more restrictive action wins.

## Behavior details

- **Runs post-execution.** Output scanning necessarily runs *after* the tool executes (`on_tool_execution`, after `call_next`), since it governs the result. It reuses the extension's existing deterministic `_detect_pii` / `_detect_secrets` — no new detection engines, no LLM in the path.
- **Findings** are recorded with reason codes `OUTPUT_PII_DETECTED:{category}` and `OUTPUT_SECRET_DETECTED`, plus `OUTPUT_REDACTED` or `OUTPUT_BLOCKED` describing the action taken. Risk score is 90 for a secret, 60 for PII only.
- **OBSERVE** passes results through unmodified, consistent with OBSERVE never altering a call elsewhere in the extension.
- **Only successful `ToolResultEvent`s are scanned** — errors and other result types pass through untouched.
- **Validation** mirrors `arg_validation`: `output_scan` rejects scanning nothing, an invalid action, or an unknown PII category at construction time, so a misconfigured policy fails loudly rather than silently doing nothing.

## Changes

- `ag2/extensions/tealtiger/types.py` — `GovernancePolicy.output_scan(...)` factory + validation.
- `ag2/extensions/tealtiger/middleware.py` — `_scan_result()` + `_redact()`; wired into `on_tool_execution` after the tool runs.
- `test/extensions/tealtiger/test_output_scan.py` — 11 tests.
- `website/docs/user-guide/extensions/tealtiger.mdx` — new "Output Scanning" section, updated evaluation-order table and reason-code list.

## Testing

- `test/extensions/tealtiger/test_output_scan.py` — 11 new tests. End-to-end cases drive a real `Agent` with `TestConfig` (secret in a result blocks the turn in ENFORCE; PII redaction is recorded and does not fail the turn; a clean result passes through with no findings), plus direct `_scan_result` cases that prove the result content is rewritten in place, that BLOCK degrades to REDACT in MONITOR, that FLAG leaves the result unchanged, and that a result is untouched when no `output_scan` policy is configured.
- **Full extension suite: `171 passed`** (`test/extensions/tealtiger/`) — no regressions.
- `ruff check` clean on the changed files.

## Breaking changes

None. `output_scan` is a new, opt-in policy; existing policies and behavior are unchanged.
