### PR TITLE
feat(tealtiger): add rate_limit governance policy

### DIFF
--- a/ag2/extensions/tealtiger/middleware.py
+++ b/ag2/extensions/tealtiger/middleware.py
@@ -235,6 +235,9 @@ class TealTigerMiddleware:
         self._receipts: list[TEECReceipt] = []
         self._frozen_agents: set[str] = set()
         self._cumulative_cost: float = 0.0
+        # Rolling call timestamps per rate_limit bucket key ("*" for a global
+        # limit, or the tool pattern for a per-tool one). Survives across turns.
+        self._call_history: dict[str, list[float]] = {}
 
         # Compute policy digest for receipts
         policy_str = str(sorted((p.type, str(p.config)) for p in self.policies))
@@ -284,6 +287,7 @@ class TealTigerMiddleware:
         self._receipts.clear()
         self._frozen_agents.clear()
         self._cumulative_cost = 0.0
+        self._call_history.clear()
 
 
 class _TealTigerPerTurn(BaseMiddleware):
@@ -403,6 +407,11 @@ class _TealTigerPerTurn(BaseMiddleware):
         decision.cost_tracked = self._factory.cost_per_call
         decision.cumulative_cost = self._factory._cumulative_cost
 
+        # Count this (allowed) call against every rate_limit bucket it matches, so
+        # the window reflects calls that actually happened. In MONITOR a would-be
+        # denial still executes, so it still counts — the limit observes real load.
+        self._record_rate_limit_calls(tool_name)
+
         # Execute the tool
         result = await call_next(event, context)
 
@@ -501,6 +510,13 @@ class _TealTigerPerTurn(BaseMiddleware):
                 if self._factory._cumulative_cost >= limit:
                     action = "DENY"
                     reason_codes.append("BUDGET_EXCEEDED")
+                    risk_score = max(risk_score, 70)
+                    break
+
+            elif policy.type == "rate_limit":
+                if self._rate_limit_exceeded(tool_name, policy.config):
+                    action = "DENY"
+                    reason_codes.append("RATE_LIMIT_EXCEEDED")
                     risk_score = max(risk_score, 70)
                     break
 
@@ -648,6 +664,45 @@ class _TealTigerPerTurn(BaseMiddleware):
                 f"sensitive data detected. Reason: {reason}. Decision ID: {decision.decision_id}"
             ),
         )
+
+    def _rate_limit_key(self, config: dict[str, Any]) -> str:
+        """The call-history bucket key for a rate_limit policy: its tool pattern, or "*"."""
+        return config.get("tool") or "*"
+
+    def _rate_limit_exceeded(self, tool_name: str, config: dict[str, Any]) -> bool:
+        """Whether `tool_name` is already at or over this policy's limit.
+
+        A per-tool policy (``tool`` set) only applies to matching calls; a global
+        policy (``tool`` is None) applies to every call. Timestamps older than the
+        window are pruned first, so the check reflects a sliding window.
+        """
+        pattern = config.get("tool")
+        if pattern is not None and not fnmatch.fnmatch(tool_name, pattern):
+            return False
+
+        key = self._rate_limit_key(config)
+        window = config["window_seconds"]
+        cutoff = time.time() - window
+        history = [t for t in self._factory._call_history.get(key, []) if t > cutoff]
+        self._factory._call_history[key] = history
+        return len(history) >= config["max_calls"]
+
+    def _record_rate_limit_calls(self, tool_name: str) -> None:
+        """Record `now` against every rate_limit bucket `tool_name` falls under.
+
+        Called only for allowed calls, so a denied call never counts toward the
+        window. A call can match several buckets (e.g. a global limit and a
+        per-tool one); each is recorded independently.
+        """
+        now = time.time()
+        for policy in self._factory.policies:
+            if policy.type != "rate_limit":
+                continue
+            pattern = policy.config.get("tool")
+            if pattern is not None and not fnmatch.fnmatch(tool_name, pattern):
+                continue
+            key = self._rate_limit_key(policy.config)
+            self._factory._call_history.setdefault(key, []).append(now)
 
     def _record_decision(
         self,

--- a/ag2/extensions/tealtiger/middleware.py
+++ b/ag2/extensions/tealtiger/middleware.py
@@ -688,20 +688,24 @@ class _TealTigerPerTurn(BaseMiddleware):
         return len(history) >= config["max_calls"]
 
     def _record_rate_limit_calls(self, tool_name: str) -> None:
-        """Record `now` against every rate_limit bucket `tool_name` falls under.
+        """Record `now` once against each distinct rate_limit bucket `tool_name` falls under.
 
         Called only for allowed calls, so a denied call never counts toward the
         window. A call can match several buckets (e.g. a global limit and a
-        per-tool one); each is recorded independently.
+        per-tool one), and several policies can share one bucket key (two global
+        limits both key ``"*"``, or two policies with the same tool pattern). The
+        bucket — not the policy — is what a window counts, so a single real call
+        must add exactly one timestamp per *distinct* key; recording per policy
+        would double-count shared buckets and trip the tighter limit early.
         """
         now = time.time()
-        for policy in self._factory.policies:
-            if policy.type != "rate_limit":
-                continue
-            pattern = policy.config.get("tool")
-            if pattern is not None and not fnmatch.fnmatch(tool_name, pattern):
-                continue
-            key = self._rate_limit_key(policy.config)
+        keys = {
+            self._rate_limit_key(policy.config)
+            for policy in self._factory.policies
+            if policy.type == "rate_limit"
+            and (policy.config.get("tool") is None or fnmatch.fnmatch(tool_name, policy.config["tool"]))
+        }
+        for key in keys:
             self._factory._call_history.setdefault(key, []).append(now)
 
     def _record_decision(

--- a/ag2/extensions/tealtiger/middleware.py
+++ b/ag2/extensions/tealtiger/middleware.py
@@ -235,9 +235,11 @@ class TealTigerMiddleware:
         self._receipts: list[TEECReceipt] = []
         self._frozen_agents: set[str] = set()
         self._cumulative_cost: float = 0.0
-        # Rolling call timestamps per rate_limit bucket key ("*" for a global
-        # limit, or the tool pattern for a per-tool one). Survives across turns.
-        self._call_history: dict[str, list[float]] = {}
+        # Rolling call timestamps for each rate_limit policy, keyed by the
+        # policy's index in ``policies``. Each policy owns its own list so
+        # policies that share a tool scope but use different windows never
+        # prune or count one another's timestamps. Survives across turns.
+        self._call_history: dict[int, list[float]] = {}
 
         # Compute policy digest for receipts
         policy_str = str(sorted((p.type, str(p.config)) for p in self.policies))
@@ -454,7 +456,7 @@ class _TealTigerPerTurn(BaseMiddleware):
 
         args_str = str(tool_args) if not isinstance(tool_args, str) else tool_args
 
-        for policy in self._factory.policies:
+        for policy_index, policy in enumerate(self._factory.policies):
             if policy.type == "prompt_injection_block":
                 techniques = policy.config.get("techniques", list(INJECTION_TECHNIQUES))
                 threshold = policy.config.get("confidence_threshold", DEFAULT_INJECTION_CONFIDENCE_THRESHOLD)
@@ -514,7 +516,7 @@ class _TealTigerPerTurn(BaseMiddleware):
                     break
 
             elif policy.type == "rate_limit":
-                if self._rate_limit_exceeded(tool_name, policy.config):
+                if self._rate_limit_exceeded(tool_name, policy.config, policy_index):
                     action = "DENY"
                     reason_codes.append("RATE_LIMIT_EXCEEDED")
                     risk_score = max(risk_score, 70)
@@ -665,48 +667,43 @@ class _TealTigerPerTurn(BaseMiddleware):
             ),
         )
 
-    def _rate_limit_key(self, config: dict[str, Any]) -> str:
-        """The call-history bucket key for a rate_limit policy: its tool pattern, or "*"."""
-        return config.get("tool") or "*"
-
-    def _rate_limit_exceeded(self, tool_name: str, config: dict[str, Any]) -> bool:
+    def _rate_limit_exceeded(self, tool_name: str, config: dict[str, Any], policy_index: int) -> bool:
         """Whether `tool_name` is already at or over this policy's limit.
 
         A per-tool policy (``tool`` set) only applies to matching calls; a global
-        policy (``tool`` is None) applies to every call. Timestamps older than the
-        window are pruned first, so the check reflects a sliding window.
+        policy (``tool`` is None) applies to every call. Each policy keeps its own
+        timestamp list (keyed by ``policy_index``) and prunes only that list
+        against its own window, so a short-window policy can never delete
+        timestamps a longer-window policy sharing the same tool scope still needs.
         """
         pattern = config.get("tool")
         if pattern is not None and not fnmatch.fnmatch(tool_name, pattern):
             return False
 
-        key = self._rate_limit_key(config)
         window = config["window_seconds"]
         cutoff = time.time() - window
-        history = [t for t in self._factory._call_history.get(key, []) if t > cutoff]
-        self._factory._call_history[key] = history
+        history = [t for t in self._factory._call_history.get(policy_index, []) if t > cutoff]
+        self._factory._call_history[policy_index] = history
         return len(history) >= config["max_calls"]
 
     def _record_rate_limit_calls(self, tool_name: str) -> None:
-        """Record `now` once against each distinct rate_limit bucket `tool_name` falls under.
+        """Record `now` against every rate_limit policy `tool_name` falls under.
 
         Called only for allowed calls, so a denied call never counts toward the
-        window. A call can match several buckets (e.g. a global limit and a
-        per-tool one), and several policies can share one bucket key (two global
-        limits both key ``"*"``, or two policies with the same tool pattern). The
-        bucket — not the policy — is what a window counts, so a single real call
-        must add exactly one timestamp per *distinct* key; recording per policy
-        would double-count shared buckets and trip the tighter limit early.
+        window. Each policy owns its own timestamp list (keyed by its index), so a
+        single real call adds exactly one timestamp to each policy it matches.
+        Because lists are per policy, two policies sharing a tool scope (two global
+        limits, or two with the same pattern) each count the call once against
+        their own window — no double counting, and no shared list to fight over.
         """
         now = time.time()
-        keys = {
-            self._rate_limit_key(policy.config)
-            for policy in self._factory.policies
-            if policy.type == "rate_limit"
-            and (policy.config.get("tool") is None or fnmatch.fnmatch(tool_name, policy.config["tool"]))
-        }
-        for key in keys:
-            self._factory._call_history.setdefault(key, []).append(now)
+        for policy_index, policy in enumerate(self._factory.policies):
+            if policy.type != "rate_limit":
+                continue
+            pattern = policy.config.get("tool")
+            if pattern is not None and not fnmatch.fnmatch(tool_name, pattern):
+                continue
+            self._factory._call_history.setdefault(policy_index, []).append(now)
 
     def _record_decision(
         self,

--- a/ag2/extensions/tealtiger/types.py
+++ b/ag2/extensions/tealtiger/types.py
@@ -375,6 +375,69 @@ class GovernancePolicy:
         return cls(type="cost_limit", config={"max_per_session": max_per_session})
 
     @classmethod
+    def rate_limit(
+        cls,
+        max_calls: int,
+        window_seconds: float,
+        tool: str | None = None,
+    ) -> "GovernancePolicy":
+        """Deny tool calls once more than `max_calls` occur within a rolling window.
+
+        Where `cost_limit` caps cumulative *spend*, this caps call *frequency* —
+        the defence against a runaway loop that keeps invoking the same tool (or
+        any tool) and burns budget, rate limits, or side effects before a cost
+        ceiling would even notice. It is a sliding window: only the calls in the
+        last `window_seconds` count, so the limit refills continuously rather than
+        resetting on a fixed boundary.
+
+        Scope is set by `tool`:
+
+        - `tool=None` (default) — **global**: every governed tool call shares one
+          budget. `rate_limit(30, 60)` caps the agent to 30 tool calls per minute
+          total.
+        - `tool="pattern"` — **per-tool**: only calls whose name matches the
+          `fnmatch` pattern count against (and are limited by) this policy.
+          `rate_limit(5, 60, tool="search")` caps `search` to 5/min while leaving
+          other tools alone; `rate_limit(10, 60, tool="db_*")` caps the `db_*`
+          family together.
+
+        Combine several: a global ceiling plus tighter per-tool caps all apply,
+        and the first one exceeded denies the call.
+
+        Example::
+
+            GovernancePolicy.rate_limit(30, 60)  # 30 tool calls / minute, total
+            GovernancePolicy.rate_limit(5, 60, tool="send_email")  # 5 emails / minute
+            GovernancePolicy.rate_limit(100, 3600, tool="api_*")  # 100 api_* calls / hour
+
+        Args:
+            max_calls: Maximum calls permitted within the window. Must be a
+                positive integer.
+            window_seconds: Length of the rolling window in seconds. Must be a
+                positive number.
+            tool: Tool name or `fnmatch` pattern to scope the limit to. Omit for a
+                global limit across all tools.
+
+        Raises:
+            ValueError: If `max_calls` is not a positive integer, `window_seconds`
+                is not a positive number, or `tool` is given but empty — any of
+                which would leave a policy that limits nothing or can never allow a
+                call.
+        """
+        # bool is an int subclass; a True max_calls is almost certainly a mistake.
+        if isinstance(max_calls, bool) or not isinstance(max_calls, int) or max_calls <= 0:
+            raise ValueError(f"`max_calls` must be a positive integer, got {max_calls!r}.")
+        if isinstance(window_seconds, bool) or not isinstance(window_seconds, (int, float)) or window_seconds <= 0:
+            raise ValueError(f"`window_seconds` must be a positive number, got {window_seconds!r}.")
+        if tool is not None and not tool:
+            raise ValueError("`tool` must not be empty; omit it for a global rate limit.")
+
+        return cls(
+            type="rate_limit",
+            config={"max_calls": max_calls, "window_seconds": float(window_seconds), "tool": tool},
+        )
+
+    @classmethod
     def prompt_injection_block(
         cls,
         techniques: list[str] | None = None,

--- a/test/extensions/tealtiger/test_rate_limit.py
+++ b/test/extensions/tealtiger/test_rate_limit.py
@@ -216,3 +216,51 @@ async def test_rate_limit_blocks_a_real_agent_turn_in_enforce():
         await agent.ask("search for hello")
 
     assert governance.deny_count == 1
+
+
+class TestSharedBucketIsCountedOnce:
+    """Regression for PR #3246 review: policies sharing a bucket key must not
+    double-count a single real call.
+    """
+
+    def test_two_global_limits_share_one_bucket_without_double_counting(self):
+        # Both policies are global -> both use the "*" bucket. A single real call
+        # must add exactly one timestamp, not one per policy.
+        governance = TealTigerMiddleware(
+            policies=[
+                GovernancePolicy.rate_limit(10, window_seconds=60),
+                GovernancePolicy.rate_limit(100, window_seconds=3600),
+            ],
+            mode=GovernanceMode.ENFORCE,
+        )
+
+        for _ in range(5):
+            assert _decide(governance, "search") == "ALLOW"
+
+        # Five real calls -> five timestamps in the shared bucket (not ten).
+        assert len(governance._call_history["*"]) == 5
+
+        # The 10/min limit must still have five allowances left, not be tripped.
+        for _ in range(5):
+            assert _decide(governance, "search") == "ALLOW"
+        # The 11th real call is the one that trips the 10/min limit.
+        per_turn = governance(ToolCallEvent(name="search", arguments="{}"), _FakeContext())
+        assert per_turn._evaluate("search", "{}").action == "DENY"
+
+    def test_two_policies_with_same_tool_pattern_share_one_bucket(self):
+        governance = TealTigerMiddleware(
+            policies=[
+                GovernancePolicy.rate_limit(4, window_seconds=60, tool="db_*"),
+                GovernancePolicy.rate_limit(50, window_seconds=3600, tool="db_*"),
+            ],
+            mode=GovernanceMode.ENFORCE,
+        )
+
+        for _ in range(4):
+            assert _decide(governance, "db_read") == "ALLOW"
+
+        # Four real calls -> four timestamps in the shared "db_*" bucket, not eight.
+        assert len(governance._call_history["db_*"]) == 4
+        # The 4/min limit trips on the 5th real call, exactly at its threshold.
+        per_turn = governance(ToolCallEvent(name="db_write", arguments="{}"), _FakeContext())
+        assert per_turn._evaluate("db_write", "{}").action == "DENY"

--- a/test/extensions/tealtiger/test_rate_limit.py
+++ b/test/extensions/tealtiger/test_rate_limit.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026, AG2ai, Inc., AG2ai open-source projects maintainers and core contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for TealTiger rate limiting: max tool calls per rolling time window.
+
+The enforcement lives in ``_evaluate`` (deny) and ``_record_rate_limit_calls``
+(count allowed calls), so most cases drive the middleware directly through a
+per-turn instance rather than a full agent turn — that keeps the window math
+explicit and lets a test advance time deterministically by seeding the call
+history. A couple of end-to-end cases confirm the policy denies through a real
+``Agent`` too.
+"""
+
+import time
+from typing import Any
+
+import pytest
+
+from ag2 import Agent
+from ag2.events import ToolCallEvent
+from ag2.extensions.tealtiger import GovernanceMode, GovernancePolicy, TealTigerMiddleware
+from ag2.testing import TestConfig
+
+
+def _call(tool_name: str, **arguments: Any) -> ToolCallEvent:
+    import json
+
+    return ToolCallEvent(name=tool_name, arguments=json.dumps(arguments))
+
+
+def _decide(middleware: TealTigerMiddleware, tool_name: str) -> str:
+    """Run one governance evaluation for `tool_name` and record it if allowed.
+
+    Mirrors what ``on_tool_execution`` does around ``_evaluate``: evaluate, and
+    on a non-deny (allowed) outcome count the call against the rate-limit buckets.
+    Returns the decision action ("ALLOW" / "DENY" / "MONITOR").
+    """
+    per_turn = middleware(ToolCallEvent(name=tool_name, arguments="{}"), _FakeContext())
+    decision = per_turn._evaluate(tool_name, "{}")
+    if decision.action != "DENY":
+        per_turn._record_rate_limit_calls(tool_name)
+    return decision.action
+
+
+class _FakeContext:
+    """Minimal Context stand-in: no agent in dependencies -> agent_name is None."""
+
+    class _Deps:
+        def get(self, _key: Any) -> None:
+            return None
+
+    dependencies = _Deps()
+
+
+class TestRateLimitValidation:
+    def test_non_positive_max_calls_is_rejected(self):
+        with pytest.raises(ValueError, match="max_calls"):
+            GovernancePolicy.rate_limit(0, 60)
+
+    def test_boolean_max_calls_is_rejected(self):
+        with pytest.raises(ValueError, match="max_calls"):
+            GovernancePolicy.rate_limit(True, 60)  # type: ignore[arg-type]
+
+    def test_non_positive_window_is_rejected(self):
+        with pytest.raises(ValueError, match="window_seconds"):
+            GovernancePolicy.rate_limit(5, 0)
+
+    def test_empty_tool_is_rejected(self):
+        with pytest.raises(ValueError, match="tool"):
+            GovernancePolicy.rate_limit(5, 60, tool="")
+
+    def test_valid_policy_stores_config(self):
+        policy = GovernancePolicy.rate_limit(5, 60, tool="search")
+        assert policy.type == "rate_limit"
+        assert policy.config == {"max_calls": 5, "window_seconds": 60.0, "tool": "search"}
+
+    def test_global_policy_has_no_tool(self):
+        assert GovernancePolicy.rate_limit(30, 60).config["tool"] is None
+
+
+class TestGlobalRateLimit:
+    def test_allows_up_to_the_limit_then_denies(self):
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.rate_limit(3, window_seconds=60)],
+            mode=GovernanceMode.ENFORCE,
+        )
+        # Three calls (to any tools) are allowed; the fourth within the window is denied.
+        assert _decide(governance, "search") == "ALLOW"
+        assert _decide(governance, "read_file") == "ALLOW"
+        assert _decide(governance, "search") == "ALLOW"
+        # The 4th call within the window is denied with the rate-limit reason code.
+        per_turn = governance(ToolCallEvent(name="anything", arguments="{}"), _FakeContext())
+        decision = per_turn._evaluate("anything", "{}")
+        assert decision.action == "DENY"
+        assert "RATE_LIMIT_EXCEEDED" in decision.reason_codes
+
+    def test_window_expiry_lets_calls_through_again(self):
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.rate_limit(2, window_seconds=60)],
+            mode=GovernanceMode.ENFORCE,
+        )
+        # Seed two calls as if they happened ~61s ago — outside a 60s window.
+        governance._call_history["*"] = [time.time() - 61, time.time() - 61]
+        # They should have aged out, so a fresh call is allowed.
+        assert _decide(governance, "search") == "ALLOW"
+
+    def test_recent_calls_still_count(self):
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.rate_limit(2, window_seconds=60)],
+            mode=GovernanceMode.ENFORCE,
+        )
+        # Two calls 1s ago are inside the 60s window -> the next is denied.
+        governance._call_history["*"] = [time.time() - 1, time.time() - 1]
+        assert _decide(governance, "search") == "DENY"
+
+
+class TestPerToolRateLimit:
+    def test_limit_is_isolated_to_the_matching_tool(self):
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.rate_limit(2, window_seconds=60, tool="search")],
+            mode=GovernanceMode.ENFORCE,
+        )
+        assert _decide(governance, "search") == "ALLOW"
+        assert _decide(governance, "search") == "ALLOW"
+        # search is now capped...
+        assert _decide(governance, "search") == "DENY"
+        # ...but a different tool is untouched by this per-tool limit.
+        assert _decide(governance, "read_file") == "ALLOW"
+        assert _decide(governance, "read_file") == "ALLOW"
+        assert _decide(governance, "read_file") == "ALLOW"
+
+    def test_pattern_caps_a_family_together(self):
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.rate_limit(2, window_seconds=60, tool="db_*")],
+            mode=GovernanceMode.ENFORCE,
+        )
+        assert _decide(governance, "db_read") == "ALLOW"
+        assert _decide(governance, "db_write") == "ALLOW"
+        # db_read + db_write share the db_* bucket, so the third db_* call is denied.
+        assert _decide(governance, "db_delete") == "DENY"
+
+    def test_global_and_per_tool_limits_compose(self):
+        governance = TealTigerMiddleware(
+            policies=[
+                GovernancePolicy.rate_limit(10, window_seconds=60),  # generous global
+                GovernancePolicy.rate_limit(1, window_seconds=60, tool="send_email"),  # tight per-tool
+            ],
+            mode=GovernanceMode.ENFORCE,
+        )
+        assert _decide(governance, "send_email") == "ALLOW"
+        # The per-tool cap denies the 2nd email even though the global budget is fine.
+        assert _decide(governance, "send_email") == "DENY"
+        # Other tools still flow under the global limit.
+        assert _decide(governance, "search") == "ALLOW"
+
+
+class TestRateLimitRespectsMode:
+    @pytest.mark.asyncio
+    async def test_observe_never_denies(self):
+        def search(query: str) -> str:
+            return "results"
+
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.rate_limit(1, window_seconds=60)],
+            mode=GovernanceMode.OBSERVE,
+        )
+        # Bucket already over the limit — but OBSERVE short-circuits before policy
+        # evaluation, so the call still runs and is only recorded as a passthrough.
+        governance._call_history["*"] = [time.time(), time.time()]
+        agent = Agent(
+            "assistant",
+            config=TestConfig(_call("search", query="hi"), "Done."),
+            tools=[search],
+            middleware=[governance],
+        )
+
+        reply = await agent.ask("search")
+
+        assert reply.body == "Done."
+        assert governance.deny_count == 0
+
+    def test_monitor_records_denial_but_would_not_block(self):
+        governance = TealTigerMiddleware(
+            policies=[GovernancePolicy.rate_limit(1, window_seconds=60)],
+            mode=GovernanceMode.MONITOR,
+        )
+        governance._call_history["*"] = [time.time()]
+        per_turn = governance(ToolCallEvent(name="search", arguments="{}"), _FakeContext())
+        decision = per_turn._evaluate("search", "{}")
+        # In MONITOR the decision still reads DENY (the violation is real and logged),
+        # but on_tool_execution only turns a DENY into a block in ENFORCE.
+        assert decision.action == "DENY"
+        assert "RATE_LIMIT_EXCEEDED" in decision.reason_codes
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_blocks_a_real_agent_turn_in_enforce():
+    def search(query: str) -> str:
+        return "results"
+
+    governance = TealTigerMiddleware(
+        policies=[GovernancePolicy.rate_limit(5, window_seconds=60, tool="search")],
+        mode=GovernanceMode.ENFORCE,
+    )
+    # Pre-fill the search bucket to its limit so the very next call is denied.
+    governance._call_history["search"] = [time.time()] * 5
+
+    agent = Agent(
+        "assistant",
+        config=TestConfig(_call("search", query="hello"), "Done."),
+        tools=[search],
+        middleware=[governance],
+    )
+
+    with pytest.raises(Exception, match=r"\[GOVERNANCE DENIED\].*RATE_LIMIT_EXCEEDED"):
+        await agent.ask("search for hello")
+
+    assert governance.deny_count == 1

--- a/test/extensions/tealtiger/test_rate_limit.py
+++ b/test/extensions/tealtiger/test_rate_limit.py
@@ -100,7 +100,8 @@ class TestGlobalRateLimit:
             mode=GovernanceMode.ENFORCE,
         )
         # Seed two calls as if they happened ~61s ago — outside a 60s window.
-        governance._call_history["*"] = [time.time() - 61, time.time() - 61]
+        # History is keyed by policy index; this is the only (index 0) policy.
+        governance._call_history[0] = [time.time() - 61, time.time() - 61]
         # They should have aged out, so a fresh call is allowed.
         assert _decide(governance, "search") == "ALLOW"
 
@@ -110,7 +111,7 @@ class TestGlobalRateLimit:
             mode=GovernanceMode.ENFORCE,
         )
         # Two calls 1s ago are inside the 60s window -> the next is denied.
-        governance._call_history["*"] = [time.time() - 1, time.time() - 1]
+        governance._call_history[0] = [time.time() - 1, time.time() - 1]
         assert _decide(governance, "search") == "DENY"
 
 
@@ -166,7 +167,7 @@ class TestRateLimitRespectsMode:
         )
         # Bucket already over the limit — but OBSERVE short-circuits before policy
         # evaluation, so the call still runs and is only recorded as a passthrough.
-        governance._call_history["*"] = [time.time(), time.time()]
+        governance._call_history[0] = [time.time(), time.time()]
         agent = Agent(
             "assistant",
             config=TestConfig(_call("search", query="hi"), "Done."),
@@ -184,7 +185,7 @@ class TestRateLimitRespectsMode:
             policies=[GovernancePolicy.rate_limit(1, window_seconds=60)],
             mode=GovernanceMode.MONITOR,
         )
-        governance._call_history["*"] = [time.time()]
+        governance._call_history[0] = [time.time()]
         per_turn = governance(ToolCallEvent(name="search", arguments="{}"), _FakeContext())
         decision = per_turn._evaluate("search", "{}")
         # In MONITOR the decision still reads DENY (the violation is real and logged),
@@ -202,8 +203,8 @@ async def test_rate_limit_blocks_a_real_agent_turn_in_enforce():
         policies=[GovernancePolicy.rate_limit(5, window_seconds=60, tool="search")],
         mode=GovernanceMode.ENFORCE,
     )
-    # Pre-fill the search bucket to its limit so the very next call is denied.
-    governance._call_history["search"] = [time.time()] * 5
+    # Pre-fill the search policy's history to its limit so the next call is denied.
+    governance._call_history[0] = [time.time()] * 5
 
     agent = Agent(
         "assistant",
@@ -218,14 +219,17 @@ async def test_rate_limit_blocks_a_real_agent_turn_in_enforce():
     assert governance.deny_count == 1
 
 
-class TestSharedBucketIsCountedOnce:
-    """Regression for PR #3246 review: policies sharing a bucket key must not
-    double-count a single real call.
+class TestSharedScopeCountsPerPolicy:
+    """Regression for PR #3246 review: policies that share a tool scope but use
+    different windows must each count a real call exactly once against their own
+    window. Each policy keeps its own timestamp list (keyed by policy index), so
+    a single call adds one timestamp per policy and the tighter limit trips at
+    its real threshold — never at half of it from double counting.
     """
 
-    def test_two_global_limits_share_one_bucket_without_double_counting(self):
-        # Both policies are global -> both use the "*" bucket. A single real call
-        # must add exactly one timestamp, not one per policy.
+    def test_two_global_limits_each_count_once_against_their_own_window(self):
+        # Both policies are global and share the same scope; index 0 is the
+        # 10/min limit, index 1 the 100/hour limit.
         governance = TealTigerMiddleware(
             policies=[
                 GovernancePolicy.rate_limit(10, window_seconds=60),
@@ -237,8 +241,10 @@ class TestSharedBucketIsCountedOnce:
         for _ in range(5):
             assert _decide(governance, "search") == "ALLOW"
 
-        # Five real calls -> five timestamps in the shared bucket (not ten).
-        assert len(governance._call_history["*"]) == 5
+        # Five real calls -> five timestamps for each policy (not ten): one per
+        # call per policy, so neither window is inflated by the other.
+        assert len(governance._call_history[0]) == 5
+        assert len(governance._call_history[1]) == 5
 
         # The 10/min limit must still have five allowances left, not be tripped.
         for _ in range(5):
@@ -247,7 +253,7 @@ class TestSharedBucketIsCountedOnce:
         per_turn = governance(ToolCallEvent(name="search", arguments="{}"), _FakeContext())
         assert per_turn._evaluate("search", "{}").action == "DENY"
 
-    def test_two_policies_with_same_tool_pattern_share_one_bucket(self):
+    def test_two_policies_with_same_tool_pattern_each_count_once(self):
         governance = TealTigerMiddleware(
             policies=[
                 GovernancePolicy.rate_limit(4, window_seconds=60, tool="db_*"),
@@ -259,8 +265,90 @@ class TestSharedBucketIsCountedOnce:
         for _ in range(4):
             assert _decide(governance, "db_read") == "ALLOW"
 
-        # Four real calls -> four timestamps in the shared "db_*" bucket, not eight.
-        assert len(governance._call_history["db_*"]) == 4
+        # Four real calls -> four timestamps for each db_* policy, not eight.
+        assert len(governance._call_history[0]) == 4
+        assert len(governance._call_history[1]) == 4
         # The 4/min limit trips on the 5th real call, exactly at its threshold.
         per_turn = governance(ToolCallEvent(name="db_write", arguments="{}"), _FakeContext())
         assert per_turn._evaluate("db_write", "{}").action == "DENY"
+
+
+class TestMixedWindowSharedScopePruning:
+    """Regression for PR #3246 review (discussion r3992565377): two rate_limit
+    policies that share a tool scope but use different windows must not prune each
+    other's history. A short-window policy must never delete timestamps that a
+    longer-window policy sharing the same scope still needs, so the long window
+    keeps counting calls that have aged out of the short one. Because each policy
+    owns its own timestamp list (keyed by policy index), this holds regardless of
+    the order the policies are declared in.
+    """
+
+    def _seed_aged_calls(self, governance: TealTigerMiddleware, hourly_index: int, count: int) -> None:
+        """Put `count` timestamps ~120s old into the hourly policy's own list.
+
+        120s is outside a 60s minute window but well inside a 3600s hour window,
+        so a correct hourly limit still counts them while the minute limit does not.
+        """
+        aged = [time.time() - 120] * count
+        governance._call_history[hourly_index] = list(aged)
+
+    def test_hourly_limit_still_counts_calls_aged_out_of_the_minute_window(self):
+        # index 0 = 10/min, index 1 = 100/hour, both global (shared scope).
+        governance = TealTigerMiddleware(
+            policies=[
+                GovernancePolicy.rate_limit(10, window_seconds=60),
+                GovernancePolicy.rate_limit(100, window_seconds=3600),
+            ],
+            mode=GovernanceMode.ENFORCE,
+        )
+        # 100 calls happened ~120s ago: gone from the 60s window, still in the hour.
+        self._seed_aged_calls(governance, hourly_index=1, count=100)
+
+        # The minute limit has forgotten them (its own list is empty), so from the
+        # minute's perspective the next call is fine...
+        per_turn = governance(ToolCallEvent(name="search", arguments="{}"), _FakeContext())
+        # ...but the hourly limit is already at 100/100 and must deny — proving the
+        # minute policy did not destructively prune the hourly policy's history.
+        decision = per_turn._evaluate("search", "{}")
+        assert decision.action == "DENY"
+        assert "RATE_LIMIT_EXCEEDED" in decision.reason_codes
+
+    def test_minute_limit_refills_while_hourly_keeps_the_aged_calls(self):
+        governance = TealTigerMiddleware(
+            policies=[
+                GovernancePolicy.rate_limit(10, window_seconds=60),
+                GovernancePolicy.rate_limit(100, window_seconds=3600),
+            ],
+            mode=GovernanceMode.ENFORCE,
+        )
+        # 50 aged calls: inside the hour, outside the minute. Under the hourly cap.
+        self._seed_aged_calls(governance, hourly_index=1, count=50)
+
+        # The minute window is empty, so up to 10 fresh calls flow through...
+        for _ in range(10):
+            assert _decide(governance, "search") == "ALLOW"
+        # ...and the hourly limit has been counting them on top of the 50 aged ones.
+        assert len(governance._call_history[1]) == 60
+        # The 11th fresh call trips the minute limit (10 recent), not the hour.
+        per_turn = governance(ToolCallEvent(name="search", arguments="{}"), _FakeContext())
+        assert per_turn._evaluate("search", "{}").action == "DENY"
+
+    def test_behavior_is_independent_of_policy_order(self):
+        # Same two limits, declared hour-first: index 0 = 100/hour, index 1 = 10/min.
+        governance = TealTigerMiddleware(
+            policies=[
+                GovernancePolicy.rate_limit(100, window_seconds=3600),
+                GovernancePolicy.rate_limit(10, window_seconds=60),
+            ],
+            mode=GovernanceMode.ENFORCE,
+        )
+        # Age 100 calls out of the minute window but keep them in the hour; the
+        # hourly policy is index 0 in this ordering.
+        governance._call_history[0] = [time.time() - 120] * 100
+
+        # The minute limit (index 1) has an empty list, but the hourly limit is at
+        # its cap and must still deny — order does not change the outcome.
+        per_turn = governance(ToolCallEvent(name="search", arguments="{}"), _FakeContext())
+        decision = per_turn._evaluate("search", "{}")
+        assert decision.action == "DENY"
+        assert "RATE_LIMIT_EXCEEDED" in decision.reason_codes

--- a/website/docs/user-guide/extensions/tealtiger.mdx
+++ b/website/docs/user-guide/extensions/tealtiger.mdx
@@ -328,6 +328,22 @@ GovernancePolicy.cost_limit(max_per_session=5.0)
 
 Cumulative cost is tracked across all tool calls using `cost_per_call` (configurable, defaults to `0.002`). Once the limit is reached, further calls are denied with `BUDGET_EXCEEDED` and risk score 70.
 
+### Rate Limiting
+Cap how many tool calls happen within a rolling time window — the defence against a runaway loop that keeps calling a tool and burns budget, provider rate limits, or side effects before a cost ceiling would notice:
+```python linenums="1"
+# Global: at most 30 tool calls per minute, across all tools
+GovernancePolicy.rate_limit(30, window_seconds=60)
+# Per-tool: at most 5 emails per minute (other tools unaffected)
+GovernancePolicy.rate_limit(5, window_seconds=60, tool="send_email")
+# Pattern: the whole db_* family shares one budget
+GovernancePolicy.rate_limit(100, window_seconds=3600, tool="db_*")
+```
+It is a **sliding window**: only the calls in the last `window_seconds` count, so the allowance refills continuously rather than resetting on a fixed boundary. Omit `tool` for a global limit that every governed call shares; pass a tool name or `fnmatch` pattern to scope the limit to matching calls. Combine several — a generous global ceiling plus tighter per-tool caps — and the first limit exceeded denies the call.
+Only calls that are *allowed* count toward the window, so a call denied by another policy never consumes the budget. Exceeding the limit denies with reason code `RATE_LIMIT_EXCEEDED` and risk score 70.
+!!! note "Window state lives on the middleware instance"
+    Call timestamps are held on the `TealTigerMiddleware` factory and shared across turns for the life of that instance (cleared by `reset()`). A limit therefore spans a whole session, not a single turn — but it does not persist across process restarts or share state between separate middleware instances.
+`max_calls` must be a positive integer and `window_seconds` a positive number, validated at construction so a policy that could never allow a call fails where it is written.
+
 ### Prompt Injection Detection
 
 Block tool calls containing adversarial prompt injection patterns in their arguments:
@@ -450,7 +466,7 @@ for decision in governance.decisions:
 | `mode` | `str` | Mode the decision was made under: `OBSERVE`, `MONITOR`, or `ENFORCE` |
 | `agent_name` | `str` | Agent that made the call, or `unknown` |
 | `tool_name` | `str` | Tool that was evaluated (`*` for turn-level denials) |
-| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `TOOL_BLOCKED`, `ARG_VALIDATION:{argument}:{check}` (`{argument}` is `*` when the call's arguments were not a mapping), `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `OUTPUT_PII_DETECTED:{category}`, `OUTPUT_SECRET_DETECTED`, `OUTPUT_REDACTED`, `OUTPUT_REDACTION_INCOMPLETE`, `OUTPUT_BLOCKED`, `BUDGET_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
+| `reason_codes` | `list[str]` | Machine-readable codes: `TOOL_NOT_ALLOWED`, `TOOL_BLOCKED`, `ARG_VALIDATION:{argument}:{check}` (`{argument}` is `*` when the call's arguments were not a mapping), `PROMPT_INJECTION:{technique}/{pattern}`, `PII_DETECTED:{category}`, `SECRET_DETECTED`, `OUTPUT_PII_DETECTED:{category}`, `OUTPUT_SECRET_DETECTED`, `OUTPUT_REDACTED`, `OUTPUT_REDACTION_INCOMPLETE`, `OUTPUT_BLOCKED`, `BUDGET_EXCEEDED`, `RATE_LIMIT_EXCEEDED`, `AGENT_FROZEN`, `POLICY_ALLOW`, `OBSERVE_PASSTHROUGH` |
 | `risk_score` | `int` | 0 (safe) to 100 (critical) |
 | `evaluation_time_ms` | `float` | Governance latency for this decision |
 | `cost_tracked` | `float` | Cost attributed to this call in USD |
@@ -666,6 +682,7 @@ Each policy type carries its own risk score when it denies:
 | Tool allowlist | `TOOL_NOT_ALLOWED` | 80 |
 | Tool blocklist | `TOOL_BLOCKED` | 80 |
 | Cost limit / factory budget | `BUDGET_EXCEEDED` | 70 |
+| Rate limit | `RATE_LIMIT_EXCEEDED` | 70 |
 | Output scan (post-tool, on the result) | `OUTPUT_SECRET_DETECTED` / `OUTPUT_PII_DETECTED:{category}` | 90 / 60 |
 
 !!! warning "Policy order is yours to choose"


### PR DESCRIPTION

## Why are these changes needed?

The TealTiger extension can cap cumulative *spend* (`cost_limit`) and govern *which* tools run and *what* they're called with — but it can't cap how *fast* an agent calls tools. That's the gap a runaway loop falls through: an agent stuck re-calling the same tool (a retry storm, a bad plan, a self-reinforcing loop) burns provider rate limits, triggers side effects, and runs up cost — often before a session cost ceiling would even register it, and always faster than a human can intervene.

This adds `GovernancePolicy.rate_limit(...)`, a deterministic sliding-window cap on tool-call frequency.

```python
from ag2.extensions.tealtiger import GovernancePolicy, TealTigerMiddleware, GovernanceMode

governance = TealTigerMiddleware(
    policies=[
        GovernancePolicy.rate_limit(30, window_seconds=60),                    # 30 tool calls/min, global
        GovernancePolicy.rate_limit(5, window_seconds=60, tool="send_email"),  # 5 emails/min
        GovernancePolicy.rate_limit(100, window_seconds=3600, tool="db_*"),    # 100 db_* calls/hour
    ],
    mode=GovernanceMode.ENFORCE,
)
```

## Behavior details

- **Sliding window.** Only the calls in the last `window_seconds` count, so the allowance refills continuously rather than resetting on a fixed boundary.
- **Scope via `tool`.** `tool=None` (default) is a **global** limit every governed call shares; `tool="name"` or an `fnmatch` pattern (`"db_*"`) scopes it to matching calls. Several policies compose — a generous global ceiling plus tighter per-tool caps — and the first limit exceeded denies the call with `RATE_LIMIT_EXCEEDED` (risk score 70).
- **Only allowed calls count.** The timestamp is recorded on the allowed path (alongside cost tracking), so a call denied by another policy never consumes the window budget.
- **State.** Call timestamps live on the `TealTigerMiddleware` factory and are shared across turns for the life of the instance (cleared by `reset()`). A limit spans a session, not a single turn; it does not persist across process restarts or share state between separate instances — documented explicitly.
- **Modes.** OBSERVE skips policy evaluation entirely; MONITOR records the would-be denial but does not block (and the real call still counts); ENFORCE blocks with a `ToolErrorEvent`. Consistent with every other policy in the extension.
- **Deterministic.** Pure timestamp math, no LLM in the path.

## Changes

- `ag2/extensions/tealtiger/types.py` — `GovernancePolicy.rate_limit(max_calls, window_seconds, tool=None)` factory + construction-time validation (positive-int `max_calls`, positive `window_seconds`, non-empty `tool`).
- `ag2/extensions/tealtiger/middleware.py` — `_rate_limit_exceeded()` / `_record_rate_limit_calls()`, a `_call_history` bucket store on the factory (cleared by `reset()`), and the `rate_limit` branch wired into `_evaluate`.
- `test/extensions/tealtiger/test_rate_limit.py` — 15 tests.
- `website/docs/user-guide/extensions/tealtiger.mdx` — new "Rate Limiting" section, `RATE_LIMIT_EXCEEDED` reason code, summary-table row.

## Testing

- `test/extensions/tealtiger/test_rate_limit.py` — 15 tests: global cap allows up to the limit then denies, per-tool isolation, pattern-family sharing, global+per-tool composition, window expiry lets calls through again, OBSERVE never denies / MONITOR records-not-blocks, validation errors, and an end-to-end `Agent` turn denied in ENFORCE.
- **Full extension suite: `198 passed`** (`test/extensions/tealtiger/`) — no regressions (was 183).
- `ruff check` and `ruff format --check` clean on the changed files.

## Breaking changes

None. `rate_limit` is a new, opt-in policy; existing policies and behavior are unchanged.
