### PR TITLE
Fix flaky live LLM test assertions

### DIFF
--- a/test/providers/agent/test_edge_cases.py
+++ b/test/providers/agent/test_edge_cases.py
@@ -10,6 +10,7 @@ malformed output, very large responses.
 import asyncio
 
 import pytest
+from pydantic import BaseModel, Field
 
 from ag2 import Agent
 from ag2.agent import KnowledgeConfig, TaskConfig
@@ -180,15 +181,7 @@ async def test_history_limiter_caps_context(provider_config) -> None:
 
 
 async def test_response_schema_strict_validation(provider_config) -> None:
-    """AgentReply.content() returns a validated instance for strict schemas.
-
-    NOTE: with ``temperature=0`` the model produces a valid response on the
-    first try, so this test exercises the happy path of strict-output
-    validation — *not* the retry-on-malformed recovery path. The retry
-    branch is covered by unit tests; here we assert the typed result and
-    that ``retries=0`` succeeds (proving no retry was needed).
-    """
-    from pydantic import BaseModel, Field
+    """AgentReply.content() returns a validated instance for strict schemas."""
 
     class StrictAnswer(BaseModel):
         answer: int = Field(..., description="The numeric answer, no text")
@@ -201,7 +194,7 @@ async def test_response_schema_strict_validation(provider_config) -> None:
     )
 
     reply = await agent.ask("What is 100 / 4? Return the integer answer.")
-    result = await reply.content(retries=0)
+    result = await reply.content(retries=1)
     assert isinstance(result, StrictAnswer)
     assert result.answer == 25
 

--- a/test/providers/agent/test_extensibility.py
+++ b/test/providers/agent/test_extensibility.py
@@ -207,13 +207,16 @@ async def test_plugin_with_dependencies_and_variables(provider_config) -> None:
 
 async def test_multiple_plugins_compose(provider_config) -> None:
     """Multiple plugins compose without overwriting each other's contributions."""
+    tool_calls: list[str] = []
 
     def tool_a() -> str:
-        """Returns 'a'."""
+        """Return the result for A."""
+        tool_calls.append("tool_a")
         return "result_a"
 
     def tool_b() -> str:
-        """Returns 'b'."""
+        """Return the result for B."""
+        tool_calls.append("tool_b")
         return "result_b"
 
     plugin_a = Plugin(prompt="If asked for A, call tool_a.", tools=[tool_a])
@@ -222,6 +225,4 @@ async def test_multiple_plugins_compose(provider_config) -> None:
     agent = Agent("composed", config=provider_config, plugins=[plugin_a, plugin_b])
     reply = await agent.ask("Get me both A and B by calling the tools.")
     assert reply.body is not None
-    body = reply.body.lower()
-    assert "result_a" in body
-    assert "result_b" in body
+    assert set(tool_calls) == {"tool_a", "tool_b"}


### PR DESCRIPTION
## Why are these changes needed?

Two live smoke tests assumed deterministic provider wording or formatting:

1. The multiple-plugin test asserted that final prose repeated exact tool return values. Z.AI called both tools but summarized their results as A and B.
2. The strict response-schema test assumed temperature zero always produces valid JSON on the first attempt. Z.AI intermittently returned the correct JSON with trailing explanatory text.

Record plugin tool execution directly instead of inspecting model prose. Allow one application-level response-validation retry while retaining the typed result and value assertions. This keeps the tests focused on supported AG2 behavior rather than a single model generation.

The touched function-level Pydantic import is also moved to module scope to follow project style.

## Related issue number

No related issue. Follow-up to failed live-LLM jobs:

- https://github.com/ag2ai/ag2/actions/runs/34592508314/job/103240803714
- https://github.com/ag2ai/ag2/actions/runs/34641571932/job/103402330028

## Checks

- [x] I've included any doc changes needed for https://docs.ag2.ai/. See https://docs.ag2.ai/latest/docs/contributor-guide/documentation/ to build and test documentation locally. (No documentation changes are needed.)
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. (The affected smoke tests now verify tool execution and validated typed output.)
- [x] I've made sure all auto checks have passed.

Validation:

- ruff check test/providers/agent/test_extensibility.py test/providers/agent/test_edge_cases.py
- ruff format --check test/providers/agent/test_extensibility.py test/providers/agent/test_edge_cases.py
- .venv/bin/pytest -q test/agent/test_response_schema.py (23 passed)
- All standard PR checks passed across supported operating systems and Python versions.
- Live OpenAI, Anthropic, Gemini, Z.AI, mixed-provider, and coverage jobs passed: https://github.com/ag2ai/ag2/actions/runs/34647503014

## AI assistance

Codex was used to inspect the failed jobs, identify both nondeterministic assertions, implement the test-only fixes, run validation, and draft this PR description. The contributor should personally confirm the attestations below after reviewing the diff and description.

- [x] I understand the changes in this PR and can explain them in my own words.
- [x] I have verified that the PR description accurately reflects the actual diff.
- [x] If AI assistance was used, I reviewed, tested, and validated the generated code/text before submitting.